### PR TITLE
Create Charge Adjustment from the Allocations → Adjustments tab

### DIFF
--- a/src/sam/accounting/adjustments.py
+++ b/src/sam/accounting/adjustments.py
@@ -4,6 +4,21 @@ from ..base import *
 #-------------------------------------------------------------------------eh-
 
 
+# Sign policy for user-visible adjustment types. Keys MUST match
+# ChargeAdjustmentType.type values exactly. Credits/Refunds return compute
+# to a project (stored as negative amounts); Debits/Reservations remove it
+# (positive amounts). This map is the single source of truth for which
+# types the webapp exposes — the integer PKs are resolved at runtime via
+# ChargeAdjustment.supported_types(). Storage-Credit and Storage-Debit are
+# intentionally omitted until disk/archive support lands.
+_SIGN_BY_TYPE: Dict[str, int] = {
+    'Refund':      -1,
+    'Credit':      -1,
+    'Debit':       +1,
+    'Reservation': +1,
+}
+
+
 #-------------------------------------------------------------------------bm-
 #----------------------------------------------------------------------------
 class ChargeAdjustment(Base):
@@ -29,6 +44,64 @@ class ChargeAdjustment(Base):
     account = relationship('Account', back_populates='charge_adjustments')
     adjustment_type = relationship('ChargeAdjustmentType', back_populates='adjustments')
     adjusted_by = relationship('User', back_populates='charge_adjustments_made')
+
+    @classmethod
+    def supported_types(cls, session) -> List['ChargeAdjustmentType']:
+        """Return ChargeAdjustmentType rows exposed by the webapp.
+
+        Ordered to match _SIGN_BY_TYPE insertion order (Refund first, since
+        it's the most-used type in practice — see legacy docs §5).
+        """
+        rows = (session.query(ChargeAdjustmentType)
+                       .filter(ChargeAdjustmentType.type.in_(_SIGN_BY_TYPE.keys()))
+                       .all())
+        order = list(_SIGN_BY_TYPE.keys())
+        return sorted(rows, key=lambda t: order.index(t.type))
+
+    @classmethod
+    def create(cls, session, *,
+               account_id: int,
+               charge_adjustment_type_id: int,
+               amount: float,
+               adjusted_by_id: int,
+               comment: Optional[str] = None) -> 'ChargeAdjustment':
+        """Create a ChargeAdjustment; server applies sign from the type.
+
+        The caller passes ``amount`` as a positive number. The sign is
+        applied here based on the type's name (Credits/Refunds → negative,
+        Debits/Reservations → positive). This guarantees the stored amount
+        is correct regardless of UI input, matching the legacy Sign
+        Enforcement pattern (see legacy_sam/doc/data_structures/
+        charge_adjustments.md §2).
+
+        Does NOT commit — caller must wrap in ``management_transaction``.
+        """
+        if amount is None or amount <= 0:
+            raise ValueError("amount must be a positive number")
+
+        adj_type = session.get(ChargeAdjustmentType, charge_adjustment_type_id)
+        if adj_type is None:
+            raise ValueError(
+                f"ChargeAdjustmentType {charge_adjustment_type_id} not found"
+            )
+        try:
+            sign = _SIGN_BY_TYPE[adj_type.type]
+        except KeyError:
+            raise ValueError(
+                f"Adjustment type '{adj_type.type}' is not supported in the webapp"
+            )
+
+        adj = cls(
+            account_id=account_id,
+            charge_adjustment_type_id=charge_adjustment_type_id,
+            amount=sign * float(amount),
+            comment=(comment or None),
+            adjustment_date=datetime.now(),
+            adjusted_by_id=adjusted_by_id,
+        )
+        session.add(adj)
+        session.flush()
+        return adj
 
     def __str__(self):
         return f"ChargeAdjustment {self.charge_adjustment_id}: {self.amount} ({self.adjustment_date})"

--- a/src/sam/queries/allocations.py
+++ b/src/sam/queries/allocations.py
@@ -145,6 +145,7 @@ ALLOCATION_TRANSACTION_SORT_COLUMNS = {
     'projcode': Project.projcode,
     'resource_name': Resource.resource_name,
     'facility_name': Facility.facility_name,
+    'allocation_type': AllocationType.allocation_type,
     'username': User.username,
 }
 
