### PR TITLE
Enable HTTPS on ALB with ACM certificate

### DIFF
--- a/infrastructure/staging/alb.tf
+++ b/infrastructure/staging/alb.tf
@@ -30,30 +30,33 @@ resource "aws_alb_target_group" "webapp" {
   tags = { Name = "${local.name_prefix}-webapp-tg" }
 }
 
-# HTTP listener (upgrade to HTTPS when ACM cert is ready)
+# HTTP listener — redirects all traffic to HTTPS
 resource "aws_alb_listener" "http" {
   load_balancer_arn = aws_alb.main.arn
   port              = 80
   protocol          = "HTTP"
 
   default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+# HTTPS listener — terminates TLS using ACM cert, forwards to target group
+resource "aws_alb_listener" "https" {
+  load_balancer_arn = aws_alb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = aws_acm_certificate_validation.webapp.certificate_arn
+
+  default_action {
     type             = "forward"
     target_group_arn = aws_alb_target_group.webapp.arn
   }
 }
-
-# HTTPS listener — required before enabling AUTH_PROVIDER=oidc
-# Uncomment when ACM certificate and DNS are ready:
-#
-# resource "aws_alb_listener" "https" {
-#   load_balancer_arn = aws_alb.main.arn
-#   port              = 443
-#   protocol          = "HTTPS"
-#   ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
-#   certificate_arn   = aws_acm_certificate.webapp.arn
-#
-#   default_action {
-#     type             = "forward"
-#     target_group_arn = aws_alb_target_group.webapp.arn
-#   }
-# }

--- a/infrastructure/staging/dns.tf
+++ b/infrastructure/staging/dns.tf
@@ -1,0 +1,59 @@
+# DNS and TLS configuration for sam-staging.csgsam.ucar.edu
+#
+# The csgsam.ucar.edu hosted zone is managed by UCAR HelpDesk (sweg-management).
+# We create records within it for ALB routing and ACM certificate validation.
+# A separate CNAME (sam-staging.ucar.edu -> sam-staging.csgsam.ucar.edu) is
+# managed outside this account by UCAR DNS team via Infoblox.
+
+data "aws_route53_zone" "csgsam" {
+  name = "csgsam.ucar.edu."
+}
+
+# --- ACM Certificate ---
+
+resource "aws_acm_certificate" "webapp" {
+  domain_name       = "${local.name_prefix}.csgsam.ucar.edu"
+  validation_method = "DNS"
+
+  tags = { Name = "${local.name_prefix}-cert" }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.webapp.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id         = data.aws_route53_zone.csgsam.zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 60
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "webapp" {
+  certificate_arn         = aws_acm_certificate.webapp.arn
+  validation_record_fqdns = [for r in aws_route53_record.cert_validation : r.fqdn]
+}
+
+# --- ALB DNS Record ---
+
+resource "aws_route53_record" "staging" {
+  zone_id = data.aws_route53_zone.csgsam.zone_id
+  name    = "${local.name_prefix}.csgsam.ucar.edu"
+  type    = "A"
+
+  alias {
+    name                   = aws_alb.main.dns_name
+    zone_id                = aws_alb.main.zone_id
+    evaluate_target_health = true
+  }
+}


### PR DESCRIPTION
## Summary

- **Adds HTTPS listener** (port 443) to the ALB using the already-issued ACM certificate for `sam-staging.csgsam.ucar.edu`
- **Converts HTTP listener** from `forward` to `301 redirect` to HTTPS — all HTTP traffic now redirects to HTTPS
- **Tracks `dns.tf`** — ACM certificate, DNS validation records, and Route53 A record (already applied in AWS, not previously committed)

## Why

The staging site was unreachable at `https://sam-staging.csgsam.ucar.edu` because the ALB had no HTTPS listener. This blocked OIDC SSO (Entra rejects non-HTTPS redirect URIs) and meant users hitting the HTTPS URL got "connection refused".

All prerequisites were already in place:
- ACM cert: **ISSUED** (validated Apr 13)
- Security group: **port 443 already open** from UCAR CIDR
- DNS: **resolves** to ALB
- Container: **healthy** with OIDC enabled

## Infrastructure Changes

| Resource | Change |
|---|---|
| `aws_alb_listener.http` | Modified: `forward` → `redirect` (HTTP 301 to HTTPS) |
| `aws_alb_listener.https` | **New**: port 443, TLS 1.3 policy, ACM cert |
| `dns.tf` (new file) | Tracks existing: ACM cert, DNS validation, Route53 A record |

## Verification

- [x] `terraform apply` completed successfully (HTTPS listener created, HTTP listener updated)
- [ ] Visit `https://sam-staging.csgsam.ucar.edu/auth/login` — should show OIDC login page
- [ ] Visit `http://sam-staging.csgsam.ucar.edu/auth/login` — should 301 redirect to HTTPS
- [ ] Click "Sign in with UCAR SSO" — should redirect to Microsoft Entra
- [ ] Complete SSO login — should redirect back and create session