### PR TITLE
Replace placeholder footer with NSF/NCAR boilerplate + build provenance

### DIFF
--- a/.github/workflows/build-images-cirrus-deploy.yaml
+++ b/.github/workflows/build-images-cirrus-deploy.yaml
@@ -166,6 +166,10 @@ jobs:
             # 'latest' only on the main branch
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
+      - name: Compute build date
+        id: build_date
+        run: echo "value=$(date -u '+%Y-%m-%d %H:%M UTC')" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -178,6 +182,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            BUILD_DATE=${{ steps.build_date.outputs.value }}
 
   # -----------------------------------------------------------------------
   # update-helm: pin helm/values.yaml to the built SHA tag, push to cirrus

--- a/.github/workflows/ci-staging.yaml
+++ b/.github/workflows/ci-staging.yaml
@@ -105,61 +105,16 @@ jobs:
           docker compose --profile test up -d
           sleep 5
 
-      - name: Wait for MySQL
-        run: |
-          for i in $(seq 1 60); do
-            if mysql -h 127.0.0.1 -proot -uroot -e "SELECT 1" 2>/dev/null; then
-              echo "MySQL accepting connections after $((i * 5))s"
-              break
-            fi
-            STATE=$(docker compose ps mysql --format "{{.State}}" 2>/dev/null || echo "unknown")
-            if [ "${STATE}" = "exited" ]; then
-              echo "MySQL container exited"
-              docker compose logs mysql --tail=200
-              exit 1
-            fi
-            sleep 5
-          done
-          for i in $(seq 1 12); do
-            if mysql -h 127.0.0.1 -proot -uroot sam -e "SELECT 1" 2>/dev/null; then
-              echo "SAM database ready"
-              break
-            fi
-            sleep 5
-          done
-          mysql -h 127.0.0.1 -proot -uroot sam -e "SELECT 1" || {
-            echo "SAM database not accessible"
-            docker compose logs mysql --tail=100
-            exit 1
-          }
+      - name: Wait for MySQL (main, port 3306)
+        run: scripts/ci/wait-for-mysql.sh
+        env:
+          COMPOSE_SERVICE: mysql
 
-      - name: Wait for mysql-test (test DB on 3307)
-        run: |
-          for i in $(seq 1 60); do
-            if mysql -h 127.0.0.1 -P 3307 -proot -uroot -e "SELECT 1" 2>/dev/null; then
-              echo "mysql-test accepting connections after $((i * 5))s"
-              break
-            fi
-            STATE=$(docker compose ps mysql-test --format "{{.State}}" 2>/dev/null || echo "unknown")
-            if [ "${STATE}" = "exited" ]; then
-              echo "mysql-test container exited"
-              docker compose logs mysql-test --tail=200
-              exit 1
-            fi
-            sleep 5
-          done
-          for i in $(seq 1 12); do
-            if mysql -h 127.0.0.1 -P 3307 -proot -uroot sam -e "SELECT 1" 2>/dev/null; then
-              echo "mysql-test sam database ready"
-              break
-            fi
-            sleep 5
-          done
-          mysql -h 127.0.0.1 -P 3307 -proot -uroot sam -e "SELECT 1" || {
-            echo "mysql-test sam database not accessible"
-            docker compose logs mysql-test --tail=100
-            exit 1
-          }
+      - name: Wait for MySQL (test, port 3307)
+        run: scripts/ci/wait-for-mysql.sh
+        env:
+          MYSQL_PORT: "3307"
+          COMPOSE_SERVICE: mysql-test
 
       - name: Wait for webapp
         run: |

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -67,8 +67,11 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
+          BUILD_DATE="$(date -u '+%Y-%m-%d %H:%M UTC')"
           docker build \
             -f containers/webapp/Dockerfile \
+            --build-arg GIT_SHA="$IMAGE_TAG" \
+            --build-arg BUILD_DATE="$BUILD_DATE" \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
             .

--- a/containers/webapp/Dockerfile
+++ b/containers/webapp/Dockerfile
@@ -37,6 +37,13 @@ WORKDIR /code
 COPY . .
 RUN pip install -e ".[test]"
 
+# Optional build provenance - set by CI via --build-arg; empty locally.
+# Placed AFTER pip install so a changing SHA does not invalidate the install layer.
+ARG GIT_SHA=""
+ARG BUILD_DATE=""
+ENV GIT_SHA=${GIT_SHA}
+ENV BUILD_DATE=${BUILD_DATE}
+
 
 #-------------------------------------------------------------------------------
 # webdev - development flask internal sever config

--- a/src/webapp/run.py
+++ b/src/webapp/run.py
@@ -191,6 +191,19 @@ def create_app(*, config_overrides: dict | None = None):
     # Register context processor for RBAC in templates
     app.context_processor(rbac_context_processor)
 
+    # Expose optional build provenance (set by CI via Docker build args) to all templates
+    @app.context_processor
+    def build_info_context_processor():
+        sha = os.getenv('GIT_SHA', '').strip()
+        if sha:
+            sha = sha[:7]
+        return {
+            'build_info': {
+                'sha': sha or None,
+                'date': os.getenv('BUILD_DATE', '').strip() or None,
+            }
+        }
+
     # Register teardown handler for automatic session cleanup
     @app.teardown_appcontext
     def shutdown_session(exception=None):

--- a/src/webapp/templates/dashboards/base.html
+++ b/src/webapp/templates/dashboards/base.html
@@ -126,7 +126,25 @@
     <footer class="footer">
         <div class="{% block footer_container_class %}container-fluid sam-fluid-1800{% endblock %}">
             <div class="text-center text-muted">
-                <small>SAM - Systems Accounting Manager &copy; 2024</small>
+                <small>
+                    This material is based upon work supported by the NSF National
+                    Center for Atmospheric Research, a major facility sponsored by
+                    the U.S. National Science Foundation and managed by the
+                    University Corporation for Atmospheric Research.
+                </small>
+                {% if build_info.sha or build_info.date %}
+                <div class="mt-1">
+                    <small class="text-muted" style="font-size: 0.75rem;">
+                        Build
+                        {% if build_info.sha %}
+                            <code>{{ build_info.sha }}</code>
+                        {% endif %}
+                        {% if build_info.date %}
+                            &middot; {{ build_info.date }}
+                        {% endif %}
+                    </small>
+                </div>
+                {% endif %}
             </div>
         </div>
     </footer>


### PR DESCRIPTION
Footer
- Swap `SAM - Systems Accounting Manager © 2024` for the standard NSF NCAR funding acknowledgement.
- Render an optional second line with short git SHA and build date, shown only when the env vars are populated (hidden cleanly in local dev).

Wiring
- `build_info_context_processor` in `src/webapp/run.py` reads `GIT_SHA` and `BUILD_DATE` from the environment and exposes them to all templates.
- `containers/webapp/Dockerfile` accepts matching `ARG`s placed *after* `pip install -e` so a changing SHA doesn't invalidate the install layer.

CI
- `build-images-cirrus-deploy.yaml`: compute a UTC `BUILD_DATE` step and pass `GIT_SHA=${{ github.sha }}` + `BUILD_DATE` as `build-args` to `docker/build-push-action`.
- `deploy-staging.yaml`: same args on the raw `docker build` used for the ECR push, so staging shows provenance too.

Drive-by
- `ci-staging.yaml` now calls `scripts/ci/wait-for-mysql.sh` for both the main and test MySQL containers, replacing ~55 lines of hand-rolled polling loops. All MySQL-dependent CI workflows now route through the one script.