@@ -302,8 +303,8 @@ def get_recent_allocation_transactions(
         - ``projcode``, ``project_id``
         - ``resource_name``, ``resource_id``
         - ``facility_name``, ``allocation_type``
-        - ``user_id``, ``username``, ``user_full_name`` (all ``None`` when the
-          transaction has no responsible user)
+        - ``user_id``, ``username``, ``user_display_name`` (all ``None`` when
+          the transaction has no responsible user)
     """
     if sort_by is not None and sort_by not in ALLOCATION_TRANSACTION_SORT_COLUMNS:
         raise ValueError(
@@ -368,7 +369,7 @@ def get_recent_allocation_transactions(
             'allocation_type': at_name,
             'user_id': user.user_id if user is not None else None,
             'username': user.username if user is not None else None,
-            'user_full_name': user.full_name if user is not None else None,
+            'user_display_name': user.display_name if user is not None else None,
         }
         for txn, project, resource, at_name, fac_name, user in rows
     ]

--- a/src/sam/queries/charges.py
+++ b/src/sam/queries/charges.py
@@ -207,9 +207,9 @@ def get_recent_charge_adjustments(
         ``account_id``, ``amount``, ``adjustment_date``, ``comment``,
         ``adjustment_type``, ``projcode``, ``project_id``, ``resource_name``,
         ``resource_id``, ``facility_name``, ``user_id``, ``username``,
-        ``user_full_name``. User fields are ``None`` when ``adjusted_by_id``
-        is NULL; ``facility_name`` is ``None`` when the project has no
-        allocation-type chain.
+        ``user_display_name``. User fields are ``None`` when
+        ``adjusted_by_id`` is NULL; ``facility_name`` is ``None`` when the
+        project has no allocation-type chain.
     """
     if sort_by is not None and sort_by not in CHARGE_ADJUSTMENT_SORT_COLUMNS:
         raise ValueError(
@@ -268,7 +268,7 @@ def get_recent_charge_adjustments(
             'facility_name': fac_name,
             'user_id': user.user_id if user is not None else None,
             'username': user.username if user is not None else None,
-            'user_full_name': user.full_name if user is not None else None,
+            'user_display_name': user.display_name if user is not None else None,
         }
         for adj, project, resource, at_name, fac_name, user in rows
     ]

--- a/src/sam/schemas/forms/__init__.py
+++ b/src/sam/schemas/forms/__init__.py
@@ -177,6 +177,9 @@ from .user import (
     ExtendAllocationsForm,
     SetShellForm,
 )
+from .adjustments import (
+    CreateChargeAdjustmentForm,
+)
 
 __all__ = [
     'HtmxFormSchema',
@@ -226,4 +229,6 @@ __all__ = [
     'RenewAllocationsForm',
     'ExtendAllocationsForm',
     'SetShellForm',
+    # Adjustments
+    'CreateChargeAdjustmentForm',
 ]

--- a/src/sam/schemas/forms/adjustments.py
+++ b/src/sam/schemas/forms/adjustments.py
@@ -1,0 +1,37 @@
+"""
+Marshmallow form validation schemas for charge-adjustment routes.
+
+Covers: Create Charge Adjustment (Allocations dashboard → Adjustments tab).
+"""
+
+import marshmallow.fields as f
+import marshmallow.validate as v
+
+from . import HtmxFormSchema
+
+
+class CreateChargeAdjustmentForm(HtmxFormSchema):
+    """Validate a staff-submitted charge adjustment.
+
+    ``project_id`` comes from the fk_search_field picker's hidden input
+    (populated by /static/js/fk-picker.js when a search result is clicked).
+    The schema only coerces to int; FK existence (does the Project row
+    exist? does the (project, resource) → Account row exist?) is a DB-backed
+    check and stays in the route per CLAUDE.md §9.
+
+    ``charge_adjustment_type_id`` membership (the set of types exposed by
+    the webapp) is likewise a DB-backed check: the supported set lives in
+    ``sam.accounting.adjustments._SIGN_BY_TYPE`` keyed by name, and is
+    resolved to IDs at runtime via ``ChargeAdjustment.supported_types()``.
+    ``ChargeAdjustment.create()`` raises ``ValueError`` if an unsupported
+    type slips through, which the route surfaces as a form error.
+
+    ``amount`` is input-neutral-positive: the user enters a positive
+    number; ``ChargeAdjustment.create()`` applies the sign by type.
+    """
+
+    project_id = f.Int(required=True)
+    resource_id = f.Int(required=True)
+    charge_adjustment_type_id = f.Int(required=True)
+    amount = f.Float(required=True, validate=v.Range(min=0, min_inclusive=False))
+    comment = f.Str(load_default=None)

--- a/src/webapp/dashboards/allocations/blueprint.py
+++ b/src/webapp/dashboards/allocations/blueprint.py
@@ -6,11 +6,12 @@ grouped hierarchically by Resource → Facility → Allocation Type → Projects
 """
 
 from flask import Blueprint, render_template, request, flash, redirect, url_for, jsonify
-from flask_login import login_required
+from flask_login import login_required, current_user
 from datetime import datetime, timedelta
 from typing import List, Dict
 
 from webapp.extensions import db, cache
+from webapp.utils.htmx import handle_htmx_form_post
 from sam.queries.allocations import (
     ALLOCATION_TRANSACTION_SORT_COLUMNS,
     count_recent_allocation_transactions,
@@ -25,6 +26,7 @@ from sam.queries.charges import (
 )
 from sam.queries.usage_cache import cached_allocation_usage, purge_usage_cache, usage_cache_info
 from sam.queries.lookups import find_project_by_code
+from sam.schemas.forms import CreateChargeAdjustmentForm
 from webapp.utils.rbac import require_permission, Permission
 from sam.resources.resources import Resource
 from ..charts import generate_facility_pie_chart_matplotlib, generate_allocation_type_pie_chart_matplotlib
@@ -750,3 +752,168 @@ def purge_cache():
 def cache_status():
     """Return usage cache statistics as JSON (admin/staff only)."""
     return jsonify(usage_cache_info())
+
+
+# ── Create Charge Adjustment ──────────────────────────────────────────────
+#
+# Staff-facing write path for the Adjustments tab. The user enters a
+# positive amount; ChargeAdjustment.create() applies the sign by type
+# (Credits/Refunds → negative, Debits/Reservations → positive). The set of
+# exposed types lives in sam.accounting.adjustments._SIGN_BY_TYPE; the
+# route resolves it to ChargeAdjustmentType rows via
+# ChargeAdjustment.supported_types(session).
+
+
+_CREATE_ADJUSTMENT_FORM_TEMPLATE = (
+    'dashboards/allocations/fragments/create_adjustment_form_htmx.html'
+)
+
+
+def _create_adjustment_form_context():
+    """Build the context dict used for initial render + error re-render."""
+    from sam.accounting.adjustments import ChargeAdjustment
+    return {
+        'types': ChargeAdjustment.supported_types(db.session),
+    }
+
+
+@bp.route('/htmx/create_adjustment_form')
+@login_required
+@require_permission(Permission.EDIT_ALLOCATIONS)
+def htmx_create_adjustment_form():
+    """Return the Create Adjustment form fragment (loaded into the modal)."""
+    ctx = _create_adjustment_form_context()
+    return render_template(
+        _CREATE_ADJUSTMENT_FORM_TEMPLATE,
+        errors=[],
+        form={},
+        **ctx,
+    )
+
+
+@bp.route('/htmx/project_search_for_adjustment')
+@login_required
+@require_permission(Permission.EDIT_ALLOCATIONS)
+def htmx_project_search_for_adjustment():
+    """Search-as-you-type backend for the Create Adjustment project picker.
+
+    Mirrors ``admin_dashboard.htmx_project_search_for_parent`` but guarded
+    by ``EDIT_ALLOCATIONS`` (the permission that also gates the Create
+    Adjustment button). Returns the same results template so the shared
+    ``fk-picker.js`` click handler populates the hidden ``project_id``
+    input on selection.
+    """
+    from sam.queries.projects import search_projects_by_code_or_title
+
+    query = (request.args.get('q') or '').strip()
+    if len(query) < 1:
+        return ''
+
+    projects = search_projects_by_code_or_title(
+        db.session, query, active=True,
+    )[:10]
+
+    return render_template(
+        'dashboards/admin/fragments/project_search_results_fk_htmx.html',
+        projects=projects,
+    )
+
+
+@bp.route('/htmx/resources_for_project')
+@login_required
+@require_permission(Permission.EDIT_ALLOCATIONS)
+def htmx_resources_for_project():
+    """Return <option> fragment for the Resource select, filtered to
+    the given project's active HPC/DAV accounts.
+
+    Query string: project_id=<int>. If absent/empty/unknown, returns a
+    single placeholder option so the select remains usable.
+    """
+    from sam.accounting.accounts import Account
+    from sam.projects.projects import Project
+    from sam.resources.resources import ResourceType
+
+    project_id_str = (request.args.get('project_id') or '').strip()
+    if not project_id_str:
+        return '<option value="">-- Select a project first --</option>'
+    try:
+        project_id = int(project_id_str)
+    except ValueError:
+        return '<option value="">-- Select a project first --</option>'
+
+    project = db.session.get(Project, project_id)
+    if project is None:
+        return '<option value="">-- Unknown project --</option>'
+
+    rows = (
+        db.session.query(Resource.resource_id, Resource.resource_name)
+        .join(Account, Account.resource_id == Resource.resource_id)
+        .join(ResourceType, Resource.resource_type_id == ResourceType.resource_type_id)
+        .filter(
+            Account.project_id == project.project_id,
+            Account.is_active,
+            Resource.is_active,
+            ResourceType.resource_type.in_(('HPC', 'DAV')),
+            ~Resource.resource_name.in_(HIDDEN_RESOURCES),
+        )
+        .distinct()
+        .order_by(Resource.resource_name)
+        .all()
+    )
+
+    if not rows:
+        return (
+            '<option value="">-- No compute accounts for this project --</option>'
+        )
+
+    opts = ['<option value="">-- Select a resource --</option>']
+    for resource_id, resource_name in rows:
+        opts.append(f'<option value="{resource_id}">{resource_name}</option>')
+    return '\n'.join(opts)
+
+
+@bp.route('/htmx/create_adjustment', methods=['POST'])
+@login_required
+@require_permission(Permission.EDIT_ALLOCATIONS)
+def htmx_create_adjustment():
+    """Create a ChargeAdjustment row. Server applies the sign by type."""
+    from sam.accounting.accounts import Account
+    from sam.accounting.adjustments import ChargeAdjustment
+    from sam.projects.projects import Project
+
+    def do_action(data):
+        project = db.session.get(Project, data['project_id'])
+        if project is None:
+            raise ValueError(f"Project {data['project_id']} not found")
+
+        account = Account.get_by_project_and_resource(
+            db.session, project.project_id, data['resource_id'],
+            exclude_deleted=True,
+        )
+        if account is None:
+            raise ValueError(
+                f"No active account for project {project.projcode} on the "
+                f"selected resource"
+            )
+
+        return ChargeAdjustment.create(
+            db.session,
+            account_id=account.account_id,
+            charge_adjustment_type_id=data['charge_adjustment_type_id'],
+            amount=data['amount'],
+            adjusted_by_id=current_user.user_id,
+            comment=data.get('comment'),
+        )
+
+    return handle_htmx_form_post(
+        schema_cls=CreateChargeAdjustmentForm,
+        template=_CREATE_ADJUSTMENT_FORM_TEMPLATE,
+        do_action=do_action,
+        success_triggers={
+            'closeActiveModal': {},
+            'refreshAdjustmentsTab': {},
+        },
+        success_message='Charge adjustment saved.',
+        error_prefix='Error creating adjustment',
+        context_fn=_create_adjustment_form_context,
+    )

--- a/src/webapp/templates/dashboards/allocations/dashboard.html
+++ b/src/webapp/templates/dashboards/allocations/dashboard.html
@@ -402,6 +402,18 @@
 
 <!-- Tab 3: Adjustments — sortable/paginated audit log, lazy-loaded -->
 <div class="tab-pane fade" id="tab-alloc-adjustments" role="tabpanel" aria-labelledby="alloc-adjustments-tab">
+    {% if has_permission(Permission.EDIT_ALLOCATIONS) %}
+    <div class="d-flex justify-content-end mb-2">
+        <button type="button" class="btn btn-sm btn-success"
+                data-bs-toggle="modal" data-bs-target="#createAdjustmentModal"
+                hx-get="{{ url_for('allocations_dashboard.htmx_create_adjustment_form') }}"
+                hx-target="#createAdjustmentFormContainer"
+                hx-swap="innerHTML">
+            <i class="fas fa-plus"></i> Create Adjustment
+        </button>
+    </div>
+    {% endif %}
+
     {{ audit_filters(
         form_id='adj-filters',
         fragment_url=url_for('allocations_dashboard.adjustments_fragment'),
@@ -462,12 +474,36 @@
     </div>
 </div>
 
-<!-- Audit row-detail modal (shared by Transactions + Adjustments rows) -->
+{% if has_permission(Permission.EDIT_ALLOCATIONS) %}
+<!-- Create Adjustment modal (Adjustments tab → "Create Adjustment" button) -->
+<div class="modal fade" id="createAdjustmentModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title"><i class="fas fa-plus"></i> Create Charge Adjustment</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div id="createAdjustmentFormContainer">
+                <div class="modal-body text-center">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="sr-only">Loading…</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+<!-- Audit row-detail modal (shared by Transactions + Adjustments rows).
+     The title text is swapped in via hx-swap-oob from each fragment template
+     so e.g. a transaction row shows "Allocation Transaction Details" and an
+     adjustment row shows "Charge Adjustment Details". -->
 <div class="modal fade" id="auditDetailsModal" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-scrollable" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">Details</h5>
+                <h5 class="modal-title" id="auditDetailsModalTitle">Details</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body" id="auditDetailsModalBody">
@@ -566,6 +602,21 @@ document.body.addEventListener('htmx:afterSwap', function(e) {
             });
         });
     });
+});
+
+/* After a successful "Create Adjustment" POST, reload the adjustments
+   table fragment, carrying the current filter form so the view stays
+   consistent with what the user was looking at. */
+document.body.addEventListener('refreshAdjustmentsTab', function() {
+    var target = document.getElementById('alloc-adjustments-fragment');
+    if (!target) return;
+    /* 300ms matches Bootstrap's modal close animation so the reload lands
+       after the modal has fully animated out of view. */
+    setTimeout(function() {
+        htmx.ajax('GET', "{{ url_for('allocations_dashboard.adjustments_fragment') }}",
+                  {target: '#alloc-adjustments-fragment', swap: 'innerHTML',
+                   source: '#adj-filters'});
+    }, 300);
 });
 
 /* Swap facility pie chart above the tabs when the active resource tab changes */

--- a/src/webapp/templates/dashboards/allocations/fragments/create_adjustment_form_htmx.html
+++ b/src/webapp/templates/dashboards/allocations/fragments/create_adjustment_form_htmx.html
@@ -1,0 +1,122 @@
+{% from 'dashboards/fragments/modal_form.html' import htmx_form with context %}
+{% from 'dashboards/fragments/form_fields.html' import number_field, textarea_field, fk_search_field with context %}
+{#
+  htmx: Create Charge Adjustment form (loaded into #createAdjustmentFormContainer).
+
+  Context:
+    types   — list of ChargeAdjustmentType rows (supported by the webapp,
+              in display order with Refund first)
+    errors  — list of validation/creation error messages
+    form    — request.form from the previous POST (on re-render) or {}
+
+  Flow: user picks type (intent text swaps) → picks project via
+  search-as-you-type (fk_search_field + fk-picker.js stores project_id) →
+  fk:selected event triggers a refresh of the Resource select with options
+  filtered to the project's active HPC/DAV accounts → user picks resource,
+  enters positive amount (sign applied server-side), optional comment.
+#}
+
+{% call htmx_form(
+    url_for('allocations_dashboard.htmx_create_adjustment'),
+    '#createAdjustmentFormContainer',
+    'Create Adjustment',
+    submit_icon='plus',
+    errors=errors
+) %}
+
+        {# ── Type ──────────────────────────────────────────────────────── #}
+        <div class="mb-3">
+            <label for="adjustmentType" class="form-label">
+                Type <span class="text-danger">*</span>
+            </label>
+            <select class="form-select" id="adjustmentType" name="charge_adjustment_type_id" required
+                    onchange="var v=this.value; document.querySelectorAll('#createAdjustmentFormContainer .adj-intent').forEach(function(el){ el.style.display = (el.dataset.typeId === v) ? '' : 'none'; });">
+                <option value="">-- Select a type --</option>
+                {% for t in types %}
+                <option value="{{ t.charge_adjustment_type_id }}"
+                    {% if form and form.get('charge_adjustment_type_id')|string == t.charge_adjustment_type_id|string %}selected{% endif %}>
+                    {{ t.type }}
+                </option>
+                {% endfor %}
+            </select>
+
+            {# Intent boilerplate — one visible at a time, toggled by the
+               select's onchange handler. Wording grounded in legacy_sam/
+               doc/data_structures/charge_adjustments.md §5. #}
+            {% set _selected_type_id = form.get('charge_adjustment_type_id')|string if form else '' %}
+            {% for t in types %}
+            {% set tid = t.charge_adjustment_type_id|string %}
+            <div class="alert alert-info mt-2 mb-0 adj-intent small"
+                 data-type-id="{{ tid }}"
+                 {% if tid != _selected_type_id %}style="display:none;"{% endif %}>
+                {% if t.type == 'Refund' %}
+                <strong>Refund.</strong>
+                Use Refund to return compute to a project because of a
+                system-caused failure — node crash, hardware fault, or a
+                job preempted through no fault of the user. This is the
+                most common adjustment type and creates the clearest audit
+                trail for system-caused returns.
+                {% elif t.type == 'Credit' %}
+                <strong>Credit.</strong>
+                Use Credit for administrative balance additions unrelated
+                to a specific job failure — goodwill, approved allocation
+                increase, or a cross-project transfer.
+                {% elif t.type == 'Debit' %}
+                <strong>Debit.</strong>
+                Use Debit to capture a compute charge that automated
+                accounting missed. The amount will be added to this
+                account's usage total.
+                {% elif t.type == 'Reservation' %}
+                <strong>Reservation.</strong>
+                Use Reservation to set aside compute on this account for
+                a planned use — for example, a dedicated block for a
+                workshop or a benchmarking run. Reserved hours count
+                against the account's used total immediately.
+                {% else %}
+                <em>{{ t.type }}.</em>
+                {% endif %}
+            </div>
+            {% endfor %}
+        </div>
+
+        {# ── Project (search-as-you-type FK picker) ──────────────────── #}
+        {{ fk_search_field('project_id', 'Project',
+                           search_url=url_for('allocations_dashboard.htmx_project_search_for_adjustment'),
+                           required=True,
+                           placeholder='Search by project code or title…',
+                           badge_class='bg-secondary text-light py-1 px-2 font-monospace',
+                           id_prefix='createAdjProject') }}
+
+        {# ── Resource ─────────────────────────────────────────────────── #}
+        {# Re-populates on fk:selected (and clears back to placeholder on
+           fk:cleared). Both events bubble from fk-picker.js. The hidden
+           project_id input (id=createAdjProject_id) is hx-included so
+           the endpoint sees the currently-selected project. #}
+        <div class="mb-3">
+            <label for="adjustmentResourceSelect" class="form-label">
+                Resource <span class="text-danger">*</span>
+            </label>
+            <select class="form-select" id="adjustmentResourceSelect"
+                    name="resource_id" required
+                    hx-get="{{ url_for('allocations_dashboard.htmx_resources_for_project') }}"
+                    hx-trigger="fk:selected from:body, fk:cleared from:body"
+                    hx-target="this"
+                    hx-swap="innerHTML"
+                    hx-include="#createAdjProject_id">
+                <option value="">-- Select a project first --</option>
+            </select>
+        </div>
+
+        {# ── Amount ──────────────────────────────────────────────────── #}
+        {{ number_field('amount', 'Amount',
+                        required=True, min=0.01, step='any',
+                        placeholder='e.g. 100',
+                        id='adjustmentAmount',
+                        help='Enter a positive number. The sign is applied automatically by type — Credits and Refunds reduce the account\'s used total; Debits and Reservations increase it.') }}
+
+        {# ── Comment ─────────────────────────────────────────────────── #}
+        {{ textarea_field('comment', 'Comment', rows=2,
+                          placeholder='Reason for this adjustment (e.g. ticket #, system event)…',
+                          id='adjustmentComment') }}
+
+{% endcall %}

--- a/src/webapp/templates/dashboards/allocations/partials/adjustment_details_modal.html
+++ b/src/webapp/templates/dashboards/allocations/partials/adjustment_details_modal.html
@@ -4,6 +4,12 @@
    Style mirrors ``render_project_info`` in project_card.html. Empty / None
    fields are omitted entirely. #}
 
+{# Set the modal title out-of-band so the shared audit modal reflects the
+   fragment type. The target id is declared on the <h5> in dashboard.html. #}
+<h5 id="auditDetailsModalTitle" class="modal-title" hx-swap-oob="true">
+    Charge Adjustment Details
+</h5>
+
 <div class="mb-3 d-flex align-items-center flex-wrap gap-2">
     <span class="badge bg-secondary fs-6">{{ r.adjustment_type }}</span>
     <span class="text-muted">·</span>
@@ -58,7 +64,7 @@
     <div class="stat-item">
         <span class="stat-label">Adjusted by:</span>
         <span class="stat-value">
-            {{ r.user_full_name or r.username }}
+            {{ r.user_display_name or r.username }}
             <small class="text-muted">({{ r.username }})</small>
         </span>
     </div>

--- a/src/webapp/templates/dashboards/allocations/partials/adjustments_table.html
+++ b/src/webapp/templates/dashboards/allocations/partials/adjustments_table.html
@@ -39,11 +39,10 @@
                 <th style="white-space:nowrap;">{{ sort_link('adjustment_date', 'Date') }}</th>
                 <th>{{ sort_link('adjustment_type', 'Type') }}</th>
                 <th>{{ sort_link('projcode', 'Project') }}</th>
-                <th>{{ sort_link('resource_name', 'Resource') }}</th>
-                <th>{{ sort_link('facility_name', 'Facility') }}</th>
+                <th style="width:130px;">{{ sort_link('resource_name', 'Resource') }}</th>
                 <th class="text-end">{{ sort_link('amount', 'Amount', align='text-end') }}</th>
                 <th>{{ sort_link('username', 'Adjusted by') }}</th>
-                <th>Comment</th>
+                <th style="width:99%;">Comment</th>
             </tr>
         </thead>
         <tbody>
@@ -70,8 +69,10 @@
                     </button>
                     {% endif %}
                 </td>
-                <td>{{ r.resource_name or '—' }}</td>
-                <td>{{ r.facility_name or '—' }}</td>
+                <td style="max-width:130px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"
+                    title="{{ r.resource_name or '' }}">
+                    {{ r.resource_name or '—' }}
+                </td>
                 <td class="text-end" style="white-space:nowrap;">
                     {% if r.amount is not none %}
                         {% set cls = 'text-success' if r.amount > 0 else ('text-danger' if r.amount < 0 else '') %}
@@ -82,20 +83,20 @@
                 </td>
                 <td>
                     {% if r.username %}
-                        <span title="{{ r.user_full_name or '' }}">{{ r.username }}</span>
+                        <span title="{{ r.user_display_name or '' }}">{{ r.username }}</span>
                     {% else %}
                         <span class="text-muted">—</span>
                     {% endif %}
                 </td>
                 <td class="small text-muted"
                     title="{{ r.comment or '' }}"
-                    style="max-width:320px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">
+                    style="overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">
                     {{ r.comment or '' }}
                 </td>
             </tr>
             {% else %}
             <tr>
-                <td colspan="8" class="text-center text-muted py-4">
+                <td colspan="7" class="text-center text-muted py-4">
                     <i class="fas fa-inbox"></i>
                     No adjustments match the current filter.
                 </td>

--- a/src/webapp/templates/dashboards/allocations/partials/transaction_details_modal.html
+++ b/src/webapp/templates/dashboards/allocations/partials/transaction_details_modal.html
@@ -6,6 +6,12 @@
    with empty / None values are simply omitted — the user doesn't see rows
    like "Requested amount —". #}
 
+{# Set the modal title out-of-band so the shared audit modal reflects the
+   fragment type. The target id is declared on the <h5> in dashboard.html. #}
+<h5 id="auditDetailsModalTitle" class="modal-title" hx-swap-oob="true">
+    Allocation Transaction Details
+</h5>
+
 {# Heading: type badge + date + optional propagated chip. #}
 <div class="mb-3 d-flex align-items-center flex-wrap gap-2">
     <span class="badge bg-secondary fs-6">{{ r.transaction_type }}</span>
@@ -103,7 +109,7 @@
     <div class="stat-item">
         <span class="stat-label">Processed by:</span>
         <span class="stat-value">
-            {{ r.user_full_name or r.username }}
+            {{ r.user_display_name or r.username }}
             <small class="text-muted">({{ r.username }})</small>
         </span>
     </div>

--- a/src/webapp/templates/dashboards/allocations/partials/transactions_table.html
+++ b/src/webapp/templates/dashboards/allocations/partials/transactions_table.html
@@ -39,11 +39,12 @@
                 <th style="white-space:nowrap;">{{ sort_link('creation_time', 'Date') }}</th>
                 <th>{{ sort_link('transaction_type', 'Type') }}</th>
                 <th>{{ sort_link('projcode', 'Project') }}</th>
-                <th>{{ sort_link('resource_name', 'Resource') }}</th>
+                <th style="width:140px;">{{ sort_link('resource_name', 'Resource') }}</th>
                 <th>{{ sort_link('facility_name', 'Facility') }}</th>
+                <th style="width:150px;">{{ sort_link('allocation_type', 'Alloc type') }}</th>
                 <th class="text-end">{{ sort_link('transaction_amount', 'Amount', align='text-end') }}</th>
                 <th>{{ sort_link('username', 'Processed by') }}</th>
-                <th>Comment</th>
+                <th style="width:99%;">Comment</th>
             </tr>
         </thead>
         <tbody>
@@ -76,8 +77,15 @@
                     </button>
                     {% endif %}
                 </td>
-                <td>{{ r.resource_name or '—' }}</td>
+                <td style="max-width:140px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"
+                    title="{{ r.resource_name or '' }}">
+                    {{ r.resource_name or '—' }}
+                </td>
                 <td>{{ r.facility_name or '—' }}</td>
+                <td style="max-width:150px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"
+                    title="{{ r.allocation_type or '' }}">
+                    {{ r.allocation_type or '—' }}
+                </td>
                 <td class="text-end" style="white-space:nowrap;">
                     {% if r.transaction_amount is not none %}
                         {{ r.transaction_amount | fmt_number }}
@@ -87,20 +95,20 @@
                 </td>
                 <td>
                     {% if r.username %}
-                        <span title="{{ r.user_full_name or '' }}">{{ r.username }}</span>
+                        <span title="{{ r.user_display_name or '' }}">{{ r.username }}</span>
                     {% else %}
                         <span class="text-muted">—</span>
                     {% endif %}
                 </td>
                 <td class="small text-muted"
                     title="{{ r.transaction_comment or '' }}"
-                    style="max-width:320px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">
+                    style="overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">
                     {{ r.transaction_comment or '' }}
                 </td>
             </tr>
             {% else %}
             <tr>
-                <td colspan="8" class="text-center text-muted py-4">
+                <td colspan="9" class="text-center text-muted py-4">
                     <i class="fas fa-inbox"></i>
                     No transactions match the current filter.
                 </td>

--- a/tests/api/test_adjustments_form_schema.py
+++ b/tests/api/test_adjustments_form_schema.py
@@ -1,0 +1,141 @@
+"""Tests for CreateChargeAdjustmentForm (sam.schemas.forms.adjustments).
+
+The schema is pure input coercion + shape validation. It does NOT validate
+that the submitted ``charge_adjustment_type_id`` is in the supported set —
+that's a DB-backed membership check the route owns (see CLAUDE.md §9).
+"""
+import pytest
+from marshmallow import ValidationError
+
+from sam.schemas.forms import CreateChargeAdjustmentForm
+
+
+pytestmark = pytest.mark.unit
+
+
+def _valid_payload():
+    return {
+        'project_id': '8',
+        'resource_id': '7',
+        'charge_adjustment_type_id': '3',
+        'amount': '100',
+        'comment': 'ticket #1234',
+    }
+
+
+class TestHappyPath:
+    def test_coerces_types(self):
+        data = CreateChargeAdjustmentForm().load(_valid_payload())
+        assert data['project_id'] == 8
+        assert data['resource_id'] == 7
+        assert data['charge_adjustment_type_id'] == 3
+        assert data['amount'] == 100.0
+        assert data['comment'] == 'ticket #1234'
+
+    def test_decimal_amount_accepted(self):
+        payload = _valid_payload()
+        payload['amount'] = '7.5'
+        data = CreateChargeAdjustmentForm().load(payload)
+        assert data['amount'] == 7.5
+
+    def test_comment_omitted_yields_none(self):
+        """An absent ``comment`` falls through to load_default=None."""
+        payload = _valid_payload()
+        del payload['comment']
+        data = CreateChargeAdjustmentForm().load(payload)
+        assert data['comment'] is None
+
+    def test_empty_comment_string_yields_none(self):
+        """HtmxFormSchema strips empty strings in pre_load — the field then
+        falls through to load_default=None, matching the ORM convention of
+        NULL-instead-of-empty-string for optional Text columns."""
+        payload = _valid_payload()
+        payload['comment'] = ''
+        data = CreateChargeAdjustmentForm().load(payload)
+        assert data['comment'] is None
+
+    def test_unknown_fields_dropped(self):
+        """EXCLUDE drops CSRF tokens / stray fields silently."""
+        payload = _valid_payload()
+        payload['csrf_token'] = 'abc'
+        payload['ignored'] = 'yes'
+        data = CreateChargeAdjustmentForm().load(payload)
+        assert 'csrf_token' not in data
+        assert 'ignored' not in data
+
+
+class TestAmountValidation:
+
+    def test_zero_rejected(self):
+        payload = _valid_payload()
+        payload['amount'] = '0'
+        with pytest.raises(ValidationError) as excinfo:
+            CreateChargeAdjustmentForm().load(payload)
+        assert 'amount' in excinfo.value.messages
+
+    def test_negative_rejected(self):
+        payload = _valid_payload()
+        payload['amount'] = '-5'
+        with pytest.raises(ValidationError) as excinfo:
+            CreateChargeAdjustmentForm().load(payload)
+        assert 'amount' in excinfo.value.messages
+
+    def test_non_numeric_rejected(self):
+        payload = _valid_payload()
+        payload['amount'] = 'not-a-number'
+        with pytest.raises(ValidationError) as excinfo:
+            CreateChargeAdjustmentForm().load(payload)
+        assert 'amount' in excinfo.value.messages
+
+
+class TestRequiredFields:
+
+    @pytest.mark.parametrize('field', [
+        'project_id', 'resource_id', 'charge_adjustment_type_id', 'amount',
+    ])
+    def test_missing_required_field(self, field):
+        payload = _valid_payload()
+        del payload[field]
+        with pytest.raises(ValidationError) as excinfo:
+            CreateChargeAdjustmentForm().load(payload)
+        assert field in excinfo.value.messages
+
+    def test_non_int_project_id_rejected(self):
+        payload = _valid_payload()
+        payload['project_id'] = 'SCSG0001'   # projcode-style string
+        with pytest.raises(ValidationError) as excinfo:
+            CreateChargeAdjustmentForm().load(payload)
+        assert 'project_id' in excinfo.value.messages
+
+
+class TestTypeIdIsShapeOnly:
+    """Schema deliberately does not gate charge_adjustment_type_id on the
+    webapp's supported set — that check requires a DB lookup and lives in
+    the route (see CLAUDE.md §9). The schema only coerces to int."""
+
+    @pytest.mark.parametrize('type_id_str', ['1', '2', '3', '4', '5', '6'])
+    def test_any_positive_int_accepted(self, type_id_str):
+        payload = _valid_payload()
+        payload['charge_adjustment_type_id'] = type_id_str
+        data = CreateChargeAdjustmentForm().load(payload)
+        assert data['charge_adjustment_type_id'] == int(type_id_str)
+
+    def test_non_int_rejected(self):
+        payload = _valid_payload()
+        payload['charge_adjustment_type_id'] = 'Credit'
+        with pytest.raises(ValidationError) as excinfo:
+            CreateChargeAdjustmentForm().load(payload)
+        assert 'charge_adjustment_type_id' in excinfo.value.messages
+
+
+class TestFlattenErrors:
+    def test_errors_renderable_in_template(self):
+        payload = _valid_payload()
+        payload['amount'] = '-1'
+        del payload['project_id']
+        try:
+            CreateChargeAdjustmentForm().load(payload)
+        except ValidationError as e:
+            flat = CreateChargeAdjustmentForm.flatten_errors(e.messages)
+            assert any('Amount' in msg for msg in flat)
+            assert any('Project Id' in msg for msg in flat)

--- a/tests/unit/test_charge_adjustment_create.py
+++ b/tests/unit/test_charge_adjustment_create.py
@@ -1,0 +1,192 @@
+"""Tests for ChargeAdjustment.create() and ChargeAdjustment.supported_types().
+
+Exercises the Sign Enforcement pattern documented in
+legacy_sam/doc/data_structures/charge_adjustments.md §2: the user supplies a
+positive amount and the server multiplies by +1 (Debit / Reservation) or -1
+(Credit / Refund) at write time so the stored amount is always the correct sign.
+
+Each test builds a minimal Account via Layer 2 factories so two xdist workers
+can't bleed state through the SAVEPOINT rollback.
+"""
+from datetime import datetime
+
+import pytest
+
+from sam.accounting.adjustments import ChargeAdjustment, ChargeAdjustmentType
+from factories import make_account, make_user
+
+
+pytestmark = pytest.mark.unit
+
+
+def _type_by_name(session, name):
+    t = (session.query(ChargeAdjustmentType)
+                .filter(ChargeAdjustmentType.type == name)
+                .first())
+    if t is None:
+        pytest.skip(f"No ChargeAdjustmentType row named {name!r} in test DB")
+    return t
+
+
+class TestSupportedTypes:
+    """ChargeAdjustment.supported_types(session) returns the v1 set in order."""
+
+    def test_returns_four_types_in_order(self, session):
+        rows = ChargeAdjustment.supported_types(session)
+        names = [r.type for r in rows]
+        # Order matches _SIGN_BY_TYPE insertion order: Refund first (most-used
+        # per legacy docs), then Credit, Debit, Reservation.
+        assert names == ['Refund', 'Credit', 'Debit', 'Reservation']
+
+    def test_excludes_storage_types(self, session):
+        names = {r.type for r in ChargeAdjustment.supported_types(session)}
+        assert 'Storage-Credit' not in names
+        assert 'Storage-Debit' not in names
+
+
+class TestCreateSignByType:
+    """create() applies sign by type name regardless of input sign."""
+
+    @pytest.mark.parametrize("type_name,expected_sign", [
+        ('Refund', -1),
+        ('Credit', -1),
+        ('Debit', +1),
+        ('Reservation', +1),
+    ])
+    def test_sign_applied(self, session, type_name, expected_sign):
+        account = make_account(session)
+        actor = make_user(session)
+        adj_type = _type_by_name(session, type_name)
+
+        adj = ChargeAdjustment.create(
+            session,
+            account_id=account.account_id,
+            charge_adjustment_type_id=adj_type.charge_adjustment_type_id,
+            amount=100.0,
+            adjusted_by_id=actor.user_id,
+        )
+
+        assert adj.charge_adjustment_id is not None
+        assert adj.amount == expected_sign * 100.0
+        assert adj.account_id == account.account_id
+        assert adj.adjusted_by_id == actor.user_id
+        assert adj.comment is None
+
+    def test_records_adjustment_date_near_now(self, session):
+        account = make_account(session)
+        actor = make_user(session)
+        refund = _type_by_name(session, 'Refund')
+        before = datetime.now()
+
+        adj = ChargeAdjustment.create(
+            session,
+            account_id=account.account_id,
+            charge_adjustment_type_id=refund.charge_adjustment_type_id,
+            amount=50.0,
+            adjusted_by_id=actor.user_id,
+        )
+
+        after = datetime.now()
+        assert before <= adj.adjustment_date <= after
+
+    def test_stores_comment(self, session):
+        account = make_account(session)
+        actor = make_user(session)
+        credit = _type_by_name(session, 'Credit')
+
+        adj = ChargeAdjustment.create(
+            session,
+            account_id=account.account_id,
+            charge_adjustment_type_id=credit.charge_adjustment_type_id,
+            amount=7.5,
+            adjusted_by_id=actor.user_id,
+            comment='ticket #1234',
+        )
+
+        assert adj.comment == 'ticket #1234'
+
+    def test_blank_comment_stored_as_none(self, session):
+        """create() normalizes empty/whitespace comment to NULL."""
+        account = make_account(session)
+        actor = make_user(session)
+        refund = _type_by_name(session, 'Refund')
+
+        adj = ChargeAdjustment.create(
+            session,
+            account_id=account.account_id,
+            charge_adjustment_type_id=refund.charge_adjustment_type_id,
+            amount=1.0,
+            adjusted_by_id=actor.user_id,
+            comment='',
+        )
+
+        assert adj.comment is None
+
+
+class TestCreateValidation:
+    """create() raises ValueError on bad inputs — defense in depth around the
+    form schema (which also enforces positive amounts)."""
+
+    def test_zero_amount_rejected(self, session):
+        account = make_account(session)
+        actor = make_user(session)
+        refund = _type_by_name(session, 'Refund')
+
+        with pytest.raises(ValueError, match="positive"):
+            ChargeAdjustment.create(
+                session,
+                account_id=account.account_id,
+                charge_adjustment_type_id=refund.charge_adjustment_type_id,
+                amount=0,
+                adjusted_by_id=actor.user_id,
+            )
+
+    def test_negative_amount_rejected(self, session):
+        account = make_account(session)
+        actor = make_user(session)
+        refund = _type_by_name(session, 'Refund')
+
+        with pytest.raises(ValueError, match="positive"):
+            ChargeAdjustment.create(
+                session,
+                account_id=account.account_id,
+                charge_adjustment_type_id=refund.charge_adjustment_type_id,
+                amount=-5.0,
+                adjusted_by_id=actor.user_id,
+            )
+
+    def test_unknown_type_id_rejected(self, session):
+        account = make_account(session)
+        actor = make_user(session)
+
+        with pytest.raises(ValueError, match="not found"):
+            ChargeAdjustment.create(
+                session,
+                account_id=account.account_id,
+                charge_adjustment_type_id=99_999_999,
+                amount=1.0,
+                adjusted_by_id=actor.user_id,
+            )
+
+    def test_unsupported_type_name_rejected(self, session):
+        """A type that exists in the DB but is not in _SIGN_BY_TYPE must be
+        rejected — this is what guards disk/archive types from slipping into
+        the compute-only v1 UI."""
+        storage_credit = (
+            session.query(ChargeAdjustmentType)
+                   .filter(ChargeAdjustmentType.type == 'Storage-Credit')
+                   .first()
+        )
+        if storage_credit is None:
+            pytest.skip("No 'Storage-Credit' row in the reference data")
+        account = make_account(session)
+        actor = make_user(session)
+
+        with pytest.raises(ValueError, match="not supported"):
+            ChargeAdjustment.create(
+                session,
+                account_id=account.account_id,
+                charge_adjustment_type_id=storage_credit.charge_adjustment_type_id,
+                amount=1.0,
+                adjusted_by_id=actor.user_id,
+            )

--- a/tests/unit/test_htmx_create_adjustment.py
+++ b/tests/unit/test_htmx_create_adjustment.py
@@ -1,0 +1,215 @@
+"""HTTP-layer tests for the Create Charge Adjustment HTMX routes.
+
+Scope follows the pattern from tests/api/test_member_management.py: this
+file exercises **auth, validation, and error re-render paths only**.
+Successful-write behavior (sign enforcement, adjusted_by, adjustment_date)
+is covered at the model layer in tests/unit/test_charge_adjustment_create.py.
+Writing a happy-path HTTP test would require full SAVEPOINT bridging
+between Flask-SQLAlchemy's db.session and the test session fixture, which
+this suite deliberately avoids.
+
+Endpoints tested:
+    GET  /allocations/htmx/create_adjustment_form
+    GET  /allocations/htmx/resources_for_project
+    POST /allocations/htmx/create_adjustment
+"""
+import os
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def scsg0001_project_id(session):
+    """SCSG0001's project_id from the test snapshot.
+
+    The snapshot preserves benkirk's real project so tests that need a
+    guaranteed-existing project can use it without factory overhead.
+    """
+    from sam.projects.projects import Project
+    p = Project.get_by_projcode(session, 'SCSG0001')
+    assert p is not None, "SCSG0001 must exist in the test snapshot"
+    return p.project_id
+
+
+# ---------------------------------------------------------------------------
+# GET /htmx/create_adjustment_form
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAdjustmentFormEndpoint:
+
+    def test_unauthenticated_redirects_or_401(self, client):
+        if os.getenv('DISABLE_AUTH') == '1':
+            pytest.skip("Auth disabled in dev environment")
+        resp = client.get('/allocations/htmx/create_adjustment_form')
+        assert resp.status_code in (302, 401)
+
+    def test_non_admin_denied(self, non_admin_client):
+        """User without EDIT_ALLOCATIONS gets 403 from @require_permission."""
+        resp = non_admin_client.get('/allocations/htmx/create_adjustment_form')
+        assert resp.status_code == 403
+
+    def test_admin_renders_four_type_options(self, auth_client):
+        """Admin sees a <select> containing exactly Refund / Credit / Debit /
+        Reservation — the four names keyed by _SIGN_BY_TYPE."""
+        resp = auth_client.get('/allocations/htmx/create_adjustment_form')
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        # Type names appear in <option> labels (and also in the .adj-intent
+        # boilerplate divs) — presence is enough; exact count is fragile.
+        for name in ('Refund', 'Credit', 'Debit', 'Reservation'):
+            assert name in html
+        # Storage-* types must not be offered.
+        assert 'Storage-Credit' not in html
+        assert 'Storage-Debit' not in html
+
+
+# ---------------------------------------------------------------------------
+# GET /htmx/resources_for_project
+# ---------------------------------------------------------------------------
+
+
+class TestResourcesForProjectEndpoint:
+
+    def test_unauthenticated_redirects_or_401(self, client, scsg0001_project_id):
+        if os.getenv('DISABLE_AUTH') == '1':
+            pytest.skip("Auth disabled in dev environment")
+        resp = client.get(
+            f'/allocations/htmx/resources_for_project?project_id={scsg0001_project_id}'
+        )
+        assert resp.status_code in (302, 401)
+
+    def test_non_admin_denied(self, non_admin_client, scsg0001_project_id):
+        resp = non_admin_client.get(
+            f'/allocations/htmx/resources_for_project?project_id={scsg0001_project_id}'
+        )
+        assert resp.status_code == 403
+
+    def test_missing_project_id_returns_placeholder(self, auth_client):
+        resp = auth_client.get('/allocations/htmx/resources_for_project')
+        assert resp.status_code == 200
+        assert 'Select a project first' in resp.get_data(as_text=True)
+
+    def test_non_int_project_id_returns_placeholder(self, auth_client):
+        resp = auth_client.get(
+            '/allocations/htmx/resources_for_project?project_id=not-a-number'
+        )
+        assert resp.status_code == 200
+        assert 'Select a project first' in resp.get_data(as_text=True)
+
+    def test_unknown_project_id_returns_placeholder(self, auth_client):
+        resp = auth_client.get(
+            '/allocations/htmx/resources_for_project?project_id=999999999'
+        )
+        assert resp.status_code == 200
+        assert 'Unknown project' in resp.get_data(as_text=True)
+
+    def test_known_project_returns_hpc_dav_options(self, auth_client, scsg0001_project_id):
+        """SCSG0001 has active HPC+DAV accounts in the snapshot — the
+        endpoint should render <option> tags for compute resources."""
+        resp = auth_client.get(
+            f'/allocations/htmx/resources_for_project?project_id={scsg0001_project_id}'
+        )
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert '<option' in html
+        # Placeholder not suppressed — the user still needs to pick one.
+        assert 'Select a resource' in html
+
+
+# ---------------------------------------------------------------------------
+# POST /htmx/create_adjustment
+# ---------------------------------------------------------------------------
+
+
+def _valid_form_data(project_id):
+    return {
+        'project_id': str(project_id),
+        'resource_id': '7',
+        'charge_adjustment_type_id': '3',   # Refund
+        'amount': '100',
+        'comment': 'test',
+    }
+
+
+class TestCreateAdjustmentPost:
+
+    def test_unauthenticated_redirects_or_401(self, client, scsg0001_project_id):
+        if os.getenv('DISABLE_AUTH') == '1':
+            pytest.skip("Auth disabled in dev environment")
+        resp = client.post(
+            '/allocations/htmx/create_adjustment',
+            data=_valid_form_data(scsg0001_project_id),
+        )
+        assert resp.status_code in (302, 401)
+
+    def test_non_admin_denied(self, non_admin_client, scsg0001_project_id):
+        resp = non_admin_client.post(
+            '/allocations/htmx/create_adjustment',
+            data=_valid_form_data(scsg0001_project_id),
+        )
+        assert resp.status_code == 403
+
+    def test_missing_required_field_rerenders_form_with_error(
+        self, auth_client, scsg0001_project_id,
+    ):
+        """Marshmallow validation error → handle_htmx_form_post re-renders
+        the form fragment with the error list. No DB commit."""
+        bad = _valid_form_data(scsg0001_project_id)
+        del bad['amount']
+        resp = auth_client.post(
+            '/allocations/htmx/create_adjustment', data=bad,
+        )
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        # Error panel is inside the re-rendered form fragment.
+        assert 'alert-danger' in html
+        assert 'Amount' in html
+
+    def test_negative_amount_rerenders_form_with_error(
+        self, auth_client, scsg0001_project_id,
+    ):
+        """Schema's Range(min=0, min_inclusive=False) rejects negative input
+        — the error comes back as a re-rendered form fragment."""
+        bad = _valid_form_data(scsg0001_project_id)
+        bad['amount'] = '-5'
+        resp = auth_client.post(
+            '/allocations/htmx/create_adjustment', data=bad,
+        )
+        assert resp.status_code == 200
+        assert 'alert-danger' in resp.get_data(as_text=True)
+
+    def test_unknown_project_id_rerenders_form_with_error(self, auth_client):
+        """ValueError raised inside do_action (FK existence check) →
+        management_transaction auto-rolls back, handle_htmx_form_post
+        catches the exception and re-renders with the prefixed message."""
+        bad = _valid_form_data(project_id=999_999_999)
+        resp = auth_client.post(
+            '/allocations/htmx/create_adjustment', data=bad,
+        )
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert 'alert-danger' in html
+        assert 'Error creating adjustment' in html
+
+    def test_unsupported_type_id_rerenders_form_with_error(
+        self, auth_client, scsg0001_project_id,
+    ):
+        """Type ID 5 (Storage-Credit) passes the schema's shape check but
+        ChargeAdjustment.create() rejects it because 'Storage-Credit' is
+        not in _SIGN_BY_TYPE. The route surfaces that ValueError as a
+        form error. The error could also surface as an FK lookup failure
+        if the (project, resource) → Account join fails first — either
+        way the response carries the "Error creating adjustment" prefix."""
+        bad = _valid_form_data(scsg0001_project_id)
+        bad['charge_adjustment_type_id'] = '5'
+        resp = auth_client.post(
+            '/allocations/htmx/create_adjustment', data=bad,
+        )
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert 'alert-danger' in html
+        assert 'Error creating adjustment' in html

--- a/tests/unit/test_query_functions.py
+++ b/tests/unit/test_query_functions.py
@@ -367,7 +367,7 @@ EXPECTED_TXN_KEYS = {
     'transaction_comment', 'auth_at_panel_mtg', 'propagated',
     'projcode', 'project_id', 'resource_name', 'resource_id',
     'facility_name', 'allocation_type',
-    'user_id', 'username', 'user_full_name',
+    'user_id', 'username', 'user_display_name',
 }
 
 
@@ -516,7 +516,7 @@ class TestRecentAllocationTransactions:
         assert len(rows) == 1
         assert rows[0]['user_id'] is None
         assert rows[0]['username'] is None
-        assert rows[0]['user_full_name'] is None
+        assert rows[0]['user_display_name'] is None
 
     def test_include_deleted_hides_then_shows_soft_deleted(self, session):
         allocation = make_allocation(session)
@@ -677,7 +677,7 @@ EXPECTED_ADJ_KEYS = {
     'adjustment_id', 'account_id', 'amount', 'adjustment_date', 'comment',
     'adjustment_type',
     'projcode', 'project_id', 'resource_name', 'resource_id', 'facility_name',
-    'user_id', 'username', 'user_full_name',
+    'user_id', 'username', 'user_display_name',
 }
 
 
@@ -819,7 +819,7 @@ class TestRecentChargeAdjustments:
         assert len(rows) == 1
         assert rows[0]['user_id'] is None
         assert rows[0]['username'] is None
-        assert rows[0]['user_full_name'] is None
+        assert rows[0]['user_display_name'] is None
 
     def test_include_deleted_hides_then_shows_soft_deleted_account(self, session):
         allocation = make_allocation(session)


### PR DESCRIPTION
## Summary

Adds a staff-facing "Create Adjustment" flow on the Allocations dashboard so the Adjustments tab is no longer read-only. The legacy SAM UI silently flipped the sign of user-entered amounts based on the selected type; this replacement is explicit about intent: the user enters a positive number, picks a type (Refund / Credit / Debit / Reservation), and the server applies the sign.

### Model layer (`sam.accounting.adjustments`)

- `_SIGN_BY_TYPE` dict keyed by type name is the single source of truth for which types the webapp exposes and which direction each moves the balance (Refund/Credit → -1, Debit/Reservation → +1). Storage-* types are omitted until disk/archive support lands. Integer PKs are resolved at runtime — no parallel ID constants to drift.
- `ChargeAdjustment.supported_types(session)` → returns the exposed rows in display order (Refund first, per legacy usage).
- `ChargeAdjustment.create(...)` classmethod: validates amount > 0, resolves the type, multiplies by sign, stamps `adjustment_date=now()` and `adjusted_by_id`; no commit (caller wraps in `management_transaction`).

### Webapp (`webapp.dashboards.allocations`)

Four new HTMX routes (all `EDIT_ALLOCATIONS`):

- `GET  /htmx/create_adjustment_form` — renders the modal form.
- `GET  /htmx/project_search_for_adjustment` — fk-picker search backend.
- `GET  /htmx/resources_for_project?project_id=N` — options filtered to the project's active HPC/DAV accounts (respects `HIDDEN_RESOURCES`).
- `POST /htmx/create_adjustment` — validates via `CreateChargeAdjustmentForm`, resolves Project + Account (FK checks inline per CLAUDE.md §9), delegates to `ChargeAdjustment.create()`, fires `closeActiveModal` + `refreshAdjustmentsTab` via HX-Trigger.

Form template (`fragments/create_adjustment_form_htmx.html`):

- Type select with in-line intent boilerplate per type, grounded in `legacy_sam/doc/data_structures/charge_adjustments.md §5`.
- Project field uses `fk_search_field` (search-as-you-type) — typing `SCSG` pulls matching active projects; selection stores the integer PK.
- Resource select cascades off the picker's `fk:selected` event and `hx-include`s the hidden project_id input.

### Polish on the surrounding tabs

- Dropped Facility column from the Adjustments table; tightened Resource column; Comment column absorbs the remaining width via `width:99%`.
- Added "Alloc type" column to the Transactions table between Facility and Amount; same Resource/Comment width treatment.
- Modal title is now fragment-aware: "Allocation Transaction Details" vs "Charge Adjustment Details" (swapped in via `hx-swap-oob` from each fragment response).
- Row tooltip + detail modal now show `user.display_name` consistently — `user_full_name` query key renamed to `user_display_name` across queries, templates, and tests.

## Schema

- New `HtmxFormSchema` subclass `CreateChargeAdjustmentForm` in `src/sam/schemas/forms/adjustments.py` (exported from the package). Takes `project_id`, `resource_id`, `charge_adjustment_type_id`, `amount > 0`, optional `comment`. FK existence and type-membership are DB-backed checks that stay in the route.

## Tests

- `tests/unit/test_charge_adjustment_create.py` — sign enforcement per type, timestamp, actor, input validation, unsupported-type rejection, `supported_types()` ordering and membership.
- `tests/api/test_adjustments_form_schema.py` — shape and coercion of `CreateChargeAdjustmentForm`.
- `tests/unit/test_htmx_create_adjustment.py` — auth / 403 / re-render error paths for all three routes.
- `tests/unit/test_query_functions.py` — follows the `user_full_name` → `user_display_name` rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)