### PR TITLE
Activate OIDC SSO for staging with critical bug fixes

### DIFF
--- a/infrastructure/staging/ecs.tf
+++ b/infrastructure/staging/ecs.tf
@@ -39,13 +39,13 @@ resource "aws_ecs_task_definition" "webapp" {
     environment = [
       { name = "PYTHONDONTWRITEBYTECODE", value = "1" },
       { name = "PYTHONUNBUFFERED", value = "1" },
-      { name = "DISABLE_AUTH", value = "1" },
-      { name = "DEV_AUTO_LOGIN_USER", value = "benkirk" },
+      { name = "DISABLE_AUTH", value = "0" },
       { name = "FLASK_DEBUG", value = "0" },
       { name = "AUDIT_ENABLED", value = "1" },
       { name = "AUDIT_LOG_PATH", value = "/var/log/sam/model_audit.log" },
       { name = "SAM_DB_REQUIRE_SSL", value = "false" },
-      { name = "AUTH_PROVIDER", value = "stub" },
+      { name = "AUTH_PROVIDER", value = "oidc" },
+      { name = "OIDC_REDIRECT_URI", value = "https://sam-staging.csgsam.ucar.edu/auth/oidc/callback" },
     ]
 
     secrets = [

--- a/src/webapp/auth/models.py
+++ b/src/webapp/auth/models.py
@@ -63,16 +63,10 @@ class AuthUser(UserMixin):
         3. Empty set (no roles)
         """
         if self._roles is None:
-            # First, check hard-coded dev role mapping
             if self.username in self.dev_role_mapping:
                 self._roles = set(self.dev_role_mapping[self.username])
             else:
-                # Fall back to database roles (future implementation)
-                # Uncomment when role/role_user tables are ready:
-                # self._roles = {ra.role.name for ra in self.sam_user.role_assignments}
-
-                # For now, return empty set if not in dev mapping
-                self._roles = set()
+                self._roles = {ra.role.name for ra in self.sam_user.role_assignments}
 
         return self._roles
 

--- a/src/webapp/auth/providers.py
+++ b/src/webapp/auth/providers.py
@@ -134,6 +134,8 @@ class OIDCAuthProvider(AuthProvider):
         2. email prefix (before @)
         """
         username = claims.get(self.username_claim)
+        if username and '@' in username:
+            username = username.split('@')[0]
         if not username:
             email = claims.get('email', '')
             username = email.split('@')[0] if email else None

--- a/src/webapp/run.py
+++ b/src/webapp/run.py
@@ -41,6 +41,9 @@ def create_app():
 
     app = Flask(__name__)
 
+    from werkzeug.middleware.proxy_fix import ProxyFix
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
+
     # Apply all UPPERCASE class attributes as Flask config
     app.config.from_object(cfg)
 

--- a/src/webapp/static/css/auth.css
+++ b/src/webapp/static/css/auth.css
@@ -41,6 +41,23 @@ body {
     margin-bottom: 35px;
 }
 
+.login-logo {
+    width: 64px;
+    height: 64px;
+    margin: 0 auto 16px;
+    background: linear-gradient(135deg, var(--ncar-blue) 0%, var(--ncar-light-blue) 100%);
+    border-radius: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 12px rgba(var(--ncar-teal-rgb), 0.3);
+}
+
+.login-logo i {
+    font-size: 28px;
+    color: white;
+}
+
 .login-header h1 {
     color: var(--ncar-navy);
     font-size: 32px;
@@ -205,4 +222,32 @@ body {
 
 .login-form {
     margin: 0;
+}
+
+/* ===================================================================
+   Help Link
+   =================================================================== */
+
+.help-link {
+    color: var(--ncar-gray);
+    font-size: 13px;
+    font-weight: 500;
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.help-link:hover {
+    color: var(--ncar-blue);
+    text-decoration: underline;
+}
+
+/* ===================================================================
+   Footer
+   =================================================================== */
+
+.login-footer {
+    text-align: center;
+    margin-top: 24px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border-color);
 }

--- a/src/webapp/templates/auth/login.html
+++ b/src/webapp/templates/auth/login.html
@@ -8,13 +8,17 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/variables.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
 </head>
 <body>
     <div class="login-container">
         <div class="login-header">
-            <h1>SAM Administration</h1>
+            <div class="login-logo">
+                <i class="fas fa-server"></i>
+            </div>
+            <h1>SAM</h1>
             <p>Systems Accounting Manager</p>
         </div>
 
@@ -37,8 +41,14 @@
         </div>
 
         <a href="{{ url_for('auth.oidc_login') }}" class="btn btn-primary btn-login btn-lg w-100">
-            Sign in with UCAR SSO
+            <i class="fas fa-shield-alt me-2"></i>Sign in with UCAR SSO
         </a>
+
+        <div class="text-center mt-3">
+            <a href="mailto:csg@ucar.edu" class="help-link">
+                <i class="fas fa-question-circle me-1"></i>Need help signing in?
+            </a>
+        </div>
 
         {% else %}
         {# ---- Stub / dev mode ---- #}
@@ -103,9 +113,9 @@
         {% endif %}
         {% endif %}
 
-        <div class="text-center mt-3">
+        <div class="login-footer">
             <small class="text-muted">
-                SAM Web UI &copy; 2024
+                NSF NCAR &middot; SAM Web UI &copy; 2026
             </small>
         </div>
     </div>

--- a/tests/unit/test_oidc_auth.py
+++ b/tests/unit/test_oidc_auth.py
@@ -428,3 +428,180 @@ class TestProductionConfigOIDCValidation:
                 ProductionConfig.validate()
             finally:
                 ProductionConfig.AUTH_PROVIDER = original
+
+
+# ---------------------------------------------------------------------------
+# UPN claim stripping tests
+# ---------------------------------------------------------------------------
+
+class TestUPNClaimStripping:
+    """Test that UPN-format preferred_username (user@domain) resolves correctly."""
+
+    def test_upn_with_domain_resolves(self, session):
+        """benkirk@ucar.edu resolves to SAM user benkirk."""
+        provider = OIDCAuthProvider(db_session=session)
+        claims = {'preferred_username': 'benkirk@ucar.edu', 'sub': '123'}
+        user = provider.resolve_user_from_claims(claims)
+        assert user is not None
+        assert user.username == 'benkirk'
+
+    def test_upn_with_different_domain(self, session):
+        """benkirk@ncar.ucar.edu also strips to benkirk."""
+        provider = OIDCAuthProvider(db_session=session)
+        claims = {'preferred_username': 'benkirk@ncar.ucar.edu', 'sub': '123'}
+        user = provider.resolve_user_from_claims(claims)
+        assert user is not None
+        assert user.username == 'benkirk'
+
+    def test_short_username_still_works(self, session):
+        """Plain benkirk (no @) still works after stripping logic."""
+        provider = OIDCAuthProvider(db_session=session)
+        claims = {'preferred_username': 'benkirk', 'sub': '123'}
+        user = provider.resolve_user_from_claims(claims)
+        assert user is not None
+        assert user.username == 'benkirk'
+
+    def test_upn_nonexistent_user(self, session):
+        """nobody@ucar.edu still returns None."""
+        provider = OIDCAuthProvider(db_session=session)
+        claims = {'preferred_username': 'nobody_xyz@ucar.edu', 'sub': '999'}
+        user = provider.resolve_user_from_claims(claims)
+        assert user is None
+
+
+# ---------------------------------------------------------------------------
+# DB role resolution tests
+# ---------------------------------------------------------------------------
+
+class TestDBRoleResolution:
+    """Test that AuthUser.roles falls back to database role_user table."""
+
+    def test_dev_mapping_takes_priority(self, session):
+        """When user is in dev_role_mapping, those roles are used."""
+        from webapp.auth.models import AuthUser
+        from sam.core.users import User
+
+        user = User.get_by_username(session, 'benkirk')
+        if user is None:
+            pytest.skip("Test user not in database")
+
+        auth_user = AuthUser(user, dev_role_mapping={'benkirk': ['admin']})
+        assert 'admin' in auth_user.roles
+
+    def test_db_roles_when_not_in_dev_mapping(self, session):
+        """When user is NOT in dev_role_mapping, roles come from role_user table."""
+        from webapp.auth.models import AuthUser
+        from sam.core.users import User
+
+        user = User.get_by_username(session, 'benkirk')
+        if user is None:
+            pytest.skip("Test user not in database")
+
+        auth_user = AuthUser(user, dev_role_mapping={})
+        roles = auth_user.roles
+        assert isinstance(roles, set)
+        db_role_names = {ra.role.name for ra in user.role_assignments}
+        assert roles == db_role_names
+
+    def test_empty_roles_when_no_assignments(self, session):
+        """User with no role_user entries and no dev mapping gets empty roles."""
+        from webapp.auth.models import AuthUser
+        from sam.core.users import User
+
+        users = session.query(User).filter(User.is_active).all()
+        user_no_roles = None
+        for u in users:
+            if not u.role_assignments:
+                user_no_roles = u
+                break
+        if user_no_roles is None:
+            pytest.skip("No user without role assignments found in database")
+
+        auth_user = AuthUser(user_no_roles, dev_role_mapping={})
+        assert auth_user.roles == set()
+
+
+# ---------------------------------------------------------------------------
+# OIDC callback session and redirect tests
+# ---------------------------------------------------------------------------
+
+class TestOIDCSessionAndRedirect:
+    """Test session state and role-based redirect after OIDC callback."""
+
+    def test_callback_sets_session_user_id(self, app):
+        """After successful callback, session contains user ID."""
+        mock_oauth = MagicMock()
+        mock_oauth.entra.authorize_access_token.return_value = {
+            'userinfo': {'preferred_username': 'benkirk', 'email': 'benkirk@ucar.edu'}
+        }
+
+        app.extensions['oauth'] = mock_oauth
+        app.config['AUTH_PROVIDER'] = 'oidc'
+        try:
+            with app.test_client() as c:
+                c.get('/auth/oidc/callback')
+                with c.session_transaction() as sess:
+                    assert '_user_id' in sess
+        finally:
+            app.config['AUTH_PROVIDER'] = 'stub'
+            app.extensions.pop('oauth', None)
+
+    def test_callback_upn_claim_creates_session(self, app):
+        """UPN-format claim (user@domain) still creates a valid session."""
+        mock_oauth = MagicMock()
+        mock_oauth.entra.authorize_access_token.return_value = {
+            'userinfo': {'preferred_username': 'benkirk@ucar.edu', 'email': 'benkirk@ucar.edu'}
+        }
+
+        app.extensions['oauth'] = mock_oauth
+        app.config['AUTH_PROVIDER'] = 'oidc'
+        try:
+            with app.test_client() as c:
+                resp = c.get('/auth/oidc/callback')
+                assert resp.status_code == 302
+                assert '/auth/login' not in resp.headers.get('Location', '')
+        finally:
+            app.config['AUTH_PROVIDER'] = 'stub'
+            app.extensions.pop('oauth', None)
+
+    def test_callback_respects_oidc_next(self, app):
+        """Callback redirects to session['oidc_next'] when set."""
+        mock_oauth = MagicMock()
+        mock_oauth.entra.authorize_access_token.return_value = {
+            'userinfo': {'preferred_username': 'benkirk', 'email': 'benkirk@ucar.edu'}
+        }
+
+        app.extensions['oauth'] = mock_oauth
+        app.config['AUTH_PROVIDER'] = 'oidc'
+        try:
+            with app.test_client() as c:
+                with c.session_transaction() as sess:
+                    sess['oidc_next'] = '/dashboard/allocations'
+
+                resp = c.get('/auth/oidc/callback')
+                assert resp.status_code == 302
+                assert '/dashboard/allocations' in resp.headers.get('Location', '')
+        finally:
+            app.config['AUTH_PROVIDER'] = 'stub'
+            app.extensions.pop('oauth', None)
+
+    def test_callback_oidc_next_consumed(self, app):
+        """oidc_next is removed from session after redirect."""
+        mock_oauth = MagicMock()
+        mock_oauth.entra.authorize_access_token.return_value = {
+            'userinfo': {'preferred_username': 'benkirk', 'email': 'benkirk@ucar.edu'}
+        }
+
+        app.extensions['oauth'] = mock_oauth
+        app.config['AUTH_PROVIDER'] = 'oidc'
+        try:
+            with app.test_client() as c:
+                with c.session_transaction() as sess:
+                    sess['oidc_next'] = '/dashboard/user'
+
+                c.get('/auth/oidc/callback')
+                with c.session_transaction() as sess:
+                    assert 'oidc_next' not in sess
+        finally:
+            app.config['AUTH_PROVIDER'] = 'stub'
+            app.extensions.pop('oauth', None)


### PR DESCRIPTION
## Summary

Activates OIDC SSO on staging using the Microsoft Entra app registration from EIT. Fixes three critical bugs that would have caused login failures, polishes the login page, and adds 11 new tests.

**This PR requires a `terraform apply` before/after merge** to update SSM parameters with real Entra credentials (stored in gitignored `secrets.auto.tfvars`).

## Critical Bug Fixes

| Bug | Impact | Fix |
|-----|--------|-----|
| UPN claim format | Entra sends `benkirk@ucar.edu`, SAM stores `benkirk`. Exact match fails silently for every user. | Strip `@domain` from `preferred_username` before lookup |
| DB role resolution | `AuthUser.roles` only read from `DEV_ROLE_MAPPING`. OIDC users got zero roles/permissions. | Activate the existing `role_user` table fallback (was commented out) |
| Missing ProxyFix | ALB terminates HTTPS, Flask sees HTTP. `url_for(_external=True)` generates `http://` callback URLs that Entra rejects. | Add `ProxyFix` middleware in `create_app()` |

## Changes (7 files, +245/-14)

### Application Code

| File | Change |
|------|--------|
| `src/webapp/auth/providers.py` | Strip `@domain` from UPN-style `preferred_username` claim |
| `src/webapp/auth/models.py` | Activate DB `role_user` lookup as fallback when user not in dev mapping |
| `src/webapp/run.py` | Add Werkzeug `ProxyFix` middleware for ALB `X-Forwarded-*` headers |
| `src/webapp/templates/auth/login.html` | Add logo icon, shield icon on SSO button, help link, updated footer |
| `src/webapp/static/css/auth.css` | Styles for logo, help link, footer separator |

### Infrastructure

| File | Change |
|------|--------|
| `infrastructure/staging/ecs.tf` | `AUTH_PROVIDER=oidc`, `DISABLE_AUTH=0`, remove `DEV_AUTO_LOGIN_USER`, add `OIDC_REDIRECT_URI` |

### Tests

| File | Change |
|------|--------|
| `tests/unit/test_oidc_auth.py` | 11 new tests (46 total): UPN stripping, DB role resolution, session assertions, oidc_next flow |

## Pre-merge: Terraform Apply Required

The SSM parameters currently hold `placeholder` values. Before OIDC will work:

```bash
cd infrastructure/staging
# secrets.auto.tfvars already has the real values (gitignored)
terraform plan   # expect: 3 SSM param updates + new task def revision
terraform apply
```

## Post-merge Verification

1. Visit `https://sam-staging.csgsam.ucar.edu/auth/login` -- SSO button visible
2. Click SSO -- redirects to Microsoft Entra
3. Authenticate with UCAR creds -- session created, redirected to dashboard
4. Check roles resolve correctly for the logged-in user
5. Logout -- clears session, redirects to Entra end-session

## Rollback

Change `AUTH_PROVIDER` back to `stub` and `DISABLE_AUTH` to `1` in `ecs.tf`, apply, redeploy.

## Test Results

```
tests/unit/test_oidc_auth.py: 46 passed
```