### PR TITLE
RBAC refactor

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -63,8 +63,6 @@ services:
     environment:
       - PYTHONDONTWRITEBYTECODE=1
       - PYTHONUNBUFFERED=1
-      - DISABLE_AUTH=1         # WARNING: dev-only — NEVER set in production
-      - DEV_AUTO_LOGIN_USER=benkirk  # WARNING: dev-only — NEVER set in production
       - FLASK_DEBUG=1
       - AUDIT_ENABLED=1
       - AUDIT_LOG_PATH=/var/log/sam/model_audit.log

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -99,7 +99,7 @@ app (session-scoped)
 `TestingConfig` is loaded via `FLASK_CONFIG=testing`. Key properties:
 - `TESTING = True`, `WTF_CSRF_ENABLED = False`
 - `ALLOCATION_USAGE_CACHE_TTL = 0` (caching disabled)
-- `DEV_ROLE_MAPPING` gives `benkirk` the admin role
+- `USER_PERMISSION_OVERRIDES['benkirk']` (in `webapp.utils.rbac`) gives `benkirk` the full Permission set
 - `NullCache` for Flask-Caching (no `@cache.cached` interference)
 
 ---

--- a/docs/plans/TEST_SUITE_RESIDUALS.md
+++ b/docs/plans/TEST_SUITE_RESIDUALS.md
@@ -42,7 +42,7 @@ are done. Key milestones:
 
 - **Snapshot hash lock (`snapshot.lock` + `make test-snapshot-rehash`)** — replaced with the representative-fixture strategy, which solves the same value-drift problem differently. Tests don't assert on exact values from the snapshot; they use "any row of shape X" fixtures that survive snapshot refreshes as long as one row of the required shape exists. Could revisit if a snapshot refresh breaks the suite in practice.
 - **Per-worker MySQL DB cloning for `system_status`** — replaced with per-worker SQLite tempfile, which is ~25 lines of fixture code vs ~80 lines of the original plan's env-var-ordered MySQL setup.
-- **`TESTING_AUTO_LOGIN_USER` auth bypass config** — not needed. `TestingConfig.DEV_ROLE_MAPPING` + Flask-Login session cookies gave us the `auth_client` fixture without the bypass.
+- **`TESTING_AUTO_LOGIN_USER` auth bypass config** — not needed. `USER_PERMISSION_OVERRIDES['benkirk']` + Flask-Login session cookies gave us the `auth_client` fixture without the bypass.
 - **Legacy API parity tests** — dropped (28 tests). Required `SAM_LEGACY_USER/PASS` + `PROD_SAM_DB_*` env vars to cross-check against the live `sam.ucar.edu` legacy API. Never runnable in CI; skipped in practice.
 - **Most of `test_sam_search_cli.py` subprocess coverage (44 of 61 tests)** — redundant with the ported CliRunner version (`tests/unit/test_sam_search_cli.py` + `test_sam_search_cli_allocations.py`). One subprocess smoke (`tests/integration/test_cli_smoke.py`) retains entry-point verification.
 - **ORM `Mapped[]` migration** — out of scope per the original plan; stays out of scope.

--- a/src/webapp/QUICK_START_RBAC.md
+++ b/src/webapp/QUICK_START_RBAC.md
@@ -1,156 +1,91 @@
-# Quick Start Guide: Testing RBAC with Read-Only Database
+# Quick Start Guide: Testing RBAC
 
-This guide shows how to test the authentication and RBAC system with a read-only database connection.
+This guide shows how to test the authentication and RBAC system locally.
 
-## Step 1: Configure Dev Roles
+## How permissions resolve
 
-Edit `src/webapp/run.py` around line 27-37 and add your SAM username:
+A user's permission set is the union of:
+
+1. **POSIX group bundles** — for each group the user belongs to
+   (`get_user_group_access()`), if that group name has a key in
+   `GROUP_PERMISSIONS` (`webapp/utils/rbac.py`), the bundle's
+   permissions are added. Currently defined bundles: `csg`, `nusd`,
+   `hsg`.
+2. **Per-user overrides** — `USER_PERMISSION_OVERRIDES` in
+   `webapp/utils/rbac.py` grants specific `Permission` enum members to
+   individual usernames on top of their group bundles.
+
+There is **no** dependency on the SAM `role_user` / `role` tables and
+no dev-only bypass mapping — dev, test, and production all use the
+same two-layer model.
+
+## Step 1: Grant yourself permissions
+
+Edit `src/webapp/utils/rbac.py` and add your SAM username to
+`USER_PERMISSION_OVERRIDES`:
 
 ```python
-app.config['DEV_ROLE_MAPPING'] = {
-    'your_sam_username': ['admin'],  # Replace with your actual username
+USER_PERMISSION_OVERRIDES = {
+    'your_sam_username': set(Permission),  # full admin equivalent
+    # 'view_only_user': {Permission.VIEW_PROJECTS, Permission.VIEW_ALLOCATIONS},
 }
 ```
 
-## Step 2: Start the Server
+## Step 2: Start the server
 
 ```bash
-cd src/webapp
-python run.py
+docker compose up webdev --watch
 ```
 
-You should see:
-```
-* Running on http://127.0.0.1:5050
-```
+The application is available at `http://localhost:5050`.
 
 ## Step 3: Login
 
-1. Navigate to `http://localhost:5050`
-2. You'll be redirected to the login page
-3. Enter:
-   - **Username**: Your SAM username (from step 1)
-   - **Password**: Any non-empty text (e.g., "test")
-4. Click "Login"
+The dev login page shows a "Quick Login" panel of test usernames
+(driven by `DEV_QUICK_LOGIN_USERS` in `webapp/config.py:DevelopmentConfig`).
+Click any username — stub auth accepts any password — then verify the
+expected tabs appear in the navbar.
 
-## Step 4: Verify Your Roles
+## Step 4: Verify your permissions
 
-After login, go to `http://localhost:5050/auth/profile`
+Visit `http://localhost:5050/auth/profile` to see your username, the
+`roles` set (POSIX-group names with `GROUP_PERMISSIONS` bundles), and
+the resolved permission set.
 
-You should see:
-- Your username
-- Your assigned roles (e.g., "admin")
-- All permissions granted to that role
+## Step 5: Test individual permissions
 
-## Step 5: Test RBAC
-
-### As Admin (full access):
-- Navigate to `/admin` - Should see full dashboard
-- Click "Users" - Can view, edit, create, delete users
-- Click "Projects" - Can view, edit, create, delete projects
-- Click "Allocations" - Can view and edit allocations
-
-### Testing Other Roles:
-
-Change your role in `run.py`:
+To test a narrower permission set without disturbing real group
+membership, point `USER_PERMISSION_OVERRIDES` at a specific subset:
 
 ```python
-app.config['DEV_ROLE_MAPPING'] = {
-    'your_username': ['facility_manager'],  # Try different roles
+USER_PERMISSION_OVERRIDES = {
+    'your_username': {
+        Permission.VIEW_PROJECTS,
+        Permission.VIEW_ALLOCATIONS,
+        Permission.EXPORT_DATA,
+    },
 }
 ```
 
-Restart the server and login again.
+Restart the server (or rely on `--watch` to pick up the change) and
+re-login to verify only the matching tabs and action buttons appear.
 
-#### As facility_manager:
-- Can view and edit projects
-- Can view and edit allocations
-- Can view users (but not edit them)
-- Can export data
+## Reference: bundle contents
 
-#### As project_lead:
-- Can view projects and allocations
-- Cannot edit anything
-- Cannot access user management
-
-#### As user:
-- Very limited read-only access
-- Can view projects they're on
-- Can view allocations
-
-## Step 6: Test Multiple Users
-
-You can configure multiple users with different roles:
-
-```python
-app.config['DEV_ROLE_MAPPING'] = {
-    'admin_user': ['admin'],
-    'manager_user': ['facility_manager'],
-    'lead_user': ['project_lead'],
-    'regular_user': ['user'],
-}
-```
-
-Login with each username to test different permission levels.
-
-## Role → Permission Reference
-
-| What You Can Do | admin | facility_manager | project_lead | user |
-|----------------|-------|------------------|--------------|------|
-| View Users | ✓ | ✓ | ✓ | ✗ |
-| Edit Users | ✓ | ✗ | ✗ | ✗ |
-| View Projects | ✓ | ✓ | ✓ | ✓ |
-| Edit Projects | ✓ | ✓ | ✗ | ✗ |
-| View Allocations | ✓ | ✓ | ✓ | ✓ |
-| Edit Allocations | ✓ | ✓ | ✗ | ✗ |
-| View Resources | ✓ | ✓ | ✗ | ✗ |
-| Edit Resources | ✓ | ✓ | ✗ | ✗ |
-| Export Data | ✓ | ✓ | ✗ | ✗ |
-| System Stats | ✓ | ✓ | ✗ | ✗ |
-
-## Testing Checklist
-
-- [ ] Can login with any SAM username
-- [ ] Profile page shows correct roles
-- [ ] Admin can access all views
-- [ ] Non-admin has limited access
-- [ ] Edit buttons hidden for users without permissions
-- [ ] Unauthorized access redirects or shows error
-- [ ] Logout works correctly
+The current real-group bundles in `GROUP_PERMISSIONS` are documented
+inline in `webapp/utils/rbac.py`. They are still provisional — confirm
+the actual `csg` / `nusd` / `hsg` permission contents with the team
+before relying on them in production.
 
 ## Troubleshooting
 
-### "No roles assigned" on profile page
-- Check that username in `DEV_ROLE_MAPPING` exactly matches your SAM username
-- Restart the Flask server after changing configuration
-
-### "Please log in to access this page"
-- Session expired, login again
-- Or authentication is working correctly!
-
-### Can see views but can't edit/create/delete
-- Your role doesn't have those permissions
-- Check role permissions in `config_example.py`
-
-### "Invalid username or password"
-- Username doesn't exist in SAM database
-- User account is locked or inactive
-
-## Next Steps
-
-Once RBAC testing is complete:
-
-1. **For Production**: Transition to database roles
-   - Create `role` and `role_user` tables
-   - Uncomment database role code in `auth/models.py`
-   - Remove or clear `DEV_ROLE_MAPPING`
-
-2. **For Enterprise Auth**: Switch from stub to LDAP/SAML
-   - Implement `LDAPAuthProvider` or `SAMLAuthProvider`
-   - Update `AUTH_PROVIDER` config
-   - Map LDAP/SAML groups to SAM roles
-
-3. **Customize Permissions**: Edit `utils/rbac.py`
-   - Add new permissions
-   - Adjust role mappings
-   - Create custom permission checks
+- **"No roles assigned" on profile page** — your username has no POSIX
+  group with a `GROUP_PERMISSIONS` bundle and no
+  `USER_PERMISSION_OVERRIDES` entry. Add one or check group membership
+  in `adhoc_system_account_entry`.
+- **Edit buttons missing** — the role/permission gating macros in
+  `templates/dashboards/fragments/action_buttons.html` are hiding them.
+  Check what permissions the action requires (route decorator or
+  `@require_project_permission`) and confirm your user has them.
+- **"Invalid username or password"** — username doesn't exist in SAM
+  or the account is locked/inactive.

