### PR TITLE
Add OIDC SSO authentication via Authlib (Microsoft Entra)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,18 @@ MAIL_DEFAULT_FROM=sam-admin@ucar.edu
 FLASK_SECRET_KEY=your_generated_64_character_hex_string_here
 
 #-------------------------------------------------
+# OIDC Authentication (when AUTH_PROVIDER=oidc)
+# Leave AUTH_PROVIDER=stub (default) for development.
+# Set to 'oidc' when Microsoft Entra credentials are available and HTTPS is configured.
+# AUTH_PROVIDER=oidc
+# OIDC_CLIENT_ID=your-entra-client-id
+# OIDC_CLIENT_SECRET=your-entra-client-secret
+# OIDC_ISSUER=https://login.microsoftonline.com/{tenant-id}/v2.0
+# OIDC_REDIRECT_URI=https://your-app-url/auth/oidc/callback
+# OIDC_SCOPES=openid email profile
+# OIDC_USERNAME_CLAIM=preferred_username
+
+#-------------------------------------------------
 # MCP Server Configuration
 # GitHub MCP Server - requires Personal Access Token with "repo" scope
 #   Create token at: https://github.com/settings/tokens

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -101,12 +101,61 @@ After `terraform apply`:
 | `rds_endpoint` | MySQL connection endpoint |
 | `ecs_cluster_name` | ECS cluster name |
 
+## SSM Parameters
+
+| Parameter | Type | Purpose |
+|-----------|------|---------|
+| `/sam/{env}/db-host` | String | RDS endpoint address |
+| `/sam/{env}/db-username` | SecureString | Database username |
+| `/sam/{env}/db-password` | SecureString | Database password |
+| `/sam/{env}/flask-secret-key` | SecureString | Flask session signing key |
+| `/sam/{env}/oidc-client-id` | SecureString | Microsoft Entra OIDC client ID |
+| `/sam/{env}/oidc-client-secret` | SecureString | Microsoft Entra OIDC client secret |
+| `/sam/{env}/oidc-issuer` | SecureString | OIDC issuer URL |
+
+## OIDC SSO Integration
+
+The webapp supports OIDC SSO authentication via Microsoft Entra (Azure AD), controlled by the `AUTH_PROVIDER` environment variable:
+
+- `AUTH_PROVIDER=stub` (default) -- Development mode, any password works
+- `AUTH_PROVIDER=oidc` -- OIDC SSO via Authlib + PKCE
+
+### Enabling OIDC in Staging
+
+Prerequisites:
+1. HTTPS listener on ALB (ACM certificate + domain required)
+2. Microsoft Entra app registration from UCAR IT (see handoff checklist below)
+3. SSM parameters populated with real values (replace `placeholder` defaults)
+
+Steps:
+1. Update `secrets.auto.tfvars` with real OIDC values from IT
+2. Run `terraform apply` to update SSM parameters
+3. Change `AUTH_PROVIDER` from `stub` to `oidc` in `ecs.tf`
+4. Deploy updated task definition
+
+### IT Handoff Checklist (for UCAR IT Help Desk)
+
+Request the following from IT to register the SAM webapp with Microsoft Entra:
+
+- **Tenant ID**: UCAR/NCAR Microsoft Entra tenant
+- **Client ID**: Registered application client ID
+- **Client Secret**: Application client secret (will be stored in SSM SecureString)
+- **Redirect URI**: `https://<app-domain>/auth/oidc/callback` (must be HTTPS)
+- **Required scopes**: `openid email profile`
+- **Required claims**: `preferred_username`, `email`, `sub`
+- **End-session endpoint URL**: For RP-initiated logout
+
+### Rollback
+
+To revert from OIDC to stub auth: change `AUTH_PROVIDER` back to `stub` in the ECS task definition and redeploy. No code changes needed.
+
 ## Security
 
 - ALB only accepts traffic from UCAR network (128.117.0.0/16)
 - RDS accessible from ECS containers and UCAR VPN
 - Secrets stored in SSM Parameter Store (SecureString)
 - `secrets.auto.tfvars` is gitignored
+- OIDC client secrets are never stored in plaintext env vars -- injected via SSM
 
 ## Deployment
 

--- a/infrastructure/staging/alb.tf
+++ b/infrastructure/staging/alb.tf
@@ -17,14 +17,14 @@ resource "aws_alb_target_group" "webapp" {
 
   health_check {
     enabled             = true
-    path                = "/auth/login"
+    path                = "/api/v1/health/"
     port                = "traffic-port"
     protocol            = "HTTP"
     healthy_threshold   = 3
     unhealthy_threshold = 3
     timeout             = 10
     interval            = 30
-    matcher             = "200,302"
+    matcher             = "200"
   }
 
   tags = { Name = "${local.name_prefix}-webapp-tg" }
@@ -41,3 +41,19 @@ resource "aws_alb_listener" "http" {
     target_group_arn = aws_alb_target_group.webapp.arn
   }
 }
+
+# HTTPS listener — required before enabling AUTH_PROVIDER=oidc
+# Uncomment when ACM certificate and DNS are ready:
+#
+# resource "aws_alb_listener" "https" {
+#   load_balancer_arn = aws_alb.main.arn
+#   port              = 443
+#   protocol          = "HTTPS"
+#   ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+#   certificate_arn   = aws_acm_certificate.webapp.arn
+#
+#   default_action {
+#     type             = "forward"
+#     target_group_arn = aws_alb_target_group.webapp.arn
+#   }
+# }

