### PR TITLE
allocations: add Exchange action for rebalancing within a project subtree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ megalinter-reports/
 .coverage.*
 Vermilion_NSFNCAR-UCAR-UCP_BrandGuide.pdf
 .playwright-mcp/
+legacy_sam

--- a/src/sam/manage/allocations.py
+++ b/src/sam/manage/allocations.py
@@ -21,6 +21,7 @@ __all__ = [
     'log_allocation_transaction',
     'create_allocation',
     'update_allocation',
+    'exchange_allocations',
     'propagate_allocation_to_subprojects',
     'detach_allocation',
     'link_allocation_to_parent',
@@ -338,6 +339,133 @@ def update_allocation(
         session.flush()
 
     return allocation
+
+
+def exchange_allocations(
+    session: Session,
+    from_allocation_id: int,
+    to_allocation_id: int,
+    amount: float,
+    user_id: int,
+    comment: Optional[str] = None,
+) -> tuple:
+    """Move ``amount`` from one dedicated allocation to another.
+
+    Conservative "exchange": preserves the combined amount across the two
+    allocations, never touches dates, operates only on dedicated (non-
+    inheriting) allocations on the same resource. Inheriting children of
+    either side cascade automatically via ``update_allocation``.
+
+    Writes two paired ``AllocationTransaction(TRANSFER)`` audit rows so
+    the operation is greppable as a single logical event, in addition to
+    the ``EDIT`` rows produced by the underlying updates.
+
+    Does NOT commit — caller wraps in ``management_transaction``.
+
+    Args:
+        session:             SQLAlchemy session.
+        from_allocation_id:  Source allocation (debited).
+        to_allocation_id:    Destination allocation (credited).
+        amount:              Positive amount to transfer.
+        user_id:             User performing the exchange (audit trail).
+        comment:             Optional human-readable note appended to both
+                             TRANSFER audit rows.
+
+    Returns:
+        Tuple[Allocation, Allocation]: (from_allocation, to_allocation)
+        after the amount updates have been applied and flushed.
+
+    Raises:
+        ValueError: If allocations missing/deleted, same id, non-positive
+            amount, cross-resource, or amount > from.amount.
+        InheritingAllocationException: If either allocation is inheriting.
+    """
+    if amount <= 0:
+        raise ValueError(f"Exchange amount must be positive, got {amount}")
+    if from_allocation_id == to_allocation_id:
+        raise ValueError("FROM and TO allocations must differ")
+
+    from_alloc = session.get(Allocation, from_allocation_id)
+    to_alloc = session.get(Allocation, to_allocation_id)
+    if from_alloc is None or from_alloc.deleted:
+        raise ValueError(f"FROM allocation {from_allocation_id} not found")
+    if to_alloc is None or to_alloc.deleted:
+        raise ValueError(f"TO allocation {to_allocation_id} not found")
+    if from_alloc.is_inheriting:
+        raise InheritingAllocationException(
+            f"FROM allocation {from_allocation_id} is inheriting; "
+            "exchanges operate only on dedicated allocations."
+        )
+    if to_alloc.is_inheriting:
+        raise InheritingAllocationException(
+            f"TO allocation {to_allocation_id} is inheriting; "
+            "exchanges operate only on dedicated allocations."
+        )
+
+    from_resource_id = from_alloc.account.resource_id if from_alloc.account else None
+    to_resource_id = to_alloc.account.resource_id if to_alloc.account else None
+    if from_resource_id is None or to_resource_id is None:
+        raise ValueError("Exchange endpoints must have valid accounts.")
+    if from_resource_id != to_resource_id:
+        raise ValueError("Exchange endpoints must be on the same resource.")
+
+    if amount > from_alloc.amount:
+        raise ValueError(
+            f"Exchange amount ({amount}) exceeds FROM allocation amount "
+            f"({from_alloc.amount})."
+        )
+
+    from_proj = from_alloc.account.project if from_alloc.account else None
+    to_proj = to_alloc.account.project if to_alloc.account else None
+    from_code = from_proj.projcode if from_proj else f"#{from_allocation_id}"
+    to_code = to_proj.projcode if to_proj else f"#{to_allocation_id}"
+    transfer_comment = f"Exchange: -{amount} {from_code} / +{amount} {to_code}"
+    if comment:
+        transfer_comment = f"{transfer_comment}; {comment}"
+
+    new_from = from_alloc.amount - amount
+    new_to = to_alloc.amount + amount
+
+    update_allocation(session, from_allocation_id, user_id, amount=new_from)
+    update_allocation(session, to_allocation_id, user_id, amount=new_to)
+
+    # Paired TRANSFER audit rows (in addition to the EDIT rows that
+    # update_allocation writes). They cross-reference each other via
+    # related_transaction_id so the exchange is greppable as a single
+    # logical operation.
+    debit = AllocationTransaction(
+        allocation_id=from_alloc.allocation_id,
+        user_id=user_id,
+        transaction_type=AllocationTransactionType.TRANSFER,
+        alloc_start_date=from_alloc.start_date,
+        alloc_end_date=from_alloc.end_date,
+        transaction_amount=-amount,
+        requested_amount=amount,
+        transaction_comment=transfer_comment,
+        propagated=False,
+    )
+    session.add(debit)
+    session.flush()
+
+    credit = AllocationTransaction(
+        allocation_id=to_alloc.allocation_id,
+        user_id=user_id,
+        transaction_type=AllocationTransactionType.TRANSFER,
+        alloc_start_date=to_alloc.start_date,
+        alloc_end_date=to_alloc.end_date,
+        transaction_amount=amount,
+        requested_amount=amount,
+        transaction_comment=transfer_comment,
+        propagated=False,
+        related_transaction_id=debit.allocation_transaction_id,
+    )
+    session.add(credit)
+    session.flush()
+
+    debit.related_transaction_id = credit.allocation_transaction_id
+    session.flush()
+
+    return from_alloc, to_alloc
 
 
 def propagate_allocation_to_subprojects(

--- a/src/sam/schemas/forms/__init__.py
+++ b/src/sam/schemas/forms/__init__.py
@@ -172,6 +172,7 @@ from .projects import (
 from .user import (
     AddMemberForm,
     EditAllocationForm,
+    ExchangeAllocationForm,
     AddAllocationForm,
     RenewAllocationsForm,
     ExtendAllocationsForm,
@@ -226,6 +227,7 @@ __all__ = [
     # User
     'AddMemberForm',
     'EditAllocationForm',
+    'ExchangeAllocationForm',
     'AddAllocationForm',
     'RenewAllocationsForm',
     'ExtendAllocationsForm',

--- a/src/sam/schemas/forms/user.py
+++ b/src/sam/schemas/forms/user.py
@@ -6,7 +6,7 @@ Covers: Add Member, Edit Allocation.
 
 import marshmallow.fields as f
 import marshmallow.validate as v
-from marshmallow import post_load
+from marshmallow import post_load, validates_schema, ValidationError
 
 from . import HtmxFormSchema
 
@@ -104,6 +104,27 @@ class ExtendAllocationsForm(HtmxFormSchema):
     def coerce_and_validate_dates(self, data, **kwargs):
         data['new_end_date'] = self.normalize_end_date(data['new_end_date'])
         return data
+
+
+class ExchangeAllocationForm(HtmxFormSchema):
+    """Move ``amount`` from one dedicated allocation to another.
+
+    The route enforces (all require DB access, so they stay inline):
+    - both allocation IDs exist, are not deleted, and are not inheriting;
+    - both allocations are on the same resource;
+    - both owning projects lie within the edit-page project's subtree;
+    - amount does not push FROM below its currently-used balance.
+    """
+    from_allocation_id = f.Int(required=True)
+    to_allocation_id = f.Int(required=True)
+    amount = f.Float(required=True, validate=v.Range(min=0, min_inclusive=False))
+
+    @validates_schema
+    def _distinct(self, data, **kwargs):
+        if data.get('from_allocation_id') == data.get('to_allocation_id'):
+            raise ValidationError(
+                {'to_allocation_id': ['FROM and TO allocations must differ.']}
+            )
 
 
 class AddAllocationForm(HtmxFormSchema):

--- a/src/webapp/dashboards/admin/blueprint.py
+++ b/src/webapp/dashboards/admin/blueprint.py
@@ -10,7 +10,7 @@ Domain-specific routes are split into sub-modules imported at the bottom:
   orgs_routes.py       — Organizations, Institutions, AOIs, Contracts, NSF Programs
 """
 
-from flask import Blueprint, render_template, request, flash, redirect, url_for, session, Response
+from flask import Blueprint, render_template, request, flash, redirect, url_for, session, Response, abort
 from webapp.utils.htmx import htmx_success, htmx_success_message
 from flask_login import login_required, current_user, login_user
 from datetime import datetime, timedelta
@@ -551,19 +551,24 @@ def expirations_export():
 
 @bp.route('/htmx/search/users')
 @login_required
-@require_permission(Permission.VIEW_USERS)
 def htmx_search_users():
     """Unified user search endpoint.
 
-    The ``context`` query parameter selects the response template:
-      fk          → FK-picker badge list (create_resource, create_contract, create_project)
-      impersonate → admin user list with active_only filter (impersonation panel)
-      member      → project member add list, excludes existing members (projcode required)
+    The ``context`` query parameter selects the response template AND
+    the permission gate:
+      fk          → FK-picker badge list (create_resource, create_contract,
+                    create_project); requires system VIEW_USERS.
+      impersonate → admin user list with active_only filter (impersonation
+                    panel); requires system IMPERSONATE_USERS.
+      member      → project member add list; requires can_manage_project_members
+                    on the target project (projcode required), so project
+                    leads/admins can search when building the add-member form.
 
     All other contexts fall back to ``fk``.
     """
     from sam.queries.users import search_users_by_pattern, get_project_member_user_ids
     from sam.projects.projects import Project
+    from webapp.utils.project_permissions import can_manage_project_members
 
     q = request.args.get('q', '').strip()
     context = request.args.get('context', 'fk')
@@ -583,10 +588,20 @@ def htmx_search_users():
 
     if context == 'member':
         projcode = request.args.get('projcode', '')
-        if projcode:
-            project = db.session.query(Project).filter_by(projcode=projcode).first()
-            if project:
-                exclude_ids = get_project_member_user_ids(db.session, project.project_id)
+        if not projcode:
+            abort(400)
+        project = db.session.query(Project).filter_by(projcode=projcode).first()
+        if not project:
+            abort(404)
+        if not can_manage_project_members(current_user, project):
+            abort(403)
+        exclude_ids = get_project_member_user_ids(db.session, project.project_id)
+    elif context == 'impersonate':
+        if not has_permission(current_user, Permission.IMPERSONATE_USERS):
+            abort(403)
+    else:
+        if not has_permission(current_user, Permission.VIEW_USERS):
+            abort(403)
 
     users = search_users_by_pattern(
         db.session, q, limit=20 if context == 'impersonate' else 15,

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -12,7 +12,9 @@ from webapp.utils.fk_validation import FKValidationError, validate_fk_existence
 from flask_login import login_required, current_user
 
 from webapp.extensions import db
-from webapp.utils.rbac import require_permission, Permission
+from webapp.utils.rbac import require_permission, has_permission, Permission
+from webapp.api.access_control import require_project_permission
+from webapp.utils.project_permissions import can_edit_project_governance
 from sam.manage import management_transaction
 
 from .blueprint import bp
@@ -363,21 +365,20 @@ def htmx_project_create():
 
 @bp.route('/project/<projcode>/edit')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
-def edit_project_page(projcode):
+@require_project_permission(Permission.EDIT_PROJECTS)
+def edit_project_page(project):
     """Full edit-project page (not a modal).
 
     Renders a three-tab page: Details | Allocations | Members.
     The Allocations tab is lazy-loaded on first click.
+
+    Access: system EDIT_PROJECTS, or project lead, or project admin
+    (``can_access_edit_project_page``). Non-admin stewards see every
+    tab but a limited edit surface gated by ``can_edit_governance``.
     """
-    from sam.projects.projects import Project
     from sam.queries.dashboard import get_project_dashboard_data
 
-    project = Project.get_by_projcode(db.session, projcode)
-    if not project:
-        return redirect(url_for('admin_dashboard.index'))
-
-    project_data = get_project_dashboard_data(db.session, projcode)
+    project_data = get_project_dashboard_data(db.session, project.projcode)
 
     # Reverse-lookup facility_id / panel_id for cascading dropdown pre-population.
     current_facility_id = None
@@ -397,30 +398,44 @@ def edit_project_page(projcode):
         pre_fill['panel_id'] = str(current_panel_id)
     form_data = _project_form_data(form=pre_fill or None)
 
+    can_edit_governance = can_edit_project_governance(current_user, project)
+    can_access_admin = has_permission(current_user, Permission.ACCESS_ADMIN_DASHBOARD)
+
     return render_template(
         'dashboards/admin/edit_project.html',
         project=project,
         project_data=project_data,
         current_facility_id=current_facility_id,
         current_panel_id=current_panel_id,
+        can_edit_governance=can_edit_governance,
+        can_access_admin=can_access_admin,
         **form_data,
     )
 
 
+GOVERNANCE_FIELDS = frozenset({
+    'facility_id', 'panel_id', 'allocation_type_id',
+    'project_lead_user_id', 'project_admin_user_id',
+    'active', 'charging_exempt', 'ext_alias',
+})
+
+
 @bp.route('/htmx/project-update/<projcode>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
-def htmx_project_update(projcode):
-    """Validate and apply project metadata updates."""
-    from sam.projects.projects import Project
+@require_project_permission(Permission.EDIT_PROJECTS)
+def htmx_project_update(project):
+    """Validate and apply project metadata updates.
+
+    Access: system EDIT_PROJECTS, or project lead/admin. Non-admin
+    stewards can only change metadata fields (title / abstract /
+    area_of_interest_id); governance-field submissions are stripped
+    server-side before validation.
+    """
     from sam.projects.areas import AreaOfInterest
     from sam.accounting.allocations import AllocationType
     from sam.core.users import User
     from sam.schemas.forms import EditProjectForm
-
-    project = Project.get_by_projcode(db.session, projcode)
-    if not project:
-        return '<div class="alert alert-danger">Project not found.</div>', 404
+    from marshmallow import ValidationError
 
     current_facility_id = None
     current_panel_id = None
@@ -429,41 +444,59 @@ def htmx_project_update(projcode):
         if project.allocation_type.panel.facility:
             current_facility_id = project.allocation_type.panel.facility_id
 
-    def _do_action(data):
-        validate_fk_existence(
-            db.session,
-            (User, data['project_lead_user_id'], 'project lead'),
-            (User, data.get('project_admin_user_id'), 'project admin'),
-            (AreaOfInterest, data['area_of_interest_id'], 'area of interest'),
-            (AllocationType, data.get('allocation_type_id'), 'allocation type'),
-        )
-        # project.update() only writes non-None kwargs, so scalar fields
-        # the user left blank (stripped to None by the schema) pass
-        # through unchanged.
-        project.update(**data)
-        return project
+    # Governance fields are admin-only. When a non-admin steward submits,
+    # drop those keys before marshmallow sees them. Defense-in-depth: the
+    # template renders them as read-only text for non-admins (so browsers
+    # don't submit them), but a crafted curl request could include them.
+    if can_edit_project_governance(current_user, project):
+        form_input = request.form
+    else:
+        form_input = {k: v for k, v in request.form.items()
+                      if k not in GOVERNANCE_FIELDS}
 
-    return handle_htmx_form_post(
-        schema_cls=EditProjectForm,
-        template='dashboards/admin/fragments/edit_project_details_htmx.html',
-        context_fn=lambda: _project_form_data(form=request.form),
-        extra_context={
-            'project': project,
-            'current_facility_id': current_facility_id,
-            'current_panel_id': current_panel_id,
-        },
-        success_triggers={'reloadEditProjectDetails': projcode},
-        success_message='Project updated successfully.',
-        success_detail=lambda p: f'{p.projcode} — {p.title}',
-        error_prefix='Error updating project',
-        do_action=_do_action,
+    def _render_with_errors(errs):
+        return render_template(
+            'dashboards/admin/fragments/edit_project_details_htmx.html',
+            project=project,
+            current_facility_id=current_facility_id,
+            current_panel_id=current_panel_id,
+            can_edit_governance=can_edit_project_governance(current_user, project),
+            errors=errs,
+            form=request.form,
+            **_project_form_data(form=request.form),
+        )
+
+    try:
+        data = EditProjectForm().load(form_input, partial=True)
+    except ValidationError as e:
+        return _render_with_errors(EditProjectForm.flatten_errors(e.messages))
+
+    try:
+        with management_transaction(db.session):
+            validate_fk_existence(
+                db.session,
+                (User, data.get('project_lead_user_id'), 'project lead'),
+                (User, data.get('project_admin_user_id'), 'project admin'),
+                (AreaOfInterest, data.get('area_of_interest_id'), 'area of interest'),
+                (AllocationType, data.get('allocation_type_id'), 'allocation type'),
+            )
+            project.update(**data)
+    except FKValidationError as e:
+        return _render_with_errors(e.errors)
+    except Exception as e:  # noqa: BLE001
+        return _render_with_errors([f'Error updating project: {e}'])
+
+    return htmx_success_message(
+        {'reloadEditProjectDetails': project.projcode},
+        'Project updated successfully.',
+        detail=f'{project.projcode} — {project.title}',
     )
 
 
 @bp.route('/htmx/project-allocation-tree/<projcode>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
-def htmx_project_allocation_tree(projcode):
+@require_project_permission(Permission.EDIT_PROJECTS)
+def htmx_project_allocation_tree(project):
     """Lazy-loaded allocation tree for the Edit Project Allocations tab.
 
     Builds a {projcode: {resource_name: resource_dict}} lookup for all active
@@ -475,7 +508,6 @@ def htmx_project_allocation_tree(projcode):
     """
     from collections import OrderedDict
     from datetime import datetime
-    from sam.projects.projects import Project
     from sam.queries.dashboard import _build_project_resources_data
 
     # Parse optional active_at date; default to today.
@@ -486,10 +518,6 @@ def htmx_project_allocation_tree(projcode):
         active_at = None
     now_str = datetime.now().strftime('%Y-%m-%d')
     active_at_str = active_at.strftime('%Y-%m-%d') if active_at else now_str
-
-    project = Project.get_by_projcode(db.session, projcode)
-    if not project:
-        return '<div class="alert alert-warning">Project not found.</div>'
 
     root = project.get_root() if hasattr(project, 'get_root') else project
 
@@ -532,11 +560,12 @@ def htmx_project_allocation_tree(projcode):
     return render_template(
         'dashboards/admin/fragments/project_allocation_tree_htmx.html',
         root=root,
-        projcode=projcode,
+        projcode=project.projcode,
         resources_by_tab=resources_by_tab,
         resources_by_projcode=resources_by_projcode,
         active_at=active_at_str,
         now_str=now_str,
+        can_edit_governance=can_edit_project_governance(current_user, project),
     )
 
 
@@ -1505,6 +1534,7 @@ def _linked_elements_context(project):
         active_organizations=[po for po in project.organizations if po.is_active],
         contracts=project.contracts,
         active_directories=[pd for pd in project.directories if pd.is_active],
+        can_edit_governance=can_edit_project_governance(current_user, project),
         errors=[],
     )
 
@@ -1521,15 +1551,14 @@ def _render_linked_elements(project, errors=None):
 
 @bp.route('/htmx/project/<projcode>/linked-elements')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
-def htmx_project_linked_elements(projcode):
-    """Render the linked-elements section for an edit-project page."""
-    from sam.projects.projects import Project
+@require_project_permission(Permission.EDIT_PROJECTS)
+def htmx_project_linked_elements(project):
+    """Render the linked-elements section for an edit-project page.
 
-    project = Project.get_by_projcode(db.session, projcode)
-    if not project:
-        return '<div class="alert alert-warning">Project not found.</div>'
-
+    Access: system EDIT_PROJECTS, or project lead/admin. Add / remove
+    actions inside the fragment remain gated by the admin-only
+    ``can_edit_governance`` flag.
+    """
     return _render_linked_elements(project)
 
 

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -14,7 +14,10 @@ from flask_login import login_required, current_user
 from webapp.extensions import db
 from webapp.utils.rbac import require_permission, has_permission, Permission
 from webapp.api.access_control import require_project_permission
-from webapp.utils.project_permissions import can_edit_project_governance
+from webapp.utils.project_permissions import (
+    can_edit_project_governance,
+    can_edit_allocations,
+)
 from sam.manage import management_transaction
 
 from .blueprint import bp
@@ -557,6 +560,40 @@ def htmx_project_allocation_tree(project):
                 'rtypes_str': ','.join(rtypes),
             }
 
+    # Exchange eligibility: a resource is eligible when at least two
+    # distinct DESCENDANT projects (NOT the edit-page project itself)
+    # hold a dedicated (non-inheriting) allocation for it. The root is
+    # never a valid exchange endpoint — see ``_exchange_candidates``.
+    # Computed from the data already loaded above; no extra DB trips.
+    can_exchange = can_edit_allocations(current_user, project)
+    descendant_projcodes = {
+        p.projcode for p in project.get_descendants(include_self=False)
+        if p.active
+    }
+    exchange_eligible_resources = set()
+    if can_exchange:
+        per_resource_counts = {}  # resource_name → count of dedicated allocs among descendants
+        for pc in descendant_projcodes:
+            for rname, rdata in resources_by_projcode.get(pc, {}).items():
+                if rdata.get('allocation_id') and not rdata.get('is_inheriting'):
+                    per_resource_counts[rname] = per_resource_counts.get(rname, 0) + 1
+        exchange_eligible_resources = {
+            rname for rname, count in per_resource_counts.items() if count >= 2
+        }
+
+    # Resolve resource_id by name so the Exchange button's URL can target
+    # /htmx/exchange-allocation-form/<projcode>/<resource_id>. Only needed
+    # when exchange eligibility is non-empty.
+    resource_id_by_name = {}
+    if exchange_eligible_resources:
+        from sam.resources.resources import Resource
+        resource_id_by_name = {
+            r.resource_name: r.resource_id
+            for r in db.session.query(Resource)
+            .filter(Resource.resource_name.in_(exchange_eligible_resources))
+            .all()
+        }
+
     return render_template(
         'dashboards/admin/fragments/project_allocation_tree_htmx.html',
         root=root,
@@ -566,6 +603,9 @@ def htmx_project_allocation_tree(project):
         active_at=active_at_str,
         now_str=now_str,
         can_edit_governance=can_edit_project_governance(current_user, project),
+        can_exchange=can_exchange,
+        exchange_eligible_resources=exchange_eligible_resources,
+        resource_id_by_name=resource_id_by_name,
     )
 
 
@@ -726,6 +766,220 @@ def htmx_add_allocation(projcode):
     return htmx_success_message(
         {'closeActiveModal': {}, 'reloadAllocationTree': projcode},
         'Allocation created successfully.',
+        detail=detail,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Exchange allocations (Edit Project → Allocations tab)
+# ---------------------------------------------------------------------------
+
+def _exchange_candidates(project, resource_id, active_at=None):
+    """Return list of dedicated allocation candidates within ``project``'s
+    subtree for ``resource_id``, restricted to allocations active at
+    ``active_at`` (defaults to now).
+
+    The edit-page project itself is EXCLUDED — exchange is strictly a
+    rebalancing between descendants. Moving amount *to* the root would
+    not change anything (descendants inherit from it); moving amount
+    *from* the root would affect children whose allocations are
+    independent of it. Either way, the root is not a valid endpoint.
+
+    Each entry is a dict: {allocation_id, amount, used, projcode,
+    project_id, resource_name}. Only non-inheriting, non-deleted
+    allocations on accounts owned by active descendant projects AND
+    active at the reference date are included. The result is sorted by
+    projcode.
+
+    Matching ``active_at`` is essential so the dropdown shows exactly the
+    allocations rendered in the tree — otherwise expired/future
+    allocations for the same (project, resource) create duplicate entries.
+    """
+    from sam.accounting.allocations import Allocation
+    from sam.accounting.accounts import Account
+    from sam.resources.resources import Resource
+    from sqlalchemy import or_ as sa_or
+
+    resource = db.session.get(Resource, resource_id)
+    if not resource:
+        return [], None
+
+    subtree = {
+        p.project_id: p for p in project.get_descendants(include_self=False)
+        if p.active
+    }
+    if not subtree:
+        return [], resource
+
+    check_date = active_at or datetime.now()
+
+    rows = (
+        db.session.query(Allocation, Account)
+        .join(Account, Allocation.account_id == Account.account_id)
+        .filter(
+            Account.project_id.in_(subtree.keys()),
+            Account.resource_id == resource_id,
+            Account.deleted == False,  # noqa: E712
+            Allocation.deleted == False,  # noqa: E712
+            Allocation.parent_allocation_id.is_(None),
+            Allocation.start_date <= check_date,
+            sa_or(
+                Allocation.end_date.is_(None),
+                Allocation.end_date >= check_date,
+            ),
+        )
+        .all()
+    )
+
+    candidates = []
+    for alloc, acct in rows:
+        proj = subtree.get(acct.project_id)
+        if proj is None:
+            continue
+        # Per-project 'used' for the FROM overdraft preview / server check.
+        usage = proj.get_detailed_allocation_usage(
+            resource_name=resource.resource_name,
+            active_at=active_at,
+        )
+        used = usage.get(resource.resource_name, {}).get('used', 0.0) if usage else 0.0
+        candidates.append({
+            'allocation_id': alloc.allocation_id,
+            'amount': alloc.amount,
+            'used': used,
+            'projcode': proj.projcode,
+            'project_id': proj.project_id,
+            'resource_name': resource.resource_name,
+            'title': proj.title or '',
+        })
+
+    candidates.sort(key=lambda c: c['projcode'])
+    return candidates, resource
+
+
+@bp.route('/htmx/exchange-allocation-form/<projcode>/<int:resource_id>')
+@login_required
+@require_project_permission(Permission.EDIT_ALLOCATIONS)
+def htmx_exchange_allocation_form(project, resource_id):
+    """Render the exchange-allocation modal form for a (project-subtree, resource) pair.
+
+    Honors the ``active_at=YYYY-MM-DD`` query parameter carried in from the
+    Allocations tab's date picker — restricts candidates to allocations
+    active at that date, matching what's displayed in the tree.
+    """
+    active_at = _parse_active_at_arg(request.args.get('active_at', ''))
+    candidates, resource = _exchange_candidates(project, resource_id, active_at=active_at)
+    if resource is None:
+        return '<div class="modal-body"><div class="alert alert-warning">Resource not found.</div></div>'
+    if len(candidates) < 2:
+        return (
+            '<div class="modal-body">'
+            '<div class="alert alert-info">'
+            '<i class="fas fa-info-circle"></i> '
+            'Exchange requires at least two dedicated allocations for this resource '
+            'within the project subtree. Inherited (shared) allocations do not count.'
+            '</div></div>'
+        )
+    return render_template(
+        'dashboards/admin/fragments/exchange_allocation_form_htmx.html',
+        project=project,
+        resource=resource,
+        candidates=candidates,
+        active_at=active_at.strftime('%Y-%m-%d'),
+    )
+
+
+@bp.route('/htmx/exchange-allocation/<projcode>', methods=['POST'])
+@login_required
+@require_project_permission(Permission.EDIT_ALLOCATIONS)
+def htmx_exchange_allocation(project):
+    """Validate and apply an allocation exchange within the project's subtree."""
+    from sam.accounting.allocations import Allocation, InheritingAllocationException
+    from sam.manage.allocations import exchange_allocations
+    from sam.schemas.forms import ExchangeAllocationForm
+    from marshmallow import ValidationError
+
+    errors = []
+    resource_id_raw = request.form.get('resource_id', '').strip()
+    try:
+        resource_id = int(resource_id_raw)
+    except (TypeError, ValueError):
+        resource_id = None
+
+    active_at = _parse_active_at_arg(request.form.get('active_at', ''))
+
+    try:
+        form_data = ExchangeAllocationForm().load(request.form)
+    except ValidationError as e:
+        errors.extend(ExchangeAllocationForm.flatten_errors(e.messages))
+        form_data = {}
+
+    def _reload_exchange_form(extra_errors=None):
+        candidates, resource = (
+            _exchange_candidates(project, resource_id, active_at=active_at)
+            if resource_id else ([], None)
+        )
+        return render_template(
+            'dashboards/admin/fragments/exchange_allocation_form_htmx.html',
+            project=project,
+            resource=resource,
+            candidates=candidates,
+            active_at=active_at.strftime('%Y-%m-%d'),
+            errors=(extra_errors or []) + errors,
+            form=request.form,
+        )
+
+    if resource_id is None:
+        return _reload_exchange_form(['Resource is required.'])
+
+    if errors:
+        return _reload_exchange_form()
+
+    from_id = form_data['from_allocation_id']
+    to_id = form_data['to_allocation_id']
+    amount = form_data['amount']
+
+    # Restrict endpoints to the edit-page project's subtree — prevents
+    # forged allocation IDs from outside the authorized scope.
+    candidates, resource = _exchange_candidates(project, resource_id, active_at=active_at)
+    by_id = {c['allocation_id']: c for c in candidates}
+    from_cand = by_id.get(from_id)
+    to_cand = by_id.get(to_id)
+    if from_cand is None or to_cand is None:
+        return _reload_exchange_form([
+            'Selected allocation is not in this project subtree for the chosen resource.'
+        ])
+
+    # Strict overdraft: cannot push FROM remaining below zero.
+    from_remaining = from_cand['amount'] - from_cand['used']
+    if amount > from_remaining:
+        return _reload_exchange_form([
+            f"Exchange amount ({amount:g}) exceeds FROM remaining balance "
+            f"({from_remaining:g})."
+        ])
+
+    try:
+        with management_transaction(db.session):
+            exchange_allocations(
+                db.session,
+                from_allocation_id=from_id,
+                to_allocation_id=to_id,
+                amount=amount,
+                user_id=current_user.user_id,
+            )
+    except InheritingAllocationException as e:
+        return _reload_exchange_form([str(e)])
+    except ValueError as e:
+        return _reload_exchange_form([str(e)])
+    except Exception as e:
+        return _reload_exchange_form([f'Error exchanging allocations: {e}'])
+
+    detail = (
+        f"{resource.resource_name}: -{amount:g} {from_cand['projcode']} / "
+        f"+{amount:g} {to_cand['projcode']}"
+    )
+    return htmx_success_message(
+        {'closeActiveModal': {}, 'reloadAllocationTree': project.projcode},
+        'Allocation exchanged successfully.',
         detail=detail,
     )
 

--- a/src/webapp/templates/dashboards/admin/edit_project.html
+++ b/src/webapp/templates/dashboards/admin/edit_project.html
@@ -208,6 +208,24 @@
   </div>
 </div>
 
+<!-- Exchange Allocation Modal (lazy-loaded) -->
+<div class="modal fade" id="exchangeAllocationModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header bg-info text-white">
+        <h5 class="modal-title"><i class="fas fa-exchange-alt"></i> Exchange Allocation</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div id="exchangeAllocationFormContainer">
+        <div class="modal-body text-center text-muted py-3">
+          <i class="fas fa-spinner fa-spin fa-2x"></i>
+          <p class="mt-2">Loading…</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Edit Allocation Modal (lazy-loaded) -->
 <div class="modal fade" id="editAllocationModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">

--- a/src/webapp/templates/dashboards/admin/edit_project.html
+++ b/src/webapp/templates/dashboards/admin/edit_project.html
@@ -16,14 +16,22 @@
 <div class="d-flex align-items-center mb-3">
   <nav aria-label="breadcrumb" class="mb-0">
     <ol class="breadcrumb mb-0">
+      {% if can_access_admin %}
       <li class="breadcrumb-item"><a href="{{ url_for('admin_dashboard.index') }}">Admin</a></li>
+      {% endif %}
       <li class="breadcrumb-item active">Edit Project</li>
       <li class="breadcrumb-item active">{{ project.projcode }}</li>
     </ol>
   </nav>
+  {% if can_access_admin %}
   <a href="{{ url_for('admin_dashboard.index') }}" class="btn btn-outline-secondary btn-sm ms-auto">
     <i class="fas fa-arrow-left"></i> Back to Admin
   </a>
+  {% else %}
+  <a href="{{ url_for('user_dashboard.index') }}" class="btn btn-outline-secondary btn-sm ms-auto">
+    <i class="fas fa-arrow-left"></i> Back to Dashboard
+  </a>
+  {% endif %}
 </div>
 
 <!-- Page header -->
@@ -91,6 +99,7 @@
 
   <!-- ── Tab 2: Allocations ─────────────────────────────────────────── -->
   <div class="tab-pane fade" id="tab-allocations" role="tabpanel">
+    {% if can_edit_governance %}
     <div class="d-flex justify-content-end gap-2 mb-3">
       <button class="btn btn-sm btn-warning"
               hx-get="{{ url_for('admin_dashboard.htmx_extend_allocations_form', projcode=project.projcode) }}"
@@ -119,6 +128,7 @@
         <i class="fas fa-plus-circle"></i> Add Allocation
       </button>
     </div>
+    {% endif %}
     <div id="allocationTreeContainer">
       <div class="text-center text-muted py-4">
         <i class="fas fa-spinner fa-spin fa-2x" aria-hidden="true"></i>

--- a/src/webapp/templates/dashboards/admin/fragments/edit_project_details_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/edit_project_details_htmx.html
@@ -67,6 +67,7 @@
     </div>
   </div>
 
+  {% if can_edit_governance %}
   <!-- ── Facility / Panel / Allocation Type ──────────────────────── -->
   <div class="row g-2 mb-3">
     <div class="col-md-4">
@@ -136,6 +137,17 @@
       </select>
     </div>
   </div>
+  {% else %}
+  <!-- ── Governance display (non-admin steward) ────────────────── -->
+  <div class="row g-2 mb-3">
+    <div class="col-md-4">
+      <label class="form-label">Allocation Type</label>
+      <div class="form-control-plaintext text-muted">
+        {{ project.allocation_type.allocation_type if project.allocation_type else '—' }}
+      </div>
+    </div>
+  </div>
+  {% endif %}
 
   {{ text_field('title', 'Title',
                 required=True, maxlength=255, default=project.title,
@@ -149,6 +161,7 @@
   <div class="row">
     <!-- ── Project Lead ──────────────────────────────────────────── -->
     <div class="col-md-6">
+      {% if can_edit_governance %}
       {{ fk_search_field('project_lead_user_id', 'Project Lead',
                          search_url=url_for('admin_dashboard.htmx_search_users', context='fk'),
                          required=True,
@@ -159,10 +172,19 @@
                          selected_id=project.project_lead_user_id,
                          selected_label=project.lead.display_name if project.lead else '',
                          id_prefix='editProjectLead') }}
+      {% else %}
+      <div class="mb-3">
+        <label class="form-label fw-semibold">Project Lead</label>
+        <div class="form-control-plaintext">
+          {{ project.lead.display_name if project.lead else '—' }}
+        </div>
+      </div>
+      {% endif %}
     </div>
 
     <!-- ── Project Admin ─────────────────────────────────────────── -->
     <div class="col-md-6">
+      {% if can_edit_governance %}
       {{ fk_search_field('project_admin_user_id', 'Project Admin',
                          search_url=url_for('admin_dashboard.htmx_search_users', context='fk'),
                          placeholder='Search to change or set admin…',
@@ -171,6 +193,15 @@
                          selected_id=project.project_admin_user_id or '',
                          selected_label=project.admin.display_name if project.admin else '',
                          id_prefix='editProjectAdmin') }}
+      {% else %}
+      <div class="mb-3">
+        <label class="form-label">Project Admin</label>
+        <div class="form-control-plaintext">
+          {{ project.admin.display_name if project.admin else '—' }}
+          <small class="text-muted ms-1">(change via Members tab)</small>
+        </div>
+      </div>
+      {% endif %}
     </div>
   </div>
 
@@ -203,15 +234,22 @@
         <label for="editProjectExtAlias" class="form-label">
           Ext. Alias <span class="text-muted">(optional)</span>
         </label>
+        {% if can_edit_governance %}
         <input type="text" class="form-control form-control-sm" id="editProjectExtAlias"
                name="ext_alias"
                value="{{ f.get('ext_alias', project.ext_alias or '') if f else (project.ext_alias or '') }}">
+        {% else %}
+        <div class="form-control-plaintext text-muted">
+          {{ project.ext_alias or '—' }}
+        </div>
+        {% endif %}
       </div>
     </div>
   </div>
 
   <!-- ── Flags ─────────────────────────────────────────────────────── -->
   <div class="row mb-3">
+    {% if can_edit_governance %}
     <div class="col-auto">
       <div class="form-check form-switch">
         <input class="form-check-input" type="checkbox" id="editProjectActive"
@@ -233,6 +271,20 @@
         </label>
       </div>
     </div>
+    {% else %}
+    <div class="col-auto">
+      <label class="form-label d-block mb-0">Active</label>
+      <span class="badge {{ 'bg-success' if project.active else 'bg-secondary' }}">
+        {{ 'Yes' if project.active else 'No' }}
+      </span>
+    </div>
+    <div class="col-auto">
+      <label class="form-label d-block mb-0">Charging Exempt</label>
+      <span class="badge {{ 'bg-warning text-dark' if project.charging_exempt else 'bg-light text-dark border' }}">
+        {{ 'Yes' if project.charging_exempt else 'No' }}
+      </span>
+    </div>
+    {% endif %}
   </div>
 
   <!-- ── Submit ────────────────────────────────────────────────────── -->

--- a/src/webapp/templates/dashboards/admin/fragments/exchange_allocation_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/exchange_allocation_form_htmx.html
@@ -1,0 +1,195 @@
+{#
+  Admin: Edit Project — Exchange Allocation modal form.
+  Loaded into #exchangeAllocationFormContainer when the Exchange button is
+  clicked on a resource row in the allocation tree.
+
+  An "exchange" moves allocation amount from one dedicated allocation to
+  another on the same resource, within the current project's subtree. The
+  overall combined amount is preserved; dates and descriptions are never
+  changed.
+
+  Context variables:
+    project     — the edit-page Project ORM object (form action scope)
+    resource    — the Resource ORM object being exchanged on
+    candidates  — list of {allocation_id, amount, used, projcode,
+                  project_id, resource_name}; already filtered to dedicated,
+                  non-inheriting, non-deleted allocations within the subtree
+    errors      — list of validation errors (on re-render)
+    form        — request.form on validation re-render
+#}
+{% from 'dashboards/fragments/modal_form.html' import htmx_form %}
+
+{% call htmx_form(
+    url_for('admin_dashboard.htmx_exchange_allocation', projcode=project.projcode),
+    '#exchangeAllocationFormContainer',
+    'Exchange',
+    submit_icon='exchange-alt',
+    submit_class='btn-info',
+    errors=errors
+) %}
+
+  <input type="hidden" name="resource_id" value="{{ resource.resource_id }}">
+  <input type="hidden" name="active_at" value="{{ active_at }}">
+
+  <div class="alert alert-info py-2 mb-3 small">
+    <i class="fas fa-exchange-alt me-1"></i>
+    Moves amount between dedicated allocations on
+    <strong>{{ resource.resource_name }}</strong> within
+    <code>{{ project.projcode }}</code>'s subtree. Dates are not changed.
+    Inherited descendants of either side cascade automatically.
+  </div>
+
+  {# FROM project #}
+  <div class="mb-3">
+    <label for="exchangeFromProject" class="form-label fw-semibold">
+      From <span class="text-danger">*</span>
+    </label>
+    <select class="form-select" id="exchangeFromProject"
+            name="from_allocation_id" required>
+      <option value="">— Select source project —</option>
+      {% for c in candidates %}
+      <option value="{{ c.allocation_id }}"
+              data-amount="{{ c.amount }}"
+              data-used="{{ c.used }}"
+              data-projcode="{{ c.projcode }}"
+              {% if form and form.get('from_allocation_id') == c.allocation_id|string %}selected{% endif %}>
+        {{ c.projcode }} — {{ c.amount | fmt_number }}{% if c.title %} — {{ c.title | truncate(50, True, '…') }}{% endif %}
+      </option>
+      {% endfor %}
+    </select>
+    <div class="form-text">
+      <span id="exchangeFromPreview" class="text-muted"></span>
+    </div>
+  </div>
+
+  {# TO project #}
+  <div class="mb-3">
+    <label for="exchangeToProject" class="form-label fw-semibold">
+      To <span class="text-danger">*</span>
+    </label>
+    <select class="form-select" id="exchangeToProject"
+            name="to_allocation_id" required>
+      <option value="">— Select destination project —</option>
+      {% for c in candidates %}
+      <option value="{{ c.allocation_id }}"
+              data-amount="{{ c.amount }}"
+              data-projcode="{{ c.projcode }}"
+              {% if form and form.get('to_allocation_id') == c.allocation_id|string %}selected{% endif %}>
+        {{ c.projcode }} — {{ c.amount | fmt_number }}{% if c.title %} — {{ c.title | truncate(50, True, '…') }}{% endif %}
+      </option>
+      {% endfor %}
+    </select>
+    <div class="form-text">
+      <span id="exchangeToPreview" class="text-muted"></span>
+    </div>
+  </div>
+
+  {# Amount to transfer #}
+  <div class="mb-3">
+    <label for="exchangeAmount" class="form-label fw-semibold">
+      Amount to transfer <span class="text-danger">*</span>
+    </label>
+    <input type="number" class="form-control" id="exchangeAmount"
+           name="amount" min="0.01" step="any" required
+           data-number-preview
+           value="{{ form.get('amount', '') if form else '' }}"
+           placeholder="e.g. 100000">
+    <div class="form-text">
+      <span class="number-preview text-primary fw-semibold"></span>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var root = document.getElementById('exchangeAllocationFormContainer');
+      if (!root) return;
+      var fromSel = root.querySelector('#exchangeFromProject');
+      var toSel   = root.querySelector('#exchangeToProject');
+      var amtInp  = root.querySelector('#exchangeAmount');
+      var fromP   = root.querySelector('#exchangeFromPreview');
+      var toP     = root.querySelector('#exchangeToPreview');
+      if (!fromSel || !toSel || !amtInp || !fromP || !toP) return;
+
+      function fmt(n) {
+        if (!isFinite(n)) return '';
+        return n.toLocaleString('en-US');
+      }
+
+      function pickedData(sel) {
+        var opt = sel.options[sel.selectedIndex];
+        if (!opt || !opt.value) return null;
+        return {
+          amount: parseFloat(opt.dataset.amount) || 0,
+          used: parseFloat(opt.dataset.used) || 0,
+          projcode: opt.dataset.projcode || ''
+        };
+      }
+
+      // Disable the currently-picked value of ``sourceSel`` in ``targetSel``
+      // so the user can't pick the same project on both sides. If the
+      // target already has that value selected, clear it.
+      function syncDisabled(sourceSel, targetSel) {
+        var pick = sourceSel.value;
+        for (var i = 0; i < targetSel.options.length; i++) {
+          var o = targetSel.options[i];
+          if (!o.value) continue; // skip placeholder
+          o.disabled = (o.value === pick);
+        }
+        if (targetSel.value && targetSel.value === pick) {
+          targetSel.value = '';
+        }
+      }
+
+      function render() {
+        var from = pickedData(fromSel);
+        var to   = pickedData(toSel);
+        var amt  = parseFloat(amtInp.value) || 0;
+
+        if (from) {
+          var newFrom = from.amount - amt;
+          var remaining = from.amount - from.used;
+          var flag = '';
+          if (amt > 0 && amt > remaining) {
+            flag = ' <span class="text-danger fw-semibold">⚠ below used (' + fmt(from.used) + ')</span>';
+          }
+          fromP.innerHTML =
+            '<strong>' + from.projcode + '</strong>: ' +
+            fmt(from.amount) + ' − ' + fmt(amt) + ' = <strong>' + fmt(newFrom) + '</strong>' +
+            ' <span class="text-muted">(used: ' + fmt(from.used) + ')</span>' + flag;
+        } else {
+          fromP.textContent = '';
+        }
+
+        if (to) {
+          var newTo = to.amount + amt;
+          toP.innerHTML =
+            '<strong>' + to.projcode + '</strong>: ' +
+            fmt(to.amount) + ' + ' + fmt(amt) + ' = <strong>' + fmt(newTo) + '</strong>';
+        } else {
+          toP.textContent = '';
+        }
+
+        var sameSelected = from && to && fromSel.value === toSel.value;
+        if (sameSelected) {
+          toP.innerHTML = '<span class="text-danger">FROM and TO must differ.</span>';
+        }
+      }
+
+      fromSel.addEventListener('change', function () {
+        syncDisabled(fromSel, toSel);
+        render();
+      });
+      toSel.addEventListener('change', function () {
+        syncDisabled(toSel, fromSel);
+        render();
+      });
+      amtInp.addEventListener('input', render);
+      // Prime: if the form re-rendered after a validation error with a
+      // FROM already picked, apply the disabled state up-front.
+      syncDisabled(fromSel, toSel);
+      syncDisabled(toSel, fromSel);
+      render();
+    })();
+  </script>
+
+{% endcall %}

--- a/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
@@ -164,30 +164,23 @@
 
       {% else %}
       {# ── Resource header row ──────────────────────────────────────── #}
-      {# Collapse toggle lives on cols 1–4 (not the <tr>) so clicks on
-         the Exchange button in Col 5 don't match Bootstrap 5's
-         capture-phase collapse delegation. Bootstrap's data-api resolves
-         via ``event.target.closest('[data-bs-toggle="collapse"]')``, so
-         keeping the attribute off Col 5 and the row itself is the only
-         selector-free way to skip the toggle for that specific cell. #}
-      {%- set _toggle_attrs = 'data-bs-toggle="collapse" data-bs-target="#' ~ body_id
-                              ~ '" aria-expanded="false" aria-controls="' ~ body_id ~ '"' -%}
       <tbody>
         <tr class="table-secondary alloc-resource-header"
-            style="border-top: 2px solid #ced4da;">
+            style="cursor:pointer; border-top: 2px solid #ced4da;"
+            data-bs-toggle="collapse"
+            data-bs-target="#{{ body_id }}"
+            aria-expanded="false"
+            aria-controls="{{ body_id }}">
 
           {# Col 1: resource name + caret #}
-          <td class="fw-semibold py-2"
-              style="vertical-align:middle; cursor:pointer;"
-              {{ _toggle_attrs | safe }}>
+          <td class="fw-semibold py-2" style="vertical-align:middle;">
             <i class="fas fa-chevron-right alloc-caret me-2 small text-muted"></i>
             <i class="fas fa-server text-primary me-1"></i>
             {{ resource_name }}
           </td>
 
           {# Col 2: progress bar — same column as tree rows #}
-          <td style="padding:0.25rem 0.4rem; vertical-align:middle; cursor:pointer;"
-              {{ _toggle_attrs | safe }}>
+          <td style="padding:0.25rem 0.4rem; vertical-align:middle;">
             {% if root_alloc %}
             <div class="progress" style="height:8px;">
               <div class="progress-bar
@@ -200,38 +193,17 @@
           </td>
 
           {# Col 3: % used #}
-          <td class="text-end small text-muted"
-              style="vertical-align:middle; white-space:nowrap; cursor:pointer;"
-              {{ _toggle_attrs | safe }}>
+          <td class="text-end small text-muted" style="vertical-align:middle; white-space:nowrap;">
             {% if root_alloc %}{{ root_alloc.percent_used | fmt_pct }} used{% endif %}
           </td>
 
           {# Col 4: allocated amount #}
-          <td class="text-end small text-muted"
-              style="vertical-align:middle; white-space:nowrap; cursor:pointer;"
-              {{ _toggle_attrs | safe }}>
+          <td class="text-end small text-muted" style="vertical-align:middle; white-space:nowrap;">
             {% if root_alloc %}{{ root_alloc.allocated | fmt_number }}{% endif %}
           </td>
 
-          {# Col 5: shared badge + Exchange button.
-             Deliberately NOT a collapse toggle — clicks here only open
-             the Exchange modal; the row's accordion stays put. #}
+          {# Col 5: shared badge #}
           <td style="vertical-align:middle;">
-            {% if can_exchange and resource_name in exchange_eligible_resources %}
-            <button class="btn btn-xs btn-outline-info py-0 px-1"
-                    style="font-size:0.7rem;"
-                    hx-get="{{ url_for('admin_dashboard.htmx_exchange_allocation_form',
-                                       projcode=projcode,
-                                       resource_id=resource_id_by_name[resource_name]) }}"
-                    hx-target="#exchangeAllocationFormContainer"
-                    hx-include="#alloc-active-at"
-                    hx-trigger="click"
-                    data-bs-toggle="modal"
-                    data-bs-target="#exchangeAllocationModal"
-                    title="Exchange allocation between projects in this subtree">
-              <i class="fas fa-exchange-alt"></i>
-            </button>
-            {% endif %}
             {% if root_alloc and root_alloc.is_inheriting %}
             <span class="badge bg-secondary bg-opacity-25 text-dark border small">shared</span>
             {% endif %}
@@ -250,6 +222,15 @@
         {%- endif -%}
       {%- endfor -%}
 
+      {#- Per-resource Exchange URL: only set for eligible resources; the
+          macro renders the button only on the current (edit-page) row. -#}
+      {%- set _exchange_url = none -%}
+      {%- if can_exchange and resource_name in exchange_eligible_resources -%}
+        {%- set _exchange_url = url_for('admin_dashboard.htmx_exchange_allocation_form',
+                                         projcode=projcode,
+                                         resource_id=resource_id_by_name[resource_name]) -%}
+      {%- endif -%}
+
       <tbody id="{{ body_id }}" class="collapse alloc-tree-body">
         {{ render_project_tree_rows([root],
                                      depth=0,
@@ -259,7 +240,8 @@
                                      can_edit_allocations=can_edit_governance,
                                      active_only=true,
                                      usage_warning_threshold=75,
-                                     usage_critical_threshold=90) }}
+                                     usage_critical_threshold=90,
+                                     exchange_url=_exchange_url) }}
       </tbody>
       {% endif %}{# /is_standalone #}
 

--- a/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
@@ -144,7 +144,7 @@
 
           {# Col 5: edit pencil (or shared badge for inherited allocations) #}
           <td style="vertical-align:middle;">
-            {% if root_alloc and root_alloc.allocation_id and not root_alloc.is_inheriting %}
+            {% if can_edit_governance and root_alloc and root_alloc.allocation_id and not root_alloc.is_inheriting %}
             <button class="btn btn-xs btn-outline-warning py-0 px-1"
                     style="font-size:0.7rem;"
                     hx-get="{{ url_for('admin_dashboard.htmx_edit_allocation_form', alloc_id=root_alloc.allocation_id) }}"
@@ -228,7 +228,7 @@
                                      current_projcode=projcode,
                                      alloc_by_projcode=alloc_by_projcode,
                                      can_view=true,
-                                     can_edit_allocations=true,
+                                     can_edit_allocations=can_edit_governance,
                                      active_only=true,
                                      usage_warning_threshold=75,
                                      usage_critical_threshold=90) }}

--- a/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
@@ -164,23 +164,30 @@
 
       {% else %}
       {# ── Resource header row ──────────────────────────────────────── #}
+      {# Collapse toggle lives on cols 1–4 (not the <tr>) so clicks on
+         the Exchange button in Col 5 don't match Bootstrap 5's
+         capture-phase collapse delegation. Bootstrap's data-api resolves
+         via ``event.target.closest('[data-bs-toggle="collapse"]')``, so
+         keeping the attribute off Col 5 and the row itself is the only
+         selector-free way to skip the toggle for that specific cell. #}
+      {%- set _toggle_attrs = 'data-bs-toggle="collapse" data-bs-target="#' ~ body_id
+                              ~ '" aria-expanded="false" aria-controls="' ~ body_id ~ '"' -%}
       <tbody>
         <tr class="table-secondary alloc-resource-header"
-            style="cursor:pointer; border-top: 2px solid #ced4da;"
-            data-bs-toggle="collapse"
-            data-bs-target="#{{ body_id }}"
-            aria-expanded="false"
-            aria-controls="{{ body_id }}">
+            style="border-top: 2px solid #ced4da;">
 
           {# Col 1: resource name + caret #}
-          <td class="fw-semibold py-2" style="vertical-align:middle;">
+          <td class="fw-semibold py-2"
+              style="vertical-align:middle; cursor:pointer;"
+              {{ _toggle_attrs | safe }}>
             <i class="fas fa-chevron-right alloc-caret me-2 small text-muted"></i>
             <i class="fas fa-server text-primary me-1"></i>
             {{ resource_name }}
           </td>
 
           {# Col 2: progress bar — same column as tree rows #}
-          <td style="padding:0.25rem 0.4rem; vertical-align:middle;">
+          <td style="padding:0.25rem 0.4rem; vertical-align:middle; cursor:pointer;"
+              {{ _toggle_attrs | safe }}>
             {% if root_alloc %}
             <div class="progress" style="height:8px;">
               <div class="progress-bar
@@ -193,17 +200,38 @@
           </td>
 
           {# Col 3: % used #}
-          <td class="text-end small text-muted" style="vertical-align:middle; white-space:nowrap;">
+          <td class="text-end small text-muted"
+              style="vertical-align:middle; white-space:nowrap; cursor:pointer;"
+              {{ _toggle_attrs | safe }}>
             {% if root_alloc %}{{ root_alloc.percent_used | fmt_pct }} used{% endif %}
           </td>
 
           {# Col 4: allocated amount #}
-          <td class="text-end small text-muted" style="vertical-align:middle; white-space:nowrap;">
+          <td class="text-end small text-muted"
+              style="vertical-align:middle; white-space:nowrap; cursor:pointer;"
+              {{ _toggle_attrs | safe }}>
             {% if root_alloc %}{{ root_alloc.allocated | fmt_number }}{% endif %}
           </td>
 
-          {# Col 5: shared badge #}
+          {# Col 5: shared badge + Exchange button.
+             Deliberately NOT a collapse toggle — clicks here only open
+             the Exchange modal; the row's accordion stays put. #}
           <td style="vertical-align:middle;">
+            {% if can_exchange and resource_name in exchange_eligible_resources %}
+            <button class="btn btn-xs btn-outline-info py-0 px-1"
+                    style="font-size:0.7rem;"
+                    hx-get="{{ url_for('admin_dashboard.htmx_exchange_allocation_form',
+                                       projcode=projcode,
+                                       resource_id=resource_id_by_name[resource_name]) }}"
+                    hx-target="#exchangeAllocationFormContainer"
+                    hx-include="#alloc-active-at"
+                    hx-trigger="click"
+                    data-bs-toggle="modal"
+                    data-bs-target="#exchangeAllocationModal"
+                    title="Exchange allocation between projects in this subtree">
+              <i class="fas fa-exchange-alt"></i>
+            </button>
+            {% endif %}
             {% if root_alloc and root_alloc.is_inheriting %}
             <span class="badge bg-secondary bg-opacity-25 text-dark border small">shared</span>
             {% endif %}

--- a/src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html
@@ -26,11 +26,13 @@
       <span class="fw-semibold">
         <i class="fas fa-building me-1 text-primary"></i> Organizations
       </span>
+      {% if can_edit_governance %}
       <button class="btn btn-sm btn-outline-success"
               type="button"
               onclick="leToggleAddForm('addOrgForm')">
         <i class="fas fa-plus"></i> Add
       </button>
+      {% endif %}
     </div>
     <div class="card-body p-0">
 
@@ -84,6 +86,7 @@
               {% if po.end_date %}{{ po.end_date | fmt_date }}{% else %}—{% endif %}
             </td>
             <td class="text-end">
+              {% if can_edit_governance %}
               <button class="btn btn-xs btn-outline-danger"
                       title="Remove organization link"
                       hx-post="{{ url_for('admin_dashboard.htmx_remove_project_organization', projcode=project.projcode, po_id=po.project_organization_id) }}"
@@ -92,6 +95,7 @@
                       hx-confirm="Remove the link to {{ po.organization.name }}?">
                 <i class="fas fa-times"></i>
               </button>
+              {% endif %}
             </td>
           </tr>
           {% endfor %}
@@ -111,11 +115,13 @@
       <span class="fw-semibold">
         <i class="fas fa-file-contract me-1 text-warning"></i> Contracts
       </span>
+      {% if can_edit_governance %}
       <button class="btn btn-sm btn-outline-success"
               type="button"
               onclick="leToggleAddForm('addContractForm')">
         <i class="fas fa-plus"></i> Add
       </button>
+      {% endif %}
     </div>
     <div class="card-body p-0">
 
@@ -167,6 +173,7 @@
             </td>
             <td class="text-muted small">{{ pc.creation_time | fmt_date }}</td>
             <td class="text-end">
+              {% if can_edit_governance %}
               <button class="btn btn-xs btn-outline-danger"
                       title="Remove contract link"
                       hx-post="{{ url_for('admin_dashboard.htmx_remove_project_contract', projcode=project.projcode, pc_id=pc.project_contract_id) }}"
@@ -175,6 +182,7 @@
                       hx-confirm="Remove link to contract {{ pc.contract.contract_number }}? If this is the only project using this contract it will also be deactivated.">
                 <i class="fas fa-times"></i>
               </button>
+              {% endif %}
             </td>
           </tr>
           {% endfor %}
@@ -193,11 +201,13 @@
       <span class="fw-semibold">
         <i class="fas fa-folder me-1 text-secondary"></i> Directories
       </span>
+      {% if can_edit_governance %}
       <button class="btn btn-sm btn-outline-success"
               type="button"
               onclick="leToggleAddForm('addDirForm')">
         <i class="fas fa-plus"></i> Add
       </button>
+      {% endif %}
     </div>
     <div class="card-body p-0">
 
@@ -244,6 +254,7 @@
               {% if pd.end_date %}{{ pd.end_date | fmt_date }}{% else %}—{% endif %}
             </td>
             <td class="text-end">
+              {% if can_edit_governance %}
               <button class="btn btn-xs btn-outline-danger"
                       title="Remove directory"
                       hx-post="{{ url_for('admin_dashboard.htmx_remove_project_directory', projcode=project.projcode, pd_id=pd.project_directory_id) }}"
@@ -252,6 +263,7 @@
                       hx-confirm="Remove directory {{ pd.directory_name }}?">
                 <i class="fas fa-times"></i>
               </button>
+              {% endif %}
             </td>
           </tr>
           {% endfor %}

--- a/src/webapp/templates/dashboards/shared/project_tree.html
+++ b/src/webapp/templates/dashboards/shared/project_tree.html
@@ -179,7 +179,8 @@
                                    active_only=false,
                                    can_edit_allocations=false,
                                    usage_warning_threshold=75,
-                                   usage_critical_threshold=90) %}
+                                   usage_critical_threshold=90,
+                                   exchange_url=none) %}
 {%- for node in nodes -%}
 {%- set is_active = node.active if node.active is defined else true -%}
 {%- if not active_only or is_active -%}
@@ -239,7 +240,7 @@
     {%- endif %}
   </td>
 
-  {# ── Col 5: shared badge + edit button ────────────────────────────── #}
+  {# ── Col 5: shared badge + edit button + exchange button ──────────── #}
   <td style="vertical-align:middle; white-space:nowrap;">
     {%- if res and res.is_inheriting -%}
     <span class="badge bg-secondary bg-opacity-25 text-dark border small">shared</span>
@@ -254,6 +255,23 @@
             data-bs-target="#editAllocationModal"
             title="Edit allocation">
       <i class="fas fa-pencil-alt"></i>
+    </button>
+    {%- endif -%}
+    {#- Exchange lives on the edit-page (current) project's row only.
+        Eligibility is decided by the caller — exchange_url is set iff
+        ≥2 descendant projects hold dedicated allocations on this
+        resource. See projects_routes.py:htmx_project_allocation_tree. -#}
+    {%- if is_current and exchange_url -%}
+    <button class="btn btn-xs btn-outline-info py-0 px-1 ms-1"
+            style="font-size:0.7rem;"
+            hx-get="{{ exchange_url }}"
+            hx-target="#exchangeAllocationFormContainer"
+            hx-include="#alloc-active-at"
+            hx-trigger="click"
+            data-bs-toggle="modal"
+            data-bs-target="#exchangeAllocationModal"
+            title="Exchange allocation between sub-projects">
+      <i class="fas fa-exchange-alt"></i>
     </button>
     {%- endif -%}
   </td>
@@ -271,7 +289,8 @@
                              active_only=active_only,
                              can_edit_allocations=can_edit_allocations,
                              usage_warning_threshold=usage_warning_threshold,
-                             usage_critical_threshold=usage_critical_threshold) }}
+                             usage_critical_threshold=usage_critical_threshold,
+                             exchange_url=exchange_url) }}
 {%- endif -%}
 
 {%- endif -%}

--- a/src/webapp/templates/dashboards/user/partials/project_card.html
+++ b/src/webapp/templates/dashboards/user/partials/project_card.html
@@ -404,8 +404,10 @@
                 </script>
                 {% endif %}
 
-                {# Edit Project button — inside the card body, visible only when expanded #}
-                {% if has_permission(Permission.EDIT_PROJECTS) %}
+                {# Edit Project button — inside the card body, visible only when expanded.
+                   Project leads/admins also see the button (they land on the same page
+                   with a constrained edit surface). #}
+                {% if can_act_on_project(Permission.EDIT_PROJECTS, project) %}
                 <div class="d-flex justify-content-end mt-3 pt-2 border-top">
                     <a href="{{ url_for('admin_dashboard.edit_project_page', projcode=project.projcode) }}"
                        class="btn btn-sm btn-warning">

--- a/src/webapp/templates/dashboards/user/partials/project_details_modal.html
+++ b/src/webapp/templates/dashboards/user/partials/project_details_modal.html
@@ -10,8 +10,9 @@
         {# Check if user can edit allocations #}
         {% set user_can_edit_allocations = has_permission(Permission.EDIT_ALLOCATIONS) if has_permission is defined and Permission is defined else false %}
 
-        {# Edit Project link — visible to EDIT_PROJECTS permission holders #}
-        {% if has_permission(Permission.EDIT_PROJECTS) %}
+        {# Edit Project link — visible to EDIT_PROJECTS permission holders
+           AND to project leads/admins (matches can_access_edit_project_page). #}
+        {% if can_act_on_project(Permission.EDIT_PROJECTS, project) %}
         <div class="d-flex justify-content-end mb-2">
             <a href="{{ url_for('admin_dashboard.edit_project_page', projcode=project.projcode) }}"
                class="btn btn-sm btn-warning">

--- a/src/webapp/utils/project_permissions.py
+++ b/src/webapp/utils/project_permissions.py
@@ -71,6 +71,31 @@ def _is_project_steward(
     return False
 
 
+def can_access_edit_project_page(user, project) -> bool:
+    """
+    Enter the admin Edit Project page (/admin/project/<projcode>/edit).
+
+    Granted to: system EDIT_PROJECTS holders, project lead, project admin.
+    The page itself opens all three tabs (Details, Allocations, Members);
+    per-field / per-action gates on each tab constrain what a non-admin
+    steward can actually change.
+    """
+    return _is_project_steward(user, project, Permission.EDIT_PROJECTS)
+
+
+def can_edit_project_governance(user, project) -> bool:
+    """
+    Edit the governance fields on the Details tab — facility, panel,
+    allocation type, lead, admin, active, charging_exempt, ext_alias.
+
+    These fields shape the project's financial / organizational
+    identity. System EDIT_PROJECTS holders only — no steward override.
+    Project leads can still reassign the admin role via the Members
+    tab's dedicated change-admin flow (``can_change_admin``).
+    """
+    return has_permission(user, Permission.EDIT_PROJECTS)
+
+
 def can_manage_project_members(user, project) -> bool:
     """
     Add/remove members from a project.

--- a/tests/unit/test_exchange_allocations.py
+++ b/tests/unit/test_exchange_allocations.py
@@ -1,0 +1,311 @@
+"""Tests for the Exchange Allocation flow:
+
+- ``ExchangeAllocationForm`` (sam.schemas.forms.user): input shape validation.
+- ``exchange_allocations()`` (sam.manage.allocations): move amount between
+  two dedicated allocations on the same resource, preserving the combined
+  total and writing paired TRANSFER audit rows.
+"""
+from datetime import datetime, timedelta
+
+import pytest
+from marshmallow import ValidationError
+
+from sam import Allocation
+from sam.accounting.allocations import (
+    AllocationTransaction,
+    AllocationTransactionType,
+    InheritingAllocationException,
+)
+from sam.manage.allocations import exchange_allocations
+from sam.schemas.forms import ExchangeAllocationForm
+
+from factories import (
+    make_account,
+    make_allocation,
+    make_project,
+    make_resource,
+    make_user,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Form schema
+# ---------------------------------------------------------------------------
+
+
+class TestExchangeAllocationForm:
+
+    def _valid(self):
+        return {'from_allocation_id': '1', 'to_allocation_id': '2', 'amount': '100'}
+
+    def test_coerces_types(self):
+        data = ExchangeAllocationForm().load(self._valid())
+        assert data['from_allocation_id'] == 1
+        assert data['to_allocation_id'] == 2
+        assert data['amount'] == 100.0
+
+    def test_missing_from_rejected(self):
+        payload = self._valid()
+        del payload['from_allocation_id']
+        with pytest.raises(ValidationError) as ei:
+            ExchangeAllocationForm().load(payload)
+        assert 'from_allocation_id' in ei.value.messages
+
+    def test_missing_amount_rejected(self):
+        payload = self._valid()
+        del payload['amount']
+        with pytest.raises(ValidationError) as ei:
+            ExchangeAllocationForm().load(payload)
+        assert 'amount' in ei.value.messages
+
+    def test_zero_amount_rejected(self):
+        payload = self._valid()
+        payload['amount'] = '0'
+        with pytest.raises(ValidationError) as ei:
+            ExchangeAllocationForm().load(payload)
+        assert 'amount' in ei.value.messages
+
+    def test_negative_amount_rejected(self):
+        payload = self._valid()
+        payload['amount'] = '-10'
+        with pytest.raises(ValidationError) as ei:
+            ExchangeAllocationForm().load(payload)
+        assert 'amount' in ei.value.messages
+
+    def test_same_from_and_to_rejected(self):
+        payload = self._valid()
+        payload['to_allocation_id'] = payload['from_allocation_id']
+        with pytest.raises(ValidationError) as ei:
+            ExchangeAllocationForm().load(payload)
+        assert 'to_allocation_id' in ei.value.messages
+
+    def test_unknown_fields_dropped(self):
+        payload = self._valid()
+        payload['csrf_token'] = 'abc'
+        data = ExchangeAllocationForm().load(payload)
+        assert 'csrf_token' not in data
+
+
+# ---------------------------------------------------------------------------
+# exchange_allocations — happy path + error cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def acting_user(session):
+    return make_user(session)
+
+
+@pytest.fixture
+def exchange_pair(session):
+    """Two dedicated allocations on the same resource, same project tree.
+
+    Returns (from_alloc, to_alloc, resource) where:
+      - parent project + child project share a tree (tree_root).
+      - Each has its own Account on `resource` and its own dedicated
+        (non-inheriting) Allocation on that account.
+    """
+    resource = make_resource(session)
+    parent_project = make_project(session)
+    child_project = make_project(session, parent=parent_project)
+
+    parent_account = make_account(
+        session, project=parent_project, resource=resource
+    )
+    child_account = make_account(
+        session, project=child_project, resource=resource
+    )
+
+    start = datetime.now() - timedelta(days=30)
+    end = datetime.now() + timedelta(days=365)
+
+    from_alloc = make_allocation(
+        session, account=parent_account,
+        amount=1_000_000.0, start_date=start, end_date=end,
+    )
+    to_alloc = make_allocation(
+        session, account=child_account,
+        amount=200_000.0, start_date=start, end_date=end,
+    )
+    return from_alloc, to_alloc, resource
+
+
+class TestExchangeAllocationsHappyPath:
+
+    def test_conserves_combined_total(self, session, exchange_pair, acting_user):
+        from_alloc, to_alloc, _ = exchange_pair
+        total_before = from_alloc.amount + to_alloc.amount
+
+        exchange_allocations(
+            session,
+            from_allocation_id=from_alloc.allocation_id,
+            to_allocation_id=to_alloc.allocation_id,
+            amount=150_000.0,
+            user_id=acting_user.user_id,
+        )
+
+        session.refresh(from_alloc)
+        session.refresh(to_alloc)
+        assert from_alloc.amount + to_alloc.amount == total_before
+
+    def test_applies_debit_and_credit(self, session, exchange_pair, acting_user):
+        from_alloc, to_alloc, _ = exchange_pair
+        original_from = from_alloc.amount
+        original_to = to_alloc.amount
+
+        exchange_allocations(
+            session,
+            from_allocation_id=from_alloc.allocation_id,
+            to_allocation_id=to_alloc.allocation_id,
+            amount=150_000.0,
+            user_id=acting_user.user_id,
+        )
+
+        session.refresh(from_alloc)
+        session.refresh(to_alloc)
+        assert from_alloc.amount == original_from - 150_000.0
+        assert to_alloc.amount == original_to + 150_000.0
+
+    def test_writes_paired_transfer_rows(self, session, exchange_pair, acting_user):
+        from_alloc, to_alloc, _ = exchange_pair
+
+        exchange_allocations(
+            session,
+            from_allocation_id=from_alloc.allocation_id,
+            to_allocation_id=to_alloc.allocation_id,
+            amount=150_000.0,
+            user_id=acting_user.user_id,
+        )
+
+        from_txns = (
+            session.query(AllocationTransaction)
+            .filter_by(
+                allocation_id=from_alloc.allocation_id,
+                transaction_type=AllocationTransactionType.TRANSFER,
+            )
+            .all()
+        )
+        to_txns = (
+            session.query(AllocationTransaction)
+            .filter_by(
+                allocation_id=to_alloc.allocation_id,
+                transaction_type=AllocationTransactionType.TRANSFER,
+            )
+            .all()
+        )
+        assert len(from_txns) == 1
+        assert len(to_txns) == 1
+        # Signed transaction_amount so TRANSFER rows are greppable by direction.
+        assert from_txns[0].transaction_amount == -150_000.0
+        assert to_txns[0].transaction_amount == 150_000.0
+
+    def test_dates_unchanged(self, session, exchange_pair, acting_user):
+        from_alloc, to_alloc, _ = exchange_pair
+        # Refresh first — MySQL DATETIME truncates microseconds on write,
+        # so the in-session Python values (set by the factory) differ
+        # from what comes back after the exchange's flush/refresh.
+        session.refresh(from_alloc)
+        session.refresh(to_alloc)
+        from_start, from_end = from_alloc.start_date, from_alloc.end_date
+        to_start, to_end = to_alloc.start_date, to_alloc.end_date
+
+        exchange_allocations(
+            session,
+            from_allocation_id=from_alloc.allocation_id,
+            to_allocation_id=to_alloc.allocation_id,
+            amount=50_000.0,
+            user_id=acting_user.user_id,
+        )
+
+        session.refresh(from_alloc)
+        session.refresh(to_alloc)
+        assert from_alloc.start_date == from_start
+        assert from_alloc.end_date == from_end
+        assert to_alloc.start_date == to_start
+        assert to_alloc.end_date == to_end
+
+
+class TestExchangeAllocationsErrors:
+
+    def test_rejects_same_from_and_to(self, session, exchange_pair, acting_user):
+        from_alloc, _, _ = exchange_pair
+        with pytest.raises(ValueError):
+            exchange_allocations(
+                session,
+                from_allocation_id=from_alloc.allocation_id,
+                to_allocation_id=from_alloc.allocation_id,
+                amount=100.0,
+                user_id=acting_user.user_id,
+            )
+
+    def test_rejects_non_positive_amount(self, session, exchange_pair, acting_user):
+        from_alloc, to_alloc, _ = exchange_pair
+        with pytest.raises(ValueError):
+            exchange_allocations(
+                session,
+                from_allocation_id=from_alloc.allocation_id,
+                to_allocation_id=to_alloc.allocation_id,
+                amount=0.0,
+                user_id=acting_user.user_id,
+            )
+
+    def test_rejects_amount_exceeding_from(self, session, exchange_pair, acting_user):
+        from_alloc, to_alloc, _ = exchange_pair
+        with pytest.raises(ValueError):
+            exchange_allocations(
+                session,
+                from_allocation_id=from_alloc.allocation_id,
+                to_allocation_id=to_alloc.allocation_id,
+                amount=from_alloc.amount + 1.0,
+                user_id=acting_user.user_id,
+            )
+
+    def test_rejects_inheriting_from(self, session, acting_user):
+        resource = make_resource(session)
+        account = make_account(session, resource=resource)
+        parent = make_allocation(session, account=account, amount=1_000.0)
+        child = make_allocation(
+            session, account=account, amount=500.0, parent=parent
+        )
+        other_account = make_account(session, resource=resource)
+        sibling = make_allocation(session, account=other_account, amount=1_000.0)
+
+        with pytest.raises(InheritingAllocationException):
+            exchange_allocations(
+                session,
+                from_allocation_id=child.allocation_id,
+                to_allocation_id=sibling.allocation_id,
+                amount=100.0,
+                user_id=acting_user.user_id,
+            )
+
+    def test_rejects_different_resources(self, session, acting_user):
+        r1 = make_resource(session)
+        r2 = make_resource(session)
+        alloc1 = make_allocation(
+            session, account=make_account(session, resource=r1), amount=1_000.0
+        )
+        alloc2 = make_allocation(
+            session, account=make_account(session, resource=r2), amount=1_000.0
+        )
+        with pytest.raises(ValueError):
+            exchange_allocations(
+                session,
+                from_allocation_id=alloc1.allocation_id,
+                to_allocation_id=alloc2.allocation_id,
+                amount=100.0,
+                user_id=acting_user.user_id,
+            )
+
+    def test_rejects_missing_allocation(self, session, exchange_pair, acting_user):
+        _, to_alloc, _ = exchange_pair
+        with pytest.raises(ValueError):
+            exchange_allocations(
+                session,
+                from_allocation_id=999_999_999,
+                to_allocation_id=to_alloc.allocation_id,
+                amount=100.0,
+                user_id=acting_user.user_id,
+            )


### PR DESCRIPTION
## Summary

Introduces an **Exchange** action on the admin Edit-Project page → Allocations tab. A project lead / admin (or system `EDIT_ALLOCATIONS` holder) can move amount between two dedicated allocations on the same resource, within the subtree rooted at the project they're editing. Total across the pair is preserved; dates and descriptions are never touched.

Builds on top of `f8b91ec` (edit-page opened to leads/admins) — that commit is also included in this branch if not already merged.

## Why

Leads want to rebalance compute budget across sub-projects they govern without filing a ticket or touching dates. Today that requires a CISL admin. Exchange is the smallest, safest primitive: conservative (no net change), scoped (own subtree only), audited (paired `TRANSFER` rows cross-referenced via `related_transaction_id`).

## Scope & guardrails

- **Who:** `can_edit_allocations(user, project)` — system `EDIT_ALLOCATIONS`, or lead/admin of the edit-page project.
- **Endpoints:** dedicated (non-inheriting) allocations only; same resource; both projects within `project.get_descendants(include_self=False)` (the edit-page project itself is excluded — see §Design notes).
- **Amount:** strict overdraft — rejected if it would push FROM below its currently-used balance (summary-table check via `get_detailed_allocation_usage`).
- **Cascade:** inheriting children of FROM/TO are updated automatically via the existing `update_allocation` path (same semantics as the Edit flow).

## UX

The Exchange button renders on the highlighted "current" row inside each eligible resource's accordion. Clicking opens a modal with:

- **From / To** project dropdowns (options: \`PROJCODE — amount — title\`), \`active_at\`-filtered so the list matches the tree view exactly; picking one disables that project in the other.
- **Amount** input with live preview: \`new_from = from − amount\` (flags overdraft below used in red) and \`new_to = to + amount\`.
- Submit calls \`POST /admin/htmx/exchange-allocation/<projcode>\`; success returns \`closeActiveModal\` + \`reloadAllocationTree\`.

## Design notes

- **Button placement.** First pass put the button on the resource-header row, which collided with Bootstrap 5's capture-phase \`data-bs-toggle="collapse"\` delegation (\`stopPropagation\` at the \`<td>\` level fires too late). Final placement is on the edit-page project's row inside the accordion body via a new \`exchange_url=\` param on \`render_project_tree_rows\` — more intuitive and removes the conflict entirely.
- **Root excluded.** Moving amount to/from the edit-page project itself either does nothing (descendants inherit) or creates spooky effects on independent children. The feature is strictly descendant ↔ descendant.
- **Audit trail.** \`exchange_allocations()\` delegates to two \`update_allocation\` calls (each writes its usual \`EDIT\` row with cascade), then writes two paired \`AllocationTransaction(TRANSFER)\` rows with signed \`transaction_amount\` and \`related_transaction_id\` cross-references so the exchange is greppable as a single logical event.
- **Schema.** New \`ExchangeAllocationForm\` in \`sam.schemas.forms.user\` — schema enforces positive amount and distinct IDs; DB-dependent checks (existence, resource match, subtree membership, overdraft) stay in the route per CLAUDE.md §9.

## Files of note

| Layer | File |
|---|---|
| Business logic | \`src/sam/manage/allocations.py\` — \`exchange_allocations()\` |
| Form schema | \`src/sam/schemas/forms/user.py\` — \`ExchangeAllocationForm\` |
| Routes | \`src/webapp/dashboards/admin/projects_routes.py\` — GET/POST + \`_exchange_candidates\` helper |
| Modal | \`src/webapp/templates/dashboards/admin/fragments/exchange_allocation_form_htmx.html\` (new) |
| Tree integration | \`src/webapp/templates/dashboards/shared/project_tree.html\` — \`exchange_url\` param |
| Tests | \`tests/unit/test_exchange_allocations.py\` (new) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)