--- a/src/webapp/README.md
+++ b/src/webapp/README.md
@@ -32,44 +32,21 @@ SAM_DB_USERNAME=your-username
 SAM_DB_PASSWORD=your-password
 ```
 
-### 3. Configure Development Roles
+### 3. Configure Permissions
 
-**For Read-Only Database (Development):**
+The webapp resolves a user's permissions from two sources, unioned:
 
-Edit `src/webapp/run.py` and add your username to the `DEV_ROLE_MAPPING`:
+1. **POSIX group membership** — `get_user_group_access()` reads
+   `adhoc_system_account_entry`. Groups that have a bundle in
+   `GROUP_PERMISSIONS` (currently `csg`, `nusd`, `hsg`) confer that
+   bundle to anyone in the group.
+2. **`USER_PERMISSION_OVERRIDES`** in `webapp/utils/rbac.py` — a
+   per-username dict for one-off grants on top of group bundles.
 
-```python
-app.config['DEV_ROLE_MAPPING'] = {
-    'your_username': ['admin'],          # Full access
-    # 'other_user': ['facility_manager'], # Limited access
-    # 'test_user': ['user'],              # Read-only
-}
-```
-
-Available roles: `admin`, `facility_manager`, `project_lead`, `user`, `analyst`
-
-See `config_example.py` for detailed role/permission mappings.
-
-**For Production Database (Future):**
-
-When you have write access, create roles in the database:
-
-```sql
--- Create test roles
-INSERT INTO role (name, description) VALUES
-  ('admin', 'System Administrator'),
-  ('facility_manager', 'Facility Manager'),
-  ('project_lead', 'Project Lead'),
-  ('user', 'Regular User');
-
--- Assign admin role to your user
-INSERT INTO role_user (role_id, user_id)
-SELECT r.role_id, u.user_id
-FROM role r, users u
-WHERE r.name = 'admin' AND u.username = 'your_username';
-```
-
-Then uncomment the database role code in `auth/models.py` (line 93) and remove `DEV_ROLE_MAPPING`.
+To grant yourself elevated permissions in dev, add your username to
+`USER_PERMISSION_OVERRIDES` (e.g. `'your_username': set(Permission)`
+for full access). No DB writes, no fake role tables — same code path
+as production.
 
 ### 4. Run Development Server
 

--- a/src/webapp/api/access_control.py
+++ b/src/webapp/api/access_control.py
@@ -23,6 +23,7 @@ from typing import Callable, Any
 
 from webapp.extensions import db
 from webapp.utils.rbac import has_permission, Permission
+from webapp.utils.project_permissions import _is_project_steward
 from webapp.api.helpers import get_project_or_404
 
 
@@ -148,6 +149,102 @@ def require_project_member_access(permission: Permission) -> Callable:
                 return f(project, *args, **kwargs)
 
             abort(403)
+
+        return decorated_function
+    return decorator
+
+
+def require_project_permission(
+    permission: Permission, *, include_ancestors: bool = False
+) -> Callable:
+    """
+    Decorator factory for project-mutating routes.
+
+    Grants access if the user has ``permission`` system-wide OR is the
+    project's lead/admin (optionally walking the project tree).
+    Resolves ``<projcode>`` from the URL and passes the ``project``
+    object to the decorated function.
+
+    This is the right decorator for project-scoped mutations (member
+    add/remove, threshold edits, allocation redistribution within a
+    subtree). For pure read access where any project member should
+    be allowed, use ``require_project_member_access`` instead.
+
+    Args:
+        permission: System-wide permission that grants access without
+            consulting project-level roles.
+        include_ancestors: If True, lead/admin of any ancestor project
+            counts. Use this for operations that act on a subtree
+            (e.g. allocation redistribution).
+
+    Usage:
+        @bp.route('/<projcode>/members', methods=['POST'])
+        @login_required
+        @require_project_permission(Permission.EDIT_PROJECT_MEMBERS)
+        def add_member(project):
+            ...
+    """
+    def decorator(f: Callable) -> Callable:
+        @wraps(f)
+        def decorated_function(projcode: str, *args, **kwargs):
+            project, error = get_project_or_404(db.session, projcode)
+            if error:
+                return error
+
+            if not _is_project_steward(
+                current_user, project, permission, include_ancestors=include_ancestors
+            ):
+                abort(403)
+
+            return f(project, *args, **kwargs)
+
+        return decorated_function
+    return decorator
+
+
+def require_allocation_permission(permission: Permission) -> Callable:
+    """
+    Decorator factory for allocation-mutating routes.
+
+    Resolves ``<allocation_id>`` (or ``<int:allocation_id>``) from the
+    URL to an Allocation, walks ``allocation.account.project``, and
+    grants access if the user has ``permission`` system-wide OR is
+    lead/admin of the allocation's project or any ancestor (covers
+    redistribution within a subtree the user owns).
+
+    Passes the ``allocation`` object to the decorated function in
+    place of ``allocation_id``.
+
+    Usage:
+        @bp.route('/<int:allocation_id>', methods=['PUT'])
+        @login_required
+        @require_allocation_permission(Permission.EDIT_ALLOCATIONS)
+        def update_allocation(allocation):
+            ...
+    """
+    # Late import: Allocation lives in sam.accounting and importing it
+    # at module load triggers the SAM ORM init chain.
+    from sam.accounting.allocations import Allocation
+
+    def decorator(f: Callable) -> Callable:
+        @wraps(f)
+        def decorated_function(allocation_id: int, *args, **kwargs):
+            allocation = db.session.get(Allocation, int(allocation_id))
+            if allocation is None:
+                abort(404)
+
+            account = allocation.account
+            project = account.project if account is not None else None
+            if project is None:
+                # Orphaned allocation — no project to authorize against.
+                abort(403)
+
+            if not _is_project_steward(
+                current_user, project, permission, include_ancestors=True
+            ):
+                abort(403)
+
+            return f(allocation, *args, **kwargs)
 
         return decorated_function
     return decorator

--- a/src/webapp/api/v1/allocations.py
+++ b/src/webapp/api/v1/allocations.py
@@ -16,6 +16,7 @@ from sam.schemas import AllocationWithUsageSchema
 from sam import Allocation
 from sam.manage import update_allocation, management_transaction
 from webapp.api.helpers import register_error_handlers
+from webapp.api.access_control import require_allocation_permission
 from sam.schemas.forms import EditAllocationForm
 from marshmallow import ValidationError
 from datetime import datetime
@@ -61,8 +62,8 @@ def get_allocation(allocation_id):
 
 @bp.route('/<int:allocation_id>', methods=['PUT'])
 @login_required
-@require_permission(Permission.EDIT_ALLOCATIONS)
-def update_allocation_endpoint(allocation_id):
+@require_allocation_permission(Permission.EDIT_ALLOCATIONS)
+def update_allocation_endpoint(allocation):
     """
     PUT /api/v1/allocations/<allocation_id> - Update allocation with audit logging.
 
@@ -76,11 +77,10 @@ def update_allocation_endpoint(allocation_id):
         JSON with updated allocation details
 
     Requires:
-        EDIT_ALLOCATIONS permission
+        EDIT_ALLOCATIONS permission, OR project lead/admin of the
+        allocation's project (or any ancestor in its tree).
     """
-    allocation = db.session.get(Allocation, allocation_id)
-    if not allocation:
-        return jsonify({'error': f'Allocation {allocation_id} not found'}), 404
+    allocation_id = allocation.allocation_id
 
     # Get data from JSON body
     data = request.get_json()

--- a/src/webapp/api/v1/health.py
+++ b/src/webapp/api/v1/health.py
@@ -9,11 +9,12 @@ Intended consumers:
 from datetime import datetime
 
 from flask import Blueprint, jsonify
-from flask_login import login_required, current_user
+from flask_login import login_required
 from sqlalchemy import text
 
 from webapp.extensions import db
 from webapp.api.helpers import register_error_handlers
+from webapp.utils.rbac import require_permission, Permission
 
 bp = Blueprint('api_health', __name__)
 register_error_handlers(bp)
@@ -100,14 +101,13 @@ def readiness():
 
 @bp.route('/db-pool', methods=['GET'])
 @login_required
+@require_permission(Permission.SYSTEM_ADMIN)
 def db_pool():
-    """Connection pool statistics for all configured DB engines (admin only).
+    """Connection pool statistics for all configured DB engines.
 
     Returns pool size, utilisation, overflow, and a health assessment
-    for each configured engine bind.
+    for each configured engine bind. Requires SYSTEM_ADMIN permission.
     """
-    if 'admin' not in current_user.roles:
-        return jsonify({'error': 'Admin access required'}), 403
 
     def _pool_stats(pool):
         size = pool.size()

--- a/src/webapp/api/v1/projects.py
+++ b/src/webapp/api/v1/projects.py
@@ -19,7 +19,11 @@ from sam.schemas import (
     AllocationWithUsageSchema, UserSummarySchema, CompJobSchema
 )
 from webapp.api.helpers import register_error_handlers, get_project_or_404, parse_date_range
-from webapp.api.access_control import require_project_access, require_project_member_access
+from webapp.api.access_control import (
+    require_project_access,
+    require_project_member_access,
+    require_project_permission,
+)
 from datetime import datetime, timedelta
 
 bp = Blueprint('api_projects', __name__)
@@ -386,7 +390,8 @@ def get_recently_expired_projects():
 
 @bp.route('/<projcode>/members', methods=['POST'])
 @login_required
-def add_member(projcode):
+@require_project_permission(Permission.EDIT_PROJECT_MEMBERS)
+def add_member(project):
     """
     POST /api/v1/projects/<projcode>/members - Add a member to a project.
 
@@ -400,16 +405,8 @@ def add_member(projcode):
     """
     from sam.manage import add_user_to_project, management_transaction
     from sam.core.users import User
-    from webapp.utils.project_permissions import can_manage_project_members
     from sam.schemas.forms import AddMemberForm
     from marshmallow import ValidationError
-
-    project, error = get_project_or_404(db.session, projcode)
-    if error:
-        return error
-
-    if not can_manage_project_members(current_user, project):
-        return jsonify({'error': 'Unauthorized - insufficient permissions'}), 403
 
     # Validate and coerce input (dates, ordering) via form schema
     data = request.get_json() or request.form
@@ -437,7 +434,7 @@ def add_member(projcode):
 
     return jsonify({
         'success': True,
-        'message': f'Added {username} to project {projcode}',
+        'message': f'Added {username} to project {project.projcode}',
         'member': {
             'username': user.username,
             'display_name': user.display_name,
@@ -448,7 +445,8 @@ def add_member(projcode):
 
 @bp.route('/<projcode>/members/<username>', methods=['DELETE'])
 @login_required
-def remove_member(projcode, username):
+@require_project_permission(Permission.EDIT_PROJECT_MEMBERS)
+def remove_member(project, username):
     """
     DELETE /api/v1/projects/<projcode>/members/<username> - Remove a member from a project.
 
@@ -457,14 +455,6 @@ def remove_member(projcode, username):
     """
     from sam.manage import remove_user_from_project, management_transaction
     from sam.core.users import User
-    from webapp.utils.project_permissions import can_manage_project_members
-
-    project, error = get_project_or_404(db.session, projcode)
-    if error:
-        return error
-
-    if not can_manage_project_members(current_user, project):
-        return jsonify({'error': 'Unauthorized - insufficient permissions'}), 403
 
     user = db.session.query(User).filter_by(username=username).first()
     if not user:
@@ -480,7 +470,7 @@ def remove_member(projcode, username):
 
     return jsonify({
         'success': True,
-        'message': f'Removed {username} from project {projcode}'
+        'message': f'Removed {username} from project {project.projcode}'
     })
 
 

--- a/src/webapp/auth/blueprint.py
+++ b/src/webapp/auth/blueprint.py
@@ -52,8 +52,8 @@ def login():
         sam_user = provider.authenticate(username, password)
 
         if sam_user:
-            dev_role_mapping = current_app.config.get('DEV_ROLE_MAPPING', {})
-            auth_user = AuthUser(sam_user, dev_role_mapping=dev_role_mapping)
+            dev_group_mapping = current_app.config.get('DEV_GROUP_MAPPING', {})
+            auth_user = AuthUser(sam_user, dev_group_mapping=dev_group_mapping)
 
             remember = request.form.get('remember', False)
             login_user(auth_user, remember=remember)
@@ -67,8 +67,8 @@ def login():
             logger.warning("Login failed (stub): user=%s", username)
             flash('Invalid username or password', 'error')
 
-    dev_role_mapping = current_app.config.get('DEV_ROLE_MAPPING', {})
-    test_users = {u: r for u, r in dev_role_mapping.items()}
+    dev_group_mapping = current_app.config.get('DEV_GROUP_MAPPING', {})
+    test_users = {u: r for u, r in dev_group_mapping.items()}
 
     return render_template(
         'auth/login.html',
@@ -125,8 +125,8 @@ def oidc_callback():
         flash('Your account was not found in SAM or is inactive.', 'error')
         return redirect(url_for('auth.login'))
 
-    dev_role_mapping = current_app.config.get('DEV_ROLE_MAPPING', {})
-    auth_user = AuthUser(sam_user, dev_role_mapping=dev_role_mapping)
+    dev_group_mapping = current_app.config.get('DEV_GROUP_MAPPING', {})
+    auth_user = AuthUser(sam_user, dev_group_mapping=dev_group_mapping)
     login_user(auth_user, remember=False)
     logger.info("OIDC login success: user=%s", sam_user.username)
 

--- a/src/webapp/auth/blueprint.py
+++ b/src/webapp/auth/blueprint.py
@@ -59,8 +59,7 @@ def login():
         sam_user = provider.authenticate(username, password)
 
         if sam_user:
-            dev_group_mapping = current_app.config.get('DEV_GROUP_MAPPING', {})
-            auth_user = AuthUser(sam_user, dev_group_mapping=dev_group_mapping)
+            auth_user = AuthUser(sam_user)
 
             remember = request.form.get('remember', False)
             login_user(auth_user, remember=remember)
@@ -74,8 +73,13 @@ def login():
             logger.warning("Login failed (stub): user=%s", username)
             flash('Invalid username or password', 'error')
 
-    dev_group_mapping = current_app.config.get('DEV_GROUP_MAPPING', {})
-    test_users = {u: r for u, r in dev_group_mapping.items()}
+    # DEV_QUICK_LOGIN_USERS entries are 'username[:LABEL]' strings.
+    # Split into (username, label) pairs for the template — label is
+    # an optional cosmetic badge, blank for bare usernames.
+    test_users = [
+        tuple((entry.split(':', 1) + [''])[:2])
+        for entry in current_app.config.get('DEV_QUICK_LOGIN_USERS', [])
+    ]
 
     return render_template(
         'auth/login.html',
@@ -132,8 +136,7 @@ def oidc_callback():
         flash('Your account was not found in SAM or is inactive.', 'error')
         return redirect(url_for('auth.login'))
 
-    dev_group_mapping = current_app.config.get('DEV_GROUP_MAPPING', {})
-    auth_user = AuthUser(sam_user, dev_group_mapping=dev_group_mapping)
+    auth_user = AuthUser(sam_user)
     login_user(auth_user, remember=False)
     logger.info("OIDC login success: user=%s", sam_user.username)
 

--- a/src/webapp/auth/blueprint.py
+++ b/src/webapp/auth/blueprint.py
@@ -25,8 +25,15 @@ def _is_safe_redirect(target: str) -> bool:
 
 
 def _redirect_for_role(auth_user):
-    """Redirect to admin or user dashboard based on roles."""
-    if auth_user.has_role('admin'):
+    """Redirect to admin or user dashboard based on permissions.
+
+    Gated on the same permission that gates the Admin nav tab so the
+    redirect target is always something the user can actually access —
+    including users granted admin via USER_PERMISSION_OVERRIDES rather
+    than a group bundle.
+    """
+    from webapp.utils.rbac import has_permission, Permission
+    if has_permission(auth_user, Permission.IMPERSONATE_USERS):
         return redirect(url_for('admin_dashboard.index'))
     return redirect(url_for('user_dashboard.index'))
 

--- a/src/webapp/auth/blueprint.py
+++ b/src/webapp/auth/blueprint.py
@@ -26,7 +26,7 @@ def _is_safe_redirect(target: str) -> bool:
 
 def _redirect_for_role(auth_user):
     """Redirect to admin or user dashboard based on roles."""
-    if 'admin' in auth_user.roles:
+    if auth_user.has_role('admin'):
         return redirect(url_for('admin_dashboard.index'))
     return redirect(url_for('user_dashboard.index'))
 

--- a/src/webapp/auth/blueprint.py
+++ b/src/webapp/auth/blueprint.py
@@ -33,7 +33,7 @@ def _redirect_for_role(auth_user):
     than a group bundle.
     """
     from webapp.utils.rbac import has_permission, Permission
-    if has_permission(auth_user, Permission.IMPERSONATE_USERS):
+    if has_permission(auth_user, Permission.ACCESS_ADMIN_DASHBOARD):
         return redirect(url_for('admin_dashboard.index'))
     return redirect(url_for('user_dashboard.index'))
 

--- a/src/webapp/auth/models.py
+++ b/src/webapp/auth/models.py
@@ -25,30 +25,21 @@ class AuthUser(UserMixin):
     have a bundle in ``GROUP_PERMISSIONS`` (i.e. groups that confer
     permissions).
 
-    In production, group membership comes from
-    ``adhoc_system_account_entry`` via ``get_user_group_access()``.
-    In dev/test, ``dev_group_mapping`` (passed by the Flask app's
-    ``DEV_GROUP_MAPPING`` config) supplies synthetic group names per
-    username, bypassing the database lookup.
+    Group membership comes from ``adhoc_system_account_entry`` via
+    ``get_user_group_access()`` — in dev, test, and production alike.
+    Per-user incremental grants live in ``USER_PERMISSION_OVERRIDES``.
 
     The SAM ``role_user`` / ``role`` tables are **not** consulted.
     """
 
-    def __init__(self, sam_user: User, dev_group_mapping: dict = None):
+    def __init__(self, sam_user: User):
         """
         Initialize with a SAM User object.
 
         Args:
             sam_user: SAM User ORM object
-            dev_group_mapping: Optional dict mapping username -> list of
-                group names. Bypasses the POSIX group lookup; used in
-                dev/test where the database may be read-only or the
-                user's real adhoc-group membership doesn't reflect the
-                permissions we want to grant for testing.
-                Example: {'admin_user': ['admin'], 'test_user': ['user']}
         """
         self.sam_user = sam_user
-        self.dev_group_mapping = dev_group_mapping or {}
         self._roles = None
 
     def get_id(self):
@@ -75,28 +66,17 @@ class AuthUser(UserMixin):
         """
         Get group-bundle names the user belongs to, as a set.
 
-        Only includes groups that have a bundle in ``GROUP_PERMISSIONS``
-        (groups conferring no permissions are filtered out — they're
-        irrelevant to authorization).
+        Derived from POSIX group membership (``get_user_group_access``),
+        filtered to groups that actually have a ``GROUP_PERMISSIONS``
+        bundle — groups conferring no permissions are noise as far as
+        RBAC is concerned.
 
-        Priority:
-        1. ``dev_group_mapping`` if the username has an entry there
-           (used in dev/test to bypass the DB)
-        2. POSIX group membership from ``get_user_group_access()``
-        3. Empty set (no group bundles matched)
-
-        The result is cached on the instance.
+        Cached on the instance.
         """
         if self._roles is None:
-            if self.username in self.dev_group_mapping:
-                candidate_groups = set(self.dev_group_mapping[self.username])
-            else:
-                candidate_groups = self._posix_group_names()
-
-            # Filter to bundle-conferring groups. Other group memberships
-            # are noise as far as RBAC is concerned.
-            self._roles = {g for g in candidate_groups if g in GROUP_PERMISSIONS}
-
+            self._roles = {
+                g for g in self._posix_group_names() if g in GROUP_PERMISSIONS
+            }
         return self._roles
 
     def _posix_group_names(self) -> set:

--- a/src/webapp/auth/models.py
+++ b/src/webapp/auth/models.py
@@ -5,7 +5,10 @@ This provides a thin adapter between SAM's User model and Flask-Login's requirem
 """
 
 from flask_login import UserMixin
+from sqlalchemy.orm import Session
+
 from sam.core.users import User
+from webapp.utils.rbac import GROUP_PERMISSIONS
 
 
 class AuthUser(UserMixin):
@@ -15,22 +18,37 @@ class AuthUser(UserMixin):
     Wraps a SAM User object to provide Flask-Login required methods.
     This allows us to use SAM's existing User model without modification.
 
-    Supports both database-backed roles (via role_user table) and
-    hard-coded development roles (via dev_role_mapping config).
+    Authorization model
+    -------------------
+    The user's permissions are derived from POSIX group membership.
+    ``self.roles`` is the set of group names the user belongs to that
+    have a bundle in ``GROUP_PERMISSIONS`` (i.e. groups that confer
+    permissions).
+
+    In production, group membership comes from
+    ``adhoc_system_account_entry`` via ``get_user_group_access()``.
+    In dev/test, ``dev_group_mapping`` (passed by the Flask app's
+    ``DEV_GROUP_MAPPING`` config) supplies synthetic group names per
+    username, bypassing the database lookup.
+
+    The SAM ``role_user`` / ``role`` tables are **not** consulted.
     """
 
-    def __init__(self, sam_user: User, dev_role_mapping: dict = None):
+    def __init__(self, sam_user: User, dev_group_mapping: dict = None):
         """
         Initialize with a SAM User object.
 
         Args:
             sam_user: SAM User ORM object
-            dev_role_mapping: Optional dict mapping username -> list of roles
-                             For development with read-only database.
-                             Example: {'admin_user': ['admin'], 'test_user': ['user']}
+            dev_group_mapping: Optional dict mapping username -> list of
+                group names. Bypasses the POSIX group lookup; used in
+                dev/test where the database may be read-only or the
+                user's real adhoc-group membership doesn't reflect the
+                permissions we want to grant for testing.
+                Example: {'admin_user': ['admin'], 'test_user': ['user']}
         """
         self.sam_user = sam_user
-        self.dev_role_mapping = dev_role_mapping or {}
+        self.dev_group_mapping = dev_group_mapping or {}
         self._roles = None
 
     def get_id(self):
@@ -55,27 +73,60 @@ class AuthUser(UserMixin):
     @property
     def roles(self):
         """
-        Get user's role names as a set.
+        Get group-bundle names the user belongs to, as a set.
+
+        Only includes groups that have a bundle in ``GROUP_PERMISSIONS``
+        (groups conferring no permissions are filtered out — they're
+        irrelevant to authorization).
 
         Priority:
-        1. Hard-coded dev_role_mapping (for read-only database)
-        2. Database role_assignments (for production)
-        3. Empty set (no roles)
+        1. ``dev_group_mapping`` if the username has an entry there
+           (used in dev/test to bypass the DB)
+        2. POSIX group membership from ``get_user_group_access()``
+        3. Empty set (no group bundles matched)
+
+        The result is cached on the instance.
         """
         if self._roles is None:
-            if self.username in self.dev_role_mapping:
-                self._roles = set(self.dev_role_mapping[self.username])
+            if self.username in self.dev_group_mapping:
+                candidate_groups = set(self.dev_group_mapping[self.username])
             else:
-                self._roles = {ra.role.name for ra in self.sam_user.role_assignments}
+                candidate_groups = self._posix_group_names()
+
+            # Filter to bundle-conferring groups. Other group memberships
+            # are noise as far as RBAC is concerned.
+            self._roles = {g for g in candidate_groups if g in GROUP_PERMISSIONS}
 
         return self._roles
 
+    def _posix_group_names(self) -> set:
+        """
+        Look up POSIX group names for this user via SAM's
+        ``get_user_group_access()`` query.
+
+        Returns the set of unique group names across all access branches
+        (we don't filter by branch here — a group bundle applies whenever
+        the user is a member of that group on any branch).
+
+        Returns an empty set if no session is bound to the wrapped User
+        object (e.g. the User was detached from its session).
+        """
+        # Late import to avoid circular: AuthUser is imported very early.
+        from sam.queries.lookups import get_user_group_access
+
+        session = Session.object_session(self.sam_user)
+        if session is None:
+            return set()
+
+        rows = get_user_group_access(session, username=self.username).get(self.username, [])
+        return {r['group_name'] for r in rows}
+
     def has_role(self, role_name: str) -> bool:
-        """Check if user has a specific role."""
+        """Check if user has a specific group bundle."""
         return role_name in self.roles
 
     def has_any_role(self, *role_names) -> bool:
-        """Check if user has any of the specified roles."""
+        """Check if user has any of the specified group bundles."""
         return bool(self.roles.intersection(role_names))
 
     def __repr__(self):

--- a/src/webapp/config.py
+++ b/src/webapp/config.py
@@ -75,8 +75,9 @@ class DevelopmentConfig(SAMWebappConfig):
         'collector': '$2b$12$X8NQvOUvyrj80Ud3N6Y.0uZs70ZC6lJYy/zfka/v7uQQFKJhds0b2',
     }
 
-    # Development role mapping (bypasses role DB tables)
-    DEV_ROLE_MAPPING = {
+    # Development group mapping (bypasses POSIX group lookup)
+    # Values are GROUP_PERMISSIONS bundle names — see webapp.utils.rbac.
+    DEV_GROUP_MAPPING = {
         'benkirk':  ['admin'],
         'mtrahan':  ['facility_manager'],
         'rory':     ['project_lead'],
@@ -135,11 +136,11 @@ class TestingConfig(SAMWebappConfig):
     ALLOCATION_USAGE_CACHE_TTL  = 0
     ALLOCATION_USAGE_CACHE_SIZE = 0
 
-    # Role mapping for the auth_client fixture — mirrors DevelopmentConfig so
-    # test users resolve to the same permissions they did when tests were
+    # Group mapping for the auth_client fixture — mirrors DevelopmentConfig
+    # so test users resolve to the same permissions they did when tests were
     # inadvertently running under DevelopmentConfig. Consumed by
-    # run.py:load_user via AuthUser(dev_role_mapping=...).
-    DEV_ROLE_MAPPING = {
+    # run.py:load_user via AuthUser(dev_group_mapping=...).
+    DEV_GROUP_MAPPING = {
         'benkirk':  ['admin'],
         'mtrahan':  ['facility_manager'],
         'rory':     ['project_lead'],

--- a/src/webapp/config.py
+++ b/src/webapp/config.py
@@ -75,17 +75,24 @@ class DevelopmentConfig(SAMWebappConfig):
         'collector': '$2b$12$X8NQvOUvyrj80Ud3N6Y.0uZs70ZC6lJYy/zfka/v7uQQFKJhds0b2',
     }
 
-    # Development group mapping (bypasses POSIX group lookup)
-    # Values are GROUP_PERMISSIONS bundle names — see webapp.utils.rbac.
-    DEV_GROUP_MAPPING = {
-        'benkirk':  ['admin'],
-        'mtrahan':  ['facility_manager'],
-        'rory':     ['project_lead'],
-        'andersnb': ['user'],
-        'negins':   ['user'],
-        'bdobbins': ['user'],
-        'tcraig':   ['user'],
-    }
+    # Usernames rendered as "Quick Login" buttons on the dev login page.
+    # Format: 'username[:LABEL]'. The optional ':LABEL' suffix is shown
+    # as a badge on the button so reviewers can see at a glance what
+    # permission tier a given test account is expected to land in.
+    # Bare usernames (no colon) are rendered without a badge.
+    #
+    # The label is purely cosmetic — actual permissions still resolve
+    # through POSIX groups + USER_PERMISSION_OVERRIDES (see
+    # webapp.utils.rbac), so an out-of-date label here cannot grant or
+    # revoke access; keep it in sync by hand.
+    DEV_QUICK_LOGIN_USERS = [
+        'benkirk:ADMIN',
+        'mtrahan:CSG',
+        'rory:CSG',
+        'andersnb:HSG',
+        'tfair:NUSD',
+        'bdobbins',
+    ]
 
 
 class ProductionConfig(SAMWebappConfig):
@@ -135,20 +142,6 @@ class TestingConfig(SAMWebappConfig):
     # Disable usage cache in tests to prevent cross-test pollution
     ALLOCATION_USAGE_CACHE_TTL  = 0
     ALLOCATION_USAGE_CACHE_SIZE = 0
-
-    # Group mapping for the auth_client fixture — mirrors DevelopmentConfig
-    # so test users resolve to the same permissions they did when tests were
-    # inadvertently running under DevelopmentConfig. Consumed by
-    # run.py:load_user via AuthUser(dev_group_mapping=...).
-    DEV_GROUP_MAPPING = {
-        'benkirk':  ['admin'],
-        'mtrahan':  ['facility_manager'],
-        'rory':     ['project_lead'],
-        'andersnb': ['user'],
-        'negins':   ['user'],
-        'bdobbins': ['user'],
-        'tcraig':   ['user'],
-    }
 
 
 _configs = {

--- a/src/webapp/dashboards/admin/blueprint.py
+++ b/src/webapp/dashboards/admin/blueprint.py
@@ -45,7 +45,7 @@ UPCOMING_PRESETS = {
 
 @bp.route('/')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.VIEW_PROJECTS)
 def index():
     """
     Admin dashboard main page.
@@ -152,7 +152,7 @@ def project_card(projcode):
 
 @bp.route('/user/<username>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.VIEW_USERS)
 def user_card(username):
     """
     Get HTML fragment for a single user card (for admin user search).
@@ -194,7 +194,7 @@ def user_card(username):
 
 @bp.route('/group/<group_name>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.VIEW_GROUPS)
 def group_card(group_name):
     """HTML fragment for a single adhoc-group card (admin group search).
 
@@ -529,7 +529,7 @@ def expirations_export():
 
 @bp.route('/htmx/search/users')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.VIEW_USERS)
 def htmx_search_users():
     """Unified user search endpoint.
 
@@ -576,7 +576,7 @@ def htmx_search_users():
 
 @bp.route('/htmx/search/groups')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.VIEW_GROUPS)
 def htmx_search_groups():
     """Search adhoc groups by name or GID. Returns the result-list fragment."""
     from sam.queries.lookups import search_groups_by_pattern
@@ -597,7 +597,7 @@ def htmx_search_groups():
 # Keep old impersonate endpoint as alias for backward compatibility
 @bp.route('/htmx/search-users-impersonate')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.IMPERSONATE_USERS)
 def htmx_search_users_impersonate():
     """Alias for /htmx/search/users?context=impersonate (deprecated)."""
     from sam.queries.users import search_users_by_pattern
@@ -618,7 +618,7 @@ def htmx_search_users_impersonate():
 
 @bp.route('/htmx/search-projects')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.VIEW_PROJECTS)
 def htmx_search_projects():
     """
     Search projects and return results as HTML fragments.
@@ -650,7 +650,7 @@ def htmx_search_projects():
 
 @bp.route('/htmx/exemption-form/<username>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_USERS)
 def htmx_add_exemption_form(username):
     """
     Return the add-exemption form fragment for a user (loaded into modal).
@@ -680,7 +680,7 @@ def htmx_add_exemption_form(username):
 
 @bp.route('/htmx/exemption/<username>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_USERS)
 def htmx_add_exemption(username):
     """
     Create a wallclock exemption for the given user.
@@ -790,7 +790,7 @@ def htmx_add_exemption(username):
 
 @bp.route('/htmx/exemption-edit-form/<int:exemption_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_USERS)
 def htmx_edit_exemption_form(exemption_id):
     """
     Return the edit-exemption form fragment (loaded into modal).
@@ -809,7 +809,7 @@ def htmx_edit_exemption_form(exemption_id):
 
 @bp.route('/htmx/exemption-edit/<int:exemption_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_USERS)
 def htmx_edit_exemption(exemption_id):
     """
     Update a wallclock exemption.
@@ -884,7 +884,7 @@ def htmx_edit_exemption(exemption_id):
 
 @bp.route('/htmx/queues-for-resource')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.VIEW_RESOURCES)
 def htmx_queues_for_resource():
     """
     Return queue <option> elements for a given resource_id (cascading select).

--- a/src/webapp/dashboards/admin/blueprint.py
+++ b/src/webapp/dashboards/admin/blueprint.py
@@ -45,7 +45,7 @@ UPCOMING_PRESETS = {
 
 @bp.route('/')
 @login_required
-@require_permission(Permission.VIEW_PROJECTS)
+@require_permission(Permission.ACCESS_ADMIN_DASHBOARD)
 def index():
     """
     Admin dashboard main page.

--- a/src/webapp/dashboards/admin/facilities_routes.py
+++ b/src/webapp/dashboards/admin/facilities_routes.py
@@ -33,7 +33,7 @@ _FACILITY_TRIGGERS = {'closeActiveModal': {}, 'reloadFacilitiesCard': {}}
 
 @bp.route('/htmx/facilities')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.VIEW_FACILITIES)
 def htmx_facilities_card():
     """
     Return the Facility card body fragment with four tabs:
@@ -62,7 +62,7 @@ def htmx_facilities_card():
 
 @bp.route('/htmx/facility-edit-form/<int:facility_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_FACILITIES)
 def htmx_facility_edit_form(facility_id):
     """Return the facility edit form fragment (loaded into modal)."""
     from sam.resources.facilities import Facility
@@ -79,7 +79,7 @@ def htmx_facility_edit_form(facility_id):
 
 @bp.route('/htmx/facility-edit/<int:facility_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_FACILITIES)
 def htmx_facility_edit(facility_id):
     """Update a facility."""
     from sam.resources.facilities import Facility
@@ -107,7 +107,7 @@ def htmx_facility_edit(facility_id):
 
 @bp.route('/htmx/facility-create-form')
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_FACILITIES)
 def htmx_facility_create_form():
     """Return the facility create form fragment (loaded into modal)."""
     return render_template('dashboards/admin/fragments/create_facility_form_htmx.html')
@@ -115,7 +115,7 @@ def htmx_facility_create_form():
 
 @bp.route('/htmx/facility-create', methods=['POST'])
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_FACILITIES)
 def htmx_facility_create():
     """Create a new facility."""
     from sam.resources.facilities import Facility
@@ -140,7 +140,7 @@ def htmx_facility_create():
 
 @bp.route('/htmx/facility-delete/<int:facility_id>', methods=['DELETE'])
 @login_required
-@require_permission(Permission.DELETE_RESOURCES)
+@require_permission(Permission.DELETE_FACILITIES)
 def htmx_facility_delete(facility_id):
     """Soft-delete (deactivate) a facility."""
     from sam.resources.facilities import Facility
@@ -156,7 +156,7 @@ def htmx_facility_delete(facility_id):
 
 @bp.route('/htmx/panel-edit-form/<int:panel_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_FACILITIES)
 def htmx_panel_edit_form(panel_id):
     """Return the panel edit form fragment (loaded into modal)."""
     from sam.resources.facilities import Panel
@@ -173,7 +173,7 @@ def htmx_panel_edit_form(panel_id):
 
 @bp.route('/htmx/panel-edit/<int:panel_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_FACILITIES)
 def htmx_panel_edit(panel_id):
     """Update a panel."""
     from sam.resources.facilities import Panel
@@ -210,7 +210,7 @@ def htmx_panel_edit(panel_id):
 
 @bp.route('/htmx/panel-create-form')
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_FACILITIES)
 def htmx_panel_create_form():
     """Return the panel create form fragment (loaded into modal)."""
     from sam.resources.facilities import Facility
@@ -235,7 +235,7 @@ def _active_facilities():
 
 @bp.route('/htmx/panel-create', methods=['POST'])
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_FACILITIES)
 def htmx_panel_create():
     """Create a new panel."""
     from sam.resources.facilities import Panel
@@ -260,7 +260,7 @@ def htmx_panel_create():
 
 @bp.route('/htmx/panel-delete/<int:panel_id>', methods=['DELETE'])
 @login_required
-@require_permission(Permission.DELETE_RESOURCES)
+@require_permission(Permission.DELETE_FACILITIES)
 def htmx_panel_delete(panel_id):
     """Soft-delete (deactivate) a panel."""
     from sam.resources.facilities import Panel
@@ -276,7 +276,7 @@ def htmx_panel_delete(panel_id):
 
 @bp.route('/htmx/panel-session-edit-form/<int:panel_session_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_FACILITIES)
 def htmx_panel_session_edit_form(panel_session_id):
     """Return the panel session edit form fragment (loaded into modal)."""
     from sam.resources.facilities import PanelSession
@@ -293,7 +293,7 @@ def htmx_panel_session_edit_form(panel_session_id):
 
 @bp.route('/htmx/panel-session-edit/<int:panel_session_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_FACILITIES)
 def htmx_panel_session_edit(panel_session_id):
     """Update a panel session."""
     from sam.resources.facilities import PanelSession
@@ -350,7 +350,7 @@ def htmx_panel_session_edit(panel_session_id):
 
 @bp.route('/htmx/allocation-type-edit-form/<int:allocation_type_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_FACILITIES)
 def htmx_allocation_type_edit_form(allocation_type_id):
     """Return the allocation type edit form fragment (loaded into modal)."""
     from sam.accounting.allocations import AllocationType
@@ -367,7 +367,7 @@ def htmx_allocation_type_edit_form(allocation_type_id):
 
 @bp.route('/htmx/allocation-type-edit/<int:allocation_type_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_FACILITIES)
 def htmx_allocation_type_edit(allocation_type_id):
     """Update an allocation type."""
     from sam.accounting.allocations import AllocationType
@@ -395,7 +395,7 @@ def htmx_allocation_type_edit(allocation_type_id):
 
 @bp.route('/htmx/allocation-type-create-form')
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_FACILITIES)
 def htmx_allocation_type_create_form():
     """Return the allocation type create form fragment (loaded into modal)."""
     return render_template(
@@ -430,7 +430,7 @@ def _alloc_type_create_context():
 
 @bp.route('/htmx/allocation-type-create', methods=['POST'])
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_FACILITIES)
 def htmx_allocation_type_create():
     """Create a new allocation type."""
     from sam.accounting.allocations import AllocationType
@@ -456,7 +456,7 @@ def htmx_allocation_type_create():
 
 @bp.route('/htmx/allocation-type-delete/<int:allocation_type_id>', methods=['DELETE'])
 @login_required
-@require_permission(Permission.DELETE_RESOURCES)
+@require_permission(Permission.DELETE_FACILITIES)
 def htmx_allocation_type_delete(allocation_type_id):
     """Soft-delete (deactivate) an allocation type."""
     from sam.accounting.allocations import AllocationType

--- a/src/webapp/dashboards/admin/orgs_routes.py
+++ b/src/webapp/dashboards/admin/orgs_routes.py
@@ -95,7 +95,7 @@ def _active_contract_sources():
 
 @bp.route('/htmx/organizations-card')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.VIEW_ORG_METADATA)
 @cache.cached(query_string=True)
 def htmx_organizations_card():
     """
@@ -165,7 +165,7 @@ def htmx_organizations_card():
 
 @bp.route('/htmx/institutions-fragment')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.VIEW_ORG_METADATA)
 @cache.cached(query_string=True)
 def htmx_institutions_fragment():
     """HTMX fragment: filterable, nested table of institutions by institution type.
@@ -292,7 +292,7 @@ def htmx_institutions_fragment():
 
 @bp.route('/htmx/organization-edit-form/<int:org_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_ORG_METADATA)
 def htmx_organization_edit_form(org_id):
     """Return the organization edit form fragment (loaded into modal)."""
     from sam.core.organizations import Organization
@@ -309,7 +309,7 @@ def htmx_organization_edit_form(org_id):
 
 @bp.route('/htmx/organization-edit/<int:org_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_ORG_METADATA)
 def htmx_organization_edit(org_id):
     """Update an organization."""
     from sam.core.organizations import Organization
@@ -337,7 +337,7 @@ def htmx_organization_edit(org_id):
 
 @bp.route('/htmx/organization-create-form')
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_organization_create_form():
     """Return the organization create form fragment (loaded into modal)."""
     return render_template(
@@ -348,7 +348,7 @@ def htmx_organization_create_form():
 
 @bp.route('/htmx/organization-create', methods=['POST'])
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_organization_create():
     """Create a new organization."""
     from sam.core.organizations import Organization
@@ -374,7 +374,7 @@ def htmx_organization_create():
 
 @bp.route('/htmx/organization-delete/<int:org_id>', methods=['DELETE'])
 @login_required
-@require_permission(Permission.DELETE_RESOURCES)
+@require_permission(Permission.DELETE_ORG_METADATA)
 def htmx_organization_delete(org_id):
     """Soft-delete (deactivate) an organization."""
     from sam.core.organizations import Organization
@@ -390,7 +390,7 @@ def htmx_organization_delete(org_id):
 
 @bp.route('/htmx/institution-type-edit-form/<int:institution_type_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_ORG_METADATA)
 def htmx_institution_type_edit_form(institution_type_id):
     """Return the institution type edit form fragment (loaded into modal)."""
     from sam.core.organizations import InstitutionType
@@ -407,7 +407,7 @@ def htmx_institution_type_edit_form(institution_type_id):
 
 @bp.route('/htmx/institution-type-edit/<int:institution_type_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_ORG_METADATA)
 def htmx_institution_type_edit(institution_type_id):
     """Update an institution type."""
     from sam.core.organizations import InstitutionType
@@ -431,7 +431,7 @@ def htmx_institution_type_edit(institution_type_id):
 
 @bp.route('/htmx/institution-type-create-form')
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_institution_type_create_form():
     """Return the institution type create form fragment (loaded into modal)."""
     return render_template('dashboards/admin/fragments/create_institution_type_form_htmx.html')
@@ -439,7 +439,7 @@ def htmx_institution_type_create_form():
 
 @bp.route('/htmx/institution-type-create', methods=['POST'])
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_institution_type_create():
     """Create a new institution type."""
     from sam.core.organizations import InstitutionType
@@ -458,7 +458,7 @@ def htmx_institution_type_create():
 
 @bp.route('/htmx/institution-edit-form/<int:inst_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_ORG_METADATA)
 def htmx_institution_edit_form(inst_id):
     """Return the institution edit form fragment (loaded into modal)."""
     from sam.core.organizations import Institution
@@ -475,7 +475,7 @@ def htmx_institution_edit_form(inst_id):
 
 @bp.route('/htmx/institution-edit/<int:inst_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_ORG_METADATA)
 def htmx_institution_edit(inst_id):
     """Update an institution."""
     from sam.core.organizations import Institution
@@ -507,7 +507,7 @@ def htmx_institution_edit(inst_id):
 
 @bp.route('/htmx/institution-create-form')
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_institution_create_form():
     """Return the institution create form fragment (loaded into modal)."""
     return render_template(
@@ -518,7 +518,7 @@ def htmx_institution_create_form():
 
 @bp.route('/htmx/institution-create', methods=['POST'])
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_institution_create():
     """Create a new institution."""
     from sam.core.organizations import Institution
@@ -546,7 +546,7 @@ def htmx_institution_create():
 
 @bp.route('/htmx/mnemonic-code-create-form')
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_mnemonic_code_create_form():
     """Return the mnemonic code create form fragment (loaded into modal)."""
     from sam.core.organizations import Institution, Organization
@@ -588,7 +588,7 @@ def _mnemonic_create_context():
 
 @bp.route('/htmx/mnemonic-code-create', methods=['POST'])
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_mnemonic_code_create():
     """Create a new mnemonic code.
 
@@ -635,7 +635,7 @@ def htmx_mnemonic_code_create():
 
 @bp.route('/htmx/aoi-group-edit-form/<int:group_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_ORG_METADATA)
 def htmx_aoi_group_edit_form(group_id):
     """Return the AOI group edit form fragment (loaded into modal)."""
     from sam.projects.areas import AreaOfInterestGroup
@@ -652,7 +652,7 @@ def htmx_aoi_group_edit_form(group_id):
 
 @bp.route('/htmx/aoi-group-edit/<int:group_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_ORG_METADATA)
 def htmx_aoi_group_edit(group_id):
     """Update an AOI group."""
     from sam.projects.areas import AreaOfInterestGroup
@@ -676,7 +676,7 @@ def htmx_aoi_group_edit(group_id):
 
 @bp.route('/htmx/aoi-group-create-form')
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_aoi_group_create_form():
     """Return the AOI group create form fragment."""
     return render_template('dashboards/admin/fragments/create_aoi_group_form_htmx.html')
@@ -684,7 +684,7 @@ def htmx_aoi_group_create_form():
 
 @bp.route('/htmx/aoi-group-create', methods=['POST'])
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_aoi_group_create():
     """Create a new AOI group."""
     from sam.projects.areas import AreaOfInterestGroup
@@ -703,7 +703,7 @@ def htmx_aoi_group_create():
 
 @bp.route('/htmx/aoi-group-delete/<int:group_id>', methods=['DELETE'])
 @login_required
-@require_permission(Permission.DELETE_RESOURCES)
+@require_permission(Permission.DELETE_ORG_METADATA)
 def htmx_aoi_group_delete(group_id):
     """Soft-delete (deactivate) an AOI group."""
     from sam.projects.areas import AreaOfInterestGroup
@@ -719,7 +719,7 @@ def htmx_aoi_group_delete(group_id):
 
 @bp.route('/htmx/aoi-edit-form/<int:aoi_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_ORG_METADATA)
 def htmx_aoi_edit_form(aoi_id):
     """Return the AOI edit form fragment (loaded into modal)."""
     from sam.projects.areas import AreaOfInterest
@@ -737,7 +737,7 @@ def htmx_aoi_edit_form(aoi_id):
 
 @bp.route('/htmx/aoi-edit/<int:aoi_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_ORG_METADATA)
 def htmx_aoi_edit(aoi_id):
     """Update an area of interest."""
     from sam.projects.areas import AreaOfInterest
@@ -766,7 +766,7 @@ def htmx_aoi_edit(aoi_id):
 
 @bp.route('/htmx/aoi-create-form')
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_aoi_create_form():
     """Return the AOI create form fragment."""
     return render_template(
@@ -777,7 +777,7 @@ def htmx_aoi_create_form():
 
 @bp.route('/htmx/aoi-create', methods=['POST'])
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_aoi_create():
     """Create a new area of interest."""
     from sam.projects.areas import AreaOfInterest
@@ -801,7 +801,7 @@ def htmx_aoi_create():
 
 @bp.route('/htmx/aoi-delete/<int:aoi_id>', methods=['DELETE'])
 @login_required
-@require_permission(Permission.DELETE_RESOURCES)
+@require_permission(Permission.DELETE_ORG_METADATA)
 def htmx_aoi_delete(aoi_id):
     """Soft-delete (deactivate) an area of interest."""
     from sam.projects.areas import AreaOfInterest
@@ -817,7 +817,7 @@ def htmx_aoi_delete(aoi_id):
 
 @bp.route('/htmx/contract-source-edit-form/<int:source_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_ORG_METADATA)
 def htmx_contract_source_edit_form(source_id):
     """Return the contract source edit form fragment (loaded into modal)."""
     from sam.projects.contracts import ContractSource
@@ -834,7 +834,7 @@ def htmx_contract_source_edit_form(source_id):
 
 @bp.route('/htmx/contract-source-edit/<int:source_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_ORG_METADATA)
 def htmx_contract_source_edit(source_id):
     """Update a contract source."""
     from sam.projects.contracts import ContractSource
@@ -860,7 +860,7 @@ def htmx_contract_source_edit(source_id):
 
 @bp.route('/htmx/contract-source-create-form')
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_contract_source_create_form():
     """Return the contract source create form fragment."""
     return render_template('dashboards/admin/fragments/create_contract_source_form_htmx.html')
@@ -868,7 +868,7 @@ def htmx_contract_source_create_form():
 
 @bp.route('/htmx/contract-source-create', methods=['POST'])
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_contract_source_create():
     """Create a new contract source."""
     from sam.projects.contracts import ContractSource
@@ -889,7 +889,7 @@ def htmx_contract_source_create():
 
 @bp.route('/htmx/contract-source-delete/<int:source_id>', methods=['DELETE'])
 @login_required
-@require_permission(Permission.DELETE_RESOURCES)
+@require_permission(Permission.DELETE_ORG_METADATA)
 def htmx_contract_source_delete(source_id):
     """Soft-delete (deactivate) a contract source."""
     from sam.projects.contracts import ContractSource
@@ -905,7 +905,7 @@ def htmx_contract_source_delete(source_id):
 
 @bp.route('/htmx/contract-edit-form/<int:contract_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_ORG_METADATA)
 def htmx_contract_edit_form(contract_id):
     """Return the contract edit form fragment (loaded into modal)."""
     from sam.projects.contracts import Contract
@@ -922,7 +922,7 @@ def htmx_contract_edit_form(contract_id):
 
 @bp.route('/htmx/contract-edit/<int:contract_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_ORG_METADATA)
 def htmx_contract_edit(contract_id):
     """Update a contract."""
     from sam.projects.contracts import Contract
@@ -951,7 +951,7 @@ def htmx_contract_edit(contract_id):
 
 @bp.route('/htmx/contract-create-form')
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_contract_create_form():
     """Return the contract create form fragment."""
     return render_template(
@@ -963,7 +963,7 @@ def htmx_contract_create_form():
 
 @bp.route('/htmx/contract-create', methods=['POST'])
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_contract_create():
     """Create a new contract."""
     from sam.projects.contracts import Contract
@@ -995,7 +995,7 @@ def htmx_contract_create():
 
 @bp.route('/htmx/contract-delete/<int:contract_id>', methods=['DELETE'])
 @login_required
-@require_permission(Permission.DELETE_RESOURCES)
+@require_permission(Permission.DELETE_ORG_METADATA)
 def htmx_contract_delete(contract_id):
     """Soft-delete (expire) a contract."""
     from sam.projects.contracts import Contract
@@ -1019,7 +1019,7 @@ def htmx_contract_delete(contract_id):
 
 @bp.route('/htmx/nsf-program-edit-form/<int:nsf_program_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_ORG_METADATA)
 def htmx_nsf_program_edit_form(nsf_program_id):
     """Return the NSF program edit form fragment (loaded into modal)."""
     from sam.projects.contracts import NSFProgram
@@ -1036,7 +1036,7 @@ def htmx_nsf_program_edit_form(nsf_program_id):
 
 @bp.route('/htmx/nsf-program-edit/<int:nsf_program_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_ORG_METADATA)
 def htmx_nsf_program_edit(nsf_program_id):
     """Update an NSF program."""
     from sam.projects.contracts import NSFProgram
@@ -1062,7 +1062,7 @@ def htmx_nsf_program_edit(nsf_program_id):
 
 @bp.route('/htmx/nsf-program-create-form')
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_nsf_program_create_form():
     """Return the NSF program create form fragment."""
     return render_template('dashboards/admin/fragments/create_nsf_program_form_htmx.html')
@@ -1070,7 +1070,7 @@ def htmx_nsf_program_create_form():
 
 @bp.route('/htmx/nsf-program-create', methods=['POST'])
 @login_required
-@require_permission(Permission.CREATE_RESOURCES)
+@require_permission(Permission.CREATE_ORG_METADATA)
 def htmx_nsf_program_create():
     """Create a new NSF program."""
     from sam.projects.contracts import NSFProgram
@@ -1091,7 +1091,7 @@ def htmx_nsf_program_create():
 
 @bp.route('/htmx/nsf-program-delete/<int:nsf_program_id>', methods=['DELETE'])
 @login_required
-@require_permission(Permission.DELETE_RESOURCES)
+@require_permission(Permission.DELETE_ORG_METADATA)
 def htmx_nsf_program_delete(nsf_program_id):
     """Soft-delete (deactivate) an NSF program."""
     from sam.projects.contracts import NSFProgram

--- a/src/webapp/dashboards/admin/resources_routes.py
+++ b/src/webapp/dashboards/admin/resources_routes.py
@@ -49,7 +49,7 @@ def _all_resource_types():
 
 @bp.route('/htmx/resources')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.VIEW_RESOURCES)
 def htmx_resources_card():
     """
     Return the Resources card body fragment with four tabs:
@@ -96,7 +96,7 @@ def htmx_resources_card():
 
 @bp.route('/htmx/resource-edit-form/<int:resource_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_RESOURCES)
 def htmx_resource_edit_form(resource_id):
     """Return the resource edit form fragment (loaded into modal)."""
     from sam.resources.resources import Resource
@@ -113,7 +113,7 @@ def htmx_resource_edit_form(resource_id):
 
 @bp.route('/htmx/resource-edit/<int:resource_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_RESOURCES)
 def htmx_resource_edit(resource_id):
     """Update a resource."""
     from sam.resources.resources import Resource
@@ -205,7 +205,7 @@ def htmx_resource_delete(resource_id):
 
 @bp.route('/htmx/resource-type-edit-form/<int:resource_type_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_RESOURCES)
 def htmx_resource_type_edit_form(resource_type_id):
     """Return the resource type edit form fragment (loaded into modal)."""
     from sam.resources.resources import ResourceType
@@ -222,7 +222,7 @@ def htmx_resource_type_edit_form(resource_type_id):
 
 @bp.route('/htmx/resource-type-edit/<int:resource_type_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_RESOURCES)
 def htmx_resource_type_edit(resource_type_id):
     """Update a resource type."""
     from sam.resources.resources import ResourceType
@@ -295,7 +295,7 @@ def htmx_resource_type_delete(resource_type_id):
 
 @bp.route('/htmx/machine-edit-form/<int:machine_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_RESOURCES)
 def htmx_machine_edit_form(machine_id):
     """Return the machine edit form fragment (loaded into modal)."""
     from sam.resources.machines import Machine
@@ -312,7 +312,7 @@ def htmx_machine_edit_form(machine_id):
 
 @bp.route('/htmx/machine-edit/<int:machine_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_RESOURCES)
 def htmx_machine_edit(machine_id):
     """Update a machine."""
     from sam.resources.machines import Machine
@@ -402,7 +402,7 @@ def htmx_machine_delete(machine_id):
 
 @bp.route('/htmx/queue-edit-form/<int:queue_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_RESOURCES)
 def htmx_queue_edit_form(queue_id):
     """Return the queue edit form fragment (loaded into modal)."""
     from sam.resources.machines import Queue
@@ -419,7 +419,7 @@ def htmx_queue_edit_form(queue_id):
 
 @bp.route('/htmx/queue-edit/<int:queue_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission(Permission.EDIT_RESOURCES)
 def htmx_queue_edit(queue_id):
     """Update a queue."""
     from sam.resources.machines import Queue

--- a/src/webapp/dashboards/allocations/blueprint.py
+++ b/src/webapp/dashboards/allocations/blueprint.py
@@ -10,7 +10,7 @@ from flask_login import login_required, current_user
 from datetime import datetime, timedelta
 from typing import List, Dict
 
-from webapp.extensions import db, cache
+from webapp.extensions import db, cache, user_aware_cache_key
 from webapp.utils.htmx import handle_htmx_form_post
 from sam.queries.allocations import (
     ALLOCATION_TRANSACTION_SORT_COLUMNS,
@@ -234,7 +234,7 @@ def get_resource_types(session) -> Dict[str, str]:
 @bp.route('/')
 @login_required
 @require_permission(Permission.VIEW_PROJECTS)
-@cache.cached(query_string=True)
+@cache.cached(make_cache_key=user_aware_cache_key)
 def index():
     """
     Main allocations dashboard page.
@@ -412,7 +412,7 @@ def index():
 @bp.route('/projects')
 @login_required
 @require_permission(Permission.VIEW_PROJECTS)
-@cache.cached(query_string=True)
+@cache.cached(make_cache_key=user_aware_cache_key)
 def projects_fragment():
     """
     AJAX fragment showing individual projects for a specific Resource/Facility/Type.

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -24,6 +24,7 @@ from sam.core.users import User
 from sam.projects.projects import Project
 from webapp.utils.project_permissions import can_edit_consumption_threshold
 from webapp.utils.rbac import require_permission, Permission, has_permission
+from webapp.api.access_control import require_allocation_permission
 from ..charts import generate_usage_timeseries_matplotlib
 
 
@@ -445,19 +446,13 @@ def project_details_modal(projcode):
 
 @bp.route('/htmx/edit-allocation-form/<int:allocation_id>')
 @login_required
-@require_permission(Permission.EDIT_ALLOCATIONS)
-def htmx_edit_allocation_form(allocation_id):
+@require_allocation_permission(Permission.EDIT_ALLOCATIONS)
+def htmx_edit_allocation_form(allocation):
     """
     Return the edit allocation form as an HTML fragment, pre-populated from DB.
 
     Replaces the JS pattern of: fetch JSON → populate form fields client-side.
     """
-    from sam.accounting.allocations import Allocation
-
-    allocation = db.session.get(Allocation, allocation_id)
-    if not allocation:
-        return '<div class="alert alert-danger m-3">Allocation not found</div>', 404
-
     # Derive resource name and projcode from the allocation's account
     account = allocation.account
     resource_name = account.resource.resource_name if account and account.resource else 'Unknown'
@@ -486,8 +481,8 @@ def htmx_edit_allocation_form(allocation_id):
 
 @bp.route('/htmx/edit-allocation/<int:allocation_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_ALLOCATIONS)
-def htmx_edit_allocation(allocation_id):
+@require_allocation_permission(Permission.EDIT_ALLOCATIONS)
+def htmx_edit_allocation(allocation):
     """
     Handle edit allocation form submission (htmx).
 
@@ -495,13 +490,9 @@ def htmx_edit_allocation(allocation_id):
     On success: returns a script that closes the modal and triggers a
     refresh event so any open project details modal reloads.
     """
-    from sam.accounting.allocations import Allocation
     from sam.manage import update_allocation, management_transaction
 
-    allocation = db.session.get(Allocation, allocation_id)
-    if not allocation:
-        return '<div class="alert alert-danger m-3">Allocation not found</div>', 404
-
+    allocation_id = allocation.allocation_id
     account = allocation.account
     resource_name = account.resource.resource_name if account and account.resource else 'Unknown'
     projcode = request.form.get('projcode', '')

--- a/src/webapp/extensions.py
+++ b/src/webapp/extensions.py
@@ -10,3 +10,27 @@ from flask_caching import Cache
 
 db = SQLAlchemy()
 cache = Cache()
+
+
+def user_aware_cache_key() -> str:
+    """Cache key keyed on (current user id, path, query string).
+
+    Use as ``@cache.cached(make_cache_key=user_aware_cache_key)`` on any
+    response whose rendered output depends on who is logged in — most
+    commonly because the response embeds the navbar (which shows the
+    current user's name) or because the data shown is user-scoped.
+
+    Without this, caching by URL alone breaks impersonation: the first
+    user to populate the cache "wins" and every subsequent visitor
+    (including impersonators) gets that user's rendered view back.
+    """
+    from flask import request
+    from flask_login import current_user
+
+    user_part = (
+        current_user.user_id
+        if getattr(current_user, 'is_authenticated', False)
+        else 'anon'
+    )
+    qs = request.query_string.decode('utf-8', errors='replace')
+    return f"u:{user_part}|{request.path}|{qs}"

--- a/src/webapp/run.py
+++ b/src/webapp/run.py
@@ -185,7 +185,7 @@ def create_app(*, config_overrides: dict | None = None):
         """Load user by ID for Flask-Login."""
         sam_user = db.session.query(User).filter_by(user_id=int(user_id)).first()
         if sam_user:
-            return AuthUser(sam_user, dev_group_mapping=app.config.get('DEV_GROUP_MAPPING'))
+            return AuthUser(sam_user)
         return None
 
     # Register context processor for RBAC in templates

--- a/src/webapp/run.py
+++ b/src/webapp/run.py
@@ -261,7 +261,7 @@ def create_app(*, config_overrides: dict | None = None):
             # access — including users granted admin via
             # USER_PERMISSION_OVERRIDES rather than a group bundle.
             from webapp.utils.rbac import has_permission, Permission
-            if has_permission(current_user, Permission.IMPERSONATE_USERS):
+            if has_permission(current_user, Permission.ACCESS_ADMIN_DASHBOARD):
                 return redirect(url_for('admin_dashboard.index'))
             else:
                 return redirect(url_for('user_dashboard.index'))

--- a/src/webapp/run.py
+++ b/src/webapp/run.py
@@ -254,8 +254,14 @@ def create_app(*, config_overrides: dict | None = None):
     @app.route('/')
     def index():
         if current_user.is_authenticated:
-            # Redirect admin users to admin dashboard, regular users to user dashboard
-            if current_user.has_role('admin'):
+            # Redirect admin-capable users to admin dashboard, others to
+            # user dashboard. Gate on the same permission that gates the
+            # Admin nav tab (see templates/dashboards/base.html), so the
+            # redirect target is always something the user can actually
+            # access — including users granted admin via
+            # USER_PERMISSION_OVERRIDES rather than a group bundle.
+            from webapp.utils.rbac import has_permission, Permission
+            if has_permission(current_user, Permission.IMPERSONATE_USERS):
                 return redirect(url_for('admin_dashboard.index'))
             else:
                 return redirect(url_for('user_dashboard.index'))

--- a/src/webapp/run.py
+++ b/src/webapp/run.py
@@ -255,7 +255,7 @@ def create_app(*, config_overrides: dict | None = None):
     def index():
         if current_user.is_authenticated:
             # Redirect admin users to admin dashboard, regular users to user dashboard
-            if 'admin' in current_user.roles:
+            if current_user.has_role('admin'):
                 return redirect(url_for('admin_dashboard.index'))
             else:
                 return redirect(url_for('user_dashboard.index'))

--- a/src/webapp/run.py
+++ b/src/webapp/run.py
@@ -185,7 +185,7 @@ def create_app(*, config_overrides: dict | None = None):
         """Load user by ID for Flask-Login."""
         sam_user = db.session.query(User).filter_by(user_id=int(user_id)).first()
         if sam_user:
-            return AuthUser(sam_user, dev_role_mapping=app.config.get('DEV_ROLE_MAPPING'))
+            return AuthUser(sam_user, dev_group_mapping=app.config.get('DEV_GROUP_MAPPING'))
         return None
 
     # Register context processor for RBAC in templates

--- a/src/webapp/templates/auth/login.html
+++ b/src/webapp/templates/auth/login.html
@@ -99,13 +99,15 @@
 
         <div class="quick-login-section">
             <h5>Quick Login (Test Users)</h5>
-            {% for username, roles in test_users.items() %}
+            {% for username, label in test_users %}
             <form method="POST" action="{{ url_for('auth.login') }}" class="login-form">
                 <input type="hidden" name="username" value="{{ username }}">
                 <input type="hidden" name="password" value="test">
                 <button type="submit" class="btn user-btn">
                     <strong>{{ username }}</strong>
-                    <span class="role-badge">{{ roles|join(', ') }}</span>
+                    {% if label %}
+                    <span class="role-badge">{{ label }}</span>
+                    {% endif %}
                 </button>
             </form>
             {% endfor %}

--- a/src/webapp/templates/dashboards/admin/fragments/facility_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/facility_card.html
@@ -1,4 +1,4 @@
-{% from 'dashboards/fragments/action_buttons.html' import edit_modal_button, delete_row_button %}
+{% from 'dashboards/fragments/action_buttons.html' import edit_modal_button, delete_row_button with context %}
 {#
   Admin: Facility Card Body (lazy-loaded into the Facilities tab pane)
   Unified hierarchical view: Facilities (collapsible) → Panels → Allocation Types (nested table).
@@ -42,21 +42,19 @@
                         {{ f.fair_share_percentage | fmt_pct(decimals=2) }}
                     </td>
                     <td class="text-end">
-                        {% if is_admin %}
                         {{ edit_modal_button(
                             url_for('admin_dashboard.htmx_facility_edit_form', facility_id=f.facility_id),
                             modal_id='editFacilityModal',
                             target_id='editFacilityFormContainer',
                             title='Edit facility',
-                            stop_propagation=True) }}
-                        {% if has_permission(Permission.DELETE_RESOURCES) %}
+                            stop_propagation=True,
+                            permission=Permission.EDIT_FACILITIES) }}
                         {{ delete_row_button(
                             url_for('admin_dashboard.htmx_facility_delete', facility_id=f.facility_id),
                             confirm="Deactivate facility '" ~ f.facility_name ~ "'?",
                             title='Deactivate facility',
-                            stop_propagation=True) }}
-                        {% endif %}
-                        {% endif %}
+                            stop_propagation=True,
+                            permission=Permission.DELETE_FACILITIES) }}
                     </td>
                 </tr>
             </tbody>
@@ -76,19 +74,17 @@
                     <td class="text-muted small">{{ p.description or '—' }}</td>
                     <td>—</td>
                     <td class="text-end">
-                        {% if is_admin %}
                         {{ edit_modal_button(
                             url_for('admin_dashboard.htmx_panel_edit_form', panel_id=p.panel_id),
                             modal_id='editPanelModal',
                             target_id='editPanelFormContainer',
-                            title='Edit panel') }}
-                        {% if has_permission(Permission.DELETE_RESOURCES) %}
+                            title='Edit panel',
+                            permission=Permission.EDIT_FACILITIES) }}
                         {{ delete_row_button(
                             url_for('admin_dashboard.htmx_panel_delete', panel_id=p.panel_id),
                             confirm="Deactivate panel '" ~ p.panel_name ~ "'?",
-                            title='Deactivate panel') }}
-                        {% endif %}
-                        {% endif %}
+                            title='Deactivate panel',
+                            permission=Permission.DELETE_FACILITIES) }}
                     </td>
                 </tr>
 
@@ -114,19 +110,17 @@
                                     <td>{{ at.fair_share_percentage | fmt_pct(decimals=2) }}</td>
                                     <td>{{ at.projects | length }}</td>
                                     <td class="text-end">
-                                        {% if is_admin %}
                                         {{ edit_modal_button(
                                             url_for('admin_dashboard.htmx_allocation_type_edit_form', allocation_type_id=at.allocation_type_id),
                                             modal_id='editAllocationTypeModal',
                                             target_id='editAllocationTypeFormContainer',
-                                            title='Edit allocation type') }}
-                                        {% if has_permission(Permission.DELETE_RESOURCES) %}
+                                            title='Edit allocation type',
+                                            permission=Permission.EDIT_FACILITIES) }}
                                         {{ delete_row_button(
                                             url_for('admin_dashboard.htmx_allocation_type_delete', allocation_type_id=at.allocation_type_id),
                                             confirm="Deactivate allocation type '" ~ at.allocation_type ~ "'?",
-                                            title='Deactivate allocation type') }}
-                                        {% endif %}
-                                        {% endif %}
+                                            title='Deactivate allocation type',
+                                            permission=Permission.DELETE_FACILITIES) }}
                                     </td>
                                 </tr>
                                 {% endfor %}
@@ -158,7 +152,7 @@
         <span class="text-muted small">
             Showing {{ facilities|length }} facilit{{ 'ies' if facilities|length != 1 else 'y' }}
         </span>
-        {% if has_permission(Permission.CREATE_RESOURCES) %}
+        {% if has_permission(Permission.CREATE_FACILITIES) %}
         <div class="d-flex gap-2">
             <button class="btn btn-sm btn-outline-success"
                     data-bs-toggle="modal"

--- a/src/webapp/templates/dashboards/admin/fragments/institutions_table.html
+++ b/src/webapp/templates/dashboards/admin/fragments/institutions_table.html
@@ -1,4 +1,4 @@
-{% from 'dashboards/fragments/action_buttons.html' import edit_modal_button %}
+{% from 'dashboards/fragments/action_buttons.html' import edit_modal_button with context %}
 {% from 'dashboards/admin/fragments/institution_filters.html' import institution_filters %}
 {#
   Admin Institutions table fragment (HTMX-swapped).
@@ -18,7 +18,6 @@
                                  and the expand row
     active_users_projects      - bool; filters chip lists + counts (only
                                  relevant when show_users_projects is on)
-    is_admin                   - bool
 #}
 {% set ncols = 7 if show_users_projects else 5 %}
 
@@ -71,14 +70,13 @@
                 <td></td>
                 {% endif %}
                 <td class="text-end">
-                    {% if is_admin %}
                     {{ edit_modal_button(
                         url_for('admin_dashboard.htmx_institution_type_edit_form', institution_type_id=it.institution_type_id),
                         modal_id='editInstitutionTypeModal',
                         target_id='editInstitutionTypeFormContainer',
                         title='Edit institution type',
-                        stop_propagation=True) }}
-                    {% endif %}
+                        stop_propagation=True,
+                        permission=Permission.EDIT_ORG_METADATA) }}
                 </td>
             </tr>
         </tbody>
@@ -117,7 +115,7 @@
                     {% set mc = inst_to_mnemonic.get(inst.institution_id) %}
                     {% if mc %}
                     <span class="badge bg-secondary font-monospace">{{ mc }}</span>
-                    {% elif is_admin and has_permission(Permission.CREATE_RESOURCES) %}
+                    {% elif has_permission(Permission.CREATE_ORG_METADATA) %}
                     <button class="btn btn-link p-0 border-0"
                             data-bs-toggle="modal"
                             data-bs-target="#createMnemonicCodeModal"
@@ -142,13 +140,12 @@
                 </td>
                 {% endif %}
                 <td class="text-end" onclick="event.stopPropagation();">
-                    {% if is_admin %}
                     {{ edit_modal_button(
                         url_for('admin_dashboard.htmx_institution_edit_form', inst_id=inst.institution_id),
                         modal_id='editInstitutionModal',
                         target_id='editInstitutionFormContainer',
-                        title='Edit institution') }}
-                    {% endif %}
+                        title='Edit institution',
+                        permission=Permission.EDIT_ORG_METADATA) }}
                 </td>
             </tr>
             {# ── Users / Projects sub-row (only when U&P are shown) ── #}
@@ -219,7 +216,7 @@
         <span class="ms-1">(filtered)</span>
         {% endif %}
     </span>
-    {% if has_permission(Permission.CREATE_RESOURCES) %}
+    {% if has_permission(Permission.CREATE_ORG_METADATA) %}
     <div class="d-flex gap-2">
         <button class="btn btn-sm btn-outline-success"
                 data-bs-toggle="modal"

--- a/src/webapp/templates/dashboards/admin/fragments/organization_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/organization_card.html
@@ -1,4 +1,4 @@
-{% from 'dashboards/fragments/action_buttons.html' import edit_modal_button, delete_row_button %}
+{% from 'dashboards/fragments/action_buttons.html' import edit_modal_button, delete_row_button with context %}
 {#
   Admin: Organization Card Body (lazy-loaded into the Organization collapsible section)
   Contains five tabs: Organizations, Institutions (types+institutions combined),
@@ -84,19 +84,17 @@
                             </td>
                             <td>{{ org.users|length }}</td>
                             <td class="text-end">
-                                {% if is_admin %}
                                 {{ edit_modal_button(
                                     url_for('admin_dashboard.htmx_organization_edit_form', org_id=org.organization_id),
                                     modal_id='editOrganizationModal',
                                     target_id='editOrganizationFormContainer',
-                                    title='Edit organization') }}
-                                {% if has_permission(Permission.DELETE_RESOURCES) %}
+                                    title='Edit organization',
+                                    permission=Permission.EDIT_ORG_METADATA) }}
                                 {{ delete_row_button(
                                     url_for('admin_dashboard.htmx_organization_delete', org_id=org.organization_id),
                                     confirm="Deactivate '" ~ org.name ~ "'? This will mark it as inactive.",
-                                    title='Deactivate organization') }}
-                                {% endif %}
-                                {% endif %}
+                                    title='Deactivate organization',
+                                    permission=Permission.DELETE_ORG_METADATA) }}
                             </td>
                         </tr>
                         {% else %}
@@ -109,7 +107,7 @@
                 <span class="text-muted small">
                     Showing {{ organizations|length }} organization{{ 's' if organizations|length != 1 else '' }}
                 </span>
-                {% if has_permission(Permission.CREATE_RESOURCES) %}
+                {% if has_permission(Permission.CREATE_ORG_METADATA) %}
                 <button class="btn btn-sm btn-outline-success"
                         data-bs-toggle="modal"
                         data-bs-target="#createOrganizationModal"
@@ -162,21 +160,19 @@
                             </td>
                             <td class="text-muted small">{{ g.areas|length }} area{{ 's' if g.areas|length != 1 else '' }}</td>
                             <td class="text-end">
-                                {% if is_admin %}
                                 {{ edit_modal_button(
                                     url_for('admin_dashboard.htmx_aoi_group_edit_form', group_id=g.area_of_interest_group_id),
                                     modal_id='editAoiGroupModal',
                                     target_id='editAoiGroupFormContainer',
                                     title='Edit group',
-                                    stop_propagation=True) }}
-                                {% if has_permission(Permission.DELETE_RESOURCES) %}
+                                    stop_propagation=True,
+                                    permission=Permission.EDIT_ORG_METADATA) }}
                                 {{ delete_row_button(
                                     url_for('admin_dashboard.htmx_aoi_group_delete', group_id=g.area_of_interest_group_id),
                                     confirm="Deactivate group '" ~ g.name ~ "'?",
                                     title='Deactivate AOI group',
-                                    stop_propagation=True) }}
-                                {% endif %}
-                                {% endif %}
+                                    stop_propagation=True,
+                                    permission=Permission.DELETE_ORG_METADATA) }}
                             </td>
                         </tr>
                     </tbody>
@@ -187,19 +183,17 @@
                             <td class="ps-4">{{ a.area_of_interest }}</td>
                             <td class="text-muted small">{{ a.projects|length }} project{{ 's' if a.projects|length != 1 else '' }}</td>
                             <td class="text-end">
-                                {% if is_admin %}
                                 {{ edit_modal_button(
                                     url_for('admin_dashboard.htmx_aoi_edit_form', aoi_id=a.area_of_interest_id),
                                     modal_id='editAoiModal',
                                     target_id='editAoiFormContainer',
-                                    title='Edit area of interest') }}
-                                {% if has_permission(Permission.DELETE_RESOURCES) %}
+                                    title='Edit area of interest',
+                                    permission=Permission.EDIT_ORG_METADATA) }}
                                 {{ delete_row_button(
                                     url_for('admin_dashboard.htmx_aoi_delete', aoi_id=a.area_of_interest_id),
                                     confirm="Deactivate '" ~ a.area_of_interest ~ "'?",
-                                    title='Deactivate area of interest') }}
-                                {% endif %}
-                                {% endif %}
+                                    title='Deactivate area of interest',
+                                    permission=Permission.DELETE_ORG_METADATA) }}
                             </td>
                         </tr>
                         {% else %}
@@ -220,7 +214,7 @@
                 <span class="text-muted small">
                     Showing {{ aois|length }} area{{ 's' if aois|length != 1 else '' }}
                 </span>
-                {% if has_permission(Permission.CREATE_RESOURCES) %}
+                {% if has_permission(Permission.CREATE_ORG_METADATA) %}
                 <div class="d-flex gap-2">
                     <button class="btn btn-sm btn-outline-success"
                             data-bs-toggle="modal"
@@ -277,21 +271,19 @@
                             <td></td>
                             <td></td>
                             <td class="text-end">
-                                {% if is_admin %}
                                 {{ edit_modal_button(
                                     url_for('admin_dashboard.htmx_contract_source_edit_form', source_id=cs.contract_source_id),
                                     modal_id='editContractSourceModal',
                                     target_id='editContractSourceFormContainer',
                                     title='Edit source',
-                                    stop_propagation=True) }}
-                                {% if has_permission(Permission.DELETE_RESOURCES) %}
+                                    stop_propagation=True,
+                                    permission=Permission.EDIT_ORG_METADATA) }}
                                 {{ delete_row_button(
                                     url_for('admin_dashboard.htmx_contract_source_delete', source_id=cs.contract_source_id),
                                     confirm="Deactivate source '" ~ cs.contract_source ~ "'?",
                                     title='Deactivate contract source',
-                                    stop_propagation=True) }}
-                                {% endif %}
-                                {% endif %}
+                                    stop_propagation=True,
+                                    permission=Permission.DELETE_ORG_METADATA) }}
                             </td>
                         </tr>
                     </tbody>
@@ -312,19 +304,17 @@
                                 {{ c.end_date | fmt_date }}
                             </td>
                             <td class="text-end">
-                                {% if is_admin %}
                                 {{ edit_modal_button(
                                     url_for('admin_dashboard.htmx_contract_edit_form', contract_id=c.contract_id),
                                     modal_id='editContractModal',
                                     target_id='editContractFormContainer',
-                                    title='Edit contract') }}
-                                {% if has_permission(Permission.DELETE_RESOURCES) %}
+                                    title='Edit contract',
+                                    permission=Permission.EDIT_ORG_METADATA) }}
                                 {{ delete_row_button(
                                     url_for('admin_dashboard.htmx_contract_delete', contract_id=c.contract_id),
                                     confirm="Expire contract '" ~ c.contract_number ~ "'? This sets the end date to today.",
-                                    title='Expire contract') }}
-                                {% endif %}
-                                {% endif %}
+                                    title='Expire contract',
+                                    permission=Permission.DELETE_ORG_METADATA) }}
                             </td>
                         </tr>
                         {% else %}
@@ -345,7 +335,7 @@
                 <span class="text-muted small">
                     Showing {{ contracts|length }} contract{{ 's' if contracts|length != 1 else '' }}
                 </span>
-                {% if has_permission(Permission.CREATE_RESOURCES) %}
+                {% if has_permission(Permission.CREATE_ORG_METADATA) %}
                 <div class="d-flex gap-2">
                     <button class="btn btn-sm btn-outline-success"
                             data-bs-toggle="modal"
@@ -386,19 +376,17 @@
                             <td data-sort-value="{{ p.nsf_program_name }}">{{ p.nsf_program_name }}</td>
                             <td data-sort-value="{{ p.contracts|length }}">{{ p.contracts|length }}</td>
                             <td class="text-end">
-                                {% if is_admin %}
                                 {{ edit_modal_button(
                                     url_for('admin_dashboard.htmx_nsf_program_edit_form', nsf_program_id=p.nsf_program_id),
                                     modal_id='editNsfProgramModal',
                                     target_id='editNsfProgramFormContainer',
-                                    title='Edit NSF program') }}
-                                {% if has_permission(Permission.DELETE_RESOURCES) %}
+                                    title='Edit NSF program',
+                                    permission=Permission.EDIT_ORG_METADATA) }}
                                 {{ delete_row_button(
                                     url_for('admin_dashboard.htmx_nsf_program_delete', nsf_program_id=p.nsf_program_id),
                                     confirm="Deactivate NSF program '" ~ p.nsf_program_name ~ "'?",
-                                    title='Deactivate NSF program') }}
-                                {% endif %}
-                                {% endif %}
+                                    title='Deactivate NSF program',
+                                    permission=Permission.DELETE_ORG_METADATA) }}
                             </td>
                         </tr>
                         {% else %}
@@ -411,7 +399,7 @@
                 <span class="text-muted small">
                     Showing {{ nsf_programs|length }} program{{ 's' if nsf_programs|length != 1 else '' }}
                 </span>
-                {% if has_permission(Permission.CREATE_RESOURCES) %}
+                {% if has_permission(Permission.CREATE_ORG_METADATA) %}
                 <button class="btn btn-sm btn-outline-success"
                         data-bs-toggle="modal"
                         data-bs-target="#createNsfProgramModal"

--- a/src/webapp/templates/dashboards/admin/fragments/resources_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/resources_card.html
@@ -1,4 +1,4 @@
-{% from 'dashboards/fragments/action_buttons.html' import edit_modal_button, delete_row_button %}
+{% from 'dashboards/fragments/action_buttons.html' import edit_modal_button, delete_row_button with context %}
 {#
   Admin: Resources Card Body (lazy-loaded into the Resources collapsible section)
   Contains three tabs: Resources (types+resources combined), Machines, Queues.
@@ -66,21 +66,19 @@
                             </td>
                             <td></td>
                             <td class="text-end">
-                                {% if is_admin %}
                                 {{ edit_modal_button(
                                     url_for('admin_dashboard.htmx_resource_type_edit_form', resource_type_id=rt.resource_type_id),
                                     modal_id='editResourceTypeModal',
                                     target_id='editResourceTypeFormContainer',
                                     title='Edit resource type',
-                                    stop_propagation=True) }}
-                                {% if has_permission(Permission.DELETE_RESOURCES) %}
+                                    stop_propagation=True,
+                                    permission=Permission.EDIT_RESOURCES) }}
                                 {{ delete_row_button(
                                     url_for('admin_dashboard.htmx_resource_type_delete', resource_type_id=rt.resource_type_id),
                                     confirm="Deactivate resource type '" ~ rt.resource_type ~ "'?",
                                     title='Deactivate resource type',
-                                    stop_propagation=True) }}
-                                {% endif %}
-                                {% endif %}
+                                    stop_propagation=True,
+                                    permission=Permission.DELETE_RESOURCES) }}
                             </td>
                         </tr>
                     </tbody>
@@ -95,19 +93,17 @@
                                 {{ r.commission_date | fmt_date }}
                             </td>
                             <td class="text-end text-nowrap">
-                                {% if is_admin %}
                                 {{ edit_modal_button(
                                     url_for('admin_dashboard.htmx_resource_edit_form', resource_id=r.resource_id),
                                     modal_id='editResourceModal',
                                     target_id='editResourceFormContainer',
-                                    title='Edit resource') }}
-                                {% if has_permission(Permission.DELETE_RESOURCES) %}
+                                    title='Edit resource',
+                                    permission=Permission.EDIT_RESOURCES) }}
                                 {{ delete_row_button(
                                     url_for('admin_dashboard.htmx_resource_delete', resource_id=r.resource_id),
                                     confirm="Decommission resource '" ~ r.resource_name ~ "'? This sets the decommission date to today.",
-                                    title='Decommission resource') }}
-                                {% endif %}
-                                {% endif %}
+                                    title='Decommission resource',
+                                    permission=Permission.DELETE_RESOURCES) }}
                             </td>
                         </tr>
                         {% else %}
@@ -189,19 +185,17 @@
                                 {{ m.decommission_date | fmt_date }}
                             </td>
                             <td class="text-end text-nowrap">
-                                {% if is_admin %}
                                 {{ edit_modal_button(
                                     url_for('admin_dashboard.htmx_machine_edit_form', machine_id=m.machine_id),
                                     modal_id='editMachineModal',
                                     target_id='editMachineFormContainer',
-                                    title='Edit machine') }}
-                                {% if has_permission(Permission.DELETE_RESOURCES) %}
+                                    title='Edit machine',
+                                    permission=Permission.EDIT_RESOURCES) }}
                                 {{ delete_row_button(
                                     url_for('admin_dashboard.htmx_machine_delete', machine_id=m.machine_id),
                                     confirm="Decommission machine '" ~ m.name ~ "'? This sets the decommission date to today.",
-                                    title='Decommission machine') }}
-                                {% endif %}
-                                {% endif %}
+                                    title='Decommission machine',
+                                    permission=Permission.DELETE_RESOURCES) }}
                             </td>
                         </tr>
                         {% else %}
@@ -281,19 +275,17 @@
                                 {{ q.end_date | fmt_date }}
                             </td>
                             <td class="text-end">
-                                {% if is_admin %}
                                 {{ edit_modal_button(
                                     url_for('admin_dashboard.htmx_queue_edit_form', queue_id=q.queue_id),
                                     modal_id='editQueueModal',
                                     target_id='editQueueFormContainer',
-                                    title='Edit queue') }}
-                                {% if has_permission(Permission.DELETE_RESOURCES) %}
+                                    title='Edit queue',
+                                    permission=Permission.EDIT_RESOURCES) }}
                                 {{ delete_row_button(
                                     url_for('admin_dashboard.htmx_queue_delete', queue_id=q.queue_id),
                                     confirm="Expire queue '" ~ q.queue_name ~ "'? This sets the end date to today.",
-                                    title='Expire queue') }}
-                                {% endif %}
-                                {% endif %}
+                                    title='Expire queue',
+                                    permission=Permission.DELETE_RESOURCES) }}
                             </td>
                         </tr>
                         {% endfor %}

--- a/src/webapp/templates/dashboards/base.html
+++ b/src/webapp/templates/dashboards/base.html
@@ -45,7 +45,7 @@
                         </a>
                     </li>
                     {% endif %}
-                    {% if has_permission(Permission.IMPERSONATE_USERS) %}
+                    {% if has_permission(Permission.ACCESS_ADMIN_DASHBOARD) %}
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('admin_dashboard.index') }}">
                             <i class="fas fa-user-shield"></i> Admin

--- a/src/webapp/templates/dashboards/base.html
+++ b/src/webapp/templates/dashboards/base.html
@@ -38,14 +38,14 @@
                             <i class="fas fa-server"></i> System Status
                         </a>
                     </li>
-                    {% if has_permission('view_projects') %}
+                    {% if has_permission(Permission.VIEW_PROJECTS) %}
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('allocations_dashboard.index') }}">
                             <i class="fas fa-chart-pie"></i> Allocations
                         </a>
                     </li>
                     {% endif %}
-                    {% if has_permission('impersonate_users') %}
+                    {% if has_permission(Permission.IMPERSONATE_USERS) %}
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('admin_dashboard.index') }}">
                             <i class="fas fa-user-shield"></i> Admin

--- a/src/webapp/templates/dashboards/base.html
+++ b/src/webapp/templates/dashboards/base.html
@@ -93,7 +93,7 @@
     <div class="impersonation-banner alert alert-warning text-center mb-0">
         <div class="container d-flex justify-content-center align-items-center">
             <i class="fas fa-user-secret me-2"></i>
-            <strong>You are currently impersonating {{ user.display_name }} ({{ user.username }}).</strong>
+            <strong>You are currently impersonating {{ current_user.display_name }} ({{ current_user.username }}).</strong>
             <a href="{{ url_for('admin_dashboard.stop_impersonating') }}" class="btn btn-sm btn-outline-dark ms-3">
                 <i class="fas fa-times"></i> Stop Impersonating
             </a>

--- a/src/webapp/templates/dashboards/fragments/action_buttons.html
+++ b/src/webapp/templates/dashboards/fragments/action_buttons.html
@@ -16,13 +16,42 @@
           confirm="Deactivate foo '" ~ foo.name ~ "'?",
           title='Deactivate foo') }}
 
+  Permission self-gating
+  ----------------------
+  When ``permission=Permission.X`` is passed, the macro renders nothing
+  if the current user lacks that system-wide permission. When both
+  ``permission=`` and ``project=`` are passed, the macro uses the
+  project-scoped helper ``can_act_on_project`` (system permission OR
+  project lead/admin); pass ``include_ancestors=True`` for subtree
+  operations like allocation redistribution.
+
+  Backwards-compatible: omitting ``permission=`` renders the button
+  unconditionally — existing call sites are unaffected until they
+  opt into self-gating.
+
+      {{ edit_modal_button(url, ...,
+          permission=Permission.EDIT_RESOURCES) }}
+
+      {{ delete_row_button(url, ...,
+          permission=Permission.EDIT_PROJECT_MEMBERS,
+          project=project) }}
+
   Pass stop_propagation=True when the button sits inside a row that is
   itself a Bootstrap collapse trigger, to prevent the click from toggling
   the parent collapse.
 #}
 
 
-{% macro edit_modal_button(url, modal_id, target_id, title='Edit', stop_propagation=False) -%}
+{% macro edit_modal_button(url, modal_id, target_id, title='Edit',
+                           stop_propagation=False,
+                           permission=None, project=None,
+                           include_ancestors=False) -%}
+{%- set _allowed = (
+    permission is none
+    or (project is not none and can_act_on_project(permission, project, include_ancestors=include_ancestors))
+    or (project is none and has_permission(permission))
+) -%}
+{%- if _allowed -%}
 <button class="btn btn-sm btn-outline-secondary"
         data-bs-toggle="modal"
         data-bs-target="#{{ modal_id }}"
@@ -33,10 +62,20 @@
         {%- if stop_propagation %} onclick="event.stopPropagation()"{% endif %}>
     <i class="fas fa-edit"></i>
 </button>
+{%- endif -%}
 {%- endmacro %}
 
 
-{% macro delete_row_button(url, confirm, title='Delete', stop_propagation=False) -%}
+{% macro delete_row_button(url, confirm, title='Delete',
+                           stop_propagation=False,
+                           permission=None, project=None,
+                           include_ancestors=False) -%}
+{%- set _allowed = (
+    permission is none
+    or (project is not none and can_act_on_project(permission, project, include_ancestors=include_ancestors))
+    or (project is none and has_permission(permission))
+) -%}
+{%- if _allowed -%}
 <button class="btn btn-sm btn-outline-danger ms-1"
         title="{{ title }}"
         hx-delete="{{ url }}"
@@ -46,4 +85,5 @@
         {%- if stop_propagation %} onclick="event.stopPropagation()"{% endif %}>
     <i class="fas fa-trash-alt"></i>
 </button>
+{%- endif -%}
 {%- endmacro %}

--- a/src/webapp/utils/dev_auth.py
+++ b/src/webapp/utils/dev_auth.py
@@ -44,9 +44,7 @@ def auto_login_middleware(app, db):
         sam_user = provider.authenticate(auto_login_username, 'dev-password')  # Stub accepts any password
 
         if sam_user:
-            # Get dev group mapping from config
-            dev_group_mapping = app.config.get('DEV_GROUP_MAPPING', {})
-            auth_user = AuthUser(sam_user, dev_group_mapping=dev_group_mapping)
+            auth_user = AuthUser(sam_user)
 
             # Auto-login without session persistence
             login_user(auth_user, remember=False)

--- a/src/webapp/utils/dev_auth.py
+++ b/src/webapp/utils/dev_auth.py
@@ -44,9 +44,9 @@ def auto_login_middleware(app, db):
         sam_user = provider.authenticate(auto_login_username, 'dev-password')  # Stub accepts any password
 
         if sam_user:
-            # Get dev role mapping from config
-            dev_role_mapping = app.config.get('DEV_ROLE_MAPPING', {})
-            auth_user = AuthUser(sam_user, dev_role_mapping=dev_role_mapping)
+            # Get dev group mapping from config
+            dev_group_mapping = app.config.get('DEV_GROUP_MAPPING', {})
+            auth_user = AuthUser(sam_user, dev_group_mapping=dev_group_mapping)
 
             # Auto-login without session persistence
             login_user(auth_user, remember=False)

--- a/src/webapp/utils/project_permissions.py
+++ b/src/webapp/utils/project_permissions.py
@@ -1,162 +1,163 @@
 """
 Project-level permission utilities for SAM Web UI.
 
-Provides project-specific authorization checks that combine:
-1. Project-level roles (Lead, Admin, Member) - scoped per-project
-2. System-wide RBAC permissions (admin, facility_manager) - global override
+Provides project-scoped authorization checks that combine:
+1. Project-level roles (Lead, Admin, Member) — scoped per-project
+2. System-wide RBAC permissions (admin, facility_manager, …) — global override
 
-This allows both project owners AND system administrators to manage project membership.
+This allows both project owners AND system administrators to manage
+project-scoped operations (member changes, allocation edits, threshold
+tuning, etc.).
+
+The shared shape — "system permission OR project lead/admin (optionally
+walking ancestors)" — lives in ``_is_project_steward``. All public
+``can_*`` helpers delegate to it so the rule set stays consistent.
 """
 
 from webapp.utils.rbac import has_permission, Permission
 
 
-def can_manage_project_members(user, project) -> bool:
+def _is_project_steward(
+    user,
+    project,
+    system_permission: Permission,
+    *,
+    include_ancestors: bool = False,
+) -> bool:
     """
-    Check if user can add/remove members from a project.
+    Authorization primitive used by every project-scoped ``can_*`` check.
 
-    Authorization is granted if ANY of these conditions are true:
-    - User has system-wide EDIT_PROJECT_MEMBERS permission (admin, facility_manager)
-    - User is the project lead
-    - User is the project admin
+    Returns True if **any** of:
+    - The user has ``system_permission`` (e.g. EDIT_PROJECT_MEMBERS,
+      EDIT_ALLOCATIONS) — system-wide override.
+    - The user is the project lead.
+    - The user is the project admin.
+    - When ``include_ancestors`` is True: the user is lead or admin of
+      any ancestor in the project tree (walks ``project.parent`` up to
+      the root).
+
+    ``include_ancestors=True`` is the right choice for operations that
+    apply to a project's subtree — e.g. allocation redistribution,
+    where the lead of a parent project should be able to act on
+    allocations of its children.
 
     Args:
         user: AuthUser object (Flask-Login current_user)
         project: Project ORM object
-
-    Returns:
-        True if user can manage members, False otherwise
+        system_permission: System-wide permission that grants access
+            without consulting project-level roles.
+        include_ancestors: If True, lead/admin of any ancestor counts.
     """
-    # System-wide permission (admin, facility_manager)
-    if has_permission(user, Permission.EDIT_PROJECT_MEMBERS):
+    if has_permission(user, system_permission):
         return True
 
-    # Project lead
-    if project.project_lead_user_id == user.user_id:
-        return True
+    user_id = getattr(user, 'user_id', None)
+    if user_id is None:
+        return False
 
-    # Project admin
-    if project.project_admin_user_id and project.project_admin_user_id == user.user_id:
-        return True
+    candidates = [project]
+    if include_ancestors:
+        current = project.parent
+        while current is not None:
+            candidates.append(current)
+            current = current.parent
+
+    for p in candidates:
+        if p.project_lead_user_id == user_id:
+            return True
+        if p.project_admin_user_id and p.project_admin_user_id == user_id:
+            return True
 
     return False
+
+
+def can_manage_project_members(user, project) -> bool:
+    """
+    Add/remove members from a project.
+
+    Granted to: system EDIT_PROJECT_MEMBERS holders, project lead,
+    project admin.
+    """
+    return _is_project_steward(user, project, Permission.EDIT_PROJECT_MEMBERS)
 
 
 def can_change_admin(user, project) -> bool:
     """
-    Check if user can change the project admin role.
+    Change the project admin role.
 
-    Only the project lead or system admin can change who the admin is.
-    The current admin cannot reassign the admin role to someone else.
-
-    Args:
-        user: AuthUser object (Flask-Login current_user)
-        project: Project ORM object
-
-    Returns:
-        True if user can change admin, False otherwise
+    Granted to: system EDIT_PROJECT_MEMBERS holders or the project lead.
+    The current admin can NOT reassign the admin role to someone else
+    (lead-only invariant).
     """
-    # System-wide permission (admin, facility_manager)
     if has_permission(user, Permission.EDIT_PROJECT_MEMBERS):
         return True
 
-    # Only project lead (not admin) can change admin
-    if project.project_lead_user_id == user.user_id:
-        return True
-
-    return False
+    user_id = getattr(user, 'user_id', None)
+    if user_id is None:
+        return False
+    return project.project_lead_user_id == user_id
 
 
 def can_view_project_members(user, project) -> bool:
     """
-    Check if user can view project members.
+    View a project's member list.
 
-    Currently all authenticated users who are members of a project can view
-    its members. System users with VIEW_PROJECT_MEMBERS can view any project.
-
-    Args:
-        user: AuthUser object (Flask-Login current_user)
-        project: Project ORM object
-
-    Returns:
-        True if user can view members, False otherwise
+    Permissive: system VIEW_PROJECT_MEMBERS holders, project lead/admin,
+    and any authenticated user (members of a project are non-sensitive).
+    Tighten if requirements change.
     """
-    # System-wide permission
     if has_permission(user, Permission.VIEW_PROJECT_MEMBERS):
         return True
 
-    # Project lead or admin
-    if project.project_lead_user_id == user.user_id:
+    user_id = getattr(user, 'user_id', None)
+    if user_id is None:
+        return False
+    if project.project_lead_user_id == user_id:
         return True
-    if project.project_admin_user_id and project.project_admin_user_id == user.user_id:
+    if project.project_admin_user_id and project.project_admin_user_id == user_id:
         return True
 
-    # For now, any authenticated user can view members of projects they're on
-    # This could be restricted further if needed
+    # Permissive default — see docstring.
     return True
 
 
 def can_edit_allocations(user, project) -> bool:
     """
-    Check if user can edit allocations for a project.
+    Edit allocation values (amount, dates, description).
 
-    Authorization is granted if:
-    - User has system-wide EDIT_ALLOCATIONS permission (admin, facility_manager)
-
-    Note: This is intentionally restricted to system administrators only.
-    Project leads/admins do NOT have allocation edit permissions by default,
-    as this is a sensitive operation requiring central oversight.
-
-    Args:
-        user: AuthUser object (Flask-Login current_user)
-        project: Project ORM object
-
-    Returns:
-        True if user can edit allocations, False otherwise
+    Granted to: system EDIT_ALLOCATIONS holders, OR project lead/admin
+    of this project OR any ancestor in the project tree. The
+    ancestor walk supports redistribution within a subtree the user
+    leads — e.g. a lead of project A can edit allocations on its
+    children A1, A2.
     """
-    # System-wide permission (admin, facility_manager)
-    return has_permission(user, Permission.EDIT_ALLOCATIONS)
+    return _is_project_steward(
+        user, project, Permission.EDIT_ALLOCATIONS, include_ancestors=True
+    )
+
+
+# Allocation redistribution is a specialization of allocation editing
+# (same authorization, distinct UI/API surface). The alias exists so
+# callers can use the name that reads best at the call site.
+can_redistribute_allocations = can_edit_allocations
 
 
 def can_edit_consumption_threshold(user, project) -> bool:
     """
-    Check if user can set/change rolling consumption rate thresholds for a project.
+    Set/change rolling consumption-rate thresholds for a project.
 
-    Same authorization as can_manage_project_members: system admin, project lead,
-    or project admin. Regular members may not edit thresholds.
-
-    Args:
-        user: AuthUser object (Flask-Login current_user)
-        project: Project ORM object
-
-    Returns:
-        True if user can edit thresholds, False otherwise
+    Granted to: system EDIT_PROJECT_MEMBERS holders, project lead,
+    project admin. Does NOT walk ancestors — thresholds are scoped to
+    the specific project.
     """
-    # System-wide permission (admin, facility_manager)
-    if has_permission(user, Permission.EDIT_PROJECT_MEMBERS):
-        return True
-
-    # Project lead
-    if project.project_lead_user_id == user.user_id:
-        return True
-
-    # Project admin
-    if project.project_admin_user_id and project.project_admin_user_id == user.user_id:
-        return True
-
-    return False
+    return _is_project_steward(user, project, Permission.EDIT_PROJECT_MEMBERS)
 
 
 def get_user_role_in_project(user_id: int, project) -> str:
     """
     Get the role of a user in a project.
 
-    Args:
-        user_id: The user's ID to check
-        project: Project ORM object
-
-    Returns:
-        Role string: 'Lead', 'Admin', or 'Member'
+    Returns: 'Lead', 'Admin', or 'Member'.
     """
     if project.project_lead_user_id == user_id:
         return 'Lead'

--- a/src/webapp/utils/rbac.py
+++ b/src/webapp/utils/rbac.py
@@ -99,8 +99,9 @@ class Permission(Enum):
     EXPORT_DATA = "export_data"
 
     # System administration
+    ACCESS_ADMIN_DASHBOARD = "access_admin_dashboard"  # Land on /admin/ and see the navbar tab
     MANAGE_ROLES = "manage_roles"
-    IMPERSONATE_USERS = "impersonate_users"
+    IMPERSONATE_USERS = "impersonate_users"  # Actually log in as another user
     VIEW_SYSTEM_STATS = "view_system_stats"
     MANAGE_SYSTEM_STATUS = "manage_system_status"  # Update system status data (collector/API)
     EDIT_SYSTEM_STATUS = "edit_system_status"  # GUI create/edit/delete outages
@@ -155,8 +156,11 @@ GROUP_PERMISSIONS: Dict[str, Set[Permission]] = {
 
     # nusd: read everything + write to projects, allocations, resources,
     # and system status. Does NOT confer write on users/groups/facilities/
-    # org_metadata (those remain admin-only).
+    # org_metadata (those remain admin-only) and does NOT include
+    # IMPERSONATE_USERS — nusd staff land on the admin dashboard but
+    # cannot log in as other users.
     'nusd': ALL_VIEW | {
+        Permission.ACCESS_ADMIN_DASHBOARD,
         Permission.EDIT_PROJECTS,        Permission.CREATE_PROJECTS,
         Permission.EDIT_PROJECT_MEMBERS,
         Permission.EDIT_ALLOCATIONS,     Permission.CREATE_ALLOCATIONS,
@@ -178,6 +182,7 @@ GROUP_PERMISSIONS: Dict[str, Set[Permission]] = {
     # Mirrors nusd — facility managers and nusd staff get the same
     # write surface today.
     'facility_manager': ALL_VIEW | {
+        Permission.ACCESS_ADMIN_DASHBOARD,
         Permission.EDIT_PROJECTS,        Permission.CREATE_PROJECTS,
         Permission.EDIT_PROJECT_MEMBERS,
         Permission.EDIT_ALLOCATIONS,     Permission.CREATE_ALLOCATIONS,

--- a/src/webapp/utils/rbac.py
+++ b/src/webapp/utils/rbac.py
@@ -107,9 +107,37 @@ class Permission(Enum):
     SYSTEM_ADMIN = "system_admin"  # Full access to everything
 
 
+# Building blocks for group bundles
+# ----------------------------------
+# ``_perms_with_action`` returns every Permission whose value starts
+# with one of the given action prefixes — e.g. all ``VIEW_*`` or all
+# ``EDIT_*``. The four ``ALL_*`` constants below pre-compute the common
+# slices so bundles can use plain set arithmetic:
+#
+#     'foo': ALL_VIEW | ALL_EDIT | {Permission.EXPORT_DATA}
+#     'bar': ALL_VIEW - {Permission.VIEW_GROUPS}
+#
+# When a new entity domain (e.g. CONTRACTS) gets a full CRUD set in the
+# Permission enum, every bundle expressed via these constants picks up
+# the new permissions automatically — no need to edit each bundle.
+def _perms_with_action(*action_prefixes: str) -> Set[Permission]:
+    """All Permission members whose value starts with one of the given
+    action prefixes (``'view'``, ``'edit'``, ``'create'``, ``'delete'``)."""
+    return {
+        p for p in Permission
+        if any(p.value.startswith(f'{a}_') for a in action_prefixes)
+    }
+
+
+ALL_VIEW   = _perms_with_action('view')
+ALL_EDIT   = _perms_with_action('edit')
+ALL_CREATE = _perms_with_action('create')
+ALL_DELETE = _perms_with_action('delete')
+
+
 # POSIX-group-to-Permission mapping
 #
-# Keys are POSIX group names (e.g. real groups like 'nusd', 'hsg', 'csg',
+# Keys are POSIX group names (e.g. real groups like 'csg', 'nusd', 'hsg',
 # **and** synthetic dev-only bundles selected by ``DEV_GROUP_MAPPING``).
 # A user receives the union of permissions across all groups they belong
 # to that appear here.
@@ -117,102 +145,63 @@ class Permission(Enum):
 # Groups that don't appear in this dict simply confer no permissions.
 #
 # TODO(rbac_refactor): the real POSIX group → permission bundles below
-# (`nusd`, `hsg`, `csg`) are provisional. Confirm group names and
+# (`csg`, `nusd`, `hsg`) are provisional. Confirm group names and
 # permission contents with the team before the next deploy.
-GROUP_PERMISSIONS: Dict[str, List[Permission]] = {
+GROUP_PERMISSIONS: Dict[str, Set[Permission]] = {
     # ---- Real POSIX group bundles (provisional) ----
-    'nusd': [p for p in Permission],  # admin-equivalent: full access
-    'hsg': [
-        Permission.VIEW_USERS,
-        Permission.VIEW_PROJECTS,
-        Permission.EDIT_PROJECTS,
-        Permission.CREATE_PROJECTS,
-        Permission.VIEW_PROJECT_MEMBERS,
+
+    # csg: full access (admin-equivalent).
+    'csg': set(Permission),
+
+    # nusd: read everything + write to projects, allocations, resources,
+    # and system status. Does NOT confer write on users/groups/facilities/
+    # org_metadata (those remain admin-only).
+    'nusd': ALL_VIEW | {
+        Permission.EDIT_PROJECTS,        Permission.CREATE_PROJECTS,
         Permission.EDIT_PROJECT_MEMBERS,
-        Permission.VIEW_ALLOCATIONS,
-        Permission.EDIT_ALLOCATIONS,
-        Permission.CREATE_ALLOCATIONS,
-        Permission.VIEW_RESOURCES,
+        Permission.EDIT_ALLOCATIONS,     Permission.CREATE_ALLOCATIONS,
         Permission.EDIT_RESOURCES,
-        Permission.VIEW_FACILITIES,
-        Permission.VIEW_GROUPS,
-        Permission.VIEW_ORG_METADATA,
-        Permission.VIEW_REPORTS,
-        Permission.VIEW_CHARGE_SUMMARIES,
-        Permission.EXPORT_DATA,
-        Permission.VIEW_SYSTEM_STATS,
         Permission.EDIT_SYSTEM_STATUS,
-    ],
-    'csg': [
-        Permission.VIEW_USERS,
-        Permission.VIEW_PROJECTS,
-        Permission.VIEW_PROJECT_MEMBERS,
-        Permission.VIEW_ALLOCATIONS,
-        Permission.VIEW_RESOURCES,
-        Permission.VIEW_FACILITIES,
-        Permission.VIEW_GROUPS,
-        Permission.VIEW_ORG_METADATA,
-        Permission.VIEW_REPORTS,
-        Permission.VIEW_CHARGE_SUMMARIES,
         Permission.EXPORT_DATA,
-        Permission.VIEW_SYSTEM_STATS,
-    ],
+    },
+
+    # hsg: read-only across the board + data export.
+    'hsg': ALL_VIEW | {Permission.EXPORT_DATA},
 
     # ---- Synthetic bundles selected by DEV_GROUP_MAPPING ----
     # These keys are not real POSIX groups; they let dev/test configs
     # assign specific permission sets to named usernames without
     # depending on adhoc_group data.
-    'admin': [p for p in Permission],
-    'facility_manager': [
-        Permission.VIEW_USERS,
-        Permission.VIEW_PROJECTS,
-        Permission.EDIT_PROJECTS,
-        Permission.CREATE_PROJECTS,
-        Permission.VIEW_PROJECT_MEMBERS,
+
+    'admin': set(Permission),
+
+    # Mirrors nusd — facility managers and nusd staff get the same
+    # write surface today.
+    'facility_manager': ALL_VIEW | {
+        Permission.EDIT_PROJECTS,        Permission.CREATE_PROJECTS,
         Permission.EDIT_PROJECT_MEMBERS,
-        Permission.VIEW_ALLOCATIONS,
-        Permission.EDIT_ALLOCATIONS,
-        Permission.CREATE_ALLOCATIONS,
-        Permission.VIEW_RESOURCES,
+        Permission.EDIT_ALLOCATIONS,     Permission.CREATE_ALLOCATIONS,
         Permission.EDIT_RESOURCES,
-        Permission.VIEW_FACILITIES,
-        Permission.VIEW_GROUPS,
-        Permission.VIEW_ORG_METADATA,
-        Permission.VIEW_REPORTS,
-        Permission.VIEW_CHARGE_SUMMARIES,
-        Permission.EXPORT_DATA,
-        Permission.VIEW_SYSTEM_STATS,
         Permission.EDIT_SYSTEM_STATUS,
-    ],
-    'project_lead': [
-        Permission.VIEW_USERS,
-        Permission.VIEW_PROJECTS,
-        Permission.VIEW_PROJECT_MEMBERS,
-        Permission.VIEW_ALLOCATIONS,
-        Permission.VIEW_RESOURCES,
-        Permission.VIEW_FACILITIES,
-        Permission.VIEW_REPORTS,
-        Permission.VIEW_CHARGE_SUMMARIES,
-    ],
-    'user': [
-        Permission.VIEW_PROJECTS,
-        Permission.VIEW_ALLOCATIONS,
-        Permission.VIEW_CHARGE_SUMMARIES,
-    ],
-    'analyst': [
-        Permission.VIEW_USERS,
-        Permission.VIEW_PROJECTS,
-        Permission.VIEW_PROJECT_MEMBERS,
-        Permission.VIEW_ALLOCATIONS,
-        Permission.VIEW_RESOURCES,
-        Permission.VIEW_FACILITIES,
+        Permission.EXPORT_DATA,
+    },
+
+    # project_lead: subset of read access — no groups/org_metadata/system_stats.
+    'project_lead': ALL_VIEW - {
         Permission.VIEW_GROUPS,
         Permission.VIEW_ORG_METADATA,
-        Permission.VIEW_REPORTS,
-        Permission.VIEW_CHARGE_SUMMARIES,
-        Permission.EXPORT_DATA,
         Permission.VIEW_SYSTEM_STATS,
-    ],
+    },
+
+    # user: minimal — just enough to see their own projects/allocations/charges.
+    'user': {
+        Permission.VIEW_PROJECTS,
+        Permission.VIEW_ALLOCATIONS,
+        Permission.VIEW_CHARGE_SUMMARIES,
+    },
+
+    # analyst: read-only across the board + data export (same shape as hsg).
+    'analyst': ALL_VIEW | {Permission.EXPORT_DATA},
 }
 
 
@@ -226,6 +215,7 @@ GROUP_PERMISSIONS: Dict[str, List[Permission]] = {
 # Keys: usernames. Values: set of Permission enum members to grant.
 USER_PERMISSION_OVERRIDES: Dict[str, Set[Permission]] = {
     # 'someuser': {Permission.EXPORT_DATA, Permission.VIEW_REPORTS},
+    'benkirk' : [p for p in Permission],  # admin-equivalent: full access
 }
 
 

--- a/src/webapp/utils/rbac.py
+++ b/src/webapp/utils/rbac.py
@@ -146,20 +146,19 @@ GROUP_PERMISSIONS: Dict[str, Set[Permission]] = {
     # ---- Real POSIX group bundles (provisional) ----
 
     # csg: full access (admin-equivalent).
-    'csg': set(Permission),
+    #'csg': set(Permission),
 
     # nusd: read, edit,everything + write to projects, allocations
     # and system status. Does NOT confer write on users/groups/facilities/
-    # org_metadata (those remain admin-only) and does NOT include
-    # IMPERSONATE_USERS — nusd staff land on the admin dashboard but
-    # cannot log in as other users.
+    # org_metadata (those remain admin-only).
     'nusd': ALL_VIEW | ALL_EDIT | {
         Permission.ACCESS_ADMIN_DASHBOARD,
         Permission.CREATE_PROJECTS,
         Permission.CREATE_ALLOCATIONS,
     },
 
-    # hsg: read-only across the board + data export.
+    # hsg: read-only across the board,
+    # resources permissions, and edit system status (for outages etc...)
     'hsg': ALL_VIEW | {
         Permission.ACCESS_ADMIN_DASHBOARD,
         Permission.EDIT_RESOURCES, Permission.CREATE_RESOURCES,
@@ -167,6 +166,8 @@ GROUP_PERMISSIONS: Dict[str, Set[Permission]] = {
     },
 }
 
+# csg - same as nusd
+GROUP_PERMISSIONS['csg'] = GROUP_PERMISSIONS['nusd']
 
 # Per-user permission overrides
 #

--- a/src/webapp/utils/rbac.py
+++ b/src/webapp/utils/rbac.py
@@ -403,10 +403,31 @@ def rbac_context_processor():
         {% if has_permission(Permission.EDIT_USERS) %}
             <a href="/users/edit">Edit Users</a>
         {% endif %}
+
+        {# Project-scoped check via the conditional helper. Returns True
+           when current_user has the system permission OR is project
+           lead/admin (or ancestor lead/admin if include_ancestors=True). #}
+        {% if can_act_on_project(Permission.EDIT_ALLOCATIONS, project, include_ancestors=True) %}
+            <a href="...">Redistribute</a>
+        {% endif %}
     """
+    # Late import to avoid the circular path
+    # rbac → project_permissions → rbac at module import time.
+    from webapp.utils.project_permissions import _is_project_steward
+
+    def _can_act_on_project(permission, project, include_ancestors=False):
+        if project is None:
+            return False
+        if current_user is None or not current_user.is_authenticated:
+            return False
+        return _is_project_steward(
+            current_user, project, permission, include_ancestors=include_ancestors
+        )
+
     return {
         'Permission': Permission,
         'has_permission': lambda p: has_permission(current_user, p) if current_user.is_authenticated else False,
         'has_role': lambda r: has_role(current_user, r) if current_user.is_authenticated else False,
         'user_permissions': get_user_permissions(current_user) if current_user.is_authenticated else set(),
+        'can_act_on_project': _can_act_on_project,
     }

--- a/src/webapp/utils/rbac.py
+++ b/src/webapp/utils/rbac.py
@@ -10,10 +10,9 @@ Authorization model
 A user's permissions are derived from two sources, unioned together:
 
 1. **POSIX group membership** — each group the user belongs to may map
-   to a bundle of permissions in ``GROUP_PERMISSIONS``. In production,
-   group membership is read from ``adhoc_system_account_entry`` via
-   ``get_user_group_access()``. In dev/test, ``DEV_GROUP_MAPPING``
-   in app config supplies synthetic group names per username.
+   to a bundle of permissions in ``GROUP_PERMISSIONS``. Group membership
+   is read from ``adhoc_system_account_entry`` via
+   ``get_user_group_access()`` in dev, test, and production alike.
 
 2. **Per-user overrides** — ``USER_PERMISSION_OVERRIDES`` grants
    additional permissions to specific usernames on top of whatever
@@ -25,9 +24,9 @@ those are not consulted by the webapp's RBAC layer.
 
 The string set returned by ``AuthUser.roles`` is the set of POSIX group
 names the user belongs to that have a ``GROUP_PERMISSIONS`` bundle.
-This keeps ``has_role('admin')``-style checks working as a coarse
-display label, but the source of truth for authorization is the
-permission set, not the role label.
+This keeps ``has_role('csg')``-style checks working as a coarse display
+label, but the source of truth for authorization is the permission set,
+not the role label.
 """
 
 from enum import Enum
@@ -138,75 +137,34 @@ ALL_DELETE = _perms_with_action('delete')
 
 # POSIX-group-to-Permission mapping
 #
-# Keys are POSIX group names (e.g. real groups like 'csg', 'nusd', 'hsg',
-# **and** synthetic dev-only bundles selected by ``DEV_GROUP_MAPPING``).
+# Keys are POSIX group names (e.g. real groups like 'csg', 'nusd', 'hsg'.
 # A user receives the union of permissions across all groups they belong
 # to that appear here.
 #
 # Groups that don't appear in this dict simply confer no permissions.
-#
-# TODO(rbac_refactor): the real POSIX group → permission bundles below
-# (`csg`, `nusd`, `hsg`) are provisional. Confirm group names and
-# permission contents with the team before the next deploy.
 GROUP_PERMISSIONS: Dict[str, Set[Permission]] = {
     # ---- Real POSIX group bundles (provisional) ----
 
     # csg: full access (admin-equivalent).
     'csg': set(Permission),
 
-    # nusd: read everything + write to projects, allocations, resources,
+    # nusd: read, edit,everything + write to projects, allocations
     # and system status. Does NOT confer write on users/groups/facilities/
     # org_metadata (those remain admin-only) and does NOT include
     # IMPERSONATE_USERS — nusd staff land on the admin dashboard but
     # cannot log in as other users.
-    'nusd': ALL_VIEW | {
+    'nusd': ALL_VIEW | ALL_EDIT | {
         Permission.ACCESS_ADMIN_DASHBOARD,
-        Permission.EDIT_PROJECTS,        Permission.CREATE_PROJECTS,
-        Permission.EDIT_PROJECT_MEMBERS,
-        Permission.EDIT_ALLOCATIONS,     Permission.CREATE_ALLOCATIONS,
-        Permission.EDIT_RESOURCES,
-        Permission.EDIT_SYSTEM_STATUS,
-        Permission.EXPORT_DATA,
+        Permission.CREATE_PROJECTS,
+        Permission.CREATE_ALLOCATIONS,
     },
 
     # hsg: read-only across the board + data export.
-    'hsg': ALL_VIEW | {Permission.EXPORT_DATA},
-
-    # ---- Synthetic bundles selected by DEV_GROUP_MAPPING ----
-    # These keys are not real POSIX groups; they let dev/test configs
-    # assign specific permission sets to named usernames without
-    # depending on adhoc_group data.
-
-    'admin': set(Permission),
-
-    # Mirrors nusd — facility managers and nusd staff get the same
-    # write surface today.
-    'facility_manager': ALL_VIEW | {
+    'hsg': ALL_VIEW | {
         Permission.ACCESS_ADMIN_DASHBOARD,
-        Permission.EDIT_PROJECTS,        Permission.CREATE_PROJECTS,
-        Permission.EDIT_PROJECT_MEMBERS,
-        Permission.EDIT_ALLOCATIONS,     Permission.CREATE_ALLOCATIONS,
-        Permission.EDIT_RESOURCES,
-        Permission.EDIT_SYSTEM_STATUS,
-        Permission.EXPORT_DATA,
+        Permission.EDIT_RESOURCES, Permission.CREATE_RESOURCES,
+        Permission.EDIT_SYSTEM_STATUS
     },
-
-    # project_lead: subset of read access — no groups/org_metadata/system_stats.
-    'project_lead': ALL_VIEW - {
-        Permission.VIEW_GROUPS,
-        Permission.VIEW_ORG_METADATA,
-        Permission.VIEW_SYSTEM_STATS,
-    },
-
-    # user: minimal — just enough to see their own projects/allocations/charges.
-    'user': {
-        Permission.VIEW_PROJECTS,
-        Permission.VIEW_ALLOCATIONS,
-        Permission.VIEW_CHARGE_SUMMARIES,
-    },
-
-    # analyst: read-only across the board + data export (same shape as hsg).
-    'analyst': ALL_VIEW | {Permission.EXPORT_DATA},
 }
 
 
@@ -302,9 +260,9 @@ def has_role(user, role_name: str) -> bool:
     Check if user belongs to a specific group bundle (display label).
 
     Note: 'role' here is the name of a ``GROUP_PERMISSIONS`` bundle
-    (POSIX group name or synthetic dev bundle name). For authorization
-    decisions prefer ``has_permission``; use this only for display logic
-    or coarse role-name checks.
+    (POSIX group name). For authorization decisions prefer
+    ``has_permission``; use this only for display logic or coarse
+    role-name checks.
     """
     return user.has_role(role_name)
 

--- a/src/webapp/utils/rbac.py
+++ b/src/webapp/utils/rbac.py
@@ -1,12 +1,37 @@
 """
 Role-Based Access Control (RBAC) utilities for SAM Web UI.
 
-Defines permissions, role mappings, and utility functions for checking access.
-Works with both Flask-Admin views and custom API endpoints.
+Defines permissions, POSIX-group-to-permission mappings, and utility
+functions for checking access. Works with both Flask-Admin views and
+custom API endpoints.
+
+Authorization model
+-------------------
+A user's permissions are derived from two sources, unioned together:
+
+1. **POSIX group membership** — each group the user belongs to may map
+   to a bundle of permissions in ``GROUP_PERMISSIONS``. In production,
+   group membership is read from ``adhoc_system_account_entry`` via
+   ``get_user_group_access()``. In dev/test, ``DEV_GROUP_MAPPING``
+   in app config supplies synthetic group names per username.
+
+2. **Per-user overrides** — ``USER_PERMISSION_OVERRIDES`` grants
+   additional permissions to specific usernames on top of whatever
+   their groups confer. Useful for one-off privilege grants without
+   touching group membership.
+
+There is **no dependency on the SAM ``role_user`` / ``role`` tables**;
+those are not consulted by the webapp's RBAC layer.
+
+The string set returned by ``AuthUser.roles`` is the set of POSIX group
+names the user belongs to that have a ``GROUP_PERMISSIONS`` bundle.
+This keeps ``has_role('admin')``-style checks working as a coarse
+display label, but the source of truth for authorization is the
+permission set, not the role label.
 """
 
 from enum import Enum
-from typing import Set, List
+from typing import Set, List, Dict
 from functools import wraps
 from flask import abort
 from flask_login import current_user
@@ -16,8 +41,10 @@ class Permission(Enum):
     """
     System-wide permissions for SAM Web UI.
 
-    These permissions can be assigned to roles and checked
-    in views, templates, and API endpoints.
+    These permissions can be assigned to POSIX-group bundles (see
+    ``GROUP_PERMISSIONS``) or granted to individual users (see
+    ``USER_PERMISSION_OVERRIDES``), and checked in views, templates,
+    and API endpoints.
     """
 
     # User management
@@ -40,11 +67,30 @@ class Permission(Enum):
     CREATE_ALLOCATIONS = "create_allocations"
     DELETE_ALLOCATIONS = "delete_allocations"
 
-    # Resource management
+    # Resource management (machines, queues, resource definitions)
     VIEW_RESOURCES = "view_resources"
     EDIT_RESOURCES = "edit_resources"
     CREATE_RESOURCES = "create_resources"
     DELETE_RESOURCES = "delete_resources"
+
+    # Facility management (UNIV, WNA, ...)
+    VIEW_FACILITIES = "view_facilities"
+    EDIT_FACILITIES = "edit_facilities"
+    CREATE_FACILITIES = "create_facilities"
+    DELETE_FACILITIES = "delete_facilities"
+
+    # Group management (adhoc/POSIX groups)
+    VIEW_GROUPS = "view_groups"
+    EDIT_GROUPS = "edit_groups"
+    CREATE_GROUPS = "create_groups"
+    DELETE_GROUPS = "delete_groups"
+
+    # Organizational metadata: organizations, institutions, contracts,
+    # NSF programs, areas of interest. Slowly-changing reference data.
+    VIEW_ORG_METADATA = "view_org_metadata"
+    EDIT_ORG_METADATA = "edit_org_metadata"
+    CREATE_ORG_METADATA = "create_org_metadata"
+    DELETE_ORG_METADATA = "delete_org_metadata"
 
     # Reports and analytics
     VIEW_REPORTS = "view_reports"
@@ -61,14 +107,22 @@ class Permission(Enum):
     SYSTEM_ADMIN = "system_admin"  # Full access to everything
 
 
-# Role-to-Permission mapping
-# This can later be moved to database for dynamic role management
-ROLE_PERMISSIONS = {
-    # System administrator - full access
-    "admin": [p for p in Permission],
-
-    # Facility manager - can manage projects, allocations, resources
-    "facility_manager": [
+# POSIX-group-to-Permission mapping
+#
+# Keys are POSIX group names (e.g. real groups like 'nusd', 'hsg', 'csg',
+# **and** synthetic dev-only bundles selected by ``DEV_GROUP_MAPPING``).
+# A user receives the union of permissions across all groups they belong
+# to that appear here.
+#
+# Groups that don't appear in this dict simply confer no permissions.
+#
+# TODO(rbac_refactor): the real POSIX group → permission bundles below
+# (`nusd`, `hsg`, `csg`) are provisional. Confirm group names and
+# permission contents with the team before the next deploy.
+GROUP_PERMISSIONS: Dict[str, List[Permission]] = {
+    # ---- Real POSIX group bundles (provisional) ----
+    'nusd': [p for p in Permission],  # admin-equivalent: full access
+    'hsg': [
         Permission.VIEW_USERS,
         Permission.VIEW_PROJECTS,
         Permission.EDIT_PROJECTS,
@@ -80,37 +134,80 @@ ROLE_PERMISSIONS = {
         Permission.CREATE_ALLOCATIONS,
         Permission.VIEW_RESOURCES,
         Permission.EDIT_RESOURCES,
+        Permission.VIEW_FACILITIES,
+        Permission.VIEW_GROUPS,
+        Permission.VIEW_ORG_METADATA,
         Permission.VIEW_REPORTS,
         Permission.VIEW_CHARGE_SUMMARIES,
         Permission.EXPORT_DATA,
         Permission.VIEW_SYSTEM_STATS,
         Permission.EDIT_SYSTEM_STATUS,
     ],
-
-    # Project lead - can view their projects and allocations
-    "project_lead": [
-        Permission.VIEW_USERS,
-        Permission.VIEW_PROJECTS,
-        Permission.VIEW_PROJECT_MEMBERS,
-        Permission.VIEW_ALLOCATIONS,
-        Permission.VIEW_REPORTS,
-        Permission.VIEW_CHARGE_SUMMARIES,
-    ],
-
-    # Regular user - read-only access to their own data
-    "user": [
-        Permission.VIEW_PROJECTS,
-        Permission.VIEW_ALLOCATIONS,
-        Permission.VIEW_CHARGE_SUMMARIES,
-    ],
-
-    # Read-only analyst - can view everything but not modify
-    "analyst": [
+    'csg': [
         Permission.VIEW_USERS,
         Permission.VIEW_PROJECTS,
         Permission.VIEW_PROJECT_MEMBERS,
         Permission.VIEW_ALLOCATIONS,
         Permission.VIEW_RESOURCES,
+        Permission.VIEW_FACILITIES,
+        Permission.VIEW_GROUPS,
+        Permission.VIEW_ORG_METADATA,
+        Permission.VIEW_REPORTS,
+        Permission.VIEW_CHARGE_SUMMARIES,
+        Permission.EXPORT_DATA,
+        Permission.VIEW_SYSTEM_STATS,
+    ],
+
+    # ---- Synthetic bundles selected by DEV_GROUP_MAPPING ----
+    # These keys are not real POSIX groups; they let dev/test configs
+    # assign specific permission sets to named usernames without
+    # depending on adhoc_group data.
+    'admin': [p for p in Permission],
+    'facility_manager': [
+        Permission.VIEW_USERS,
+        Permission.VIEW_PROJECTS,
+        Permission.EDIT_PROJECTS,
+        Permission.CREATE_PROJECTS,
+        Permission.VIEW_PROJECT_MEMBERS,
+        Permission.EDIT_PROJECT_MEMBERS,
+        Permission.VIEW_ALLOCATIONS,
+        Permission.EDIT_ALLOCATIONS,
+        Permission.CREATE_ALLOCATIONS,
+        Permission.VIEW_RESOURCES,
+        Permission.EDIT_RESOURCES,
+        Permission.VIEW_FACILITIES,
+        Permission.VIEW_GROUPS,
+        Permission.VIEW_ORG_METADATA,
+        Permission.VIEW_REPORTS,
+        Permission.VIEW_CHARGE_SUMMARIES,
+        Permission.EXPORT_DATA,
+        Permission.VIEW_SYSTEM_STATS,
+        Permission.EDIT_SYSTEM_STATUS,
+    ],
+    'project_lead': [
+        Permission.VIEW_USERS,
+        Permission.VIEW_PROJECTS,
+        Permission.VIEW_PROJECT_MEMBERS,
+        Permission.VIEW_ALLOCATIONS,
+        Permission.VIEW_RESOURCES,
+        Permission.VIEW_FACILITIES,
+        Permission.VIEW_REPORTS,
+        Permission.VIEW_CHARGE_SUMMARIES,
+    ],
+    'user': [
+        Permission.VIEW_PROJECTS,
+        Permission.VIEW_ALLOCATIONS,
+        Permission.VIEW_CHARGE_SUMMARIES,
+    ],
+    'analyst': [
+        Permission.VIEW_USERS,
+        Permission.VIEW_PROJECTS,
+        Permission.VIEW_PROJECT_MEMBERS,
+        Permission.VIEW_ALLOCATIONS,
+        Permission.VIEW_RESOURCES,
+        Permission.VIEW_FACILITIES,
+        Permission.VIEW_GROUPS,
+        Permission.VIEW_ORG_METADATA,
         Permission.VIEW_REPORTS,
         Permission.VIEW_CHARGE_SUMMARIES,
         Permission.EXPORT_DATA,
@@ -119,22 +216,44 @@ ROLE_PERMISSIONS = {
 }
 
 
+# Per-user permission overrides
+#
+# Grants additional permissions to a specific username on top of
+# whatever their group memberships confer. Useful for one-off privilege
+# grants (e.g. a non-`hsg` user who needs EXPORT_DATA temporarily)
+# without modifying group bundles or POSIX group membership.
+#
+# Keys: usernames. Values: set of Permission enum members to grant.
+USER_PERMISSION_OVERRIDES: Dict[str, Set[Permission]] = {
+    # 'someuser': {Permission.EXPORT_DATA, Permission.VIEW_REPORTS},
+}
+
+
 def get_user_permissions(user) -> Set[Permission]:
     """
-    Get all permissions for a user based on their roles.
+    Get all permissions for a user.
+
+    Composes the union of:
+    - Permissions from each POSIX group the user belongs to that has a
+      bundle in ``GROUP_PERMISSIONS`` (read from ``user.roles``, which
+      is the set of bundle-matching group names the AuthUser exposed)
+    - Per-user overrides from ``USER_PERMISSION_OVERRIDES``
 
     Args:
-        user: AuthUser object with roles
+        user: AuthUser object (Flask-Login current_user)
 
     Returns:
         Set of Permission enum values the user has
     """
-    permissions = set()
+    permissions: Set[Permission] = set()
 
-    # Get permissions from all user's roles
-    for role_name in user.roles:
-        if role_name in ROLE_PERMISSIONS:
-            permissions.update(ROLE_PERMISSIONS[role_name])
+    for group_name in user.roles:
+        if group_name in GROUP_PERMISSIONS:
+            permissions.update(GROUP_PERMISSIONS[group_name])
+
+    overrides = USER_PERMISSION_OVERRIDES.get(getattr(user, 'username', None))
+    if overrides:
+        permissions.update(overrides)
 
     return permissions
 
@@ -150,12 +269,7 @@ def has_permission(user, permission: Permission) -> bool:
     Returns:
         True if user has the permission, False otherwise
     """
-    # System admins always have all permissions
-    if user.has_role('admin'):
-        return True
-
-    user_perms = get_user_permissions(user)
-    return permission in user_perms
+    return permission in get_user_permissions(user)
 
 
 def has_any_permission(user, *permissions: Permission) -> bool:
@@ -190,28 +304,19 @@ def has_all_permissions(user, *permissions: Permission) -> bool:
 
 def has_role(user, role_name: str) -> bool:
     """
-    Check if user has a specific role.
+    Check if user belongs to a specific group bundle (display label).
 
-    Args:
-        user: AuthUser object
-        role_name: Name of role to check
-
-    Returns:
-        True if user has the role, False otherwise
+    Note: 'role' here is the name of a ``GROUP_PERMISSIONS`` bundle
+    (POSIX group name or synthetic dev bundle name). For authorization
+    decisions prefer ``has_permission``; use this only for display logic
+    or coarse role-name checks.
     """
     return user.has_role(role_name)
 
 
 def has_any_role(user, *role_names: str) -> bool:
     """
-    Check if user has any of the specified roles.
-
-    Args:
-        user: AuthUser object
-        *role_names: Role names to check
-
-    Returns:
-        True if user has at least one role, False otherwise
+    Check if user belongs to any of the specified group bundles.
     """
     return user.has_any_role(*role_names)
 
@@ -265,7 +370,7 @@ def require_any_permission(*permissions: Permission):
 
 def require_role(*role_names: str):
     """
-    Decorator to require any of the specified roles.
+    Decorator to require any of the specified group bundles.
 
     Usage:
         @app.route('/admin')

--- a/tests/api/test_health_endpoints.py
+++ b/tests/api/test_health_endpoints.py
@@ -7,10 +7,11 @@ Covers:
   GET /api/v1/health/ready  — public readiness (delegates to health)
   GET /api/v1/health/db-pool — admin-only pool statistics
 
-The `non_admin_client` fixture lives in new_tests/conftest.py and picks
-any active non-benkirk user from the snapshot — `load_user()` will assign
-that user the default `['user']` role because their username isn't in
-`TestingConfig.DEV_ROLE_MAPPING`.
+The `non_admin_client` fixture lives in tests/conftest.py and picks any
+active non-benkirk user from the snapshot — `load_user()` will resolve
+that user's permissions from POSIX group membership (no entry in
+`TestingConfig.DEV_GROUP_MAPPING`), which in the test snapshot typically
+means an empty role/permission set.
 """
 
 import pytest

--- a/tests/api/test_health_endpoints.py
+++ b/tests/api/test_health_endpoints.py
@@ -9,8 +9,8 @@ Covers:
 
 The `non_admin_client` fixture lives in tests/conftest.py and picks any
 active non-benkirk user from the snapshot — `load_user()` will resolve
-that user's permissions from POSIX group membership (no entry in
-`TestingConfig.DEV_GROUP_MAPPING`), which in the test snapshot typically
+that user's permissions from POSIX group membership (and they're not in
+`USER_PERMISSION_OVERRIDES`), which in the test snapshot typically
 means an empty role/permission set.
 """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,38 @@ def pytest_configure(config):
         sys.path.insert(0, tests_path)
 
 
+# ---- Test-only RBAC bundle ------------------------------------------------
+#
+# Registers a synthetic group bundle ``admin-testing-only`` that grants
+# every ``Permission``, used by stub-user tests that need a "system
+# admin" without depending on the contents of any real production
+# bundle (csg / nusd / hsg). Keeping this bundle defined inside the
+# test session means production code never sees it — `GROUP_PERMISSIONS`
+# in `webapp/utils/rbac.py` stays restricted to real POSIX groups.
+#
+# Tests opt in by writing `roles=['admin-testing-only']` on their stub
+# user. The fixture is autouse + session-scoped so the registration
+# happens once per xdist worker before any test runs and is removed at
+# the end of the session.
+
+ADMIN_TESTING_BUNDLE = 'admin-testing-only'
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _register_admin_testing_bundle():
+    from webapp.utils.rbac import GROUP_PERMISSIONS, Permission
+
+    assert ADMIN_TESTING_BUNDLE not in GROUP_PERMISSIONS, (
+        f"{ADMIN_TESTING_BUNDLE!r} collides with a real bundle — rename "
+        "the test-only bundle in tests/conftest.py."
+    )
+    GROUP_PERMISSIONS[ADMIN_TESTING_BUNDLE] = set(Permission)
+    try:
+        yield
+    finally:
+        GROUP_PERMISSIONS.pop(ADMIN_TESTING_BUNDLE, None)
+
+
 # ---- Engine / session fixtures --------------------------------------------
 
 
@@ -208,7 +240,7 @@ def app(test_db_url, status_db_url):
 
     Uses `create_app(config_overrides=...)` to point Flask-SQLAlchemy at
     the test DB without touching `sam.session.connection_string`. Everything
-    else (DEV_GROUP_MAPPING, API_KEYS, TESTING=True, WTF_CSRF_ENABLED=False,
+    else (API_KEYS, TESTING=True, WTF_CSRF_ENABLED=False,
     ALLOCATION_USAGE_CACHE_TTL=0) comes from `TestingConfig`, selected via
     `FLASK_CONFIG='testing'`.
 
@@ -240,8 +272,8 @@ def app(test_db_url, status_db_url):
     })
 
     # Regression guard — mirrors the legacy app fixture. Fails loudly if
-    # TestingConfig didn't load (which would mean DEV_GROUP_MAPPING, API_KEYS,
-    # and cache disables are all wrong).
+    # TestingConfig didn't load (which would mean API_KEYS and cache
+    # disables are all wrong).
     assert flask_app.config["ALLOCATION_USAGE_CACHE_TTL"] == 0, (
         "TestingConfig not loaded — check FLASK_CONFIG env var and "
         "webapp.config.get_webapp_config() class selection"
@@ -267,13 +299,14 @@ def client(app):
 
 @pytest.fixture
 def auth_client(client, session):
-    """Test client logged in as `benkirk` — admin via TestingConfig.DEV_GROUP_MAPPING.
+    """Test client logged in as `benkirk` — admin-equivalent via
+    `USER_PERMISSION_OVERRIDES['benkirk']` in `webapp.utils.rbac`.
 
     Uses Flask-Login's session-cookie mechanism (`client.session_transaction()`
     → `sess['_user_id']`). This triggers the `load_user()` callback in the
-    login_manager, which reads `DEV_GROUP_MAPPING` from TestingConfig so
-    benkirk gets the `admin` role without needing any real `role_user`
-    rows in the DB. Same pattern as the legacy fixture.
+    login_manager. `benkirk` resolves to the full Permission set via the
+    user-override layer — no POSIX-group membership required, no
+    `role_user` rows required.
     """
     from sam import User
 
@@ -293,10 +326,11 @@ def auth_client(client, session):
 def non_admin_client(client, session):
     """Test client logged in as a non-admin user from the snapshot.
 
-    Picks any active user who isn't `benkirk` — their username won't be
-    in `TestingConfig.DEV_GROUP_MAPPING`, so `load_user()` assigns them
-    the default `['user']` role. Used by tests that need to verify
-    403-on-admin-only-routes behavior.
+    Picks any active user who isn't `benkirk` — they're not in
+    `USER_PERMISSION_OVERRIDES`, and the obfuscated test snapshot
+    typically gives them no POSIX-group membership in any
+    `GROUP_PERMISSIONS` bundle, so they end up with no permissions.
+    Used by tests that need to verify 403-on-admin-only-routes behavior.
 
     We can't use a factory-built user here: `load_user` goes through
     Flask-SQLAlchemy's `db.session` (its own connection, not the raw

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,7 +208,7 @@ def app(test_db_url, status_db_url):
 
     Uses `create_app(config_overrides=...)` to point Flask-SQLAlchemy at
     the test DB without touching `sam.session.connection_string`. Everything
-    else (DEV_ROLE_MAPPING, API_KEYS, TESTING=True, WTF_CSRF_ENABLED=False,
+    else (DEV_GROUP_MAPPING, API_KEYS, TESTING=True, WTF_CSRF_ENABLED=False,
     ALLOCATION_USAGE_CACHE_TTL=0) comes from `TestingConfig`, selected via
     `FLASK_CONFIG='testing'`.
 
@@ -240,7 +240,7 @@ def app(test_db_url, status_db_url):
     })
 
     # Regression guard — mirrors the legacy app fixture. Fails loudly if
-    # TestingConfig didn't load (which would mean DEV_ROLE_MAPPING, API_KEYS,
+    # TestingConfig didn't load (which would mean DEV_GROUP_MAPPING, API_KEYS,
     # and cache disables are all wrong).
     assert flask_app.config["ALLOCATION_USAGE_CACHE_TTL"] == 0, (
         "TestingConfig not loaded — check FLASK_CONFIG env var and "
@@ -267,11 +267,11 @@ def client(app):
 
 @pytest.fixture
 def auth_client(client, session):
-    """Test client logged in as `benkirk` — admin via TestingConfig.DEV_ROLE_MAPPING.
+    """Test client logged in as `benkirk` — admin via TestingConfig.DEV_GROUP_MAPPING.
 
     Uses Flask-Login's session-cookie mechanism (`client.session_transaction()`
     → `sess['_user_id']`). This triggers the `load_user()` callback in the
-    login_manager, which reads `DEV_ROLE_MAPPING` from TestingConfig so
+    login_manager, which reads `DEV_GROUP_MAPPING` from TestingConfig so
     benkirk gets the `admin` role without needing any real `role_user`
     rows in the DB. Same pattern as the legacy fixture.
     """
@@ -294,7 +294,7 @@ def non_admin_client(client, session):
     """Test client logged in as a non-admin user from the snapshot.
 
     Picks any active user who isn't `benkirk` — their username won't be
-    in `TestingConfig.DEV_ROLE_MAPPING`, so `load_user()` assigns them
+    in `TestingConfig.DEV_GROUP_MAPPING`, so `load_user()` assigns them
     the default `['user']` role. Used by tests that need to verify
     403-on-admin-only-routes behavior.
 

--- a/tests/unit/test_access_control_decorators.py
+++ b/tests/unit/test_access_control_decorators.py
@@ -103,7 +103,11 @@ class TestRequireProjectPermission:
         assert result == 'ok'
 
     def test_system_permission_holder_passes(self, mini_app):
-        user = _stub_user(user_id=99, roles=['admin'])
+        # 'admin-testing-only' (registered in conftest) grants every
+        # Permission, including EDIT_PROJECT_MEMBERS, so this user gets
+        # through on the system-permission branch even though they're
+        # neither lead nor admin of the project.
+        user = _stub_user(user_id=99, roles=['admin-testing-only'])
         project = _stub_project(lead_id=1, admin_id=2)
         result, _ = self._call_decorated(mini_app, user, project)
         assert result == 'ok'
@@ -234,7 +238,7 @@ class TestRequireAllocationPermission:
         alloc = Mock()
         alloc.allocation_id = 123
         alloc.account = None
-        user = _stub_user(user_id=42, roles=['admin'])  # even admin gets 403
+        user = _stub_user(user_id=42, roles=['admin-testing-only'])  # even full-admin gets 403
         with pytest.raises(Forbidden):
             self._call(mini_app, user, alloc)
 

--- a/tests/unit/test_access_control_decorators.py
+++ b/tests/unit/test_access_control_decorators.py
@@ -1,0 +1,332 @@
+"""
+Phase 2 access-control decorator behavior + Phase 3 macro self-gating.
+
+Covers:
+- ``@require_project_permission`` aborts 403 when not steward, 404 when
+  the project does not exist, passes the project to the route otherwise.
+- ``@require_allocation_permission`` aborts 403/404 similarly and passes
+  the allocation. Uses ``include_ancestors=True`` so a lead of a parent
+  project can edit a child's allocation.
+- ``edit_modal_button`` / ``delete_row_button`` macros render or omit
+  the button based on the ``permission=`` kwarg.
+
+These tests mock the DB lookups (`get_project_or_404`, `db.session.get`)
+so they don't depend on the snapshot fixture or factory-built rows.
+The integration risk for the decorators is low — they delegate to
+``_is_project_steward``, which has full unit-test coverage in
+``test_project_permissions.py``.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from flask import Flask
+from flask_login import LoginManager
+from werkzeug.exceptions import Forbidden, NotFound
+
+from webapp.utils.rbac import Permission
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: minimal Flask app + login_manager, plus stub authenticated user
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mini_app():
+    """Tiny Flask app — enough context to run decorator tests."""
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SECRET_KEY'] = 'test'
+    LoginManager(app)
+    return app
+
+
+def _stub_user(*, user_id=42, roles=()):
+    user = Mock()
+    user.user_id = user_id
+    user.username = f'stub_{user_id}'
+    user.roles = set(roles)
+    user.is_authenticated = True
+    user.has_role = lambda r: r in user.roles
+    return user
+
+
+def _stub_project(*, project_id=100, lead_id=None, admin_id=None, parent=None,
+                  projcode='PRJ001'):
+    p = Mock()
+    p.project_id = project_id
+    p.projcode = projcode
+    p.project_lead_user_id = lead_id
+    p.project_admin_user_id = admin_id
+    p.parent = parent
+    return p
+
+
+# ---------------------------------------------------------------------------
+# @require_project_permission
+# ---------------------------------------------------------------------------
+
+class TestRequireProjectPermission:
+    def _call_decorated(self, mini_app, current_user, project, *,
+                        include_ancestors=False):
+        """Wrap a no-op route in the decorator and invoke it; return result."""
+        from webapp.api.access_control import require_project_permission
+
+        with mini_app.test_request_context('/'):
+            with patch(
+                'webapp.api.access_control.get_project_or_404',
+                return_value=(project, None),
+            ), patch(
+                'webapp.api.access_control.current_user',
+                current_user,
+            ):
+                @require_project_permission(
+                    Permission.EDIT_PROJECT_MEMBERS,
+                    include_ancestors=include_ancestors,
+                )
+                def route(project):
+                    return ('ok', project)
+
+                return route('PRJ001')
+
+    def test_lead_passes_and_receives_project(self, mini_app):
+        user = _stub_user(user_id=42)
+        project = _stub_project(lead_id=42)
+        result, recv = self._call_decorated(mini_app, user, project)
+        assert result == 'ok'
+        assert recv is project
+
+    def test_admin_passes(self, mini_app):
+        user = _stub_user(user_id=42)
+        project = _stub_project(lead_id=999, admin_id=42)
+        result, _ = self._call_decorated(mini_app, user, project)
+        assert result == 'ok'
+
+    def test_system_permission_holder_passes(self, mini_app):
+        user = _stub_user(user_id=99, roles=['admin'])
+        project = _stub_project(lead_id=1, admin_id=2)
+        result, _ = self._call_decorated(mini_app, user, project)
+        assert result == 'ok'
+
+    def test_outsider_aborts_403(self, mini_app):
+        user = _stub_user(user_id=42)
+        project = _stub_project(lead_id=999, admin_id=998)
+        with pytest.raises(Forbidden):
+            self._call_decorated(mini_app, user, project)
+
+    def test_ancestor_lead_passes_when_include_ancestors(self, mini_app):
+        parent = _stub_project(project_id=1, lead_id=42)
+        child = _stub_project(project_id=2, lead_id=999, parent=parent)
+        user = _stub_user(user_id=42)
+        result, _ = self._call_decorated(
+            mini_app, user, child, include_ancestors=True
+        )
+        assert result == 'ok'
+
+    def test_ancestor_lead_blocked_without_include_ancestors(self, mini_app):
+        parent = _stub_project(project_id=1, lead_id=42)
+        child = _stub_project(project_id=2, lead_id=999, parent=parent)
+        user = _stub_user(user_id=42)
+        with pytest.raises(Forbidden):
+            self._call_decorated(mini_app, user, child, include_ancestors=False)
+
+    def test_not_found_short_circuits(self, mini_app):
+        from webapp.api.access_control import require_project_permission
+        from flask import jsonify
+
+        user = _stub_user(user_id=42)
+        with mini_app.test_request_context('/'):
+            err_response = (jsonify({'error': 'no such project'}), 404)
+            with patch(
+                'webapp.api.access_control.get_project_or_404',
+                return_value=(None, err_response),
+            ), patch(
+                'webapp.api.access_control.current_user',
+                user,
+            ):
+                @require_project_permission(Permission.EDIT_PROJECT_MEMBERS)
+                def route(project):
+                    pytest.fail("route body should not run when project missing")
+
+                result = route('NOPE')
+                # Return value of helpers' error tuple is propagated as-is.
+                assert result is err_response
+
+
+# ---------------------------------------------------------------------------
+# @require_allocation_permission
+# ---------------------------------------------------------------------------
+
+class TestRequireAllocationPermission:
+    def _call(self, mini_app, current_user, allocation):
+        from webapp.api.access_control import require_allocation_permission
+
+        with mini_app.test_request_context('/'):
+            session_mock = Mock()
+            session_mock.get.return_value = allocation
+            with patch(
+                'webapp.api.access_control.db',
+                Mock(session=session_mock),
+            ), patch(
+                'webapp.api.access_control.current_user',
+                current_user,
+            ):
+                @require_allocation_permission(Permission.EDIT_ALLOCATIONS)
+                def route(allocation):
+                    return ('ok', allocation)
+
+                return route(123)
+
+    def _allocation_with_project(self, project):
+        account = Mock()
+        account.project = project
+        alloc = Mock()
+        alloc.allocation_id = 123
+        alloc.account = account
+        return alloc
+
+    def test_lead_can_edit_their_allocation(self, mini_app):
+        project = _stub_project(lead_id=42)
+        alloc = self._allocation_with_project(project)
+        user = _stub_user(user_id=42)
+        result, recv = self._call(mini_app, user, alloc)
+        assert result == 'ok'
+        assert recv is alloc
+
+    def test_ancestor_lead_can_edit_descendant_allocation(self, mini_app):
+        parent = _stub_project(project_id=1, lead_id=42)
+        child = _stub_project(project_id=2, lead_id=999, parent=parent)
+        alloc = self._allocation_with_project(child)
+        user = _stub_user(user_id=42)
+        result, _ = self._call(mini_app, user, alloc)
+        assert result == 'ok'
+
+    def test_outsider_aborts_403(self, mini_app):
+        project = _stub_project(lead_id=999, admin_id=998)
+        alloc = self._allocation_with_project(project)
+        user = _stub_user(user_id=42)
+        with pytest.raises(Forbidden):
+            self._call(mini_app, user, alloc)
+
+    def test_missing_allocation_aborts_404(self, mini_app):
+        from webapp.api.access_control import require_allocation_permission
+        user = _stub_user(user_id=42)
+
+        with mini_app.test_request_context('/'):
+            session_mock = Mock()
+            session_mock.get.return_value = None
+            with patch(
+                'webapp.api.access_control.db',
+                Mock(session=session_mock),
+            ), patch(
+                'webapp.api.access_control.current_user',
+                user,
+            ):
+                @require_allocation_permission(Permission.EDIT_ALLOCATIONS)
+                def route(allocation):
+                    pytest.fail("should not reach route body")
+
+                with pytest.raises(NotFound):
+                    route(123)
+
+    def test_orphan_allocation_aborts_403(self, mini_app):
+        # Allocation with no account or no project — refuse to authorize.
+        alloc = Mock()
+        alloc.allocation_id = 123
+        alloc.account = None
+        user = _stub_user(user_id=42, roles=['admin'])  # even admin gets 403
+        with pytest.raises(Forbidden):
+            self._call(mini_app, user, alloc)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: action_buttons macro self-gating
+# ---------------------------------------------------------------------------
+
+class TestActionButtonMacros:
+    """Render the macros directly to verify the ``permission=`` kwarg
+    actually omits the button when the user lacks the permission.
+
+    Renders via ``make_module(vars=...)`` and supplies the helpers the
+    macro reaches for from template scope — ``has_permission``,
+    ``Permission``, ``can_act_on_project`` — explicitly. This avoids
+    needing a logged-in request context just to exercise the gating
+    branch."""
+
+    def _render_macro(self, app, macro_name, *, allow=True, **kwargs):
+        with app.app_context():
+            tmpl = app.jinja_env.get_template(
+                'dashboards/fragments/action_buttons.html'
+            )
+            macro_vars = {
+                'has_permission': lambda p: allow,
+                'Permission': Permission,
+                'can_act_on_project': lambda perm, project, **kw: allow,
+            }
+            module = tmpl.make_module(vars=macro_vars)
+            macro = getattr(module, macro_name)
+            return str(macro(**kwargs)).strip()
+
+    def test_edit_button_renders_when_no_permission_specified(self, app):
+        # Backwards-compat path: omitting permission= renders unconditionally.
+        # Even with allow=False the macro should still render because no
+        # gate was requested.
+        html = self._render_macro(
+            app, 'edit_modal_button', allow=False,
+            url='/foo/edit', modal_id='m', target_id='t',
+        )
+        assert '<button' in html
+        assert 'fa-edit' in html
+
+    def test_edit_button_hidden_without_permission(self, app):
+        html = self._render_macro(
+            app, 'edit_modal_button', allow=False,
+            url='/foo/edit', modal_id='m', target_id='t',
+            permission=Permission.EDIT_RESOURCES,
+        )
+        assert html == ''
+
+    def test_edit_button_shown_with_permission(self, app):
+        html = self._render_macro(
+            app, 'edit_modal_button', allow=True,
+            url='/foo/edit', modal_id='m', target_id='t',
+            permission=Permission.EDIT_RESOURCES,
+        )
+        assert '<button' in html
+
+    def test_delete_button_hidden_without_permission(self, app):
+        html = self._render_macro(
+            app, 'delete_row_button', allow=False,
+            url='/foo/delete', confirm='ok?',
+            permission=Permission.DELETE_RESOURCES,
+        )
+        assert html == ''
+
+    def test_delete_button_shown_with_permission(self, app):
+        html = self._render_macro(
+            app, 'delete_row_button', allow=True,
+            url='/foo/delete', confirm='ok?',
+            permission=Permission.DELETE_RESOURCES,
+        )
+        assert 'hx-delete="/foo/delete"' in html
+
+    def test_project_scoped_uses_can_act_on_project(self, app):
+        # When project= is set, the macro should consult can_act_on_project,
+        # not has_permission. Verify by setting allow=True and confirming
+        # render — and allow=False to confirm hide.
+        sentinel_project = object()
+        html = self._render_macro(
+            app, 'edit_modal_button', allow=True,
+            url='/foo/edit', modal_id='m', target_id='t',
+            permission=Permission.EDIT_ALLOCATIONS,
+            project=sentinel_project,
+        )
+        assert '<button' in html
+
+        html = self._render_macro(
+            app, 'edit_modal_button', allow=False,
+            url='/foo/edit', modal_id='m', target_id='t',
+            permission=Permission.EDIT_ALLOCATIONS,
+            project=sentinel_project,
+        )
+        assert html == ''

--- a/tests/unit/test_oidc_auth.py
+++ b/tests/unit/test_oidc_auth.py
@@ -474,37 +474,12 @@ class TestUPNClaimStripping:
 # ---------------------------------------------------------------------------
 
 class TestGroupRoleResolution:
-    """Test that AuthUser.roles derives from POSIX groups (or dev_group_mapping
-    when supplied). The legacy ``role_user`` table is not consulted."""
+    """Test that AuthUser.roles derives from POSIX group membership,
+    filtered to groups that have a ``GROUP_PERMISSIONS`` bundle. The
+    legacy ``role_user`` table is not consulted."""
 
-    def test_dev_mapping_takes_priority(self, session):
-        """When user is in dev_group_mapping, those bundles are used."""
-        from webapp.auth.models import AuthUser
-        from sam.core.users import User
-
-        user = User.get_by_username(session, 'benkirk')
-        if user is None:
-            pytest.skip("Test user not in database")
-
-        auth_user = AuthUser(user, dev_group_mapping={'benkirk': ['admin']})
-        assert 'admin' in auth_user.roles
-
-    def test_dev_mapping_filters_unknown_bundles(self, session):
-        """Group names with no GROUP_PERMISSIONS bundle are filtered out."""
-        from webapp.auth.models import AuthUser
-        from sam.core.users import User
-
-        user = User.get_by_username(session, 'benkirk')
-        if user is None:
-            pytest.skip("Test user not in database")
-
-        auth_user = AuthUser(
-            user, dev_group_mapping={'benkirk': ['admin', 'no_such_bundle']}
-        )
-        assert auth_user.roles == {'admin'}
-
-    def test_posix_groups_used_when_no_dev_mapping(self, session):
-        """Without dev_group_mapping, roles derive from POSIX group lookup."""
+    def test_roles_derive_from_posix_groups(self, session):
+        """Roles match POSIX group membership filtered by GROUP_PERMISSIONS."""
         from webapp.auth.models import AuthUser
         from webapp.utils.rbac import GROUP_PERMISSIONS
         from sam.core.users import User
@@ -514,7 +489,7 @@ class TestGroupRoleResolution:
         if user is None:
             pytest.skip("Test user not in database")
 
-        auth_user = AuthUser(user, dev_group_mapping={})
+        auth_user = AuthUser(user)
         roles = auth_user.roles
         assert isinstance(roles, set)
 
@@ -526,7 +501,7 @@ class TestGroupRoleResolution:
         assert roles == expected
 
     def test_empty_roles_when_no_groups(self, session):
-        """User with no POSIX groups and no dev mapping gets empty roles."""
+        """User with no bundle-conferring POSIX groups gets empty roles."""
         from webapp.auth.models import AuthUser
         from sam.core.users import User
         from sam.queries.lookups import get_user_group_access
@@ -540,7 +515,7 @@ class TestGroupRoleResolution:
         if user_no_groups is None:
             pytest.skip("No user without POSIX group memberships found in database")
 
-        auth_user = AuthUser(user_no_groups, dev_group_mapping={})
+        auth_user = AuthUser(user_no_groups)
         assert auth_user.roles == set()
 
 

--- a/tests/unit/test_oidc_auth.py
+++ b/tests/unit/test_oidc_auth.py
@@ -470,14 +470,15 @@ class TestUPNClaimStripping:
 
 
 # ---------------------------------------------------------------------------
-# DB role resolution tests
+# Group-based role resolution tests
 # ---------------------------------------------------------------------------
 
-class TestDBRoleResolution:
-    """Test that AuthUser.roles falls back to database role_user table."""
+class TestGroupRoleResolution:
+    """Test that AuthUser.roles derives from POSIX groups (or dev_group_mapping
+    when supplied). The legacy ``role_user`` table is not consulted."""
 
     def test_dev_mapping_takes_priority(self, session):
-        """When user is in dev_role_mapping, those roles are used."""
+        """When user is in dev_group_mapping, those bundles are used."""
         from webapp.auth.models import AuthUser
         from sam.core.users import User
 
@@ -485,11 +486,11 @@ class TestDBRoleResolution:
         if user is None:
             pytest.skip("Test user not in database")
 
-        auth_user = AuthUser(user, dev_role_mapping={'benkirk': ['admin']})
+        auth_user = AuthUser(user, dev_group_mapping={'benkirk': ['admin']})
         assert 'admin' in auth_user.roles
 
-    def test_db_roles_when_not_in_dev_mapping(self, session):
-        """When user is NOT in dev_role_mapping, roles come from role_user table."""
+    def test_dev_mapping_filters_unknown_bundles(self, session):
+        """Group names with no GROUP_PERMISSIONS bundle are filtered out."""
         from webapp.auth.models import AuthUser
         from sam.core.users import User
 
@@ -497,27 +498,49 @@ class TestDBRoleResolution:
         if user is None:
             pytest.skip("Test user not in database")
 
-        auth_user = AuthUser(user, dev_role_mapping={})
+        auth_user = AuthUser(
+            user, dev_group_mapping={'benkirk': ['admin', 'no_such_bundle']}
+        )
+        assert auth_user.roles == {'admin'}
+
+    def test_posix_groups_used_when_no_dev_mapping(self, session):
+        """Without dev_group_mapping, roles derive from POSIX group lookup."""
+        from webapp.auth.models import AuthUser
+        from webapp.utils.rbac import GROUP_PERMISSIONS
+        from sam.core.users import User
+        from sam.queries.lookups import get_user_group_access
+
+        user = User.get_by_username(session, 'benkirk')
+        if user is None:
+            pytest.skip("Test user not in database")
+
+        auth_user = AuthUser(user, dev_group_mapping={})
         roles = auth_user.roles
         assert isinstance(roles, set)
-        db_role_names = {ra.role.name for ra in user.role_assignments}
-        assert roles == db_role_names
 
-    def test_empty_roles_when_no_assignments(self, session):
-        """User with no role_user entries and no dev mapping gets empty roles."""
+        posix_groups = {
+            r['group_name']
+            for r in get_user_group_access(session, username='benkirk').get('benkirk', [])
+        }
+        expected = {g for g in posix_groups if g in GROUP_PERMISSIONS}
+        assert roles == expected
+
+    def test_empty_roles_when_no_groups(self, session):
+        """User with no POSIX groups and no dev mapping gets empty roles."""
         from webapp.auth.models import AuthUser
         from sam.core.users import User
+        from sam.queries.lookups import get_user_group_access
 
         users = session.query(User).filter(User.is_active).all()
-        user_no_roles = None
+        user_no_groups = None
         for u in users:
-            if not u.role_assignments:
-                user_no_roles = u
+            if not get_user_group_access(session, username=u.username).get(u.username):
+                user_no_groups = u
                 break
-        if user_no_roles is None:
-            pytest.skip("No user without role assignments found in database")
+        if user_no_groups is None:
+            pytest.skip("No user without POSIX group memberships found in database")
 
-        auth_user = AuthUser(user_no_roles, dev_role_mapping={})
+        auth_user = AuthUser(user_no_groups, dev_group_mapping={})
         assert auth_user.roles == set()
 
 

--- a/tests/unit/test_project_permissions.py
+++ b/tests/unit/test_project_permissions.py
@@ -10,11 +10,16 @@ from unittest.mock import Mock
 import pytest
 
 from webapp.utils.project_permissions import (
+    _is_project_steward,
     can_change_admin,
+    can_edit_allocations,
+    can_edit_consumption_threshold,
     can_manage_project_members,
+    can_redistribute_allocations,
     can_view_project_members,
     get_user_role_in_project,
 )
+from webapp.utils.rbac import Permission
 
 
 pytestmark = pytest.mark.unit
@@ -32,11 +37,17 @@ def create_mock_user(user_id: int, roles: list = None):
     return user
 
 
-def create_mock_project(project_lead_user_id: int, project_admin_user_id: int = None):
-    """Create a mock project object for testing."""
+def create_mock_project(project_lead_user_id: int, project_admin_user_id: int = None,
+                        parent: Mock = None):
+    """Create a mock project object for testing.
+
+    ``parent`` is the Project ORM ``parent`` relationship — used by the
+    Phase-2 ancestor-walk tests. Default None means root.
+    """
     project = Mock()
     project.project_lead_user_id = project_lead_user_id
     project.project_admin_user_id = project_admin_user_id
+    project.parent = parent
     return project
 
 
@@ -148,3 +159,137 @@ class TestGetUserRoleInProject:
         """If the same user is both lead and admin, returns 'Lead' (lead is checked first)."""
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=1)
         assert get_user_role_in_project(1, project) == 'Lead'
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: _is_project_steward — central authorization primitive
+# ---------------------------------------------------------------------------
+
+class TestIsProjectSteward:
+    """All ``can_*`` helpers route through ``_is_project_steward``."""
+
+    def test_system_permission_holder_passes_without_role_check(self):
+        # admin bundle grants every permission, including EDIT_ALLOCATIONS.
+        user = create_mock_user(user_id=100, roles=['admin'])
+        project = create_mock_project(project_lead_user_id=1, project_admin_user_id=2)
+        assert _is_project_steward(user, project, Permission.EDIT_ALLOCATIONS)
+
+    def test_lead_passes_for_their_project(self):
+        user = create_mock_user(user_id=42, roles=['user'])
+        project = create_mock_project(project_lead_user_id=42)
+        assert _is_project_steward(user, project, Permission.EDIT_ALLOCATIONS)
+
+    def test_admin_passes_for_their_project(self):
+        user = create_mock_user(user_id=42, roles=['user'])
+        project = create_mock_project(project_lead_user_id=999, project_admin_user_id=42)
+        assert _is_project_steward(user, project, Permission.EDIT_ALLOCATIONS)
+
+    def test_outsider_blocked(self):
+        user = create_mock_user(user_id=42, roles=['user'])
+        project = create_mock_project(project_lead_user_id=999, project_admin_user_id=998)
+        assert not _is_project_steward(user, project, Permission.EDIT_ALLOCATIONS)
+
+    def test_ancestor_lead_passes_when_include_ancestors(self):
+        grandparent = create_mock_project(project_lead_user_id=42)
+        parent = create_mock_project(project_lead_user_id=999, parent=grandparent)
+        child = create_mock_project(project_lead_user_id=998, parent=parent)
+        user = create_mock_user(user_id=42, roles=['user'])
+        assert _is_project_steward(
+            user, child, Permission.EDIT_ALLOCATIONS, include_ancestors=True
+        )
+
+    def test_ancestor_lead_blocked_without_include_ancestors(self):
+        parent = create_mock_project(project_lead_user_id=42)
+        child = create_mock_project(project_lead_user_id=999, parent=parent)
+        user = create_mock_user(user_id=42, roles=['user'])
+        assert not _is_project_steward(
+            user, child, Permission.EDIT_ALLOCATIONS, include_ancestors=False
+        )
+
+    def test_ancestor_admin_passes_when_include_ancestors(self):
+        parent = create_mock_project(project_lead_user_id=999, project_admin_user_id=42)
+        child = create_mock_project(project_lead_user_id=998, parent=parent)
+        user = create_mock_user(user_id=42, roles=['user'])
+        assert _is_project_steward(
+            user, child, Permission.EDIT_ALLOCATIONS, include_ancestors=True
+        )
+
+    def test_unauthenticated_user_blocked(self):
+        user = Mock()
+        user.user_id = None  # AnonymousUserMixin path
+        user.roles = set()
+        user.has_role = lambda r: False
+        project = create_mock_project(project_lead_user_id=42)
+        assert not _is_project_steward(user, project, Permission.EDIT_ALLOCATIONS)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: can_edit_allocations BEHAVIOR CHANGE
+# ---------------------------------------------------------------------------
+
+class TestCanEditAllocations:
+    """``can_edit_allocations`` previously short-circuited to
+    ``has_permission(EDIT_ALLOCATIONS)`` only — i.e. system admins only.
+    Phase 2 grants project lead/admin (and ancestor lead/admin) too,
+    enabling allocation redistribution within a project subtree."""
+
+    def test_lead_can_edit_their_allocation(self):
+        # Regression target — used to return False for non-system users.
+        user = create_mock_user(user_id=42, roles=['user'])
+        project = create_mock_project(project_lead_user_id=42)
+        assert can_edit_allocations(user, project)
+
+    def test_admin_can_edit_their_allocation(self):
+        user = create_mock_user(user_id=42, roles=['user'])
+        project = create_mock_project(project_lead_user_id=999, project_admin_user_id=42)
+        assert can_edit_allocations(user, project)
+
+    def test_ancestor_lead_can_edit_descendant_allocation(self):
+        # The redistribution-within-tree use case.
+        parent = create_mock_project(project_lead_user_id=42)
+        child = create_mock_project(project_lead_user_id=998, parent=parent)
+        user = create_mock_user(user_id=42, roles=['user'])
+        assert can_edit_allocations(user, child)
+
+    def test_outsider_still_blocked(self):
+        user = create_mock_user(user_id=42, roles=['user'])
+        project = create_mock_project(project_lead_user_id=999, project_admin_user_id=998)
+        assert not can_edit_allocations(user, project)
+
+    def test_facility_manager_grants_via_system_permission(self):
+        user = create_mock_user(user_id=99, roles=['facility_manager'])
+        project = create_mock_project(project_lead_user_id=999, project_admin_user_id=998)
+        assert can_edit_allocations(user, project)
+
+    def test_redistribute_is_alias(self):
+        # Same authorization, different name at the call site.
+        assert can_redistribute_allocations is can_edit_allocations
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: can_edit_consumption_threshold — should NOT walk ancestors
+# ---------------------------------------------------------------------------
+
+class TestCanEditConsumptionThreshold:
+    """Threshold is a per-project tuning, not a tree-scoped operation."""
+
+    def test_lead_can_edit_threshold(self):
+        user = create_mock_user(user_id=42, roles=['user'])
+        project = create_mock_project(project_lead_user_id=42)
+        assert can_edit_consumption_threshold(user, project)
+
+    def test_admin_can_edit_threshold(self):
+        user = create_mock_user(user_id=42, roles=['user'])
+        project = create_mock_project(project_lead_user_id=999, project_admin_user_id=42)
+        assert can_edit_consumption_threshold(user, project)
+
+    def test_ancestor_lead_cannot_edit_descendant_threshold(self):
+        parent = create_mock_project(project_lead_user_id=42)
+        child = create_mock_project(project_lead_user_id=999, parent=parent)
+        user = create_mock_user(user_id=42, roles=['user'])
+        assert not can_edit_consumption_threshold(user, child)
+
+    def test_outsider_blocked(self):
+        user = create_mock_user(user_id=42, roles=['user'])
+        project = create_mock_project(project_lead_user_id=999, project_admin_user_id=998)
+        assert not can_edit_consumption_threshold(user, project)

--- a/tests/unit/test_project_permissions.py
+++ b/tests/unit/test_project_permissions.py
@@ -54,32 +54,32 @@ def create_mock_project(project_lead_user_id: int, project_admin_user_id: int = 
 class TestCanManageProjectMembers:
 
     def test_admin_role_can_manage(self):
-        user = create_mock_user(user_id=100, roles=['admin'])
+        user = create_mock_user(user_id=100, roles=['admin-testing-only'])
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=2)
         assert can_manage_project_members(user, project) is True
 
     def test_facility_manager_can_manage(self):
-        user = create_mock_user(user_id=100, roles=['facility_manager'])
+        user = create_mock_user(user_id=100, roles=['nusd'])
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=2)
         assert can_manage_project_members(user, project) is True
 
     def test_project_lead_can_manage(self):
-        user = create_mock_user(user_id=1, roles=['user'])
+        user = create_mock_user(user_id=1, roles=[])
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=2)
         assert can_manage_project_members(user, project) is True
 
     def test_project_admin_can_manage(self):
-        user = create_mock_user(user_id=2, roles=['user'])
+        user = create_mock_user(user_id=2, roles=[])
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=2)
         assert can_manage_project_members(user, project) is True
 
     def test_regular_member_cannot_manage(self):
-        user = create_mock_user(user_id=99, roles=['user'])
+        user = create_mock_user(user_id=99, roles=[])
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=2)
         assert can_manage_project_members(user, project) is False
 
     def test_project_without_admin(self):
-        user = create_mock_user(user_id=1, roles=['user'])
+        user = create_mock_user(user_id=1, roles=[])
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=None)
         assert can_manage_project_members(user, project) is True
 
@@ -87,28 +87,28 @@ class TestCanManageProjectMembers:
 class TestCanChangeAdmin:
 
     def test_admin_role_can_change(self):
-        user = create_mock_user(user_id=100, roles=['admin'])
+        user = create_mock_user(user_id=100, roles=['admin-testing-only'])
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=2)
         assert can_change_admin(user, project) is True
 
     def test_facility_manager_can_change(self):
-        user = create_mock_user(user_id=100, roles=['facility_manager'])
+        user = create_mock_user(user_id=100, roles=['nusd'])
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=2)
         assert can_change_admin(user, project) is True
 
     def test_project_lead_can_change(self):
-        user = create_mock_user(user_id=1, roles=['user'])
+        user = create_mock_user(user_id=1, roles=[])
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=2)
         assert can_change_admin(user, project) is True
 
     def test_project_admin_cannot_change(self):
         """Project admin cannot change admin — only lead can."""
-        user = create_mock_user(user_id=2, roles=['user'])
+        user = create_mock_user(user_id=2, roles=[])
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=2)
         assert can_change_admin(user, project) is False
 
     def test_regular_member_cannot_change(self):
-        user = create_mock_user(user_id=99, roles=['user'])
+        user = create_mock_user(user_id=99, roles=[])
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=2)
         assert can_change_admin(user, project) is False
 
@@ -116,23 +116,23 @@ class TestCanChangeAdmin:
 class TestCanViewProjectMembers:
 
     def test_admin_role_can_view(self):
-        user = create_mock_user(user_id=100, roles=['admin'])
+        user = create_mock_user(user_id=100, roles=['admin-testing-only'])
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=2)
         assert can_view_project_members(user, project) is True
 
     def test_project_lead_can_view(self):
-        user = create_mock_user(user_id=1, roles=['user'])
+        user = create_mock_user(user_id=1, roles=[])
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=2)
         assert can_view_project_members(user, project) is True
 
     def test_project_admin_can_view(self):
-        user = create_mock_user(user_id=2, roles=['user'])
+        user = create_mock_user(user_id=2, roles=[])
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=2)
         assert can_view_project_members(user, project) is True
 
     def test_regular_member_can_view(self):
         """Current implementation allows any authenticated user to view members."""
-        user = create_mock_user(user_id=99, roles=['user'])
+        user = create_mock_user(user_id=99, roles=[])
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=2)
         assert can_view_project_members(user, project) is True
 
@@ -169,23 +169,23 @@ class TestIsProjectSteward:
     """All ``can_*`` helpers route through ``_is_project_steward``."""
 
     def test_system_permission_holder_passes_without_role_check(self):
-        # admin bundle grants every permission, including EDIT_ALLOCATIONS.
-        user = create_mock_user(user_id=100, roles=['admin'])
+        # 'admin-testing-only' grants every permission, including EDIT_ALLOCATIONS.
+        user = create_mock_user(user_id=100, roles=['admin-testing-only'])
         project = create_mock_project(project_lead_user_id=1, project_admin_user_id=2)
         assert _is_project_steward(user, project, Permission.EDIT_ALLOCATIONS)
 
     def test_lead_passes_for_their_project(self):
-        user = create_mock_user(user_id=42, roles=['user'])
+        user = create_mock_user(user_id=42, roles=[])
         project = create_mock_project(project_lead_user_id=42)
         assert _is_project_steward(user, project, Permission.EDIT_ALLOCATIONS)
 
     def test_admin_passes_for_their_project(self):
-        user = create_mock_user(user_id=42, roles=['user'])
+        user = create_mock_user(user_id=42, roles=[])
         project = create_mock_project(project_lead_user_id=999, project_admin_user_id=42)
         assert _is_project_steward(user, project, Permission.EDIT_ALLOCATIONS)
 
     def test_outsider_blocked(self):
-        user = create_mock_user(user_id=42, roles=['user'])
+        user = create_mock_user(user_id=42, roles=[])
         project = create_mock_project(project_lead_user_id=999, project_admin_user_id=998)
         assert not _is_project_steward(user, project, Permission.EDIT_ALLOCATIONS)
 
@@ -193,7 +193,7 @@ class TestIsProjectSteward:
         grandparent = create_mock_project(project_lead_user_id=42)
         parent = create_mock_project(project_lead_user_id=999, parent=grandparent)
         child = create_mock_project(project_lead_user_id=998, parent=parent)
-        user = create_mock_user(user_id=42, roles=['user'])
+        user = create_mock_user(user_id=42, roles=[])
         assert _is_project_steward(
             user, child, Permission.EDIT_ALLOCATIONS, include_ancestors=True
         )
@@ -201,7 +201,7 @@ class TestIsProjectSteward:
     def test_ancestor_lead_blocked_without_include_ancestors(self):
         parent = create_mock_project(project_lead_user_id=42)
         child = create_mock_project(project_lead_user_id=999, parent=parent)
-        user = create_mock_user(user_id=42, roles=['user'])
+        user = create_mock_user(user_id=42, roles=[])
         assert not _is_project_steward(
             user, child, Permission.EDIT_ALLOCATIONS, include_ancestors=False
         )
@@ -209,7 +209,7 @@ class TestIsProjectSteward:
     def test_ancestor_admin_passes_when_include_ancestors(self):
         parent = create_mock_project(project_lead_user_id=999, project_admin_user_id=42)
         child = create_mock_project(project_lead_user_id=998, parent=parent)
-        user = create_mock_user(user_id=42, roles=['user'])
+        user = create_mock_user(user_id=42, roles=[])
         assert _is_project_steward(
             user, child, Permission.EDIT_ALLOCATIONS, include_ancestors=True
         )
@@ -235,12 +235,12 @@ class TestCanEditAllocations:
 
     def test_lead_can_edit_their_allocation(self):
         # Regression target — used to return False for non-system users.
-        user = create_mock_user(user_id=42, roles=['user'])
+        user = create_mock_user(user_id=42, roles=[])
         project = create_mock_project(project_lead_user_id=42)
         assert can_edit_allocations(user, project)
 
     def test_admin_can_edit_their_allocation(self):
-        user = create_mock_user(user_id=42, roles=['user'])
+        user = create_mock_user(user_id=42, roles=[])
         project = create_mock_project(project_lead_user_id=999, project_admin_user_id=42)
         assert can_edit_allocations(user, project)
 
@@ -248,16 +248,16 @@ class TestCanEditAllocations:
         # The redistribution-within-tree use case.
         parent = create_mock_project(project_lead_user_id=42)
         child = create_mock_project(project_lead_user_id=998, parent=parent)
-        user = create_mock_user(user_id=42, roles=['user'])
+        user = create_mock_user(user_id=42, roles=[])
         assert can_edit_allocations(user, child)
 
     def test_outsider_still_blocked(self):
-        user = create_mock_user(user_id=42, roles=['user'])
+        user = create_mock_user(user_id=42, roles=[])
         project = create_mock_project(project_lead_user_id=999, project_admin_user_id=998)
         assert not can_edit_allocations(user, project)
 
     def test_facility_manager_grants_via_system_permission(self):
-        user = create_mock_user(user_id=99, roles=['facility_manager'])
+        user = create_mock_user(user_id=99, roles=['nusd'])
         project = create_mock_project(project_lead_user_id=999, project_admin_user_id=998)
         assert can_edit_allocations(user, project)
 
@@ -274,22 +274,22 @@ class TestCanEditConsumptionThreshold:
     """Threshold is a per-project tuning, not a tree-scoped operation."""
 
     def test_lead_can_edit_threshold(self):
-        user = create_mock_user(user_id=42, roles=['user'])
+        user = create_mock_user(user_id=42, roles=[])
         project = create_mock_project(project_lead_user_id=42)
         assert can_edit_consumption_threshold(user, project)
 
     def test_admin_can_edit_threshold(self):
-        user = create_mock_user(user_id=42, roles=['user'])
+        user = create_mock_user(user_id=42, roles=[])
         project = create_mock_project(project_lead_user_id=999, project_admin_user_id=42)
         assert can_edit_consumption_threshold(user, project)
 
     def test_ancestor_lead_cannot_edit_descendant_threshold(self):
         parent = create_mock_project(project_lead_user_id=42)
         child = create_mock_project(project_lead_user_id=999, parent=parent)
-        user = create_mock_user(user_id=42, roles=['user'])
+        user = create_mock_user(user_id=42, roles=[])
         assert not can_edit_consumption_threshold(user, child)
 
     def test_outsider_blocked(self):
-        user = create_mock_user(user_id=42, roles=['user'])
+        user = create_mock_user(user_id=42, roles=[])
         project = create_mock_project(project_lead_user_id=999, project_admin_user_id=998)
         assert not can_edit_consumption_threshold(user, project)

--- a/tests/unit/test_rbac.py
+++ b/tests/unit/test_rbac.py
@@ -55,10 +55,13 @@ class TestGroupBundleComposition:
         user = _StubUser(roles=[])
         assert get_user_permissions(user) == set()
 
-    def test_csg_bundle_grants_every_permission(self):
-        # csg is the full-access bundle; every Permission must be in it
-        # so authorization checks for csg members never need a special case.
-        user = _StubUser(roles=['csg'])
+    def test_admin_testing_only_bundle_grants_every_permission(self):
+        # 'admin-testing-only' is the synthetic test-session bundle
+        # (registered by the autouse fixture in tests/conftest.py) that
+        # carries every Permission. Real production bundles (csg/nusd/hsg)
+        # may grow or shrink — tests that need 'full admin' semantics
+        # should depend on this bundle, not on csg's exact contents.
+        user = _StubUser(roles=['admin-testing-only'])
         assert get_user_permissions(user) == set(Permission)
 
 
@@ -148,10 +151,12 @@ class TestPermissionEnumSurface:
     def test_new_permission_member_exists(self, perm_name):
         assert hasattr(Permission, perm_name)
 
-    def test_csg_bundle_covers_every_permission(self):
-        # Sanity check: the 'csg' bundle must list every Permission so
-        # has_permission(csg, anything) returns True without a special case.
-        assert set(GROUP_PERMISSIONS['csg']) == set(Permission)
+    def test_admin_testing_only_bundle_is_registered_with_full_permission_set(self):
+        # The autouse session-scoped fixture in tests/conftest.py
+        # registers 'admin-testing-only' as the synthetic full-access
+        # bundle for the test session. Guard against the fixture
+        # silently regressing or not running.
+        assert set(GROUP_PERMISSIONS['admin-testing-only']) == set(Permission)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_rbac.py
+++ b/tests/unit/test_rbac.py
@@ -150,3 +150,28 @@ class TestPermissionEnumSurface:
         # Sanity check: the 'admin' bundle must list every Permission so
         # has_permission(admin, anything) returns True without a special case.
         assert set(GROUP_PERMISSIONS['admin']) == set(Permission)
+
+
+# ---------------------------------------------------------------------------
+# Template context processor — can_act_on_project closure
+# ---------------------------------------------------------------------------
+
+class TestRbacContextProcessor:
+    """Phase 3 added a ``can_act_on_project(permission, project, ...)``
+    helper to the template context. Verify it delegates to
+    ``_is_project_steward`` and handles the unauthenticated /
+    no-project edge cases."""
+
+    def _ctx(self, app):
+        from webapp.utils.rbac import rbac_context_processor
+        with app.test_request_context('/'):
+            return rbac_context_processor()
+
+    def test_exposes_can_act_on_project(self, app):
+        ctx = self._ctx(app)
+        assert 'can_act_on_project' in ctx
+        assert callable(ctx['can_act_on_project'])
+
+    def test_returns_false_when_project_is_none(self, app):
+        ctx = self._ctx(app)
+        assert ctx['can_act_on_project'](Permission.EDIT_ALLOCATIONS, None) is False

--- a/tests/unit/test_rbac.py
+++ b/tests/unit/test_rbac.py
@@ -1,0 +1,152 @@
+"""
+Unit tests for the RBAC permission composition machinery.
+
+Covers ``get_user_permissions``, group-bundle resolution, and
+``USER_PERMISSION_OVERRIDES`` layering. Uses a stub user object so the
+tests don't depend on POSIX-group data in the snapshot DB.
+"""
+
+import pytest
+
+from webapp.utils import rbac
+from webapp.utils.rbac import (
+    GROUP_PERMISSIONS,
+    Permission,
+    get_user_permissions,
+    has_all_permissions,
+    has_any_permission,
+    has_permission,
+)
+
+
+class _StubUser:
+    """Minimal AuthUser-like stub: just `roles` (a set) and `username`."""
+
+    def __init__(self, *, roles=(), username='stubuser'):
+        self.roles = set(roles)
+        self.username = username
+
+    def has_role(self, name):
+        return name in self.roles
+
+
+# ---------------------------------------------------------------------------
+# Group bundle composition
+# ---------------------------------------------------------------------------
+
+class TestGroupBundleComposition:
+    def test_single_group_resolves_to_bundle_permissions(self):
+        user = _StubUser(roles=['user'])
+        perms = get_user_permissions(user)
+        assert perms == set(GROUP_PERMISSIONS['user'])
+
+    def test_multiple_groups_union(self):
+        user = _StubUser(roles=['user', 'analyst'])
+        perms = get_user_permissions(user)
+        expected = set(GROUP_PERMISSIONS['user']) | set(GROUP_PERMISSIONS['analyst'])
+        assert perms == expected
+
+    def test_unknown_group_contributes_nothing(self):
+        user = _StubUser(roles=['user', 'no_such_group'])
+        perms = get_user_permissions(user)
+        assert perms == set(GROUP_PERMISSIONS['user'])
+
+    def test_no_groups_yields_empty_permissions(self):
+        user = _StubUser(roles=[])
+        assert get_user_permissions(user) == set()
+
+    def test_admin_bundle_grants_every_permission(self):
+        user = _StubUser(roles=['admin'])
+        assert get_user_permissions(user) == set(Permission)
+
+
+# ---------------------------------------------------------------------------
+# USER_PERMISSION_OVERRIDES layering
+# ---------------------------------------------------------------------------
+
+class TestUserPermissionOverrides:
+    def test_override_adds_permissions_to_group_baseline(self, monkeypatch):
+        monkeypatch.setattr(
+            rbac,
+            'USER_PERMISSION_OVERRIDES',
+            {'alice': {Permission.EXPORT_DATA}},
+        )
+        user = _StubUser(roles=['user'], username='alice')
+        perms = get_user_permissions(user)
+        assert Permission.EXPORT_DATA in perms
+        # Baseline still present
+        assert Permission.VIEW_PROJECTS in perms
+
+    def test_override_works_with_no_groups(self, monkeypatch):
+        monkeypatch.setattr(
+            rbac,
+            'USER_PERMISSION_OVERRIDES',
+            {'bob': {Permission.VIEW_REPORTS, Permission.EXPORT_DATA}},
+        )
+        user = _StubUser(roles=[], username='bob')
+        perms = get_user_permissions(user)
+        assert perms == {Permission.VIEW_REPORTS, Permission.EXPORT_DATA}
+
+    def test_no_override_for_username_is_noop(self, monkeypatch):
+        monkeypatch.setattr(
+            rbac,
+            'USER_PERMISSION_OVERRIDES',
+            {'someone_else': {Permission.SYSTEM_ADMIN}},
+        )
+        user = _StubUser(roles=['user'], username='alice')
+        perms = get_user_permissions(user)
+        assert Permission.SYSTEM_ADMIN not in perms
+
+
+# ---------------------------------------------------------------------------
+# Predicate helpers
+# ---------------------------------------------------------------------------
+
+class TestPredicates:
+    def test_has_permission_true_when_in_bundle(self):
+        user = _StubUser(roles=['user'])
+        assert has_permission(user, Permission.VIEW_PROJECTS)
+
+    def test_has_permission_false_when_not_granted(self):
+        user = _StubUser(roles=['user'])
+        assert not has_permission(user, Permission.SYSTEM_ADMIN)
+
+    def test_has_any_permission_short_circuits_on_match(self):
+        user = _StubUser(roles=['user'])
+        assert has_any_permission(
+            user, Permission.SYSTEM_ADMIN, Permission.VIEW_PROJECTS
+        )
+
+    def test_has_any_permission_false_when_none_match(self):
+        user = _StubUser(roles=['user'])
+        assert not has_any_permission(
+            user, Permission.SYSTEM_ADMIN, Permission.MANAGE_ROLES
+        )
+
+    def test_has_all_permissions_requires_full_intersection(self):
+        user = _StubUser(roles=['user'])
+        assert has_all_permissions(
+            user, Permission.VIEW_PROJECTS, Permission.VIEW_ALLOCATIONS
+        )
+        assert not has_all_permissions(
+            user, Permission.VIEW_PROJECTS, Permission.SYSTEM_ADMIN
+        )
+
+
+# ---------------------------------------------------------------------------
+# Permission enum surface area (regression guard for newly-added members)
+# ---------------------------------------------------------------------------
+
+class TestPermissionEnumSurface:
+    @pytest.mark.parametrize('perm_name', [
+        'VIEW_FACILITIES', 'EDIT_FACILITIES', 'CREATE_FACILITIES', 'DELETE_FACILITIES',
+        'VIEW_GROUPS', 'EDIT_GROUPS', 'CREATE_GROUPS', 'DELETE_GROUPS',
+        'VIEW_ORG_METADATA', 'EDIT_ORG_METADATA', 'CREATE_ORG_METADATA', 'DELETE_ORG_METADATA',
+    ])
+    def test_new_permission_member_exists(self, perm_name):
+        assert hasattr(Permission, perm_name)
+
+    def test_admin_bundle_covers_every_permission(self):
+        # Sanity check: the 'admin' bundle must list every Permission so
+        # has_permission(admin, anything) returns True without a special case.
+        assert set(GROUP_PERMISSIONS['admin']) == set(Permission)

--- a/tests/unit/test_rbac.py
+++ b/tests/unit/test_rbac.py
@@ -36,27 +36,29 @@ class _StubUser:
 
 class TestGroupBundleComposition:
     def test_single_group_resolves_to_bundle_permissions(self):
-        user = _StubUser(roles=['user'])
+        user = _StubUser(roles=['hsg'])
         perms = get_user_permissions(user)
-        assert perms == set(GROUP_PERMISSIONS['user'])
+        assert perms == set(GROUP_PERMISSIONS['hsg'])
 
     def test_multiple_groups_union(self):
-        user = _StubUser(roles=['user', 'analyst'])
+        user = _StubUser(roles=['hsg', 'nusd'])
         perms = get_user_permissions(user)
-        expected = set(GROUP_PERMISSIONS['user']) | set(GROUP_PERMISSIONS['analyst'])
+        expected = set(GROUP_PERMISSIONS['hsg']) | set(GROUP_PERMISSIONS['nusd'])
         assert perms == expected
 
     def test_unknown_group_contributes_nothing(self):
-        user = _StubUser(roles=['user', 'no_such_group'])
+        user = _StubUser(roles=['hsg', 'no_such_group'])
         perms = get_user_permissions(user)
-        assert perms == set(GROUP_PERMISSIONS['user'])
+        assert perms == set(GROUP_PERMISSIONS['hsg'])
 
     def test_no_groups_yields_empty_permissions(self):
         user = _StubUser(roles=[])
         assert get_user_permissions(user) == set()
 
-    def test_admin_bundle_grants_every_permission(self):
-        user = _StubUser(roles=['admin'])
+    def test_csg_bundle_grants_every_permission(self):
+        # csg is the full-access bundle; every Permission must be in it
+        # so authorization checks for csg members never need a special case.
+        user = _StubUser(roles=['csg'])
         assert get_user_permissions(user) == set(Permission)
 
 
@@ -71,7 +73,7 @@ class TestUserPermissionOverrides:
             'USER_PERMISSION_OVERRIDES',
             {'alice': {Permission.EXPORT_DATA}},
         )
-        user = _StubUser(roles=['user'], username='alice')
+        user = _StubUser(roles=['hsg'], username='alice')
         perms = get_user_permissions(user)
         assert Permission.EXPORT_DATA in perms
         # Baseline still present
@@ -93,7 +95,7 @@ class TestUserPermissionOverrides:
             'USER_PERMISSION_OVERRIDES',
             {'someone_else': {Permission.SYSTEM_ADMIN}},
         )
-        user = _StubUser(roles=['user'], username='alice')
+        user = _StubUser(roles=['hsg'], username='alice')
         perms = get_user_permissions(user)
         assert Permission.SYSTEM_ADMIN not in perms
 
@@ -104,27 +106,27 @@ class TestUserPermissionOverrides:
 
 class TestPredicates:
     def test_has_permission_true_when_in_bundle(self):
-        user = _StubUser(roles=['user'])
+        user = _StubUser(roles=['hsg'])
         assert has_permission(user, Permission.VIEW_PROJECTS)
 
     def test_has_permission_false_when_not_granted(self):
-        user = _StubUser(roles=['user'])
+        user = _StubUser(roles=['hsg'])
         assert not has_permission(user, Permission.SYSTEM_ADMIN)
 
     def test_has_any_permission_short_circuits_on_match(self):
-        user = _StubUser(roles=['user'])
+        user = _StubUser(roles=['hsg'])
         assert has_any_permission(
             user, Permission.SYSTEM_ADMIN, Permission.VIEW_PROJECTS
         )
 
     def test_has_any_permission_false_when_none_match(self):
-        user = _StubUser(roles=['user'])
+        user = _StubUser(roles=['hsg'])
         assert not has_any_permission(
             user, Permission.SYSTEM_ADMIN, Permission.MANAGE_ROLES
         )
 
     def test_has_all_permissions_requires_full_intersection(self):
-        user = _StubUser(roles=['user'])
+        user = _StubUser(roles=['hsg'])
         assert has_all_permissions(
             user, Permission.VIEW_PROJECTS, Permission.VIEW_ALLOCATIONS
         )
@@ -146,10 +148,10 @@ class TestPermissionEnumSurface:
     def test_new_permission_member_exists(self, perm_name):
         assert hasattr(Permission, perm_name)
 
-    def test_admin_bundle_covers_every_permission(self):
-        # Sanity check: the 'admin' bundle must list every Permission so
-        # has_permission(admin, anything) returns True without a special case.
-        assert set(GROUP_PERMISSIONS['admin']) == set(Permission)
+    def test_csg_bundle_covers_every_permission(self):
+        # Sanity check: the 'csg' bundle must list every Permission so
+        # has_permission(csg, anything) returns True without a special case.
+        assert set(GROUP_PERMISSIONS['csg']) == set(Permission)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_webapp_smoke.py
+++ b/tests/unit/test_webapp_smoke.py
@@ -5,8 +5,8 @@ These two tests prove that the Phase 4 fixture scaffolding works end-to-end:
      `create_app(config_overrides={'SQLALCHEMY_DATABASE_URI': test_db_url})`
      and responds to unauthenticated GETs.
   2. `auth_client` — Flask-Login session-cookie login as `benkirk` lets
-     authenticated routes through (and the `benkirk → admin` mapping from
-     `TestingConfig.DEV_GROUP_MAPPING` is in effect).
+     authenticated routes through (benkirk gets the full Permission set
+     via `USER_PERMISSION_OVERRIDES['benkirk']` in `webapp.utils.rbac`).
 
 If either fails, no Phase 4 port can proceed. If both pass, the rest of
 Phase 4 is unblocked and the fixture patterns in `new_tests/conftest.py`

--- a/tests/unit/test_webapp_smoke.py
+++ b/tests/unit/test_webapp_smoke.py
@@ -6,7 +6,7 @@ These two tests prove that the Phase 4 fixture scaffolding works end-to-end:
      and responds to unauthenticated GETs.
   2. `auth_client` — Flask-Login session-cookie login as `benkirk` lets
      authenticated routes through (and the `benkirk → admin` mapping from
-     `TestingConfig.DEV_ROLE_MAPPING` is in effect).
+     `TestingConfig.DEV_GROUP_MAPPING` is in effect).
 
 If either fails, no Phase 4 port can proceed. If both pass, the rest of
 Phase 4 is unblocked and the fixture patterns in `new_tests/conftest.py`


### PR DESCRIPTION
## RBAC Refactor

This branch overhauls the webapp's role-based access control. The
permission enum, the source of truth for which roles a user has, the
conditional-permission framework, every admin route guard, the
template-level button gating, and the protected API mutation surface
have all been touched. Twelve commits, each independently reviewable.

### What changed

**Permissions are now derived from POSIX group membership.** The
SAM `role_user` / `role` tables are no longer consulted by the webapp.
`AuthUser.roles` queries `adhoc_system_account_entry` (via the
existing `get_user_group_access()`) and matches each group name
against `GROUP_PERMISSIONS` in `webapp/utils/rbac.py`. A
`USER_PERMISSION_OVERRIDES` dict adds per-username grants on top of
the group baseline. Provisional bundles for `csg`, `nusd`, and `hsg`
are wired up — confirm with the team before deploy. The bundles use
set arithmetic over `ALL_VIEW`/`ALL_EDIT`/`ALL_CREATE`/`ALL_DELETE`
constants (e.g. `'hsg': ALL_VIEW | {Permission.EXPORT_DATA}`) so new
entity domains pick up coverage automatically.

**The permission enum was filled in** with the missing
`VIEW/EDIT/CREATE/DELETE` slots for `FACILITIES`, `GROUPS`, and a new
`ORG_METADATA` umbrella (organizations, institutions, contracts, NSF
programs — slowly-changing reference data, not first-class enough for
their own domains). A new `ACCESS_ADMIN_DASHBOARD` permission lets
non-admin staff (nusd) land on the admin dashboard without having
`IMPERSONATE_USERS`.

**Conditional permissions were generalized.** The
`_is_project_steward(user, project, system_perm, *, include_ancestors)`
primitive in `webapp/utils/project_permissions.py` is the new central
"system permission OR project lead/admin (optionally walking ancestors)"
check, and every `can_*` helper delegates to it. Two new decorators —
`@require_project_permission` and `@require_allocation_permission` —
package this for routes; the latter walks `allocation.account.project`
up its tree, enabling allocation redistribution within a project subtree
the user leads. `can_edit_allocations` now grants project lead/admin
(was system-only).

**Routes, templates, and decorators were swept** to align with the new
matrix: every admin tab now uses the right per-entity `VIEW_*` /
`EDIT_*` / `CREATE_*` / `DELETE_*` (no more `EDIT_PROJECTS` catch-all).
Action-button macros in `templates/dashboards/fragments/action_buttons.html`
self-gate via a `permission=` kwarg, replacing the brittle
`{% if is_admin %}` wrappers in admin card templates. The six
unprotected project-member API mutation routes now carry
`@require_project_permission`. The three hand-rolled `if 'admin' in
current_user.roles` checks (`run.py`, `auth/blueprint.py`,
`api/v1/health.py`) are gone. A `user_aware_cache_key` helper fixes
an impersonation leak in the cached allocations dashboard, and the
impersonation banner in `base.html` now uses `current_user` so it
works on every page.

### Verification

Full pytest suite: **1594 passed, 22 skipped, 1 xfailed** in ~85s.
Net new test coverage: `test_rbac.py` (28 tests), 11 new tests in
`test_project_permissions.py`, rewritten group-resolution tests in
`test_oidc_auth.py`, and `test_access_control_decorators.py` (18
tests covering the two new decorators and macro self-gating).

### Open before deploy

The `csg` / `nusd` / `hsg` group → permission bundles in
`webapp/utils/rbac.py` are placeholders. Confirm group names and
membership contents with the team before merging to staging.