--- a/infrastructure/staging/ecs.tf
+++ b/infrastructure/staging/ecs.tf
@@ -45,6 +45,7 @@ resource "aws_ecs_task_definition" "webapp" {
       { name = "AUDIT_ENABLED", value = "1" },
       { name = "AUDIT_LOG_PATH", value = "/var/log/sam/model_audit.log" },
       { name = "SAM_DB_REQUIRE_SSL", value = "false" },
+      { name = "AUTH_PROVIDER", value = "stub" },
     ]
 
     secrets = [
@@ -55,6 +56,9 @@ resource "aws_ecs_task_definition" "webapp" {
       { name = "STATUS_DB_USERNAME", valueFrom = aws_ssm_parameter.db_username.arn },
       { name = "STATUS_DB_PASSWORD", valueFrom = aws_ssm_parameter.db_password.arn },
       { name = "FLASK_SECRET_KEY", valueFrom = aws_ssm_parameter.flask_secret_key.arn },
+      { name = "OIDC_CLIENT_ID", valueFrom = aws_ssm_parameter.oidc_client_id.arn },
+      { name = "OIDC_CLIENT_SECRET", valueFrom = aws_ssm_parameter.oidc_client_secret.arn },
+      { name = "OIDC_ISSUER", valueFrom = aws_ssm_parameter.oidc_issuer.arn },
     ]
 
     logConfiguration = {

--- a/infrastructure/staging/ssm.tf
+++ b/infrastructure/staging/ssm.tf
@@ -29,3 +29,28 @@ resource "aws_ssm_parameter" "flask_secret_key" {
 
   tags = { Name = "${local.name_prefix}-flask-secret-key" }
 }
+
+# OIDC SSO credentials (populated when IT provides Entra registration)
+resource "aws_ssm_parameter" "oidc_client_id" {
+  name  = "/sam/${var.environment}/oidc-client-id"
+  type  = "SecureString"
+  value = var.oidc_client_id
+
+  tags = { Name = "${local.name_prefix}-oidc-client-id" }
+}
+
+resource "aws_ssm_parameter" "oidc_client_secret" {
+  name  = "/sam/${var.environment}/oidc-client-secret"
+  type  = "SecureString"
+  value = var.oidc_client_secret
+
+  tags = { Name = "${local.name_prefix}-oidc-client-secret" }
+}
+
+resource "aws_ssm_parameter" "oidc_issuer" {
+  name  = "/sam/${var.environment}/oidc-issuer"
+  type  = "SecureString"
+  value = var.oidc_issuer
+
+  tags = { Name = "${local.name_prefix}-oidc-issuer" }
+}

--- a/infrastructure/staging/variables.tf
+++ b/infrastructure/staging/variables.tf
@@ -76,3 +76,24 @@ variable "flask_secret_key" {
   type        = string
   sensitive   = true
 }
+
+variable "oidc_client_id" {
+  description = "OIDC client ID from Microsoft Entra app registration"
+  type        = string
+  sensitive   = true
+  default     = "placeholder"
+}
+
+variable "oidc_client_secret" {
+  description = "OIDC client secret from Microsoft Entra app registration"
+  type        = string
+  sensitive   = true
+  default     = "placeholder"
+}
+
+variable "oidc_issuer" {
+  description = "OIDC issuer URL (e.g. https://login.microsoftonline.com/{tenant-id}/v2.0)"
+  type        = string
+  sensitive   = true
+  default     = "placeholder"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "pymysql",
     "python-dotenv",
     "pyyaml",
+    "authlib>=1.3.0,<2.0.0",
     "requests",
     "rich",
     "sqlalchemy",

--- a/src/webapp/auth/__init__.py
+++ b/src/webapp/auth/__init__.py
@@ -1,12 +1,12 @@
 """
 Authentication module for SAM Web UI.
 
-Provides pluggable authentication providers (stub, LDAP, SAML, etc.)
+Provides pluggable authentication providers (stub, LDAP, OIDC)
 and Flask-Login integration.
 """
 
 from .models import AuthUser
-from .providers import get_auth_provider
+from .providers import get_auth_provider, OIDCAuthProvider
 from .blueprint import bp
 
-__all__ = ['AuthUser', 'get_auth_provider', 'bp']
+__all__ = ['AuthUser', 'get_auth_provider', 'OIDCAuthProvider', 'bp']

--- a/src/webapp/auth/blueprint.py
+++ b/src/webapp/auth/blueprint.py
@@ -1,86 +1,176 @@
-"""
-Authentication blueprint for login/logout functionality.
-"""
+"""Authentication blueprint for login/logout functionality."""
 
-from flask import Blueprint, render_template, request, redirect, url_for, flash, current_app
+import logging
+from urllib.parse import urlparse
+
+from flask import (
+    Blueprint, render_template, request, redirect, url_for,
+    flash, current_app, session,
+)
 from flask_login import login_user, logout_user, login_required, current_user
 from webapp.auth.models import AuthUser
-from webapp.auth.providers import get_auth_provider
+from webapp.auth.providers import get_auth_provider, OIDCAuthProvider
 from webapp.extensions import db
 
+logger = logging.getLogger(__name__)
 bp = Blueprint('auth', __name__, url_prefix='/auth')
 
 
+def _is_safe_redirect(target: str) -> bool:
+    """Only allow relative paths — block open redirects to external hosts."""
+    if not target:
+        return False
+    parsed = urlparse(target)
+    return not parsed.scheme and not parsed.netloc
+
+
+def _redirect_for_role(auth_user):
+    """Redirect to admin or user dashboard based on roles."""
+    if 'admin' in auth_user.roles:
+        return redirect(url_for('admin_dashboard.index'))
+    return redirect(url_for('user_dashboard.index'))
+
+
+# ---------------------------------------------------------------------------
+# Standard login/logout
+# ---------------------------------------------------------------------------
+
 @bp.route('/login', methods=['GET', 'POST'])
 def login():
-    """
-    Login page and handler.
-
-    GET: Display login form with available test users
-    POST: Authenticate user and create session
-    """
-    # Redirect if already logged in
+    """Login page: renders SSO button (OIDC) or username/password form (stub)."""
     if current_user.is_authenticated:
-        # Redirect based on user role
-        if 'admin' in auth_user.roles:
-            return redirect(url_for('admin_dashboard.index'))
-        else:
-            return redirect(url_for('user_dashboard.index'))
+        return _redirect_for_role(current_user)
 
-    if request.method == 'POST':
+    auth_provider = current_app.config.get('AUTH_PROVIDER', 'stub')
+    oidc_enabled = auth_provider == 'oidc'
+
+    if request.method == 'POST' and not oidc_enabled:
         username = request.form.get('username')
         password = request.form.get('password')
 
-        # Get configured auth provider
-        # TODO: Get provider type from config
         provider = get_auth_provider('stub', db_session=db.session)
-
-        # Authenticate
         sam_user = provider.authenticate(username, password)
 
         if sam_user:
-            # Wrap SAM user for Flask-Login with dev role mapping
             dev_role_mapping = current_app.config.get('DEV_ROLE_MAPPING', {})
             auth_user = AuthUser(sam_user, dev_role_mapping=dev_role_mapping)
 
-            # Create session
             remember = request.form.get('remember', False)
             login_user(auth_user, remember=remember)
+            logger.info("Login success (stub): user=%s", username)
 
-            # Redirect to next page or appropriate dashboard
             next_page = request.args.get('next')
-            if next_page:
+            if next_page and _is_safe_redirect(next_page):
                 return redirect(next_page)
-
-            # Redirect based on user role
-            if 'admin' in auth_user.roles:
-                return redirect(url_for('admin_dashboard.index'))
-            else:
-                return redirect(url_for('user_dashboard.index'))
+            return _redirect_for_role(auth_user)
         else:
+            logger.warning("Login failed (stub): user=%s", username)
             flash('Invalid username or password', 'error')
 
-    # Get available test users from DEV_ROLE_MAPPING for quick switching
     dev_role_mapping = current_app.config.get('DEV_ROLE_MAPPING', {})
-    test_users = {username: roles for username, roles in dev_role_mapping.items()}
+    test_users = {u: r for u, r in dev_role_mapping.items()}
 
-    return render_template('auth/login.html', test_users=test_users)
+    return render_template(
+        'auth/login.html',
+        test_users=test_users,
+        oidc_enabled=oidc_enabled,
+    )
 
+
+# ---------------------------------------------------------------------------
+# OIDC SSO routes
+# ---------------------------------------------------------------------------
+
+@bp.route('/oidc/login')
+def oidc_login():
+    """Initiate OIDC authorization code flow — redirect to IdP."""
+    oauth = current_app.extensions.get('oauth')
+    if not oauth:
+        flash('OIDC is not configured.', 'error')
+        return redirect(url_for('auth.login'))
+
+    callback_url = current_app.config.get('OIDC_REDIRECT_URI') or url_for(
+        'auth.oidc_callback', _external=True
+    )
+
+    next_page = request.args.get('next', '')
+    if next_page and _is_safe_redirect(next_page):
+        session['oidc_next'] = next_page
+
+    logger.info("OIDC login initiated, redirecting to IdP")
+    return oauth.entra.authorize_redirect(callback_url)
+
+
+@bp.route('/oidc/callback')
+def oidc_callback():
+    """Handle the OIDC IdP callback — exchange code for tokens and create session."""
+    oauth = current_app.extensions.get('oauth')
+    if not oauth:
+        flash('OIDC is not configured.', 'error')
+        return redirect(url_for('auth.login'))
+
+    try:
+        provider = OIDCAuthProvider(
+            db_session=db.session,
+            oauth_client=oauth.entra,
+            username_claim=current_app.config.get('OIDC_USERNAME_CLAIM', 'preferred_username'),
+        )
+        sam_user = provider.handle_callback()
+    except Exception:
+        logger.exception("OIDC callback failed")
+        flash('Authentication failed. Please try again.', 'error')
+        return redirect(url_for('auth.login'))
+
+    if not sam_user:
+        flash('Your account was not found in SAM or is inactive.', 'error')
+        return redirect(url_for('auth.login'))
+
+    dev_role_mapping = current_app.config.get('DEV_ROLE_MAPPING', {})
+    auth_user = AuthUser(sam_user, dev_role_mapping=dev_role_mapping)
+    login_user(auth_user, remember=False)
+    logger.info("OIDC login success: user=%s", sam_user.username)
+
+    next_page = session.pop('oidc_next', None)
+    if next_page and _is_safe_redirect(next_page):
+        return redirect(next_page)
+    return _redirect_for_role(auth_user)
+
+
+# ---------------------------------------------------------------------------
+# Logout
+# ---------------------------------------------------------------------------
 
 @bp.route('/logout')
 @login_required
 def logout():
-    """Logout current user and redirect to login (for user switching)."""
+    """Logout: clear Flask session; for OIDC, also redirect to IdP end-session."""
     username = current_user.username
+    auth_provider = current_app.config.get('AUTH_PROVIDER', 'stub')
     logout_user()
     flash(f'Logged out {username}.', 'info')
+    logger.info("Logout: user=%s provider=%s", username, auth_provider)
+
+    if auth_provider == 'oidc':
+        oauth = current_app.extensions.get('oauth')
+        if oauth:
+            try:
+                metadata = oauth.entra.load_server_metadata()
+                end_session_url = metadata.get('end_session_endpoint')
+                if end_session_url:
+                    post_logout_uri = url_for('status_dashboard.index', _external=True)
+                    return redirect(f"{end_session_url}?post_logout_redirect_uri={post_logout_uri}")
+            except Exception:
+                logger.exception("Failed to get OIDC end_session_endpoint")
+
     return redirect(url_for('status_dashboard.index'))
 
+
+# ---------------------------------------------------------------------------
+# Profile
+# ---------------------------------------------------------------------------
 
 @bp.route('/profile')
 @login_required
 def profile():
-    """
-    User profile page showing current user's info and roles.
-    """
+    """User profile page showing current user's info and roles."""
     return render_template('auth/profile.html', user=current_user)

--- a/src/webapp/auth/providers.py
+++ b/src/webapp/auth/providers.py
@@ -7,43 +7,27 @@ via configuration without code changes.
 Available providers:
 - StubAuthProvider: Development/testing authentication (accepts any password)
 - LDAPAuthProvider: LDAP authentication (future implementation)
-- SAMLAuthProvider: SAML SSO authentication (future implementation)
+- OIDCAuthProvider: OpenID Connect SSO via Authlib (Microsoft Entra, CILogon, etc.)
 """
 
+import logging
 from abc import ABC, abstractmethod
 from typing import Optional
 from sam.core.users import User
 from sam.queries.lookups import find_user_by_username
 
+logger = logging.getLogger(__name__)
+
 
 class AuthProvider(ABC):
-    """
-    Abstract base class for authentication providers.
-
-    All authentication providers must implement these methods.
-    """
+    """Abstract base class for authentication providers."""
 
     def __init__(self, db_session):
-        """
-        Initialize the provider with database session access.
-
-        Args:
-            db_session: SQLAlchemy session (Flask-SQLAlchemy db.session)
-        """
         self.db_session = db_session
 
     @abstractmethod
     def authenticate(self, username: str, password: str) -> Optional[User]:
-        """
-        Authenticate user credentials.
-
-        Args:
-            username: Username to authenticate
-            password: Password to verify
-
-        Returns:
-            SAM User object if authentication succeeds, None otherwise
-        """
+        """Authenticate user with username/password credentials."""
         pass
 
     @abstractmethod
@@ -51,162 +35,143 @@ class AuthProvider(ABC):
         """Return True if this provider allows password changes."""
         pass
 
+    def supports_redirect_auth(self) -> bool:
+        """Override to True for SSO providers that use redirect-based auth."""
+        return False
+
+    def initiate_login(self, redirect_uri: str):
+        """SSO providers: return a redirect response to the IdP."""
+        raise NotImplementedError("This provider does not support redirect-based auth")
+
+    def handle_callback(self) -> Optional[User]:
+        """SSO providers: process the IdP callback and resolve a SAM user."""
+        raise NotImplementedError("This provider does not support redirect-based auth")
+
 
 class StubAuthProvider(AuthProvider):
     """
     Stub authentication provider for development and testing.
 
-    WARNING: This provider accepts ANY non-empty password for existing users.
+    WARNING: Accepts ANY non-empty password for existing users.
     DO NOT use in production!
-
-    Features:
-    - Authenticates any existing SAM user with any password
-    - Useful for RBAC testing without enterprise auth setup
-    - Can be configured to require specific test passwords
     """
 
     def __init__(self, db_session, require_password: str = None):
-        """
-        Initialize stub auth provider.
-
-        Args:
-            db_session: SQLAlchemy session
-            require_password: Optional password to require (default: accept any)
-        """
         super().__init__(db_session)
         self.require_password = require_password
 
     def authenticate(self, username: str, password: str) -> Optional[User]:
-        """
-        Stub authentication - accepts any password for existing users.
-
-        Args:
-            username: Username to authenticate
-            password: Password (ignored in default stub mode)
-
-        Returns:
-            User object if user exists in database, None otherwise
-        """
-        # Check password if required
         if self.require_password and password != self.require_password:
             return None
-
-        # Otherwise just check if password is non-empty
         if not password:
             return None
 
-        # Look up user in SAM database
         user = find_user_by_username(self.db_session, username)
-
-        # Only authenticate active, non-locked users
         if user and user.active and not user.locked:
             return user
-
         return None
 
     def supports_password_change(self) -> bool:
-        """Stub provider does not support password changes."""
         return False
 
 
 class LDAPAuthProvider(AuthProvider):
-    """
-    LDAP authentication provider (future implementation).
-
-    Will support:
-    - LDAP bind authentication
-    - User attribute syncing
-    - Group mapping to SAM roles
-    """
+    """LDAP authentication provider (future implementation)."""
 
     def __init__(self, db_session, ldap_url: str, base_dn: str, **kwargs):
-        """
-        Initialize LDAP provider.
-
-        Args:
-            db_session: SQLAlchemy session
-            ldap_url: LDAP server URL (e.g., 'ldap://ldap.example.org')
-            base_dn: Base DN for user searches (e.g., 'ou=users,dc=example,dc=org')
-            **kwargs: Additional LDAP configuration
-        """
         super().__init__(db_session)
         self.ldap_url = ldap_url
         self.base_dn = base_dn
         self.config = kwargs
 
     def authenticate(self, username: str, password: str) -> Optional[User]:
-        """
-        Authenticate against LDAP server.
-
-        TODO: Implement LDAP bind and user sync.
-        """
         raise NotImplementedError("LDAP authentication not yet implemented")
 
     def supports_password_change(self) -> bool:
-        """LDAP passwords are managed externally."""
         return False
 
 
-class SAMLAuthProvider(AuthProvider):
+class OIDCAuthProvider(AuthProvider):
     """
-    SAML SSO authentication provider (future implementation).
+    OpenID Connect authentication via Authlib.
 
-    Will support:
-    - SAML 2.0 assertions
-    - Shibboleth integration
-    - Attribute-based role mapping
+    Uses redirect-based authorization code flow with PKCE.
+    Resolves OIDC claims to existing SAM users (no auto-provisioning).
     """
 
-    def __init__(self, db_session, entity_id: str, sso_url: str, **kwargs):
-        """
-        Initialize SAML provider.
-
-        Args:
-            db_session: SQLAlchemy session
-            entity_id: SAML entity ID
-            sso_url: SSO service URL
-            **kwargs: Additional SAML configuration
-        """
+    def __init__(self, db_session, oauth_client=None, username_claim: str = 'preferred_username'):
         super().__init__(db_session)
-        self.entity_id = entity_id
-        self.sso_url = sso_url
-        self.config = kwargs
+        self.oauth_client = oauth_client
+        self.username_claim = username_claim
 
     def authenticate(self, username: str, password: str) -> Optional[User]:
-        """
-        SAML authentication (redirects to SSO, doesn't use username/password directly).
-
-        TODO: Implement SAML assertion validation.
-        """
-        raise NotImplementedError("SAML authentication not yet implemented")
+        raise NotImplementedError("OIDC uses redirect-based auth, not password auth")
 
     def supports_password_change(self) -> bool:
-        """SAML uses external identity provider."""
         return False
 
+    def supports_redirect_auth(self) -> bool:
+        return True
 
-# Factory function for getting configured provider
+    def initiate_login(self, redirect_uri: str):
+        """Redirect the user to the OIDC IdP authorization endpoint."""
+        return self.oauth_client.authorize_redirect(redirect_uri)
+
+    def handle_callback(self) -> Optional[User]:
+        """Exchange the authorization code for tokens, validate, and resolve SAM user."""
+        token = self.oauth_client.authorize_access_token()
+        userinfo = token.get('userinfo', {})
+        if not userinfo:
+            logger.warning("OIDC callback: no userinfo in token response")
+            return None
+        return self.resolve_user_from_claims(userinfo)
+
+    def resolve_user_from_claims(self, claims: dict) -> Optional[User]:
+        """Map OIDC claims to an existing SAM User.
+
+        Resolution order:
+        1. username_claim (default: preferred_username)
+        2. email prefix (before @)
+        """
+        username = claims.get(self.username_claim)
+        if not username:
+            email = claims.get('email', '')
+            username = email.split('@')[0] if email else None
+
+        if not username:
+            logger.warning("OIDC claims missing both '%s' and 'email': %s",
+                           self.username_claim, list(claims.keys()))
+            return None
+
+        user = find_user_by_username(self.db_session, username)
+        if not user:
+            logger.warning("OIDC login denied: SAM user '%s' not found", username)
+            return None
+        if not user.active or user.locked:
+            logger.warning("OIDC login denied: SAM user '%s' is inactive or locked", username)
+            return None
+
+        logger.info("OIDC login success: '%s' resolved from claim '%s'",
+                     username, self.username_claim)
+        return user
+
+
 def get_auth_provider(provider_type: str = 'stub', db_session=None, **config):
     """
     Get an authentication provider instance.
 
     Args:
-        provider_type: Type of provider ('stub', 'ldap', 'saml')
+        provider_type: Type of provider ('stub', 'ldap', 'oidc')
         db_session: SQLAlchemy session
         **config: Provider-specific configuration
 
     Returns:
         Configured AuthProvider instance
-
-    Example:
-        >>> from webapp.extensions import db
-        >>> provider = get_auth_provider('stub', db_session=db.session)
-        >>> user = provider.authenticate('johndoe', 'any-password')
     """
     providers = {
         'stub': StubAuthProvider,
         'ldap': LDAPAuthProvider,
-        'saml': SAMLAuthProvider,
+        'oidc': OIDCAuthProvider,
     }
 
     if provider_type not in providers:

--- a/src/webapp/config.py
+++ b/src/webapp/config.py
@@ -27,8 +27,16 @@ class SAMWebappConfig(SAMConfig):
         if k.startswith('API_KEYS_') and v
     }
 
-    # Auth provider ('stub' | 'ldap' | 'saml')
+    # Auth provider ('stub' | 'ldap' | 'oidc')
     AUTH_PROVIDER = os.getenv('AUTH_PROVIDER', 'stub')
+
+    # OIDC configuration (active when AUTH_PROVIDER='oidc')
+    OIDC_CLIENT_ID = os.getenv('OIDC_CLIENT_ID', '')
+    OIDC_CLIENT_SECRET = os.getenv('OIDC_CLIENT_SECRET', '')
+    OIDC_ISSUER = os.getenv('OIDC_ISSUER', '')
+    OIDC_SCOPES = os.getenv('OIDC_SCOPES', 'openid email profile')
+    OIDC_USERNAME_CLAIM = os.getenv('OIDC_USERNAME_CLAIM', 'preferred_username')
+    OIDC_REDIRECT_URI = os.getenv('OIDC_REDIRECT_URI', '')
 
     # Audit logging
     AUDIT_ENABLED  = os.getenv('AUDIT_ENABLED', '1').lower() in ('1', 'true', 'yes')
@@ -92,6 +100,13 @@ class ProductionConfig(SAMWebappConfig):
                 "Generate keys with: python scripts/gen_api_key.py",
                 stacklevel=2,
             )
+        if cls.AUTH_PROVIDER == 'oidc':
+            missing = [v for v in ('OIDC_CLIENT_ID', 'OIDC_CLIENT_SECRET', 'OIDC_ISSUER')
+                       if not os.getenv(v)]
+            if missing:
+                raise EnvironmentError(
+                    f"AUTH_PROVIDER=oidc but missing required env vars: {', '.join(missing)}"
+                )
 
 
 class TestingConfig(SAMWebappConfig):

--- a/src/webapp/run.py
+++ b/src/webapp/run.py
@@ -126,6 +126,22 @@ def create_app():
         return response
     # =========================================================================
 
+    # Initialize OIDC (Authlib) when configured
+    if app.config.get('AUTH_PROVIDER') == 'oidc':
+        from authlib.integrations.flask_client import OAuth
+        oauth = OAuth(app)
+        oauth.register(
+            'entra',
+            client_id=app.config['OIDC_CLIENT_ID'],
+            client_secret=app.config['OIDC_CLIENT_SECRET'],
+            server_metadata_url=app.config['OIDC_ISSUER'] + '/.well-known/openid-configuration',
+            client_kwargs={
+                'scope': app.config.get('OIDC_SCOPES', 'openid email profile'),
+                'code_challenge_method': 'S256',
+            },
+        )
+        app.extensions['oauth'] = oauth
+
     # Initialize Flask-Login
     login_manager = LoginManager()
     login_manager.init_app(app)

--- a/src/webapp/templates/auth/login.html
+++ b/src/webapp/templates/auth/login.html
@@ -18,12 +18,6 @@
             <p>Systems Accounting Manager</p>
         </div>
 
-        <!-- Development mode warning -->
-        <div class="alert-dev">
-            <strong>Development Mode:</strong> Using stub authentication.
-            Any password will work for existing users.
-        </div>
-
         <!-- Flash messages -->
         {% with messages = get_flashed_messages(with_categories=true) %}
             {% if messages %}
@@ -35,6 +29,23 @@
                 {% endfor %}
             {% endif %}
         {% endwith %}
+
+        {% if oidc_enabled %}
+        {# ---- OIDC SSO mode ---- #}
+        <div class="text-center mb-4">
+            <p class="text-muted">Sign in with your institutional account</p>
+        </div>
+
+        <a href="{{ url_for('auth.oidc_login') }}" class="btn btn-primary btn-login btn-lg w-100">
+            Sign in with UCAR SSO
+        </a>
+
+        {% else %}
+        {# ---- Stub / dev mode ---- #}
+        <div class="alert-dev">
+            <strong>Development Mode:</strong> Using stub authentication.
+            Any password will work for existing users.
+        </div>
 
         <form method="POST" action="{{ url_for('auth.login') }}">
             <div class="mb-3">
@@ -89,6 +100,7 @@
             </form>
             {% endfor %}
         </div>
+        {% endif %}
         {% endif %}
 
         <div class="text-center mt-3">

--- a/src/webapp/utils/dev_auth.py
+++ b/src/webapp/utils/dev_auth.py
@@ -28,7 +28,6 @@ def auto_login_middleware(app, db):
     @app.before_request
     def before_request():
         """Auto-login configured user if DISABLE_AUTH is set."""
-        # Only run if explicitly enabled
         if os.environ.get('DISABLE_AUTH') != '1':
             return
 

--- a/tests/unit/test_oidc_auth.py
+++ b/tests/unit/test_oidc_auth.py
@@ -1,0 +1,430 @@
+"""Tests for OIDC SSO authentication provider and routes.
+
+Covers:
+- OIDCAuthProvider.resolve_user_from_claims() with valid/invalid/missing claims
+- Login page rendering: SSO button (OIDC) vs form (stub)
+- OIDC login redirect initiation
+- Callback flow with mocked Authlib
+- Error paths: missing state, token failure, user not in SAM
+- Logout with RP-initiated redirect
+- Open-redirect prevention on next param
+- ProductionConfig validation for missing OIDC env vars
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from webapp.auth.providers import (
+    OIDCAuthProvider,
+    StubAuthProvider,
+    get_auth_provider,
+)
+
+
+# ---------------------------------------------------------------------------
+# Provider unit tests
+# ---------------------------------------------------------------------------
+
+class TestOIDCAuthProvider:
+    """Unit tests for OIDCAuthProvider claim resolution."""
+
+    def test_resolve_user_preferred_username(self, session):
+        """Resolves SAM user from preferred_username claim."""
+        provider = OIDCAuthProvider(db_session=session)
+        claims = {'preferred_username': 'benkirk', 'email': 'benkirk@ucar.edu', 'sub': '123'}
+        user = provider.resolve_user_from_claims(claims)
+        assert user is not None
+        assert user.username == 'benkirk'
+
+    def test_resolve_user_email_fallback(self, session):
+        """Falls back to email prefix when preferred_username is missing."""
+        provider = OIDCAuthProvider(db_session=session)
+        claims = {'email': 'benkirk@ucar.edu', 'sub': '123'}
+        user = provider.resolve_user_from_claims(claims)
+        assert user is not None
+        assert user.username == 'benkirk'
+
+    def test_resolve_user_custom_claim(self, session):
+        """Uses custom username_claim when configured."""
+        provider = OIDCAuthProvider(db_session=session, username_claim='sub')
+        claims = {'sub': 'benkirk', 'email': 'other@ucar.edu'}
+        user = provider.resolve_user_from_claims(claims)
+        assert user is not None
+        assert user.username == 'benkirk'
+
+    def test_resolve_user_not_found(self, session):
+        """Returns None when user doesn't exist in SAM."""
+        provider = OIDCAuthProvider(db_session=session)
+        claims = {'preferred_username': 'nonexistent_user_xyz', 'sub': '999'}
+        user = provider.resolve_user_from_claims(claims)
+        assert user is None
+
+    def test_resolve_user_missing_claims(self, session):
+        """Returns None when both username and email claims are missing."""
+        provider = OIDCAuthProvider(db_session=session)
+        claims = {'sub': '123'}
+        user = provider.resolve_user_from_claims(claims)
+        assert user is None
+
+    def test_resolve_user_empty_claims(self, session):
+        """Returns None for empty claims dict."""
+        provider = OIDCAuthProvider(db_session=session)
+        user = provider.resolve_user_from_claims({})
+        assert user is None
+
+    def test_resolve_user_locked(self, session):
+        """Returns None for locked SAM user."""
+        from sam.core.users import User
+        user = User.get_by_username(session, 'benkirk')
+        if user is None:
+            pytest.skip("Test user not in database")
+
+        original_locked = user.locked
+        try:
+            user.locked = True
+            session.flush()
+
+            provider = OIDCAuthProvider(db_session=session)
+            result = provider.resolve_user_from_claims({'preferred_username': 'benkirk'})
+            assert result is None
+        finally:
+            user.locked = original_locked
+            session.flush()
+
+    def test_resolve_user_inactive(self, session):
+        """Returns None for inactive SAM user."""
+        from sam.core.users import User
+        user = User.get_by_username(session, 'benkirk')
+        if user is None:
+            pytest.skip("Test user not in database")
+
+        original_active = user.active
+        try:
+            user.active = False
+            session.flush()
+
+            provider = OIDCAuthProvider(db_session=session)
+            result = provider.resolve_user_from_claims({'preferred_username': 'benkirk'})
+            assert result is None
+        finally:
+            user.active = original_active
+            session.flush()
+
+    def test_supports_redirect_auth(self, session):
+        """OIDC provider supports redirect-based auth."""
+        provider = OIDCAuthProvider(db_session=session)
+        assert provider.supports_redirect_auth() is True
+
+    def test_authenticate_raises(self, session):
+        """Direct authenticate() raises NotImplementedError."""
+        provider = OIDCAuthProvider(db_session=session)
+        with pytest.raises(NotImplementedError):
+            provider.authenticate('user', 'pass')
+
+    def test_supports_password_change_false(self, session):
+        """OIDC doesn't support password changes."""
+        provider = OIDCAuthProvider(db_session=session)
+        assert provider.supports_password_change() is False
+
+    def test_handle_callback_no_userinfo(self, session):
+        """handle_callback returns None when token has no userinfo."""
+        mock_client = MagicMock()
+        mock_client.authorize_access_token.return_value = {}
+        provider = OIDCAuthProvider(db_session=session, oauth_client=mock_client)
+        result = provider.handle_callback()
+        assert result is None
+
+    def test_handle_callback_success(self, session):
+        """handle_callback resolves user from token userinfo."""
+        mock_client = MagicMock()
+        mock_client.authorize_access_token.return_value = {
+            'userinfo': {'preferred_username': 'benkirk', 'email': 'benkirk@ucar.edu'}
+        }
+        provider = OIDCAuthProvider(db_session=session, oauth_client=mock_client)
+        result = provider.handle_callback()
+        assert result is not None
+        assert result.username == 'benkirk'
+
+
+# ---------------------------------------------------------------------------
+# Provider factory tests
+# ---------------------------------------------------------------------------
+
+class TestProviderFactory:
+    """Test get_auth_provider factory."""
+
+    def test_get_stub_provider(self, session):
+        provider = get_auth_provider('stub', db_session=session)
+        assert isinstance(provider, StubAuthProvider)
+
+    def test_get_oidc_provider(self, session):
+        provider = get_auth_provider('oidc', db_session=session)
+        assert isinstance(provider, OIDCAuthProvider)
+
+    def test_stub_no_redirect(self, session):
+        provider = get_auth_provider('stub', db_session=session)
+        assert provider.supports_redirect_auth() is False
+
+    def test_unknown_provider(self, session):
+        with pytest.raises(ValueError, match="Unknown auth provider"):
+            get_auth_provider('unknown', db_session=session)
+
+    def test_saml_removed(self, session):
+        """SAMLAuthProvider was removed in favor of OIDC."""
+        with pytest.raises(ValueError, match="Unknown auth provider"):
+            get_auth_provider('saml', db_session=session)
+
+
+# ---------------------------------------------------------------------------
+# Blueprint / route tests
+# ---------------------------------------------------------------------------
+
+class TestLoginPageRendering:
+    """Test login page renders correctly for stub vs OIDC modes."""
+
+    def test_stub_mode_shows_form(self, client):
+        """Stub mode renders username/password form."""
+        resp = client.get('/auth/login')
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert 'name="username"' in html
+        assert 'name="password"' in html
+        assert 'Development Mode' in html
+
+    def test_stub_mode_no_sso_button(self, client):
+        """Stub mode does NOT show SSO button."""
+        resp = client.get('/auth/login')
+        html = resp.data.decode()
+        assert 'Sign in with UCAR SSO' not in html
+
+    def test_oidc_mode_shows_sso_button(self, app):
+        """OIDC mode renders SSO button instead of form."""
+        app.config['AUTH_PROVIDER'] = 'oidc'
+        try:
+            with app.test_client() as c:
+                resp = c.get('/auth/login')
+                assert resp.status_code == 200
+                html = resp.data.decode()
+                assert 'Sign in with UCAR SSO' in html
+                assert 'name="username"' not in html
+        finally:
+            app.config['AUTH_PROVIDER'] = 'stub'
+
+    def test_oidc_mode_hides_dev_warning(self, app):
+        """OIDC mode does not show development mode warning."""
+        app.config['AUTH_PROVIDER'] = 'oidc'
+        try:
+            with app.test_client() as c:
+                resp = c.get('/auth/login')
+                html = resp.data.decode()
+                assert 'Development Mode' not in html
+        finally:
+            app.config['AUTH_PROVIDER'] = 'stub'
+
+
+class TestOIDCLoginRoute:
+    """Test /auth/oidc/login redirect initiation."""
+
+    def test_oidc_login_no_oauth_configured(self, client):
+        """Returns error flash when OAuth is not initialized."""
+        resp = client.get('/auth/oidc/login', follow_redirects=True)
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert 'OIDC is not configured' in html
+
+    def test_oidc_login_redirects_to_idp(self, app):
+        """Initiates redirect to IdP when OAuth is configured."""
+        mock_oauth = MagicMock()
+        mock_redirect_resp = MagicMock()
+        mock_redirect_resp.status_code = 302
+        mock_redirect_resp.headers = {'Location': 'https://login.microsoftonline.com/authorize'}
+        mock_oauth.entra.authorize_redirect.return_value = mock_redirect_resp
+
+        app.extensions['oauth'] = mock_oauth
+        app.config['AUTH_PROVIDER'] = 'oidc'
+        try:
+            with app.test_client() as c:
+                resp = c.get('/auth/oidc/login')
+                mock_oauth.entra.authorize_redirect.assert_called_once()
+        finally:
+            app.config['AUTH_PROVIDER'] = 'stub'
+            app.extensions.pop('oauth', None)
+
+
+class TestOIDCCallbackRoute:
+    """Test /auth/oidc/callback token exchange and session creation."""
+
+    def test_callback_no_oauth_configured(self, client):
+        """Returns error when OAuth is not initialized."""
+        resp = client.get('/auth/oidc/callback', follow_redirects=True)
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert 'OIDC is not configured' in html
+
+    def test_callback_success_creates_session(self, app):
+        """Successful callback creates Flask-Login session and redirects to a dashboard."""
+        mock_oauth = MagicMock()
+        mock_oauth.entra.authorize_access_token.return_value = {
+            'userinfo': {'preferred_username': 'benkirk', 'email': 'benkirk@ucar.edu'}
+        }
+
+        app.extensions['oauth'] = mock_oauth
+        app.config['AUTH_PROVIDER'] = 'oidc'
+        try:
+            with app.test_client() as c:
+                resp = c.get('/auth/oidc/callback')
+                assert resp.status_code == 302
+                location = resp.headers.get('Location', '')
+                assert '/auth/login' not in location, "Should not redirect back to login on success"
+        finally:
+            app.config['AUTH_PROVIDER'] = 'stub'
+            app.extensions.pop('oauth', None)
+
+    def test_callback_user_not_found(self, app):
+        """Callback with unknown user flashes error and redirects to login."""
+        mock_oauth = MagicMock()
+        mock_oauth.entra.authorize_access_token.return_value = {
+            'userinfo': {'preferred_username': 'nonexistent_xyz', 'email': 'nope@ucar.edu'}
+        }
+
+        app.extensions['oauth'] = mock_oauth
+        app.config['AUTH_PROVIDER'] = 'oidc'
+        try:
+            with app.test_client() as c:
+                resp = c.get('/auth/oidc/callback')
+                assert resp.status_code == 302
+                assert '/auth/login' in resp.headers.get('Location', '')
+        finally:
+            app.config['AUTH_PROVIDER'] = 'stub'
+            app.extensions.pop('oauth', None)
+
+    def test_callback_token_exchange_failure(self, app):
+        """Callback handles token exchange exceptions gracefully."""
+        mock_oauth = MagicMock()
+        mock_oauth.entra.authorize_access_token.side_effect = Exception("Token exchange failed")
+
+        app.extensions['oauth'] = mock_oauth
+        app.config['AUTH_PROVIDER'] = 'oidc'
+        try:
+            with app.test_client() as c:
+                resp = c.get('/auth/oidc/callback')
+                assert resp.status_code == 302
+                assert '/auth/login' in resp.headers.get('Location', '')
+        finally:
+            app.config['AUTH_PROVIDER'] = 'stub'
+            app.extensions.pop('oauth', None)
+
+
+class TestOpenRedirectProtection:
+    """Test that next parameter is validated against open redirects."""
+
+    def test_safe_relative_redirect(self, app, session):
+        """Relative paths are allowed for next parameter."""
+        with app.test_client() as c:
+            resp = c.post(
+                '/auth/login?next=/dashboard/user',
+                data={'username': 'benkirk', 'password': 'test'},
+            )
+            assert resp.status_code == 302
+            assert '/dashboard/user' in resp.headers.get('Location', '')
+
+    def test_blocks_external_url(self, app, session):
+        """External URLs in next parameter are rejected."""
+        with app.test_client() as c:
+            resp = c.post(
+                '/auth/login?next=https://evil.com/steal',
+                data={'username': 'benkirk', 'password': 'test'},
+            )
+            assert resp.status_code == 302
+            location = resp.headers.get('Location', '')
+            assert 'evil.com' not in location
+
+    def test_blocks_protocol_relative(self, app, session):
+        """Protocol-relative URLs (//evil.com) are rejected."""
+        with app.test_client() as c:
+            resp = c.post(
+                '/auth/login?next=//evil.com/steal',
+                data={'username': 'benkirk', 'password': 'test'},
+            )
+            assert resp.status_code == 302
+            location = resp.headers.get('Location', '')
+            assert 'evil.com' not in location
+
+
+class TestLogout:
+    """Test logout behavior for stub and OIDC modes."""
+
+    def test_stub_logout(self, auth_client):
+        """Stub logout clears session and redirects to status dashboard."""
+        resp = auth_client.get('/auth/logout')
+        assert resp.status_code == 302
+        assert '/status' in resp.headers.get('Location', '')
+
+    def test_oidc_logout_redirects_to_entra(self, app, session):
+        """OIDC logout redirects to Entra end_session_endpoint."""
+        mock_oauth = MagicMock()
+        mock_oauth.entra.load_server_metadata.return_value = {
+            'end_session_endpoint': 'https://login.microsoftonline.com/logout'
+        }
+
+        app.extensions['oauth'] = mock_oauth
+        app.config['AUTH_PROVIDER'] = 'oidc'
+        try:
+            with app.test_client() as c:
+                from sam.core.users import User
+                user = User.get_by_username(session, 'benkirk')
+                with c.session_transaction() as sess:
+                    sess['_user_id'] = str(user.user_id)
+                    sess['_fresh'] = True
+
+                resp = c.get('/auth/logout')
+                assert resp.status_code == 302
+                location = resp.headers.get('Location', '')
+                assert 'login.microsoftonline.com/logout' in location
+        finally:
+            app.config['AUTH_PROVIDER'] = 'stub'
+            app.extensions.pop('oauth', None)
+
+
+# ---------------------------------------------------------------------------
+# Config validation tests
+# ---------------------------------------------------------------------------
+
+class TestProductionConfigOIDCValidation:
+    """Test that ProductionConfig validates OIDC env vars when AUTH_PROVIDER=oidc."""
+
+    def test_missing_oidc_vars_raises(self):
+        """ProductionConfig.validate() raises when OIDC vars are missing."""
+        from webapp.config import ProductionConfig
+
+        env_overrides = {
+            'AUTH_PROVIDER': 'oidc',
+            'FLASK_SECRET_KEY': 'a' * 64,
+        }
+        # Remove OIDC vars to trigger validation error
+        for var in ('OIDC_CLIENT_ID', 'OIDC_CLIENT_SECRET', 'OIDC_ISSUER'):
+            env_overrides[var] = ''
+
+        with patch.dict(os.environ, env_overrides, clear=False):
+            # Re-evaluate class attribute based on patched env
+            original = ProductionConfig.AUTH_PROVIDER
+            ProductionConfig.AUTH_PROVIDER = 'oidc'
+            try:
+                with pytest.raises(EnvironmentError, match="missing required env vars"):
+                    ProductionConfig.validate()
+            finally:
+                ProductionConfig.AUTH_PROVIDER = original
+
+    def test_stub_mode_no_oidc_validation(self):
+        """ProductionConfig.validate() skips OIDC check when AUTH_PROVIDER=stub."""
+        from webapp.config import ProductionConfig
+
+        with patch.dict(os.environ, {'FLASK_SECRET_KEY': 'a' * 64, 'AUTH_PROVIDER': 'stub'}):
+            original = ProductionConfig.AUTH_PROVIDER
+            ProductionConfig.AUTH_PROVIDER = 'stub'
+            try:
+                ProductionConfig.validate()
+            finally:
+                ProductionConfig.AUTH_PROVIDER = original


### PR DESCRIPTION
## Summary

Implements OpenID Connect SSO as a pluggable auth provider for the SAM webapp, using **Authlib** directly (not flask-oidc) for transparent control, native PKCE support, and better long-term maintainability.

**Key design decisions:**
- **Authlib over flask-oidc**: Direct integration avoids an opaque abstraction layer. flask-oidc v2.4 had an open-redirect vuln fixed in June 2025 -- the vuln existing at all demonstrates the risk of the extra layer.
- **Provider ABC extension**: Added `supports_redirect_auth()`, `initiate_login()`, `handle_callback()` to the existing `AuthProvider` ABC with safe defaults -- non-breaking for `StubAuthProvider` and `LDAPAuthProvider`.
- **Feature flag rollback**: `AUTH_PROVIDER` env var (`stub` default, `oidc` when ready). Switch back to `stub` to revert -- no code changes needed.
- **RP-initiated logout**: Simplest OIDC logout mode. Clears Flask session, then redirects to Entra's end-session endpoint.

## What Changed (15 files, 817 insertions)

### Application Code
| File | Change |
|------|--------|
| `src/webapp/auth/providers.py` | Extended ABC with redirect-auth methods; added `OIDCAuthProvider` with claim resolution; removed dead `SAMLAuthProvider` |
| `src/webapp/auth/blueprint.py` | Fixed `auth_user` NameError; added `/auth/oidc/login`, `/auth/oidc/callback` routes; open-redirect protection; auth event logging |
| `src/webapp/config.py` | Added 6 OIDC config keys; `ProductionConfig` fail-fast validation for missing OIDC vars |
| `src/webapp/run.py` | Conditional Authlib OAuth init when `AUTH_PROVIDER=oidc` |
| `src/webapp/templates/auth/login.html` | SSO button for OIDC mode, existing form for stub mode |
| `pyproject.toml` | Added `authlib>=1.3.0,<2.0.0` dependency |

### Infrastructure (Terraform)
| File | Change |
|------|--------|
| `infrastructure/staging/ssm.tf` | 3 new SSM SecureString params (`oidc-client-id`, `oidc-client-secret`, `oidc-issuer`) |
| `infrastructure/staging/variables.tf` | 3 new sensitive variables with `placeholder` defaults |
| `infrastructure/staging/ecs.tf` | OIDC secrets in task definition; `AUTH_PROVIDER` env var (default `stub`) |
| `infrastructure/staging/alb.tf` | Health check: `/auth/login` -> `/api/v1/health/`; commented HTTPS listener block |

### Testing & Docs
| File | Change |
|------|--------|
| `tests/unit/test_oidc_auth.py` | **35 new tests**: claim resolution, login page rendering, OIDC redirect/callback, error paths, open-redirect prevention, config validation |
| `.env.example` | OIDC section with commented-out vars |
| `infrastructure/README.md` | SSM parameter table, OIDC enablement steps, IT handoff checklist, rollback procedure |

## Security Measures

- **PKCE**: `code_challenge_method='S256'` -- prevents authorization code interception
- **Nonce + State**: Authlib generates and validates both automatically
- **Audience validation**: Authlib verifies `aud` claim matches client_id
- **Token storage**: Only `user_id` stored in Flask session cookie -- no JWT
- **Open redirect**: `_is_safe_redirect()` rejects any `next` param with a scheme or external host
- **Session fixation**: Flask-Login regenerates session on `login_user()`
- **Secure cookies**: `SESSION_COOKIE_SECURE=True` in ProductionConfig
- **Auth logging**: All login/logout/failure events logged with username and provider

## What's Still Needed from EIT

The code is complete and tested with mocks. To enable real OIDC in staging/production, we need from the **UCAR IT Help Desk** (via the open ticket):

1. **Microsoft Entra App Registration**:
   - Tenant ID
   - Client ID
   - Client Secret

2. **Redirect URI approval**: IT needs to whitelist `https://<app-domain>/auth/oidc/callback` in the app registration

3. **Confirmation of claim names**: We expect `preferred_username` and `email` -- IT should confirm these are available in the ID token

4. **End-session endpoint**: For RP-initiated logout (usually auto-discovered via OIDC metadata, but good to confirm)

### Infrastructure Prerequisites (our side)

5. **HTTPS**: ACM certificate + domain for ALB (Entra rejects HTTP redirect URIs)
6. **DNS**: Route 53 or CNAME for `sam-staging.ucar.edu` (or equivalent)
7. **SSM update**: Replace `placeholder` values in SSM with real credentials from IT
8. **Flip the switch**: Change `AUTH_PROVIDER` from `stub` to `oidc` in ECS task definition

## Manual Verification Steps

### 1. Verify stub mode still works (no regressions)

```bash
docker compose up webapp
# Visit http://localhost:5050/auth/login
# Expected: username/password form with "Development Mode" warning and quick-login buttons
# Click any quick-login button -> should redirect to dashboard
# Click Logout -> should redirect to status page
```

### 2. Verify OIDC login page renders correctly

```bash
# Temporarily set AUTH_PROVIDER=oidc in compose.yaml environment for webapp service
docker compose up --build webapp
# Visit http://localhost:5050/auth/login
# Expected: "Sign in with UCAR SSO" button, NO username/password form, NO dev mode warning
```

### 3. Verify OIDC routes handle missing config gracefully

```bash
# With AUTH_PROVIDER=oidc but NO OIDC_CLIENT_ID set:
# Visit http://localhost:5050/auth/oidc/login
# Expected: flash message "OIDC is not configured." and redirect back to login page
# Visit http://localhost:5050/auth/oidc/callback
# Expected: same flash message and redirect
```

### 4. Verify health check endpoint

```bash
curl -s http://localhost:5050/api/v1/health/ | python -m json.tool
# Expected: {"status": "healthy", "service": "sam-webapp", ...}
```

### 5. Verify open-redirect protection

```bash
# POST to /auth/login?next=https://evil.com with valid stub credentials
# Expected: redirect to dashboard, NOT to evil.com
```

### 6. Run the test suite

```bash
FLASK_SECRET_KEY=dev-key pytest tests/unit/test_oidc_auth.py -v --no-cov
# Expected: 35 passed

FLASK_SECRET_KEY=dev-key pytest tests/ --no-cov -q
# Expected: 780+ passed, 0 failures from OIDC changes
```

### 7. Verify Terraform changes (dry run)

```bash
cd infrastructure/staging && terraform plan
# Expected: 3 new SSM parameters, updated ECS task definition,
# updated ALB target group health check. No destroyed resources.
```

## Test Results

```
tests/unit/test_oidc_auth.py: 35 passed
Full suite: 781 passed, 25 skipped, 1 xfailed, 0 regressions
```