### PR TITLE
Facility-Scoped RBAC Manager

### DIFF
--- a/docs/plans/FACILITY_SCOPED_ADMIN.md
+++ b/docs/plans/FACILITY_SCOPED_ADMIN.md
@@ -1,0 +1,571 @@
+# Facility-Scoped RBAC Manager — Implementation Plan
+
+> **Purpose**: introduce a third RBAC tier — per-user permission grants
+> bounded to a specific subset of facilities — so that a "WNA manager"
+> can hold `CREATE_PROJECTS`, `EDIT_PROJECTS`, `CREATE_ALLOCATIONS`,
+> etc. but only within WNA.
+
+This plan is self-contained: pick it up in a fresh session and execute
+it phase-by-phase without needing additional context. All file
+references include line numbers as of the commit that authored this
+doc; verify with `git grep` if anything has shifted.
+
+---
+
+## Context
+
+### Why this RBAC tier
+
+Today's two RBAC tiers (`docs/plans/EDIT_PROJECTS.md`,
+`webapp/utils/rbac.py`):
+
+1. **Bundle / system grants** (`GROUP_PERMISSIONS`,
+   `USER_PERMISSION_OVERRIDES`) — unscoped, granted globally. A holder
+   of system `EDIT_PROJECTS` can edit any project in the database.
+2. **Project-steward grants** (`_is_project_steward` in
+   `src/webapp/utils/project_permissions.py`) — per-project, derived
+   from being the project's lead, admin, or an ancestor lead/admin.
+
+Operationally there's a missing tier: someone trusted to manage one
+facility's project portfolio (create projects, allocate, edit
+metadata) without giving them control over every other facility's
+projects. Examples:
+
+- A WNA program manager who provisions WNA projects/allocations.
+- A NCAR-internal admin who governs only NCAR-classed projects.
+- A CISL/CSL liaison whose grant straddles two facilities but stops
+  short of UNIV/WNA/NCAR.
+
+### Why this is feasible (cheap to add)
+
+Three structural facts make this graft small:
+
+1. **Every project has a deterministic facility chain** —
+   `Project → allocation_type → panel → facility`. The 3-step lookup
+   is consistent across the codebase and used by `get_active_projects(
+   facility_name=...)` in `src/sam/queries/projects.py:56`. Edge case:
+   `Project.allocation_type_id` is nullable; ~20 orphan projects exist
+   without one. Deny-by-default fallback for scoped users (orphans
+   require an unscoped admin).
+2. **Project-scoped decorators already centralize the permission
+   funnel** — `require_project_permission`, `require_project_member_access`,
+   and `require_allocation_permission` (all in
+   `src/webapp/api/access_control.py`) call `_is_project_steward`.
+   A single change to that helper carries facility scope into every
+   gated route automatically.
+3. **`has_permission` stays untouched** — we add a sibling helper
+   that takes the facility argument. Existing callers don't change.
+
+### Out of scope for v1
+
+- **Group-bundle facility scoping** (`GROUP_PERMISSIONS['csg']`
+  scoped to NCAR) — defer until operational pressure exists.
+- **DB-backed storage** — config stays in `src/webapp/utils/rbac.py`,
+  matching the existing `USER_PERMISSION_OVERRIDES` pattern.
+  Preserves git-blame audit trail. Revisit when ops asks for
+  zero-deploy admin grants.
+- **New `Permission` enum members** — facility scope is metadata
+  about *who* gets which existing permission, not a new permission
+  category.
+
+---
+
+## Architecture
+
+### Storage
+
+Add a new top-level dict in `src/webapp/utils/rbac.py` alongside
+`USER_PERMISSION_OVERRIDES`:
+
+```python
+# Per-user, per-facility permission grants. The user is granted
+# `permission` only when the target project's facility is in the set.
+# Permissions held here are ADDITIVE to whatever USER_PERMISSION_OVERRIDES
+# / GROUP_PERMISSIONS confer (which apply unconditionally).
+#
+# Format: {username: {facility_name: {Permission, ...}}}
+USER_FACILITY_PERMISSIONS: dict[str, dict[str, set[Permission]]] = {
+    'wna_manager': {
+        'WNA': {
+            Permission.CREATE_PROJECTS,
+            Permission.EDIT_PROJECTS,
+            Permission.CREATE_ALLOCATIONS,
+            Permission.EDIT_ALLOCATIONS,
+            Permission.EDIT_PROJECT_MEMBERS,
+            Permission.VIEW_PROJECTS,
+            Permission.VIEW_ALLOCATIONS,
+            Permission.VIEW_PROJECT_MEMBERS,
+            Permission.ACCESS_ADMIN_DASHBOARD,
+        },
+    },
+    # Multi-facility example:
+    'cisl_csl_admin': {
+        'CISL': {Permission.EDIT_PROJECTS, Permission.CREATE_ALLOCATIONS},
+        'CSL':  {Permission.EDIT_PROJECTS, Permission.CREATE_ALLOCATIONS},
+    },
+}
+```
+
+**Why a separate dict (not nested into `USER_PERMISSION_OVERRIDES`)**:
+
+- Preserves the existing dict's value type (`set[Permission]`).
+  Every current call site keeps its existing iteration semantics
+  with zero defensive type-checking.
+- Scoped vs unscoped grants compose cleanly: a user can hold
+  `VIEW_PROJECTS` unscoped (sees everything in lists) AND
+  `EDIT_PROJECTS` scoped to WNA (can only edit WNA projects). Two
+  dicts, one entry in each.
+- Easy to grep: scope-related logic only ever consults the new dict;
+  unscoped logic is unchanged.
+
+### Helpers
+
+In `src/webapp/utils/rbac.py`, after the existing `has_permission`:
+
+```python
+def has_permission_for_facility(user, permission, facility_name):
+    """True iff the user holds ``permission`` AND it applies to the
+    given facility — either unconditionally (system grant) or via
+    a USER_FACILITY_PERMISSIONS entry naming this facility.
+
+    Args:
+        user: Flask-Login current_user wrapper (AuthUser).
+        permission: Permission enum member.
+        facility_name: Facility.facility_name string. Pass None for
+            orphan projects (no allocation_type chain) — only system
+            admins can act on those.
+
+    Returns:
+        bool. False for unauthenticated users.
+    """
+    # System grant — applies to every facility, including unknown ones.
+    if has_permission(user, permission):
+        return True
+    if facility_name is None:
+        return False  # orphan projects: only unscoped admins
+    if not getattr(user, 'is_authenticated', False):
+        return False
+    scoped = USER_FACILITY_PERMISSIONS.get(user.username, {})
+    return permission in scoped.get(facility_name, set())
+
+
+def user_facility_scope(user, permission):
+    """Return the set of facility names where ``user`` may exercise
+    ``permission``, or ``None`` for "unscoped" (any facility, including
+    orphan projects).
+
+    Use at listing-filter call sites: ``None`` → skip the filter,
+    ``set`` → constrain results to those facilities.
+    """
+    if has_permission(user, permission):
+        return None
+    if not getattr(user, 'is_authenticated', False):
+        return set()
+    scoped = USER_FACILITY_PERMISSIONS.get(user.username, {})
+    return {f for f, perms in scoped.items() if permission in perms}
+```
+
+In `src/sam/projects/projects.py`, add a property on `Project`:
+
+```python
+@property
+def facility_name(self) -> str | None:
+    """The facility this project belongs to, derived through the
+    allocation_type → panel → facility chain. Returns None for
+    orphan projects (no allocation_type — ~20 such rows in the
+    snapshot DB)."""
+    if not self.allocation_type:
+        return None
+    if not self.allocation_type.panel:
+        return None
+    if not self.allocation_type.panel.facility:
+        return None
+    return self.allocation_type.panel.facility.facility_name
+```
+
+### Enforcement points
+
+#### A. Project-scoped decorators — automatic via `_is_project_steward`
+
+In `src/webapp/utils/project_permissions.py`, the only line to change
+in `_is_project_steward`:
+
+```python
+# Before (line ~52):
+if has_permission(user, system_permission):
+    return True
+
+# After:
+if has_permission_for_facility(user, system_permission, project.facility_name):
+    return True
+```
+
+Every route currently using `@require_project_permission`,
+`@require_project_member_access`, or `@require_allocation_permission`
+(all funnel through `_is_project_steward`) inherits facility scope
+without touching the decorators or the routes.
+
+Affected decorators in `src/webapp/api/access_control.py`:
+- `require_project_access` (lines ~87)
+- `require_project_member_access` (lines ~121)
+- `require_project_permission` (lines ~157)
+- `require_allocation_permission` (lines ~205)
+
+#### B. Bare `@require_permission(...)` on create routes
+
+These have no project context — the user is creating something new.
+Three handlers need inline checks after the form parse:
+
+1. **`htmx_create_project`** in `src/webapp/dashboards/admin/projects_routes.py`
+   (~line 110-200 area) — currently `@require_permission(CREATE_PROJECTS)`.
+   The form's `facility_id` is the facility. After form validation:
+
+   ```python
+   chosen_facility = db.session.get(Facility, form_data['facility_id'])
+   if not has_permission_for_facility(
+       current_user, Permission.CREATE_PROJECTS, chosen_facility.facility_name
+   ):
+       abort(403)
+   ```
+
+2. **`htmx_add_allocation`** (POST handler) — already on the
+   project-scoped chain (the route includes `<projcode>`); after
+   the steward-helper update in (A), it inherits facility scope
+   automatically. Verify in Phase 2 testing.
+
+3. **Cascading dropdown filters** — `htmx_panels_for_facility`
+   (`projects_routes.py:117`) and `htmx_alloc_types_for_panel`
+   (`projects_routes.py:147`). Both currently
+   `@require_permission(CREATE_PROJECTS)`. Filter the facility option
+   list at the source: only render facilities the user is allowed
+   to create within. For scoped users, also block the route from
+   responding for a non-allowed facility (defense in depth):
+
+   ```python
+   allowed = user_facility_scope(current_user, Permission.CREATE_PROJECTS)
+   if allowed is not None and chosen_facility.facility_name not in allowed:
+       abort(403)
+   ```
+
+#### C. Listing routes — server-side filter + UI dropdown restriction
+
+The user-preferred shape is to **restrict the available choices in
+the UI** rather than just filtering results. Two patterns:
+
+**C1. Routes with a facility-picker UI**:
+
+Currently the only one is the admin expirations / recently-expired
+page (`src/webapp/dashboards/admin/blueprint.py` `expirations_fragment`
+at line ~325, `expirations_export` at line ~447, plus the dashboard
+template at `src/webapp/templates/dashboards/admin/dashboard.html:131-140`).
+
+Two changes per route:
+
+1. **Render the facility multi-select from the user's allowed set**.
+   Replace the hardcoded `<option>` list (currently 7 hardcoded
+   facilities) with options derived from the union of:
+   - `USER_FACILITY_PERMISSIONS[user.username].keys()` (scoped
+     facilities the user can act on)
+   - All facilities (when `user_facility_scope(VIEW_PROJECTS)` is
+     `None` — i.e., system-permission holder)
+
+   The view function passes `allowed_facility_names` into the
+   template; the multi-select iterates that list.
+
+2. **Server-side intersect**. After parsing the `facilities` query
+   parameter, intersect with `user_facility_scope(VIEW_PROJECTS)`:
+
+   ```python
+   allowed = user_facility_scope(current_user, Permission.VIEW_PROJECTS)
+   facilities = request.args.getlist('facilities')
+   if allowed is not None:
+       facilities = [f for f in facilities if f in allowed] or sorted(allowed)
+   ```
+
+   The existing `facility_names=...` argument on
+   `get_projects_by_allocation_end_date` already accepts the list
+   (`src/sam/queries/projects.py`), so no query-helper changes
+   needed.
+
+**C2. Routes with no facility UI** (global search):
+
+`htmx_search_projects()` in `src/webapp/dashboards/admin/blueprint.py:659`
+currently calls `search_projects_by_code_or_title()` unrestricted.
+Append a facility filter when the user is scoped:
+
+```python
+allowed = user_facility_scope(current_user, Permission.VIEW_PROJECTS)
+if allowed is not None:
+    query = query.join(...).filter(Facility.facility_name.in_(allowed))
+```
+
+The `Project → AllocationType → Panel → Facility` join is the same
+one used in `get_active_projects(facility_name=...)`.
+
+#### D. API endpoints
+
+`src/webapp/api/v1/projects.py:106` (`list_projects`) already accepts
+a `?facility=` query parameter. For scoped users, default-restrict
+the result set when the caller didn't pass the parameter (or
+intersect when they did):
+
+```python
+allowed = user_facility_scope(current_user, Permission.VIEW_PROJECTS)
+requested_facility = request.args.get('facility')
+if allowed is not None:
+    if requested_facility and requested_facility not in allowed:
+        abort(403)
+    facility_filter = requested_facility or sorted(allowed)
+else:
+    facility_filter = requested_facility
+```
+
+---
+
+## Phased rollout
+
+Each phase is independently shippable. Phases 1-4 add zero behavior
+change for any user without a `USER_FACILITY_PERMISSIONS` entry.
+
+### Phase 1 — Plumbing (foundation)
+
+**Files:**
+- `src/webapp/utils/rbac.py` — add `USER_FACILITY_PERMISSIONS` dict
+  (initially empty), `has_permission_for_facility()`,
+  `user_facility_scope()`.
+- `src/sam/projects/projects.py` — add `Project.facility_name`
+  property.
+
+**Tests:** new `tests/unit/test_rbac.py::TestFacilityScopedPermissions`
+class:
+- `test_has_permission_for_facility_grants_via_system_perm`
+- `test_has_permission_for_facility_grants_via_scoped_entry`
+- `test_has_permission_for_facility_denies_other_facility`
+- `test_has_permission_for_facility_denies_orphan_project`
+- `test_has_permission_for_facility_unauthenticated_returns_false`
+- `test_user_facility_scope_returns_none_for_system_admin`
+- `test_user_facility_scope_returns_set_for_scoped_user`
+- `test_user_facility_scope_returns_empty_set_for_unauthenticated`
+
+`Project.facility_name` test in `tests/unit/test_new_models.py`
+or wherever Project tests live:
+- Returns the right facility for a project with a full chain.
+- Returns `None` for a project with `allocation_type_id IS NULL`
+  (use a factory).
+
+No route changes; no behavior change.
+
+### Phase 2 — Steward enforcement
+
+**File:** `src/webapp/utils/project_permissions.py` —
+`_is_project_steward` calls `has_permission_for_facility(user,
+system_permission, project.facility_name)` instead of bare
+`has_permission(user, system_permission)`.
+
+**Tests:**
+- `tests/unit/test_project_permissions.py::TestIsProjectSteward` —
+  add cases for facility-scoped users:
+  - Scoped to project's facility → passes.
+  - Scoped to a different facility → fails (still falls through to
+    lead/admin check, which itself can pass).
+  - Project leads/admins still pass regardless of scope.
+
+**Manual smoke** (after Phase 5 — once a real `wna_manager` is
+configured):
+- Log in as `wna_manager`. Hit `/admin/project/<wna_projcode>/edit` →
+  expect 200. Hit `/admin/project/<ncar_projcode>/edit` → expect 403.
+- Existing tests for non-scoped users stay green.
+
+### Phase 3 — Listing filters & dropdown restriction
+
+**Server side:**
+- `src/webapp/dashboards/admin/blueprint.py` —
+  `expirations_fragment`, `expirations_export`,
+  `htmx_search_projects` add `user_facility_scope` intersection.
+- `src/webapp/api/v1/projects.py:list_projects` — same.
+
+**Template side:**
+- `src/webapp/templates/dashboards/admin/dashboard.html:131-140` —
+  facility multi-select renders from `allowed_facility_names`
+  context var, not hardcoded list.
+- View functions that render the page pass `allowed_facility_names`
+  computed from `user_facility_scope(VIEW_PROJECTS)` + (if `None`)
+  the full facility list.
+
+**Tests:**
+- `tests/api/` — `test_list_projects_facility_scoped` calls the API
+  as a scoped user and asserts only allowed-facility projects come
+  back; passing `?facility=NCAR` as a WNA-scoped user → 403.
+- `tests/unit/` HTMX route smoke for the expirations fragment.
+
+### Phase 4 — Create-route inline checks
+
+**Files:**
+- `src/webapp/dashboards/admin/projects_routes.py` —
+  `htmx_create_project` adds inline `has_permission_for_facility`
+  check after form parse.
+- `src/webapp/dashboards/admin/projects_routes.py:117,147` —
+  `htmx_panels_for_facility`, `htmx_alloc_types_for_panel` filter
+  facility options + 403 on disallowed facility.
+- `src/webapp/templates/dashboards/admin/fragments/create_project_form_htmx.html`
+  — facility cascade dropdown options driven by allowed set.
+
+**Tests:**
+- `tests/unit/test_create_project.py` — POST as scoped user with a
+  forged out-of-scope `facility_id` → 403; allowed `facility_id` →
+  200.
+
+### Phase 5 — Configure first manager + e2e
+
+- Add `wna_manager` (or whichever real username we want) to
+  `USER_FACILITY_PERMISSIONS` with the WNA-scoped permission set.
+- Run full suite: `source etc/config_env.sh && pytest`.
+- Manual e2e: `docker compose up webdev --watch`, log in via
+  `dlawren` (or a designated WNA test user), confirm the
+  user-experience matrix in **Verification** below.
+
+---
+
+## Verification matrix
+
+For Phase 5 (full e2e). Test as three users:
+
+| User              | System perms                         | Facility scope        |
+|---|---|---|
+| `benkirk`         | `set(Permission)` (full admin)       | n/a (unscoped)        |
+| `wna_manager`     | none                                 | `WNA` → CRUD perms    |
+| `dlawren`         | none                                 | none (project lead)   |
+
+Expected behavior:
+
+| Action | benkirk | wna_manager | dlawren |
+|---|---|---|---|
+| Open `/admin/` dashboard | ✓ | ✓ (via `ACCESS_ADMIN_DASHBOARD` in scope) | ✗ |
+| Search "all projects" → see NCAR result | ✓ | ✗ | ✗ |
+| Search "all projects" → see WNA result | ✓ | ✓ | ✗ |
+| Open WNA project edit page | ✓ | ✓ | only own |
+| Open NCAR project edit page | ✓ | ✗ | only own |
+| Create new WNA project | ✓ | ✓ | ✗ |
+| Create new NCAR project | ✓ | ✗ | ✗ |
+| Forge POST with `facility_id=ncar` as wna_manager | n/a | ✗ (403) | n/a |
+| Expirations dropdown shows NCAR option | ✓ | ✗ | ✗ |
+| Expirations dropdown shows WNA option | ✓ | ✓ | ✗ |
+
+Smoke `pytest`. The full suite should pass with no `wna_manager`
+entry, and pass again with the entry added (only the new tests
+should newly exercise the scoped paths).
+
+---
+
+## Pain points & decision log
+
+### 1. Orphan projects (`allocation_type_id IS NULL`)
+
+`Project.facility_name` returns `None`. `has_permission_for_facility`
+returns False for any scoped user when `facility_name` is None. Only
+unscoped system admins can act on orphans.
+
+**Decision**: deny-by-default for scoped users. Acceptable — orphan
+projects are rare (~20 in the snapshot) and represent
+data-cleanup-pending state. Operationally, full admins handle them.
+
+### 2. Group bundles stay unscoped in v1
+
+`GROUP_PERMISSIONS['csg' / 'nusd' / 'hsg']` remain unscoped.
+Extending the bundle storage to support facility scope is a
+follow-up if the operational pattern emerges. Today's bundles
+already grant their members fairly broad access, so there's no
+clear "scoped bundle" use case.
+
+**Decision**: defer. Per-user `USER_FACILITY_PERMISSIONS` covers
+the immediate need.
+
+### 3. Read access semantics
+
+A WNA-scoped manager with `VIEW_PROJECTS` in their
+`USER_FACILITY_PERMISSIONS` entry sees only WNA projects in
+admin lists. If they should see — but not edit — other
+facilities' projects, grant them unscoped `VIEW_PROJECTS` in
+`USER_PERMISSION_OVERRIDES` plus scoped `EDIT_PROJECTS` /
+`CREATE_PROJECTS` in `USER_FACILITY_PERMISSIONS`. The two dicts
+compose: unscoped grants always pass `has_permission_for_facility`;
+scoped grants apply only to matching facilities.
+
+**Decision**: document the pattern; no code change needed.
+
+### 4. Audit trail
+
+Existing `management_transaction` logging
+(`src/sam/manage/transaction.py`) doesn't distinguish "facility-scoped
+grant" from "global grant" — both show as `user=X action=UPDATE
+model=Y`. The distinction is in `rbac.py` config (visible in git
+blame).
+
+**Decision**: acceptable for v1. If audit needs to surface "this
+edit was made under facility-scoped authority," add a structured
+metadata field to the audit row in a follow-up.
+
+### 5. Storage in source vs DB
+
+Per the prior decision recorded in
+`~/.claude/projects/.../memory/feedback_contain_unstable_modules.md`'s
+neighborhood (and the `USER_PERMISSION_OVERRIDES` precedent), keeping
+RBAC config in source preserves git-blame audit trail of who got
+admin when. No DB migration needed.
+
+**Decision**: in-source. Revisit if zero-deploy admin grants become
+a real ops requirement.
+
+---
+
+## Critical files
+
+| Concern | File |
+|---|---|
+| Storage + helpers | `src/webapp/utils/rbac.py` |
+| Facility resolution on Project | `src/sam/projects/projects.py` |
+| Steward check (single line) | `src/webapp/utils/project_permissions.py:_is_project_steward` |
+| Project-create handler inline check | `src/webapp/dashboards/admin/projects_routes.py` (`htmx_create_project`, `htmx_panels_for_facility`, `htmx_alloc_types_for_panel`) |
+| Listing filters (server) | `src/webapp/dashboards/admin/blueprint.py:325,447,659` |
+| API listing | `src/webapp/api/v1/projects.py:106` |
+| Filter dropdown (UI) | `src/webapp/templates/dashboards/admin/dashboard.html:131-140` |
+| Cascade dropdown (UI) | `src/webapp/templates/dashboards/admin/fragments/create_project_form_htmx.html` |
+| Tests | `tests/unit/test_rbac.py`, `tests/unit/test_project_permissions.py`, `tests/unit/test_create_project.py`, `tests/api/test_list_projects_*.py` |
+
+---
+
+## Reference: facility list (current snapshot)
+
+```
+facility_id | facility_name | active
+1           | NCAR          | 1
+2           | UNIV          | 1
+3           | CSL           | 1
+4           | WNA           | 1
+5           | CISL          | 1
+6           | XSEDE         | 0
+7           | ASD           | 1
+```
+
+(Verify with `mysql -h 127.0.0.1 -uroot -proot sam -e "SELECT
+facility_id, facility_name, active FROM facility ORDER BY
+facility_name;"`.)
+
+---
+
+## Pickup checklist
+
+When restarting in a fresh session, confirm:
+
+- [ ] No `USER_FACILITY_PERMISSIONS` entry exists yet in
+  `src/webapp/utils/rbac.py` (Phase 5 not started).
+- [ ] `Project.facility_name` not yet present in
+  `src/sam/projects/projects.py` (Phase 1 not started).
+- [ ] `has_permission_for_facility` not yet defined in
+  `src/webapp/utils/rbac.py` (Phase 1 not started).
+- [ ] `_is_project_steward` still uses bare `has_permission` (Phase
+  2 not started — `git grep "has_permission(user, system_permission)"
+  src/webapp/utils/project_permissions.py`).
+
+If any check fails, that phase is partially landed — `git log`
+reveals where to resume.

--- a/src/sam/projects/projects.py
+++ b/src/sam/projects/projects.py
@@ -413,6 +413,27 @@ class Project(Base, TimestampMixin, ActiveFlagMixin, SessionMixin, NestedSetMixi
         return user in self.users
 
     @property
+    def facility_name(self) -> Optional[str]:
+        """The facility this project belongs to, derived via the
+        ``allocation_type → panel → facility`` chain.
+
+        Returns ``None`` for orphan projects — those with no
+        ``allocation_type`` assigned, or whose allocation_type chain
+        is broken. The RBAC facility-scope layer treats ``None`` as
+        "unscoped users cannot act here" (only system-permission
+        holders may)."""
+        at = self.allocation_type
+        if at is None:
+            return None
+        panel = at.panel
+        if panel is None:
+            return None
+        facility = panel.facility
+        if facility is None:
+            return None
+        return facility.facility_name
+
+    @property
     def active_directories(self) -> List[str]:
         """Return a list of active project directories (if any)."""
         dirs=[]

--- a/src/sam/queries/allocations.py
+++ b/src/sam/queries/allocations.py
@@ -144,7 +144,10 @@ ALLOCATION_TRANSACTION_SORT_COLUMNS = {
     'transaction_amount': AllocationTransaction.transaction_amount,
     'projcode': Project.projcode,
     'resource_name': Resource.resource_name,
-    'facility_name': Facility.facility_name,
+    # URL-facing sort key is the row-dict key ('facility'); maps to the
+    # underlying SQL column ``Facility.facility_name``. Keep the key
+    # consistent with the row-level identifier produced below.
+    'facility': Facility.facility_name,
     'allocation_type': AllocationType.allocation_type,
     'username': User.username,
 }
@@ -365,7 +368,7 @@ def get_recent_allocation_transactions(
             'project_id': project.project_id,
             'resource_name': resource.resource_name,
             'resource_id': resource.resource_id,
-            'facility_name': fac_name,
+            'facility': fac_name,
             'allocation_type': at_name,
             'user_id': user.user_id if user is not None else None,
             'username': user.username if user is not None else None,

--- a/src/sam/queries/charges.py
+++ b/src/sam/queries/charges.py
@@ -76,7 +76,9 @@ CHARGE_ADJUSTMENT_SORT_COLUMNS = {
     'amount': ChargeAdjustment.amount,
     'projcode': Project.projcode,
     'resource_name': Resource.resource_name,
-    'facility_name': Facility.facility_name,
+    # URL-facing sort key is the row-dict key ('facility'); maps to the
+    # underlying SQL column ``Facility.facility_name``.
+    'facility': Facility.facility_name,
     'username': User.username,
 }
 
@@ -265,7 +267,7 @@ def get_recent_charge_adjustments(
             'project_id': project.project_id,
             'resource_name': resource.resource_name,
             'resource_id': resource.resource_id,
-            'facility_name': fac_name,
+            'facility': fac_name,
             'user_id': user.user_id if user is not None else None,
             'username': user.username if user is not None else None,
             'user_display_name': user.display_name if user is not None else None,

--- a/src/sam/queries/dashboard.py
+++ b/src/sam/queries/dashboard.py
@@ -739,7 +739,13 @@ def get_resource_detail_data(
         Dictionary with structure:
         {
             'project': Project object,
-            'resource': Resource object,
+            'resource_obj': Resource object,
+                # Named ``resource_obj`` (not ``resource``) to avoid
+                # colliding with the row-level ``'resource'`` key used
+                # everywhere else in the query layer, where that key
+                # holds the resource *name string*. Keep this
+                # distinction — a scope filter that keys off
+                # ``row['resource']`` assumes a string.
             'resource_summary': {
                 'resource_name': str,
                 'allocated': float,
@@ -900,7 +906,7 @@ def get_resource_detail_data(
         if not account:
             return {
                 'project': project,
-                'resource': resource,
+                'resource_obj': resource,
                 'resource_summary': resource_summary,
                 'daily_charges': { 'dates': None, 'values': None }
             }
@@ -954,7 +960,7 @@ def get_resource_detail_data(
 
     return {
         'project': project,
-        'resource': resource,
+        'resource_obj': resource,
         'resource_summary': resource_summary,
         'daily_charges': daily_charges,
     }

--- a/src/sam/queries/projects.py
+++ b/src/sam/queries/projects.py
@@ -30,9 +30,21 @@ from sam.accounting.accounts import Account, AccountUser
 # Project Search Queries
 # ============================================================================
 
-def search_projects_by_code_or_title(session: Session, search_term: str, active: Optional[bool] = None) -> List[Project]:
-    """Search projects by project code or title, optionally filtered by active status."""
-    # Ensure search_term is case-insensitive for projcode and title
+def search_projects_by_code_or_title(
+    session: Session,
+    search_term: str,
+    active: Optional[bool] = None,
+    facility_names: Optional[List[str]] = None,
+) -> List[Project]:
+    """Search projects by project code or title, optionally filtered by
+    active status and/or a facility allowlist.
+
+    ``facility_names`` — when supplied, results are restricted to
+    projects whose ``allocation_type → panel → facility`` chain resolves
+    to one of the listed facility names. Projects with a broken chain
+    (orphans) are excluded, matching the facility-scoped RBAC rule
+    that only unscoped system holders may reach orphan projects.
+    """
     like_search_term = f"%{search_term}%"
     query = session.query(Project)\
         .filter(
@@ -43,6 +55,12 @@ def search_projects_by_code_or_title(session: Session, search_term: str, active:
         )
     if active is not None:
         query = query.filter(Project.active == active)
+    if facility_names:
+        query = query\
+            .join(AllocationType, Project.allocation_type_id == AllocationType.allocation_type_id)\
+            .join(Panel, AllocationType.panel_id == Panel.panel_id)\
+            .join(Facility, Panel.facility_id == Facility.facility_id)\
+            .filter(Facility.facility_name.in_(facility_names))
     return query.all()
 
 

--- a/src/webapp/api/access_control.py
+++ b/src/webapp/api/access_control.py
@@ -22,7 +22,7 @@ from flask_login import current_user
 from typing import Callable, Any
 
 from webapp.extensions import db
-from webapp.utils.rbac import has_permission, Permission
+from webapp.utils.rbac import has_permission, has_permission_for_facility, Permission
 from webapp.utils.project_permissions import _is_project_steward
 from webapp.api.helpers import get_project_or_404
 
@@ -137,7 +137,9 @@ def require_project_access(f: Callable = None, *, include_ancestors: bool = Fals
         if error:
             return error
 
-        if has_permission(current_user, Permission.VIEW_PROJECTS):
+        if has_permission_for_facility(
+            current_user, Permission.VIEW_PROJECTS, project.facility_name
+        ):
             return f(project, *args, **kwargs)
 
         sam_user = _get_sam_user()
@@ -175,8 +177,11 @@ def require_project_member_access(
             if error:
                 return error
 
-            # Check access: specific permission OR user is project member
-            if has_permission(current_user, permission):
+            # Check access: specific permission (incl. facility scope) OR
+            # user is project member.
+            if has_permission_for_facility(
+                current_user, permission, project.facility_name
+            ):
                 return f(project, *args, **kwargs)
 
             sam_user = _get_sam_user()

--- a/src/webapp/api/v1/projects.py
+++ b/src/webapp/api/v1/projects.py
@@ -12,7 +12,11 @@ Example usage:
 
 from flask import Blueprint, jsonify, request
 from flask_login import login_required, current_user
-from webapp.utils.rbac import require_permission, Permission
+from flask import abort
+from webapp.utils.rbac import (
+    require_permission, require_permission_any_facility,
+    Permission, user_facility_scope,
+)
 from webapp.extensions import db
 from sam.schemas import (
     ProjectSchema, ProjectListSchema, ProjectSummarySchema,
@@ -102,7 +106,7 @@ def _format_project_allocation_tuple(project, alloc, res_name, days_value, days_
 
 @bp.route('/', methods=['GET'])
 @login_required
-@require_permission(Permission.VIEW_PROJECTS)
+@require_permission_any_facility(Permission.VIEW_PROJECTS)
 def list_projects():
     """
     GET /api/v1/projects - List projects with pagination and filtering.
@@ -125,26 +129,47 @@ def list_projects():
 
     from sam.queries.projects import search_projects_by_code_or_title, get_active_projects
     from sam.projects.projects import Project
+    from sam.accounting.allocations import AllocationType
+    from sam.resources.facilities import Facility, Panel
+
+    # Facility-scope the caller. None → no restriction (system holder).
+    # Empty set → scoped user with no VIEW_PROJECTS anywhere → 0 rows.
+    # Populated set → restrict to those facilities; reject an explicit
+    # ?facility=<other> request outright so the caller sees a 403
+    # instead of a silent empty result.
+    allowed = user_facility_scope(current_user, Permission.VIEW_PROJECTS)
+    if allowed == set():
+        return jsonify({'projects': [], 'page': page, 'per_page': per_page, 'total': 0})
+    if allowed is not None and facility and facility not in allowed:
+        abort(403)
+    facility_filter = None if allowed is None else sorted(allowed)
 
     total = 0
     projects = []
 
     # Build query based on filters
     if search:
-        projects_list = search_projects_by_code_or_title(db.session, search, active=active)
+        projects_list = search_projects_by_code_or_title(
+            db.session, search, active=active, facility_names=facility_filter,
+        )
         total = len(projects_list)
         start = (page - 1) * per_page
         end = start + per_page
         projects = projects_list[start:end]
     elif facility:
-        # This branch remains unpaginated as in the original implementation
-        # and its active status depends on how get_active_projects internally filters.
+        # Explicit single-facility filter already intersected with scope above.
         projects = get_active_projects(db.session, facility_name=facility)
         total = len(projects)
     else:
         query = db.session.query(Project)
         if active is not None:
             query = query.filter(Project.active == active)
+        if facility_filter is not None:
+            query = query\
+                .join(AllocationType, Project.allocation_type_id == AllocationType.allocation_type_id)\
+                .join(Panel, AllocationType.panel_id == Panel.panel_id)\
+                .join(Facility, Panel.facility_id == Facility.facility_id)\
+                .filter(Facility.facility_name.in_(facility_filter))
         total = query.count()
         projects = query.limit(per_page).offset((page - 1) * per_page).all()
 

--- a/src/webapp/auth/blueprint.py
+++ b/src/webapp/auth/blueprint.py
@@ -32,8 +32,8 @@ def _redirect_for_role(auth_user):
     including users granted admin via USER_PERMISSION_OVERRIDES rather
     than a group bundle.
     """
-    from webapp.utils.rbac import has_permission, Permission
-    if has_permission(auth_user, Permission.ACCESS_ADMIN_DASHBOARD):
+    from webapp.utils.rbac import has_permission_any_facility, Permission
+    if has_permission_any_facility(auth_user, Permission.ACCESS_ADMIN_DASHBOARD):
         return redirect(url_for('admin_dashboard.index'))
     return redirect(url_for('user_dashboard.index'))
 

--- a/src/webapp/config.py
+++ b/src/webapp/config.py
@@ -92,6 +92,7 @@ class DevelopmentConfig(SAMWebappConfig):
         'andersnb:HSG',
         'tfair:NUSD',
         'dlawren:PROJ_TREE_LEAD',
+        'sureshm:WNA_SCOPED_ADMIN',
         'bdobbins',
     ]
 

--- a/src/webapp/dashboards/admin/blueprint.py
+++ b/src/webapp/dashboards/admin/blueprint.py
@@ -27,8 +27,9 @@ from webapp.auth.models import AuthUser
 from sam.core.users import User
 from webapp.utils.rbac import (
     apply_facility_scope, can_impersonate, get_user_permissions,
-    has_permission, Permission, require_permission,
-    require_permission_any_facility, user_facility_scope,
+    has_permission, has_permission_any_facility, Permission,
+    require_permission, require_permission_any_facility,
+    user_facility_scope,
 )
 import logging
 logger = logging.getLogger(__name__)
@@ -197,7 +198,7 @@ def project_card(projcode):
 
 @bp.route('/user/<username>')
 @login_required
-@require_permission(Permission.VIEW_USERS)
+@require_permission_any_facility(Permission.VIEW_USERS)
 def user_card(username):
     """
     Get HTML fragment for a single user card (for admin user search).
@@ -245,7 +246,7 @@ def user_card(username):
 
 @bp.route('/group/<group_name>')
 @login_required
-@require_permission(Permission.VIEW_GROUPS)
+@require_permission_any_facility(Permission.VIEW_GROUPS)
 def group_card(group_name):
     """HTML fragment for a single adhoc-group card (admin group search).
 
@@ -594,9 +595,14 @@ def htmx_search_users():
     The ``context`` query parameter selects the response template AND
     the permission gate:
       fk          → FK-picker badge list (create_resource, create_contract,
-                    create_project); requires system VIEW_USERS.
-      impersonate → admin user list with active_only filter (impersonation
-                    panel); requires system IMPERSONATE_USERS.
+                    create_project); requires VIEW_USERS (any-facility —
+                    scoped managers need to pick users for their
+                    in-scope projects).
+      impersonate → admin user list with active_only filter (shown in the
+                    Users & Groups tab). Requires VIEW_USERS (any-facility);
+                    the impersonate button inside each result row is
+                    itself gated on IMPERSONATE_USERS in the template,
+                    so non-impersonators see a plain directory listing.
       member      → project member add list; requires can_manage_project_members
                     on the target project (projcode required), so project
                     leads/admins can search when building the add-member form.
@@ -633,11 +639,12 @@ def htmx_search_users():
         if not can_manage_project_members(current_user, project):
             abort(403)
         exclude_ids = get_project_member_user_ids(db.session, project.project_id)
-    elif context == 'impersonate':
-        if not has_permission(current_user, Permission.IMPERSONATE_USERS):
-            abort(403)
     else:
-        if not has_permission(current_user, Permission.VIEW_USERS):
+        # Both 'fk' and 'impersonate' contexts return a listing of users;
+        # the impersonate button inside the 'impersonate' result row is
+        # template-gated on IMPERSONATE_USERS, so admitting VIEW_USERS
+        # holders (including facility-scoped managers) is safe here.
+        if not has_permission_any_facility(current_user, Permission.VIEW_USERS):
             abort(403)
 
     users = search_users_by_pattern(
@@ -650,7 +657,7 @@ def htmx_search_users():
 
 @bp.route('/htmx/search/groups')
 @login_required
-@require_permission(Permission.VIEW_GROUPS)
+@require_permission_any_facility(Permission.VIEW_GROUPS)
 def htmx_search_groups():
     """Search adhoc groups by name or GID. Returns the result-list fragment."""
     from sam.queries.lookups import search_groups_by_pattern
@@ -967,7 +974,7 @@ def htmx_edit_exemption(exemption_id):
 
 @bp.route('/htmx/queues-for-resource')
 @login_required
-@require_permission(Permission.VIEW_RESOURCES)
+@require_permission_any_facility(Permission.VIEW_RESOURCES)
 def htmx_queues_for_resource():
     """
     Return queue <option> elements for a given resource_id (cascading select).

--- a/src/webapp/dashboards/admin/blueprint.py
+++ b/src/webapp/dashboards/admin/blueprint.py
@@ -27,13 +27,43 @@ from webapp.auth.models import AuthUser
 from sam.core.users import User
 from webapp.utils.rbac import (
     can_impersonate, get_user_permissions, has_permission,
-    Permission, require_permission,
+    Permission, require_permission, require_permission_any_facility,
+    user_facility_scope,
 )
 import logging
 logger = logging.getLogger(__name__)
 
 
 bp = Blueprint('admin_dashboard', __name__, url_prefix='/admin')
+
+
+def _apply_facility_scope(requested, permission, default=None):
+    """
+    Combine a user-submitted ``facilities`` list with the caller's
+    facility-scoped RBAC grants for ``permission``.
+
+    Returns the effective facility-name list to pass to downstream
+    queries. ``None`` (or an empty returned list where the caller
+    coerces falsy) means "no restriction".
+
+    Semantics:
+    - Unscoped users (system-permission holders): their ``requested``
+      selection wins; if empty, ``default`` applies.
+    - Scoped users: the returned list is the intersection of their
+      allowed set with the request, or their full allowed set when
+      the request is empty / the intersection is empty.
+    - Users with an empty scope (no entry at all) get an empty list —
+      the caller should treat that as "no rows".
+    """
+    allowed = user_facility_scope(current_user, permission)
+    if allowed is None:
+        return list(requested) if requested else (list(default) if default else None)
+    if not allowed:
+        return []
+    if not requested:
+        return sorted(allowed)
+    intersected = [f for f in requested if f in allowed]
+    return intersected or sorted(allowed)
 
 
 # Usage threshold configuration (percentage)
@@ -50,7 +80,7 @@ UPCOMING_PRESETS = {
 
 @bp.route('/')
 @login_required
-@require_permission(Permission.ACCESS_ADMIN_DASHBOARD)
+@require_permission_any_facility(Permission.ACCESS_ADMIN_DASHBOARD)
 def index():
     """
     Admin dashboard main page.
@@ -60,9 +90,29 @@ def index():
     - Project search
     - Allocation expirations tracking
     """
+    # Full facility list for unscoped users, the user's allowed set
+    # otherwise. The template iterates this to build the expirations
+    # facility multi-select so scoped users can't see (or pick)
+    # facilities they cannot act on.
+    from sam.resources.facilities import Facility
+    allowed = user_facility_scope(current_user, Permission.VIEW_PROJECTS)
+    if allowed is None:
+        allowed_facility_names = [
+            f.facility_name for f in
+            db.session.query(Facility).order_by(Facility.facility_name).all()
+        ]
+    else:
+        allowed_facility_names = sorted(allowed)
+
+    # The two default selections carry over from the hardcoded template
+    # (UNIV and WNA). Keep them only if they survive the allowed set.
+    default_selected = [f for f in ('UNIV', 'WNA') if f in allowed_facility_names]
+
     return render_template(
         'dashboards/admin/dashboard.html',
-        user=current_user
+        user=current_user,
+        allowed_facility_names=allowed_facility_names,
+        default_selected_facilities=default_selected,
     )
 
 
@@ -142,7 +192,7 @@ def stop_impersonating():
 
 @bp.route('/project/<projcode>')
 @login_required
-@require_permission(Permission.VIEW_PROJECTS)
+@require_permission_any_facility(Permission.VIEW_PROJECTS)
 def project_card(projcode):
     """
     Get HTML fragment for a single project card (for admin project search).
@@ -155,6 +205,14 @@ def project_card(projcode):
 
     if not project_data:
         return '<div class="alert alert-warning">Project not found</div>'
+
+    # Facility-scoped users must not see cards for projects outside
+    # their granted facilities — even if they somehow land on the URL.
+    allowed = user_facility_scope(current_user, Permission.VIEW_PROJECTS)
+    if allowed is not None:
+        project = find_project_by_code(db.session, projcode)
+        if project is None or project.facility_name not in allowed:
+            abort(403)
 
     # Render a wrapper template that calls the macro
     return render_template(
@@ -322,7 +380,7 @@ def _get_abandoned_users_data(expired_results: List[Tuple]) -> List[Dict]:
 
 @bp.route('/expirations')
 @login_required
-@require_permission(Permission.VIEW_PROJECTS)
+@require_permission_any_facility(Permission.VIEW_PROJECTS)
 def expirations_fragment():
     """
     AJAX endpoint for loading expirations data.
@@ -337,9 +395,11 @@ def expirations_fragment():
         HTML fragment with project cards or user table
     """
     view_type = request.args.get('view', 'upcoming')
-    facilities = request.args.getlist('facilities')
-    if not facilities:
-        facilities = ['UNIV', 'WNA']
+    facilities = _apply_facility_scope(
+        request.args.getlist('facilities'),
+        Permission.VIEW_PROJECTS,
+        default=['UNIV', 'WNA'],
+    )
     resource = request.args.get('resource', None)
     if resource == '':
         resource = None
@@ -396,14 +456,18 @@ def expirations_fragment():
 
 @bp.route('/expirations/deactivate-expired', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
+@require_permission_any_facility(Permission.EDIT_PROJECTS)
 def deactivate_expired():
     """
     Bulk-deactivate every project currently shown on the Expired (90+ days)
     tab, respecting the same facility/resource filters. Re-runs the query
     server-side so the action operates on exactly the set the user saw.
     """
-    facilities = request.form.getlist('facilities') or ['UNIV', 'WNA']
+    facilities = _apply_facility_scope(
+        request.form.getlist('facilities'),
+        Permission.EDIT_PROJECTS,
+        default=['UNIV', 'WNA'],
+    )
     resource = request.form.get('resource') or None
 
     results = get_projects_with_expired_allocations(
@@ -444,7 +508,7 @@ def deactivate_expired():
 
 @bp.route('/expirations/export')
 @login_required
-@require_permission(Permission.VIEW_PROJECTS)
+@require_permission_any_facility(Permission.VIEW_PROJECTS)
 def expirations_export():
     """
     Export expirations data to CSV.
@@ -459,9 +523,11 @@ def expirations_export():
         CSV file download
     """
     export_type = request.args.get('export_type', 'upcoming')
-    facilities = request.args.getlist('facilities')
-    if not facilities:
-        facilities = ['UNIV', 'WNA']
+    facilities = _apply_facility_scope(
+        request.args.getlist('facilities'),
+        Permission.VIEW_PROJECTS,
+        default=['UNIV', 'WNA'],
+    )
     resource = request.args.get('resource', None)
     if resource == '':
         resource = None
@@ -655,7 +721,7 @@ def htmx_search_users_impersonate():
 
 @bp.route('/htmx/search-projects')
 @login_required
-@require_permission(Permission.VIEW_PROJECTS)
+@require_permission_any_facility(Permission.VIEW_PROJECTS)
 def htmx_search_projects():
     """
     Search projects and return results as HTML fragments.
@@ -671,8 +737,17 @@ def htmx_search_projects():
     if len(query) < 1:
         return ''
 
+    # Facility-scoped users see only their allowed set. None → no filter.
+    allowed = user_facility_scope(current_user, Permission.VIEW_PROJECTS)
+    if allowed == set():
+        # Scoped user with no VIEW_PROJECTS entry anywhere → no results.
+        return ''
+    facility_filter = None if allowed is None else sorted(allowed)
+
     projects = search_projects_by_code_or_title(
-        db.session, query, active=True if active_only else None
+        db.session, query,
+        active=True if active_only else None,
+        facility_names=facility_filter,
     )[:10]  # Limit results
 
     return render_template(

--- a/src/webapp/dashboards/admin/blueprint.py
+++ b/src/webapp/dashboards/admin/blueprint.py
@@ -26,44 +26,15 @@ from sam.queries.lookups import find_project_by_code, get_user_group_access
 from webapp.auth.models import AuthUser
 from sam.core.users import User
 from webapp.utils.rbac import (
-    can_impersonate, get_user_permissions, has_permission,
-    Permission, require_permission, require_permission_any_facility,
-    user_facility_scope,
+    apply_facility_scope, can_impersonate, get_user_permissions,
+    has_permission, Permission, require_permission,
+    require_permission_any_facility, user_facility_scope,
 )
 import logging
 logger = logging.getLogger(__name__)
 
 
 bp = Blueprint('admin_dashboard', __name__, url_prefix='/admin')
-
-
-def _apply_facility_scope(requested, permission, default=None):
-    """
-    Combine a user-submitted ``facilities`` list with the caller's
-    facility-scoped RBAC grants for ``permission``.
-
-    Returns the effective facility-name list to pass to downstream
-    queries. ``None`` (or an empty returned list where the caller
-    coerces falsy) means "no restriction".
-
-    Semantics:
-    - Unscoped users (system-permission holders): their ``requested``
-      selection wins; if empty, ``default`` applies.
-    - Scoped users: the returned list is the intersection of their
-      allowed set with the request, or their full allowed set when
-      the request is empty / the intersection is empty.
-    - Users with an empty scope (no entry at all) get an empty list —
-      the caller should treat that as "no rows".
-    """
-    allowed = user_facility_scope(current_user, permission)
-    if allowed is None:
-        return list(requested) if requested else (list(default) if default else None)
-    if not allowed:
-        return []
-    if not requested:
-        return sorted(allowed)
-    intersected = [f for f in requested if f in allowed]
-    return intersected or sorted(allowed)
 
 
 # Usage threshold configuration (percentage)
@@ -395,7 +366,7 @@ def expirations_fragment():
         HTML fragment with project cards or user table
     """
     view_type = request.args.get('view', 'upcoming')
-    facilities = _apply_facility_scope(
+    facilities = apply_facility_scope(
         request.args.getlist('facilities'),
         Permission.VIEW_PROJECTS,
         default=['UNIV', 'WNA'],
@@ -463,7 +434,7 @@ def deactivate_expired():
     tab, respecting the same facility/resource filters. Re-runs the query
     server-side so the action operates on exactly the set the user saw.
     """
-    facilities = _apply_facility_scope(
+    facilities = apply_facility_scope(
         request.form.getlist('facilities'),
         Permission.EDIT_PROJECTS,
         default=['UNIV', 'WNA'],
@@ -523,7 +494,7 @@ def expirations_export():
         CSV file download
     """
     export_type = request.args.get('export_type', 'upcoming')
-    facilities = _apply_facility_scope(
+    facilities = apply_facility_scope(
         request.args.getlist('facilities'),
         Permission.VIEW_PROJECTS,
         default=['UNIV', 'WNA'],

--- a/src/webapp/dashboards/admin/facilities_routes.py
+++ b/src/webapp/dashboards/admin/facilities_routes.py
@@ -15,7 +15,9 @@ from webapp.utils.htmx import (
     htmx_success_message,
 )
 from webapp.extensions import db
-from webapp.utils.rbac import require_permission, Permission
+from webapp.utils.rbac import (
+    require_permission, require_permission_any_facility, Permission,
+)
 from sam.manage import management_transaction
 from sam.schemas.forms.facilities import (
     EditFacilityForm, CreateFacilityForm, CreatePanelForm,
@@ -33,7 +35,7 @@ _FACILITY_TRIGGERS = {'closeActiveModal': {}, 'reloadFacilitiesCard': {}}
 
 @bp.route('/htmx/facilities')
 @login_required
-@require_permission(Permission.VIEW_FACILITIES)
+@require_permission_any_facility(Permission.VIEW_FACILITIES)
 def htmx_facilities_card():
     """
     Return the Facility card body fragment with four tabs:

--- a/src/webapp/dashboards/admin/orgs_routes.py
+++ b/src/webapp/dashboards/admin/orgs_routes.py
@@ -15,8 +15,10 @@ from webapp.utils.htmx import (
     htmx_not_found,
     htmx_success_message,
 )
-from webapp.extensions import db, cache
-from webapp.utils.rbac import require_permission, Permission
+from webapp.extensions import db, cache, user_aware_cache_key
+from webapp.utils.rbac import (
+    require_permission, require_permission_any_facility, Permission,
+)
 from sam.manage import management_transaction
 from sam.core.users import User
 from sam.queries.admin import (
@@ -95,8 +97,8 @@ def _active_contract_sources():
 
 @bp.route('/htmx/organizations-card')
 @login_required
-@require_permission(Permission.VIEW_ORG_METADATA)
-@cache.cached(query_string=True)
+@require_permission_any_facility(Permission.VIEW_ORG_METADATA)
+@cache.cached(make_cache_key=user_aware_cache_key)
 def htmx_organizations_card():
     """
     Return the Organization card body fragment with seven tabs:
@@ -165,8 +167,8 @@ def htmx_organizations_card():
 
 @bp.route('/htmx/institutions-fragment')
 @login_required
-@require_permission(Permission.VIEW_ORG_METADATA)
-@cache.cached(query_string=True)
+@require_permission_any_facility(Permission.VIEW_ORG_METADATA)
+@cache.cached(make_cache_key=user_aware_cache_key)
 def htmx_institutions_fragment():
     """HTMX fragment: filterable, nested table of institutions by institution type.
 

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -12,7 +12,12 @@ from webapp.utils.fk_validation import FKValidationError, validate_fk_existence
 from flask_login import login_required, current_user
 
 from webapp.extensions import db
-from webapp.utils.rbac import require_permission, has_permission, Permission
+from flask import abort
+from webapp.utils.rbac import (
+    require_permission, require_permission_any_facility,
+    has_permission, has_permission_for_facility,
+    Permission, user_facility_scope,
+)
 from webapp.api.access_control import require_project_permission
 from webapp.utils.project_permissions import (
     can_edit_project_governance,
@@ -50,12 +55,17 @@ def _project_form_data(form=None) -> dict:
         .order_by(AreaOfInterestGroup.name)
         .all()
     )
-    facilities = (
+    facilities_q = (
         db.session.query(Facility)
         .filter(Facility.is_active)
         .order_by(Facility.facility_name)
-        .all()
     )
+    # Facility-scoped users only ever see (and can submit) facilities
+    # they have CREATE_PROJECTS on. None → no restriction.
+    allowed = user_facility_scope(current_user, Permission.CREATE_PROJECTS)
+    if allowed is not None:
+        facilities_q = facilities_q.filter(Facility.facility_name.in_(allowed))
+    facilities = facilities_q.all()
     mnemonics = (
         db.session.query(MnemonicCode)
         .filter(MnemonicCode.is_active)
@@ -107,7 +117,7 @@ def _project_form_data(form=None) -> dict:
 
 @bp.route('/htmx/project-create-form')
 @login_required
-@require_permission(Permission.CREATE_PROJECTS)
+@require_permission_any_facility(Permission.CREATE_PROJECTS)
 def htmx_project_create_form():
     """Return the project create form fragment (loaded into modal on button click)."""
     return render_template(
@@ -118,26 +128,39 @@ def htmx_project_create_form():
 
 @bp.route('/htmx/panels-for-facility')
 @login_required
-@require_permission(Permission.CREATE_PROJECTS)
+@require_permission_any_facility(Permission.CREATE_PROJECTS)
 def htmx_panels_for_facility():
     """Return <option> elements for the Panel select, filtered by facility.
 
     Called via hx-get when the Facility select changes.
     """
-    from sam.resources.facilities import Panel
+    from sam.resources.facilities import Facility, Panel
 
     facility_id_str = request.args.get('facility_id', '').strip()
     if not facility_id_str:
         return '<option value="">— Select facility first —</option>'
     try:
-        panels = (
-            db.session.query(Panel)
-            .filter(Panel.facility_id == int(facility_id_str), Panel.is_active)
-            .order_by(Panel.panel_name)
-            .all()
-        )
+        facility_id_int = int(facility_id_str)
     except (ValueError, TypeError):
         return '<option value="">— Select facility first —</option>'
+
+    # Facility-scope gate: a user with CREATE_PROJECTS only on WNA must
+    # not be able to discover NCAR panels by forging facility_id. Deny
+    # at the source rather than filter the returned list silently.
+    facility = db.session.get(Facility, facility_id_int)
+    if facility is None:
+        return '<option value="">— Select facility first —</option>'
+    if not has_permission_for_facility(
+        current_user, Permission.CREATE_PROJECTS, facility.facility_name,
+    ):
+        abort(403)
+
+    panels = (
+        db.session.query(Panel)
+        .filter(Panel.facility_id == facility_id_int, Panel.is_active)
+        .order_by(Panel.panel_name)
+        .all()
+    )
 
     return render_template(
         'dashboards/admin/fragments/panel_options_htmx.html',
@@ -148,26 +171,41 @@ def htmx_panels_for_facility():
 
 @bp.route('/htmx/alloc-types-for-panel')
 @login_required
-@require_permission(Permission.CREATE_PROJECTS)
+@require_permission_any_facility(Permission.CREATE_PROJECTS)
 def htmx_alloc_types_for_panel():
     """Return <option> elements for the AllocationType select, filtered by panel.
 
     Called via hx-get when the Panel select changes.
     """
     from sam.accounting.allocations import AllocationType
+    from sam.resources.facilities import Panel
 
     panel_id_str = request.args.get('panel_id', '').strip()
     if not panel_id_str:
         return '<option value="">— None —</option>'
     try:
-        alloc_types = (
-            db.session.query(AllocationType)
-            .filter(AllocationType.panel_id == int(panel_id_str), AllocationType.is_active)
-            .order_by(AllocationType.allocation_type)
-            .all()
-        )
+        panel_id_int = int(panel_id_str)
     except (ValueError, TypeError):
         return '<option value="">— None —</option>'
+
+    # Resolve the panel's facility for the scope check — a scoped user
+    # must not be able to harvest allocation-type options from facilities
+    # outside their grant by probing panel_ids directly.
+    panel = db.session.get(Panel, panel_id_int)
+    if panel is None:
+        return '<option value="">— None —</option>'
+    if not has_permission_for_facility(
+        current_user, Permission.CREATE_PROJECTS,
+        panel.facility.facility_name if panel.facility else None,
+    ):
+        abort(403)
+
+    alloc_types = (
+        db.session.query(AllocationType)
+        .filter(AllocationType.panel_id == panel_id_int, AllocationType.is_active)
+        .order_by(AllocationType.allocation_type)
+        .all()
+    )
 
     return render_template(
         'dashboards/admin/fragments/alloc_type_options_htmx.html',
@@ -178,7 +216,7 @@ def htmx_alloc_types_for_panel():
 
 @bp.route('/htmx/org-search-for-project')
 @login_required
-@require_permission(Permission.CREATE_PROJECTS)
+@require_permission_any_facility(Permission.CREATE_PROJECTS)
 def htmx_org_search_for_project():
     """Search organizations for the project create form FK picker.
 
@@ -210,7 +248,7 @@ def htmx_org_search_for_project():
 
 @bp.route('/htmx/contract-search-for-project')
 @login_required
-@require_permission(Permission.CREATE_PROJECTS)
+@require_permission_any_facility(Permission.CREATE_PROJECTS)
 def htmx_contract_search_for_project():
     """Search contracts for the project create form FK picker.
 
@@ -241,7 +279,7 @@ def htmx_contract_search_for_project():
 
 @bp.route('/htmx/project-search-for-parent')
 @login_required
-@require_permission(Permission.CREATE_PROJECTS)
+@require_permission_any_facility(Permission.CREATE_PROJECTS)
 def htmx_project_search_for_parent():
     """Search projects for use as parent FK in the create form.
 
@@ -266,7 +304,7 @@ def htmx_project_search_for_parent():
 
 @bp.route('/htmx/project-next-projcode')
 @login_required
-@require_permission(Permission.CREATE_PROJECTS)
+@require_permission_any_facility(Permission.CREATE_PROJECTS)
 def htmx_project_next_projcode():
     """Compute and return a preview of the next available projcode.
 
@@ -295,7 +333,7 @@ def htmx_project_next_projcode():
 
 @bp.route('/htmx/project-create', methods=['POST'])
 @login_required
-@require_permission(Permission.CREATE_PROJECTS)
+@require_permission_any_facility(Permission.CREATE_PROJECTS)
 def htmx_project_create():
     """Validate form and create a new project."""
     from sam.projects.projects import Project
@@ -320,6 +358,16 @@ def htmx_project_create():
             (Contract, data.get('contract_id'), 'contract'),
             (Organization, data.get('organization_id'), 'organization'),
         )
+        # Facility-scope gate: the decorator-level CREATE_PROJECTS check
+        # only knows whether the user holds the permission anywhere.
+        # Scoped users must additionally be creating inside a facility
+        # they have been granted. FK existence is already validated
+        # above, so the lookup is guaranteed to resolve.
+        chosen_facility = db.session.get(Facility, data['facility_id'])
+        if not has_permission_for_facility(
+            current_user, Permission.CREATE_PROJECTS, chosen_facility.facility_name,
+        ):
+            abort(403)
         if Project.get_by_projcode(db.session, data['projcode']):
             raise FKValidationError(
                 [f'Project code "{data["projcode"]}" is already in use.']
@@ -402,7 +450,8 @@ def edit_project_page(project):
     form_data = _project_form_data(form=pre_fill or None)
 
     can_edit_governance = can_edit_project_governance(current_user, project)
-    can_access_admin = has_permission(current_user, Permission.ACCESS_ADMIN_DASHBOARD)
+    from webapp.utils.rbac import has_permission_any_facility
+    can_access_admin = has_permission_any_facility(current_user, Permission.ACCESS_ADMIN_DASHBOARD)
 
     return render_template(
         'dashboards/admin/edit_project.html',

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -18,7 +18,9 @@ from webapp.utils.rbac import (
     has_permission, has_permission_for_facility,
     Permission, user_facility_scope,
 )
-from webapp.api.access_control import require_project_permission
+from webapp.api.access_control import (
+    require_project_permission, require_allocation_permission,
+)
 from webapp.utils.project_permissions import (
     can_edit_project_governance,
     can_edit_allocations,
@@ -450,6 +452,7 @@ def edit_project_page(project):
     form_data = _project_form_data(form=pre_fill or None)
 
     can_edit_governance = can_edit_project_governance(current_user, project)
+    can_edit_allocs = can_edit_allocations(current_user, project)
     from webapp.utils.rbac import has_permission_any_facility
     can_access_admin = has_permission_any_facility(current_user, Permission.ACCESS_ADMIN_DASHBOARD)
 
@@ -460,6 +463,7 @@ def edit_project_page(project):
         current_facility_id=current_facility_id,
         current_panel_id=current_panel_id,
         can_edit_governance=can_edit_governance,
+        can_edit_allocations=can_edit_allocs,
         can_access_admin=can_access_admin,
         **form_data,
     )
@@ -652,6 +656,7 @@ def htmx_project_allocation_tree(project):
         active_at=active_at_str,
         now_str=now_str,
         can_edit_governance=can_edit_project_governance(current_user, project),
+        can_edit_allocations=can_exchange,
         can_exchange=can_exchange,
         exchange_eligible_resources=exchange_eligible_resources,
         resource_id_by_name=resource_id_by_name,
@@ -660,16 +665,11 @@ def htmx_project_allocation_tree(project):
 
 @bp.route('/htmx/add-allocation-form/<projcode>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
-def htmx_add_allocation_form(projcode):
+@require_project_permission(Permission.EDIT_ALLOCATIONS, include_ancestors=True)
+def htmx_add_allocation_form(project):
     """Return the add-allocation sub-form (loaded into modal on button click)."""
     import calendar
-    from sam.projects.projects import Project
     from sam.resources.resources import Resource
-
-    project = Project.get_by_projcode(db.session, projcode)
-    if not project:
-        return '<div class="alert alert-warning">Project not found.</div>'
 
     # Resources already linked to this project (via any account, even deleted).
     linked_resource_ids = {
@@ -708,18 +708,13 @@ def htmx_add_allocation_form(projcode):
 
 @bp.route('/htmx/add-allocation/<projcode>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
-def htmx_add_allocation(projcode):
+@require_project_permission(Permission.EDIT_ALLOCATIONS, include_ancestors=True)
+def htmx_add_allocation(project):
     """Create a new account + allocation for the project."""
-    from sam.projects.projects import Project
     from sam.resources.resources import Resource
     from sam.manage.allocations import create_allocation
     from sam.schemas.forms import AddAllocationForm
     from marshmallow import ValidationError
-
-    project = Project.get_by_projcode(db.session, projcode)
-    if not project:
-        return '<div class="alert alert-danger">Project not found.</div>', 404
 
     errors = []
 
@@ -813,7 +808,7 @@ def htmx_add_allocation(projcode):
         )
 
     return htmx_success_message(
-        {'closeActiveModal': {}, 'reloadAllocationTree': projcode},
+        {'closeActiveModal': {}, 'reloadAllocationTree': project.projcode},
         'Allocation created successfully.',
         detail=detail,
     )
@@ -1147,19 +1142,13 @@ def _build_renew_candidates(project, source_active_at):
 
 @bp.route('/htmx/renew-allocations-form/<projcode>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
-def htmx_renew_allocations_form(projcode):
+@require_project_permission(Permission.EDIT_ALLOCATIONS, include_ancestors=True)
+def htmx_renew_allocations_form(project):
     """Return the Renew Allocations modal form fragment.
 
     Query params:
         active_at (YYYY-MM-DD): which allocations to renew. Defaults to today.
     """
-    from sam.projects.projects import Project
-
-    project = Project.get_by_projcode(db.session, projcode)
-    if not project:
-        return '<div class="alert alert-warning">Project not found.</div>'
-
     # Renew always operates from the root of the project tree.
     root = project.get_root() if hasattr(project, 'get_root') else project
 
@@ -1183,18 +1172,13 @@ def htmx_renew_allocations_form(projcode):
 
 @bp.route('/htmx/renew-allocations/<projcode>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
-def htmx_renew_allocations(projcode):
+@require_project_permission(Permission.EDIT_ALLOCATIONS, include_ancestors=True)
+def htmx_renew_allocations(project):
     """Create renewed allocations for the selected resources."""
-    from sam.projects.projects import Project
     from sam.resources.resources import Resource
     from sam.manage.renew import renew_project_allocations, analyze_renew_preconditions
     from sam.schemas.forms import RenewAllocationsForm
     from marshmallow import ValidationError
-
-    project = Project.get_by_projcode(db.session, projcode)
-    if not project:
-        return '<div class="alert alert-danger">Project not found.</div>', 404
 
     root = project.get_root() if hasattr(project, 'get_root') else project
 
@@ -1332,7 +1316,7 @@ def htmx_renew_allocations(projcode):
         names = ', '.join(sorted(resource_name.get(r, f'#{r}') for r in no_source_ids))
         detail_parts.append(f'skipped (no source at {source_dt.strftime("%Y-%m-%d")}): {names}')
     return htmx_success_message(
-        {'closeActiveModal': {}, 'reloadAllocationTree': projcode},
+        {'closeActiveModal': {}, 'reloadAllocationTree': project.projcode},
         'Allocations renewed successfully.',
         detail='; '.join(detail_parts),
     )
@@ -1400,15 +1384,9 @@ def _build_extend_candidates(project, source_active_at):
 
 @bp.route('/htmx/extend-allocations-form/<projcode>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
-def htmx_extend_allocations_form(projcode):
+@require_project_permission(Permission.EDIT_ALLOCATIONS, include_ancestors=True)
+def htmx_extend_allocations_form(project):
     """Return the Extend Allocations modal form fragment."""
-    from sam.projects.projects import Project
-
-    project = Project.get_by_projcode(db.session, projcode)
-    if not project:
-        return '<div class="alert alert-warning">Project not found.</div>'
-
     root = project.get_root() if hasattr(project, 'get_root') else project
 
     source_active_at = _parse_active_at_arg(request.args.get('active_at', ''))
@@ -1430,17 +1408,12 @@ def htmx_extend_allocations_form(projcode):
 
 @bp.route('/htmx/extend-allocations/<projcode>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
-def htmx_extend_allocations(projcode):
+@require_project_permission(Permission.EDIT_ALLOCATIONS, include_ancestors=True)
+def htmx_extend_allocations(project):
     """Push end_date forward on the selected allocations."""
-    from sam.projects.projects import Project
     from sam.manage.extend import extend_project_allocations
     from sam.schemas.forms import ExtendAllocationsForm
     from marshmallow import ValidationError
-
-    project = Project.get_by_projcode(db.session, projcode)
-    if not project:
-        return '<div class="alert alert-danger">Project not found.</div>', 404
 
     root = project.get_root() if hasattr(project, 'get_root') else project
 
@@ -1524,26 +1497,21 @@ def htmx_extend_allocations(projcode):
         f'{new_end.strftime("%Y-%m-%d")}'
     )
     return htmx_success_message(
-        {'closeActiveModal': {}, 'reloadAllocationTree': projcode},
+        {'closeActiveModal': {}, 'reloadAllocationTree': project.projcode},
         'Allocations extended successfully.',
         detail=detail,
     )
 
 
-@bp.route('/htmx/edit-allocation-form/<int:alloc_id>')
+@bp.route('/htmx/edit-allocation-form/<int:allocation_id>')
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
-def htmx_edit_allocation_form(alloc_id):
+@require_allocation_permission(Permission.EDIT_ALLOCATIONS)
+def htmx_edit_allocation_form(allocation):
     """Return the edit-allocation form fragment (loaded into modal)."""
-    from sam.accounting.allocations import Allocation
     from sam.manage.allocations import get_partitioned_descendant_sum, date_ranges_overlap
     from sam.accounting.accounts import Account
 
-    allocation = db.session.get(Allocation, alloc_id)
-    if not allocation:
-        return '<div class="alert alert-warning">Allocation not found.</div>'
-
-    projcode = allocation.account.project.projcode if allocation.account else ''
+    projcode = allocation.account.project.projcode
 
     # Flaw 1 fix: sum standalone (non-inherited) descendant allocations only
     partitioned_sum = get_partitioned_descendant_sum(db.session, allocation)
@@ -1615,22 +1583,19 @@ def htmx_edit_allocation_form(alloc_id):
     )
 
 
-@bp.route('/htmx/edit-allocation/<int:alloc_id>', methods=['POST'])
+@bp.route('/htmx/edit-allocation/<int:allocation_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
-def htmx_edit_allocation(alloc_id):
+@require_allocation_permission(Permission.EDIT_ALLOCATIONS)
+def htmx_edit_allocation(allocation):
     """Validate and apply allocation edits with cascade + audit logging."""
-    from sam.accounting.allocations import Allocation, InheritingAllocationException
+    from sam.accounting.allocations import InheritingAllocationException
     from sam.manage.allocations import update_allocation, detach_allocation
     from sam.manage.allocations import get_partitioned_descendant_sum
     from sam.schemas.forms import EditAllocationForm
     from marshmallow import ValidationError
 
-    allocation = db.session.get(Allocation, alloc_id)
-    if not allocation:
-        return '<div class="alert alert-danger">Allocation not found.</div>', 404
-
-    projcode = allocation.account.project.projcode if allocation.account else ''
+    alloc_id = allocation.allocation_id
+    projcode = allocation.account.project.projcode
 
     break_inheritance = request.form.get('break_inheritance') == 'true'
 
@@ -1719,21 +1684,17 @@ def htmx_edit_allocation(alloc_id):
     )
 
 
-@bp.route('/htmx/detach-allocation/<int:alloc_id>', methods=['POST'])
+@bp.route('/htmx/detach-allocation/<int:allocation_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
-def htmx_detach_allocation(alloc_id):
+@require_allocation_permission(Permission.EDIT_ALLOCATIONS)
+def htmx_detach_allocation(allocation):
     """Break parent_allocation_id link without editing other fields."""
-    from sam.accounting.allocations import Allocation
     from sam.manage.allocations import detach_allocation
 
-    allocation = db.session.get(Allocation, alloc_id)
-    if not allocation:
-        return '<div class="alert alert-danger">Allocation not found.</div>', 404
-    projcode = allocation.account.project.projcode if allocation.account else ''
+    projcode = allocation.account.project.projcode
     try:
         with management_transaction(db.session):
-            detach_allocation(db.session, alloc_id, current_user.user_id)
+            detach_allocation(db.session, allocation.allocation_id, current_user.user_id)
     except ValueError as e:
         return f'<div class="alert alert-danger">{e}</div>', 400
     return htmx_success_message(
@@ -1742,18 +1703,14 @@ def htmx_detach_allocation(alloc_id):
     )
 
 
-@bp.route('/htmx/link-allocation-to-parent/<int:alloc_id>', methods=['POST'])
+@bp.route('/htmx/link-allocation-to-parent/<int:allocation_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
-def htmx_link_allocation_to_parent(alloc_id):
+@require_allocation_permission(Permission.EDIT_ALLOCATIONS)
+def htmx_link_allocation_to_parent(allocation):
     """Re-link a standalone child allocation to its parent-project allocation."""
-    from sam.accounting.allocations import Allocation
     from sam.manage.allocations import link_allocation_to_parent
 
-    allocation = db.session.get(Allocation, alloc_id)
-    if not allocation:
-        return '<div class="alert alert-danger">Allocation not found.</div>', 404
-    projcode = allocation.account.project.projcode if allocation.account else ''
+    projcode = allocation.account.project.projcode
 
     try:
         parent_allocation_id = int(request.form.get('parent_allocation_id', '0'))
@@ -1765,7 +1722,7 @@ def htmx_link_allocation_to_parent(alloc_id):
     try:
         with management_transaction(db.session):
             link_allocation_to_parent(
-                db.session, alloc_id, parent_allocation_id, current_user.user_id
+                db.session, allocation.allocation_id, parent_allocation_id, current_user.user_id
             )
     except ValueError as e:
         return f'<div class="alert alert-danger">{e}</div>', 400
@@ -1776,17 +1733,15 @@ def htmx_link_allocation_to_parent(alloc_id):
     )
 
 
-@bp.route('/htmx/propagate-allocation-to-remaining/<int:alloc_id>', methods=['POST'])
+@bp.route('/htmx/propagate-allocation-to-remaining/<int:allocation_id>', methods=['POST'])
 @login_required
-@require_permission(Permission.EDIT_PROJECTS)
-def htmx_propagate_to_remaining(alloc_id):
+@require_allocation_permission(Permission.EDIT_ALLOCATIONS)
+def htmx_propagate_to_remaining(allocation):
     """Create child allocations for active descendants that don't yet have one."""
-    from sam.accounting.allocations import Allocation
     from sam.accounting.accounts import Account
     from sam.manage.allocations import propagate_allocation_to_subprojects
 
-    allocation = db.session.get(Allocation, alloc_id)
-    if not allocation or allocation.is_inheriting:
+    if allocation.is_inheriting:
         return '<div class="alert alert-danger">Invalid allocation.</div>', 400
     project = allocation.account.project
     resource_id = allocation.account.resource_id

--- a/src/webapp/dashboards/admin/resources_routes.py
+++ b/src/webapp/dashboards/admin/resources_routes.py
@@ -15,7 +15,9 @@ from webapp.utils.htmx import (
     htmx_success_message,
 )
 from webapp.extensions import db
-from webapp.utils.rbac import require_permission, Permission
+from webapp.utils.rbac import (
+    require_permission, require_permission_any_facility, Permission,
+)
 from sam.manage import management_transaction
 from sam.schemas.forms.resources import (
     EditResourceForm, CreateResourceForm,
@@ -49,7 +51,7 @@ def _all_resource_types():
 
 @bp.route('/htmx/resources')
 @login_required
-@require_permission(Permission.VIEW_RESOURCES)
+@require_permission_any_facility(Permission.VIEW_RESOURCES)
 def htmx_resources_card():
     """
     Return the Resources card body fragment with four tabs:

--- a/src/webapp/dashboards/allocations/blueprint.py
+++ b/src/webapp/dashboards/allocations/blueprint.py
@@ -27,7 +27,11 @@ from sam.queries.charges import (
 from sam.queries.usage_cache import cached_allocation_usage, purge_usage_cache, usage_cache_info
 from sam.queries.lookups import find_project_by_code
 from sam.schemas.forms import CreateChargeAdjustmentForm
-from webapp.utils.rbac import require_permission, Permission
+from flask import abort
+from webapp.utils.rbac import (
+    apply_facility_scope, filter_rows_by_facility, require_permission,
+    require_permission_any_facility, user_facility_scope, Permission,
+)
 from webapp.api.access_control import require_project_access
 from sam.resources.resources import Resource
 from ..charts import (
@@ -238,7 +242,7 @@ def get_resource_types(session) -> Dict[str, str]:
 
 @bp.route('/')
 @login_required
-@require_permission(Permission.VIEW_PROJECTS)
+@require_permission_any_facility(Permission.VIEW_PROJECTS)
 @cache.cached(make_cache_key=user_aware_cache_key)
 def index():
     """
@@ -264,6 +268,39 @@ def index():
 
     # Allow cache bypass for debugging / stale data
     force_refresh = request.args.get('force_refresh', 'false').lower() == 'true'
+
+    # Facility scope resolution.
+    # ``allowed_facility_names`` is the user's universe — every facility
+    # they may *ever* see on this dashboard. For unscoped users that's
+    # every active facility; for scoped users it's their grant.
+    # ``selected_facilities`` is the currently-displayed subset, built
+    # from ``?facilities=...`` clamped against allowed — so a forged
+    # out-of-scope value falls back to the full allowed set rather than
+    # widening or erroring.
+    from sam.resources.facilities import Facility as FacilityModel
+    allowed = user_facility_scope(current_user, Permission.VIEW_PROJECTS)
+    if allowed is None:
+        allowed_facility_names = [
+            f.facility_name for f in
+            db.session.query(FacilityModel)
+            .filter(FacilityModel.is_active)
+            .order_by(FacilityModel.facility_name)
+            .all()
+        ]
+    else:
+        allowed_facility_names = sorted(allowed)
+    requested_facilities = request.args.getlist('facilities')
+    selected_facilities = apply_facility_scope(
+        requested_facilities, Permission.VIEW_PROJECTS,
+        default=allowed_facility_names,
+    )
+    # Normalize: ``apply_facility_scope`` returns ``None`` for the
+    # unscoped-with-no-request path; for row filtering we need the
+    # effective allowed set either way.
+    effective_facilities = (
+        allowed_facility_names if selected_facilities is None
+        else list(selected_facilities)
+    )
 
     # Get all active resources for the selector
     all_resources = [
@@ -292,15 +329,35 @@ def index():
         root_only=True,          # Exclude inheriting child allocations — root amount == total
     )
 
+    # Drop rows for facilities outside the user's effective selection.
+    # Every downstream aggregator keys off row['facility'], so one
+    # filter at the source cascades through grouped_data, overviews,
+    # pace charts, and allocation-type charts.
+    summary_data = filter_rows_by_facility(summary_data, effective_facilities)
+
     # Group results hierarchically for tab structure
     grouped_data = group_by_resource_facility(summary_data)
 
     # Get resource type mapping for conditional display
     resource_types = get_resource_types(db.session)
 
-    # Batch-fetch all facility overviews in a single query
-    # Also returns per-type annualized rates (same query, grouped one level deeper)
-    all_overviews, type_annualized_rates = get_all_facility_overviews(db.session, list(grouped_data.keys()), active_at)
+    # Batch-fetch all facility overviews in a single query.
+    # Also returns per-type annualized rates (same query, grouped one level deeper).
+    # The helper issues an un-facility-filtered fetch internally, so we
+    # post-filter both returns to respect ``effective_facilities``.
+    all_overviews, type_annualized_rates = get_all_facility_overviews(
+        db.session, list(grouped_data.keys()), active_at,
+    )
+    if effective_facilities is not None:
+        _allowed_set = set(effective_facilities)
+        all_overviews = {
+            rn: [row for row in rows if row.get('facility') in _allowed_set]
+            for rn, rows in all_overviews.items()
+        }
+        type_annualized_rates = {
+            key: rate for key, rate in type_annualized_rates.items()
+            if key[1] in _allowed_set  # key is (resource, facility, allocation_type)
+        }
 
     # Generate facility pie chart SVGs (cached via lru_cache)
     resource_overviews = {}
@@ -336,6 +393,9 @@ def index():
         force_refresh=force_refresh,
         root_only=True,     # Exclude inheriting child allocations — root amount == total
     )
+    # Scope filter: pace charts, usage pies, allocation-type usage
+    # charts all iterate this list and key off row['facility'].
+    per_project_usage = filter_rows_by_facility(per_project_usage, effective_facilities)
 
     # Derive TOTAL grouping (resource+facility+type, no projcode) Python-side
     usage_type_data = _aggregate_usage_to_total(per_project_usage)
@@ -426,12 +486,14 @@ def index():
         resource_types=resource_types,
         audit_start_date=audit_start_date.strftime('%Y-%m-%d'),
         audit_end_date=audit_end_date.strftime('%Y-%m-%d'),
+        allowed_facility_names=allowed_facility_names,
+        selected_facilities=effective_facilities,
     )
 
 
 @bp.route('/projects')
 @login_required
-@require_permission(Permission.VIEW_PROJECTS)
+@require_permission_any_facility(Permission.VIEW_PROJECTS)
 @cache.cached(make_cache_key=user_aware_cache_key)
 def projects_fragment():
     """
@@ -455,6 +517,15 @@ def projects_fragment():
     # Validate required params
     if not resource or not facility or not allocation_type:
         return '<p class="text-danger mb-0">Missing required parameters</p>'
+
+    # Enforce facility scope: a scoped user must not be able to drill
+    # into a facility outside their grant by hand-crafting the URL.
+    # Unlike the index route (where we clamp to the allowed set), here
+    # the user asked for *exactly one* facility — if it's out of scope
+    # that's a forged request, not a narrowing choice.
+    allowed = user_facility_scope(current_user, Permission.VIEW_PROJECTS)
+    if allowed is not None and facility not in allowed:
+        abort(403)
 
     # Parse date
     if active_at_str:
@@ -576,11 +647,18 @@ def _parse_audit_filters(request_args, sort_whitelist):
 
 @bp.route('/transactions_fragment')
 @login_required
-@require_permission(Permission.VIEW_PROJECTS)
+@require_permission_any_facility(Permission.VIEW_PROJECTS)
 def transactions_fragment():
     """HTMX fragment: sortable, paginated table of recent allocation transactions."""
     filters, sort, page = _parse_audit_filters(
         request.args, ALLOCATION_TRANSACTION_SORT_COLUMNS,
+    )
+    # Intersect the user-chosen facility filter (shared with the index
+    # route) against their scope. ``None`` → unrestricted (unscoped
+    # user, no ``?facilities=`` param); a list is passed through to
+    # the query's ``facility_name`` kwarg for SQL-time filtering.
+    filters['facility_name'] = apply_facility_scope(
+        request.args.getlist('facilities'), Permission.VIEW_PROJECTS,
     )
     offset = (page['n'] - 1) * page['per_page']
 
@@ -605,11 +683,14 @@ def transactions_fragment():
 
 @bp.route('/adjustments_fragment')
 @login_required
-@require_permission(Permission.VIEW_PROJECTS)
+@require_permission_any_facility(Permission.VIEW_PROJECTS)
 def adjustments_fragment():
     """HTMX fragment: sortable, paginated table of recent charge adjustments."""
     filters, sort, page = _parse_audit_filters(
         request.args, CHARGE_ADJUSTMENT_SORT_COLUMNS,
+    )
+    filters['facility_name'] = apply_facility_scope(
+        request.args.getlist('facilities'), Permission.VIEW_PROJECTS,
     )
     offset = (page['n'] - 1) * page['per_page']
 
@@ -634,7 +715,7 @@ def adjustments_fragment():
 
 @bp.route('/transaction_details/<int:transaction_id>')
 @login_required
-@require_permission(Permission.VIEW_PROJECTS)
+@require_permission_any_facility(Permission.VIEW_PROJECTS)
 def transaction_details(transaction_id: int):
     """HTMX fragment: full detail for a single allocation transaction.
 
@@ -650,6 +731,11 @@ def transaction_details(transaction_id: int):
     )
     if not rows:
         return '<p class="text-danger mb-0">Transaction not found.</p>'
+    # Facility-scope the lookup: deny inspecting a transaction whose
+    # project lives outside the user's allowed set.
+    allowed = user_facility_scope(current_user, Permission.VIEW_PROJECTS)
+    if allowed is not None and rows[0].get('facility') not in allowed:
+        abort(403)
     return render_template(
         'dashboards/allocations/partials/transaction_details_modal.html',
         r=rows[0],
@@ -658,7 +744,7 @@ def transaction_details(transaction_id: int):
 
 @bp.route('/adjustment_details/<int:adjustment_id>')
 @login_required
-@require_permission(Permission.VIEW_PROJECTS)
+@require_permission_any_facility(Permission.VIEW_PROJECTS)
 def adjustment_details(adjustment_id: int):
     """HTMX fragment: full detail for a single charge adjustment."""
     rows = get_recent_charge_adjustments(
@@ -668,6 +754,9 @@ def adjustment_details(adjustment_id: int):
     )
     if not rows:
         return '<p class="text-danger mb-0">Adjustment not found.</p>'
+    allowed = user_facility_scope(current_user, Permission.VIEW_PROJECTS)
+    if allowed is not None and rows[0].get('facility') not in allowed:
+        abort(403)
     return render_template(
         'dashboards/allocations/partials/adjustment_details_modal.html',
         r=rows[0],

--- a/src/webapp/extensions.py
+++ b/src/webapp/extensions.py
@@ -13,7 +13,7 @@ cache = Cache()
 
 
 def user_aware_cache_key() -> str:
-    """Cache key keyed on (current user id, path, query string).
+    """Cache key keyed on (current user id, path, query string, facility scope).
 
     Use as ``@cache.cached(make_cache_key=user_aware_cache_key)`` on any
     response whose rendered output depends on who is logged in — most
@@ -23,9 +23,17 @@ def user_aware_cache_key() -> str:
     Without this, caching by URL alone breaks impersonation: the first
     user to populate the cache "wins" and every subsequent visitor
     (including impersonators) gets that user's rendered view back.
+
+    The scope tag partitions cache entries by the user's
+    ``VIEW_PROJECTS`` facility scope so two scoped users with disjoint
+    facility grants don't collide (``user_id`` already disambiguates
+    today, but the scope tag future-proofs against routes where two
+    users might legitimately share a user-id slot — e.g. team-role
+    impersonation — and makes the dependency explicit).
     """
     from flask import request
     from flask_login import current_user
+    from webapp.utils.rbac import user_facility_scope, Permission
 
     user_part = (
         current_user.user_id
@@ -33,4 +41,14 @@ def user_aware_cache_key() -> str:
         else 'anon'
     )
     qs = request.query_string.decode('utf-8', errors='replace')
-    return f"u:{user_part}|{request.path}|{qs}"
+    scope = user_facility_scope(current_user, Permission.VIEW_PROJECTS)
+    if scope is None:
+        scope_part = 'all'
+    elif not scope:
+        scope_part = 'none'
+    else:
+        # ``user_facility_scope`` returns a ``set`` — iteration order is
+        # not stable across processes. ``sorted`` gives a deterministic
+        # key so two users with the same scope get the same slot.
+        scope_part = ','.join(sorted(scope))
+    return f"u:{user_part}|{request.path}|{qs}|s:{scope_part}"

--- a/src/webapp/run.py
+++ b/src/webapp/run.py
@@ -260,8 +260,8 @@ def create_app(*, config_overrides: dict | None = None):
             # redirect target is always something the user can actually
             # access — including users granted admin via
             # USER_PERMISSION_OVERRIDES rather than a group bundle.
-            from webapp.utils.rbac import has_permission, Permission
-            if has_permission(current_user, Permission.ACCESS_ADMIN_DASHBOARD):
+            from webapp.utils.rbac import has_permission_any_facility, Permission
+            if has_permission_any_facility(current_user, Permission.ACCESS_ADMIN_DASHBOARD):
                 return redirect(url_for('admin_dashboard.index'))
             else:
                 return redirect(url_for('user_dashboard.index'))

--- a/src/webapp/templates/dashboards/admin/dashboard.html
+++ b/src/webapp/templates/dashboards/admin/dashboard.html
@@ -64,7 +64,7 @@
                 <div class="card mb-3">
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <h5 class="mb-0"><i class="fas fa-search"></i> Search Projects</h5>
-                        {% if has_permission(Permission.CREATE_PROJECTS) %}
+                        {% if has_permission_any_facility(Permission.CREATE_PROJECTS) %}
                         <button type="button" class="btn btn-sm btn-success"
                                 data-bs-toggle="modal"
                                 data-bs-target="#createProjectModal"
@@ -130,13 +130,12 @@
                                     <label for="facilities-filter" class="form-label small mb-1"><strong>Facilities</strong></label>
                                     <select class="form-control form-control-sm" id="facilities-filter"
                                             name="facilities" multiple size="4" style="width: 200px;">
-                                        <option value="ASD">ASD</option>
-                                        <option value="CSL">CSL</option>
-                                        <option value="CISL">CISL</option>
-                                        <option value="NCAR">NCAR</option>
-                                        <option value="UNIV" selected>UNIV</option>
-                                        <option value="WNA" selected>WNA</option>
-                                        <option value="XSEDE">XSEDE</option>
+                                        {% for facility_name in allowed_facility_names %}
+                                        <option value="{{ facility_name }}"
+                                            {% if facility_name in default_selected_facilities %}selected{% endif %}>
+                                            {{ facility_name }}
+                                        </option>
+                                        {% endfor %}
                                     </select>
                                     <small class="form-text text-muted">Hold Ctrl/Cmd to select multiple</small>
                                 </div>

--- a/src/webapp/templates/dashboards/admin/edit_project.html
+++ b/src/webapp/templates/dashboards/admin/edit_project.html
@@ -99,7 +99,7 @@
 
   <!-- ── Tab 2: Allocations ─────────────────────────────────────────── -->
   <div class="tab-pane fade" id="tab-allocations" role="tabpanel">
-    {% if can_edit_governance %}
+    {% if can_edit_allocations %}
     <div class="d-flex justify-content-end gap-2 mb-3">
       <button class="btn btn-sm btn-warning"
               hx-get="{{ url_for('admin_dashboard.htmx_extend_allocations_form', projcode=project.projcode) }}"

--- a/src/webapp/templates/dashboards/admin/fragments/edit_allocation_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/edit_allocation_form_htmx.html
@@ -27,7 +27,7 @@
     import number_field, date_field, text_field with context %}
 
 {% call htmx_form(
-    url_for('admin_dashboard.htmx_edit_allocation', alloc_id=allocation.allocation_id),
+    url_for('admin_dashboard.htmx_edit_allocation', allocation_id=allocation.allocation_id),
     '#editAllocationFormContainer',
     'Save Changes',
     submit_icon='save',
@@ -94,7 +94,7 @@
         </div>
         <div class="mt-2">
           <button type="button" class="btn btn-sm btn-danger"
-                  hx-post="{{ url_for('admin_dashboard.htmx_detach_allocation', alloc_id=allocation.allocation_id) }}"
+                  hx-post="{{ url_for('admin_dashboard.htmx_detach_allocation', allocation_id=allocation.allocation_id) }}"
                   hx-target="#editAllocationFormContainer"
                   hx-confirm="Permanently detach allocation #{{ allocation.allocation_id }}? This breaks inheritance and cannot be undone from this view."
                   data-confirm-title="Detach allocation"
@@ -153,7 +153,7 @@
     {{ 'do' if unlinked_descendants_count != 1 else 'does' }} not yet have
     an allocation for this resource.
     <button type="button" class="btn btn-sm btn-outline-secondary ms-2"
-            hx-post="{{ url_for('admin_dashboard.htmx_propagate_to_remaining', alloc_id=allocation.allocation_id) }}"
+            hx-post="{{ url_for('admin_dashboard.htmx_propagate_to_remaining', allocation_id=allocation.allocation_id) }}"
             hx-target="#editAllocationFormContainer"
             hx-confirm="Create linked child allocations for {{ unlinked_descendants_count }} remaining sub-project(s)?"
             data-confirm-title="Propagate allocation"
@@ -184,7 +184,7 @@
     making it functionally identical to an originally-linked child.
     <div class="mt-2">
       <button type="button" class="btn btn-sm btn-primary"
-              hx-post="{{ url_for('admin_dashboard.htmx_link_allocation_to_parent', alloc_id=allocation.allocation_id) }}"
+              hx-post="{{ url_for('admin_dashboard.htmx_link_allocation_to_parent', allocation_id=allocation.allocation_id) }}"
               hx-vals='{"parent_allocation_id": {{ relink_candidate.allocation_id }}}'
               hx-target="#editAllocationFormContainer"
               hx-confirm="Re-link allocation #{{ allocation.allocation_id }} to parent #{{ relink_candidate.allocation_id }}? Amount will change from {{ allocation.amount | fmt_number }} to {{ relink_candidate.amount | fmt_number }} and dates will match the parent."

--- a/src/webapp/templates/dashboards/admin/fragments/expirations_cards.html
+++ b/src/webapp/templates/dashboards/admin/fragments/expirations_cards.html
@@ -1,7 +1,7 @@
 {% from 'dashboards/user/partials/project_card.html' import render_project_card with context %}
 
 {% if projects_data %}
-    {% if view_type == 'expired' and has_permission(Permission.EDIT_PROJECTS) %}
+    {% if view_type == 'expired' and has_permission_any_facility(Permission.EDIT_PROJECTS) %}
     <div class="mb-3 text-end">
         <button type="button" class="btn btn-sm btn-outline-danger"
                 hx-post="{{ url_for('admin_dashboard.deactivate_expired') }}"

--- a/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
@@ -144,10 +144,10 @@
 
           {# Col 5: edit pencil (or shared badge for inherited allocations) #}
           <td style="vertical-align:middle;">
-            {% if can_edit_governance and root_alloc and root_alloc.allocation_id and not root_alloc.is_inheriting %}
+            {% if can_edit_allocations and root_alloc and root_alloc.allocation_id and not root_alloc.is_inheriting %}
             <button class="btn btn-xs btn-outline-warning py-0 px-1"
                     style="font-size:0.7rem;"
-                    hx-get="{{ url_for('admin_dashboard.htmx_edit_allocation_form', alloc_id=root_alloc.allocation_id) }}"
+                    hx-get="{{ url_for('admin_dashboard.htmx_edit_allocation_form', allocation_id=root_alloc.allocation_id) }}"
                     hx-target="#editAllocationFormContainer"
                     hx-trigger="click"
                     data-bs-toggle="modal"

--- a/src/webapp/templates/dashboards/admin/fragments/project_modals.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_modals.html
@@ -4,7 +4,7 @@
   Create modal: form loaded lazily via HTMX when button is clicked.
 #}
 
-{% if has_permission(Permission.CREATE_PROJECTS) %}
+{% if has_permission_any_facility(Permission.CREATE_PROJECTS) %}
 {{ modal_scaffold('createProjectModal', 'New Project',
                   icon='folder-plus', container_id='createProjectFormContainer', size='xl') }}
 {% endif %}

--- a/src/webapp/templates/dashboards/allocations/dashboard.html
+++ b/src/webapp/templates/dashboards/allocations/dashboard.html
@@ -139,6 +139,12 @@
     {%- else -%}{{ selected_resources|join(', ') }}
     {%- endif %}
 {%- endset %}
+{% set _facility_summary -%}
+    {%- if selected_facilities|length == allowed_facility_names|length -%}All facilities
+    {%- elif selected_facilities|length > 3 -%}{{ selected_facilities|length }} facilities
+    {%- else -%}{{ selected_facilities|join(', ') }}
+    {%- endif %}
+{%- endset %}
 <div class="card mb-3">
     <div class="card-header py-2 collapse-toggle collapsed"
          data-bs-toggle="collapse" data-bs-target="#allocationsFilterPanel"
@@ -147,6 +153,8 @@
         <span class="text-muted small">
             <i class="fas fa-filter me-1"></i>
             <strong class="text-dark me-2">Filters</strong>
+            Facilities: <strong class="text-dark">{{ _facility_summary }}</strong>
+            <span class="mx-2">·</span>
             Resources: <strong class="text-dark">{{ _resource_summary }}</strong>
             <span class="mx-2">·</span>
             Active at: <strong class="text-dark">{{ active_at }}</strong>
@@ -154,7 +162,22 @@
     </div>
     <div class="collapse" id="allocationsFilterPanel">
         <div class="card-body py-3">
-            <form method="GET" class="d-flex flex-wrap align-items-start gap-4 mb-0" id="dateFilterForm">
+            <form method="GET" class="d-flex flex-wrap align-items-start gap-4 mb-0"
+                  id="allocations-facility-filter-form">
+                <div>
+                    <label for="facilities" class="form-label small mb-1"><strong>Facilities</strong></label>
+                    <select class="form-control form-control-sm" id="facilities" name="facilities"
+                            multiple size="{{ [allowed_facility_names|length, 4]|min if allowed_facility_names|length else 4 }}"
+                            style="width: 200px;">
+                        {% for facility_name in allowed_facility_names %}
+                        <option value="{{ facility_name }}"
+                            {% if facility_name in selected_facilities %}selected{% endif %}>
+                            {{ facility_name }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                    <small class="form-text text-muted">Hold Ctrl/Cmd to select multiple</small>
+                </div>
                 <div>
                     <label for="resources" class="form-label small mb-1"><strong>Resources</strong></label>
                     <select class="form-control form-control-sm" id="resources" name="resources"
@@ -422,7 +445,7 @@
     <div id="alloc-transactions-fragment"
          hx-get="{{ url_for('allocations_dashboard.transactions_fragment') }}"
          hx-trigger="shown.bs.tab from:#alloc-transactions-tab once"
-         hx-include="#tx-filters"
+         hx-include="#tx-filters, #allocations-facility-filter-form"
          hx-swap="innerHTML">
         <div class="text-center text-muted py-4">
             <div class="spinner-border text-primary" role="status">
@@ -456,7 +479,7 @@
     <div id="alloc-adjustments-fragment"
          hx-get="{{ url_for('allocations_dashboard.adjustments_fragment') }}"
          hx-trigger="shown.bs.tab from:#alloc-adjustments-tab once"
-         hx-include="#adj-filters"
+         hx-include="#adj-filters, #allocations-facility-filter-form"
          hx-swap="innerHTML">
         <div class="text-center text-muted py-4">
             <div class="spinner-border text-primary" role="status">

--- a/src/webapp/templates/dashboards/allocations/partials/adjustment_details_modal.html
+++ b/src/webapp/templates/dashboards/allocations/partials/adjustment_details_modal.html
@@ -43,10 +43,10 @@
     </div>
     {% endif %}
 
-    {% if r.facility_name %}
+    {% if r.facility %}
     <div class="stat-item">
         <span class="stat-label">Facility:</span>
-        <span class="stat-value">{{ r.facility_name }}</span>
+        <span class="stat-value">{{ r.facility }}</span>
     </div>
     {% endif %}
 

--- a/src/webapp/templates/dashboards/allocations/partials/adjustments_table.html
+++ b/src/webapp/templates/dashboards/allocations/partials/adjustments_table.html
@@ -14,7 +14,7 @@
        href="#"
        hx-get="{{ fragment_url }}?sort_by={{ col }}&sort_dir={{ next_dir }}&page=1"
        hx-target="#{{ target_id }}"
-       hx-include="#{{ form_id }}"
+       hx-include="#{{ form_id }}, #allocations-facility-filter-form"
        hx-swap="innerHTML">
         {{ label }}
         {% if is_active %}
@@ -105,5 +105,6 @@
         </tbody>
     </table>
 
-    {{ pagination(page, total, fragment_url, target_id, form_id, sort) }}
+    {{ pagination(page, total, fragment_url, target_id, form_id, sort,
+                   extra_include='#allocations-facility-filter-form') }}
 </div>

--- a/src/webapp/templates/dashboards/allocations/partials/transaction_details_modal.html
+++ b/src/webapp/templates/dashboards/allocations/partials/transaction_details_modal.html
@@ -51,10 +51,10 @@
     </div>
     {% endif %}
 
-    {% if r.facility_name %}
+    {% if r.facility %}
     <div class="stat-item">
         <span class="stat-label">Facility:</span>
-        <span class="stat-value">{{ r.facility_name }}</span>
+        <span class="stat-value">{{ r.facility }}</span>
     </div>
     {% endif %}
 

--- a/src/webapp/templates/dashboards/allocations/partials/transactions_table.html
+++ b/src/webapp/templates/dashboards/allocations/partials/transactions_table.html
@@ -14,7 +14,7 @@
        href="#"
        hx-get="{{ fragment_url }}?sort_by={{ col }}&sort_dir={{ next_dir }}&page=1"
        hx-target="#{{ target_id }}"
-       hx-include="#{{ form_id }}"
+       hx-include="#{{ form_id }}, #allocations-facility-filter-form"
        hx-swap="innerHTML">
         {{ label }}
         {% if is_active %}
@@ -40,7 +40,7 @@
                 <th>{{ sort_link('transaction_type', 'Type') }}</th>
                 <th>{{ sort_link('projcode', 'Project') }}</th>
                 <th style="width:140px;">{{ sort_link('resource_name', 'Resource') }}</th>
-                <th>{{ sort_link('facility_name', 'Facility') }}</th>
+                <th>{{ sort_link('facility', 'Facility') }}</th>
                 <th style="width:150px;">{{ sort_link('allocation_type', 'Alloc type') }}</th>
                 <th class="text-end">{{ sort_link('transaction_amount', 'Amount', align='text-end') }}</th>
                 <th>{{ sort_link('username', 'Processed by') }}</th>
@@ -81,7 +81,7 @@
                     title="{{ r.resource_name or '' }}">
                     {{ r.resource_name or '—' }}
                 </td>
-                <td>{{ r.facility_name or '—' }}</td>
+                <td>{{ r.facility or '—' }}</td>
                 <td style="max-width:150px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"
                     title="{{ r.allocation_type or '' }}">
                     {{ r.allocation_type or '—' }}
@@ -117,5 +117,6 @@
         </tbody>
     </table>
 
-    {{ pagination(page, total, fragment_url, target_id, form_id, sort) }}
+    {{ pagination(page, total, fragment_url, target_id, form_id, sort,
+                   extra_include='#allocations-facility-filter-form') }}
 </div>

--- a/src/webapp/templates/dashboards/base.html
+++ b/src/webapp/templates/dashboards/base.html
@@ -38,7 +38,7 @@
                             <i class="fas fa-server"></i> System Status
                         </a>
                     </li>
-                    {% if has_permission(Permission.VIEW_PROJECTS) %}
+                    {% if has_permission_any_facility(Permission.VIEW_PROJECTS) %}
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('allocations_dashboard.index') }}">
                             <i class="fas fa-chart-pie"></i> Allocations

--- a/src/webapp/templates/dashboards/base.html
+++ b/src/webapp/templates/dashboards/base.html
@@ -45,7 +45,7 @@
                         </a>
                     </li>
                     {% endif %}
-                    {% if has_permission(Permission.ACCESS_ADMIN_DASHBOARD) %}
+                    {% if has_permission_any_facility(Permission.ACCESS_ADMIN_DASHBOARD) %}
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('admin_dashboard.index') }}">
                             <i class="fas fa-user-shield"></i> Admin

--- a/src/webapp/templates/dashboards/fragments/pagination.html
+++ b/src/webapp/templates/dashboards/fragments/pagination.html
@@ -14,8 +14,12 @@
     max_links  - (optional) max numbered-page links to render. Default 9.
                  Renders a windowed nav around the current page when the
                  page count exceeds this.
+    extra_include - (optional) extra selector appended to hx-include
+                 (e.g. a sibling filter form that's part of the same
+                 effective query but outside the main form_id scope).
 #}
-{% macro pagination(page, total, fragment_url, target_id, form_id, sort, max_links=9) %}
+{% macro pagination(page, total, fragment_url, target_id, form_id, sort, max_links=9, extra_include='') %}
+{% set _include = '#' ~ form_id ~ (', ' ~ extra_include if extra_include else '') %}
 {% set per_page = page['per_page'] %}
 {% set cur = page['n'] %}
 {% set last = ((total - 1) // per_page + 1) if total > 0 else 1 %}
@@ -47,7 +51,7 @@
             <a class="page-link" href="#"
                hx-get="{{ fragment_url }}?page={{ cur - 1 }}{{ _sort_params }}"
                hx-target="#{{ target_id }}"
-               hx-include="#{{ form_id }}"
+               hx-include="{{ _include }}"
                hx-swap="innerHTML"
                aria-label="Previous"><span aria-hidden="true">&laquo;</span></a>
             {% else %}
@@ -60,7 +64,7 @@
             <a class="page-link" href="#"
                hx-get="{{ fragment_url }}?page=1{{ _sort_params }}"
                hx-target="#{{ target_id }}"
-               hx-include="#{{ form_id }}"
+               hx-include="{{ _include }}"
                hx-swap="innerHTML">1</a>
         </li>
         {% if start_page > 2 %}
@@ -76,7 +80,7 @@
             <a class="page-link" href="#"
                hx-get="{{ fragment_url }}?page={{ p }}{{ _sort_params }}"
                hx-target="#{{ target_id }}"
-               hx-include="#{{ form_id }}"
+               hx-include="{{ _include }}"
                hx-swap="innerHTML">{{ p }}</a>
             {% endif %}
         </li>
@@ -90,7 +94,7 @@
             <a class="page-link" href="#"
                hx-get="{{ fragment_url }}?page={{ last }}{{ _sort_params }}"
                hx-target="#{{ target_id }}"
-               hx-include="#{{ form_id }}"
+               hx-include="{{ _include }}"
                hx-swap="innerHTML">{{ last }}</a>
         </li>
         {% endif %}
@@ -101,7 +105,7 @@
             <a class="page-link" href="#"
                hx-get="{{ fragment_url }}?page={{ cur + 1 }}{{ _sort_params }}"
                hx-target="#{{ target_id }}"
-               hx-include="#{{ form_id }}"
+               hx-include="{{ _include }}"
                hx-swap="innerHTML"
                aria-label="Next"><span aria-hidden="true">&raquo;</span></a>
             {% else %}

--- a/src/webapp/templates/dashboards/shared/project_tree.html
+++ b/src/webapp/templates/dashboards/shared/project_tree.html
@@ -100,7 +100,7 @@
         {%- if can_edit_allocations and res.allocation_id -%}
         <button class="btn btn-xs btn-outline-warning py-0 px-1 flex-shrink-0"
                 style="font-size:0.7rem;"
-                hx-get="{{ url_for('admin_dashboard.htmx_edit_allocation_form', alloc_id=res.allocation_id) }}"
+                hx-get="{{ url_for('admin_dashboard.htmx_edit_allocation_form', allocation_id=res.allocation_id) }}"
                 hx-target="#editAllocationFormContainer"
                 hx-trigger="click"
                 data-bs-toggle="modal"
@@ -248,7 +248,7 @@
     {%- if can_edit_allocations and res and res.allocation_id -%}
     <button class="btn btn-xs btn-outline-warning py-0 px-1 ms-1"
             style="font-size:0.7rem;"
-            hx-get="{{ url_for('admin_dashboard.htmx_edit_allocation_form', alloc_id=res.allocation_id) }}"
+            hx-get="{{ url_for('admin_dashboard.htmx_edit_allocation_form', allocation_id=res.allocation_id) }}"
             hx-target="#editAllocationFormContainer"
             hx-trigger="click"
             data-bs-toggle="modal"

--- a/src/webapp/templates/dashboards/user/partials/user_card.html
+++ b/src/webapp/templates/dashboards/user/partials/user_card.html
@@ -234,7 +234,7 @@
     <div class="card-body border-top pt-3">
         <div class="d-flex justify-content-between align-items-center mb-2">
             <strong><i class="fas fa-clock"></i> Wallclock Exemptions</strong>
-            {% if is_admin %}
+            {% if is_admin and has_permission(Permission.EDIT_USERS) %}
             <button class="btn btn-sm btn-outline-success"
                     data-bs-toggle="modal" data-bs-target="#addExemptionModal"
                     hx-get="{{ url_for('admin_dashboard.htmx_add_exemption_form', username=sam_user.username) }}"
@@ -255,7 +255,7 @@
                         <th>End</th>
                         <th>Limit (hrs)</th>
                         <th>Comment</th>
-                        {% if is_admin %}<th></th>{% endif %}
+                        {% if is_admin and has_permission(Permission.EDIT_USERS) %}<th></th>{% endif %}
                     </tr>
                 </thead>
                 <tbody>
@@ -272,7 +272,7 @@
                         </td>
                         <td>{{ ex.time_limit_hours }}</td>
                         <td>{{ ex.comment or '' }}</td>
-                        {% if is_admin %}
+                        {% if is_admin and has_permission(Permission.EDIT_USERS) %}
                         <td>
                             <button class="btn btn-sm btn-outline-warning py-0"
                                     data-bs-toggle="modal" data-bs-target="#editExemptionModal"

--- a/src/webapp/utils/project_permissions.py
+++ b/src/webapp/utils/project_permissions.py
@@ -14,7 +14,7 @@ walking ancestors)" — lives in ``_is_project_steward``. All public
 ``can_*`` helpers delegate to it so the rule set stays consistent.
 """
 
-from webapp.utils.rbac import has_permission, Permission
+from webapp.utils.rbac import has_permission, has_permission_for_facility, Permission
 
 
 def _is_project_steward(
@@ -28,8 +28,12 @@ def _is_project_steward(
     Authorization primitive used by every project-scoped ``can_*`` check.
 
     Returns True if **any** of:
-    - The user has ``system_permission`` (e.g. EDIT_PROJECT_MEMBERS,
-      EDIT_ALLOCATIONS) — system-wide override.
+    - The user has ``system_permission`` for the target project's
+      facility — either unconditionally (system-wide grant) or via a
+      ``USER_FACILITY_PERMISSIONS`` entry covering
+      ``project.facility_name``. Orphan projects (no
+      ``allocation_type`` chain) can only be reached by unscoped
+      system holders.
     - The user is the project lead.
     - The user is the project admin.
     - When ``include_ancestors`` is True: the user is lead or admin of
@@ -48,7 +52,7 @@ def _is_project_steward(
             without consulting project-level roles.
         include_ancestors: If True, lead/admin of any ancestor counts.
     """
-    if has_permission(user, system_permission):
+    if has_permission_for_facility(user, system_permission, project.facility_name):
         return True
 
     user_id = getattr(user, 'user_id', None)

--- a/src/webapp/utils/rbac.py
+++ b/src/webapp/utils/rbac.py
@@ -222,7 +222,20 @@ USER_FACILITY_PERMISSIONS: Dict[str, Dict[str, Set[Permission]]] = {
             Permission.VIEW_ALLOCATIONS,
             Permission.EDIT_ALLOCATIONS,
             Permission.CREATE_ALLOCATIONS,
+            # Reference-data + directory viewers: the admin dashboard's
+            # Resources, Organizations, Facilities, and Users & Groups
+            # tabs all pull read-only card fragments gated on these
+            # VIEW_* permissions. Granting them here lets a scoped
+            # manager see the cards globally (directory lookup is
+            # inherently cross-facility — project membership spans
+            # users outside WNA). Write buttons remain hidden — they
+            # gate on CREATE_/EDIT_/DELETE_ which this tier does not
+            # confer.
+            Permission.VIEW_RESOURCES,
             Permission.VIEW_ORG_METADATA,
+            Permission.VIEW_FACILITIES,
+            Permission.VIEW_USERS,
+            Permission.VIEW_GROUPS,
         },
     },
 }

--- a/src/webapp/utils/rbac.py
+++ b/src/webapp/utils/rbac.py
@@ -222,6 +222,7 @@ USER_FACILITY_PERMISSIONS: Dict[str, Dict[str, Set[Permission]]] = {
             Permission.VIEW_ALLOCATIONS,
             Permission.EDIT_ALLOCATIONS,
             Permission.CREATE_ALLOCATIONS,
+            Permission.VIEW_ORG_METADATA,
         },
     },
 }

--- a/src/webapp/utils/rbac.py
+++ b/src/webapp/utils/rbac.py
@@ -359,6 +359,53 @@ def user_facility_scope(user, permission: Permission):
     return {f for f, perms in scoped.items() if permission in perms}
 
 
+def apply_facility_scope(requested, permission: Permission, default=None):
+    """
+    Combine a user-submitted ``facilities`` list with the caller's
+    facility-scoped RBAC grants for ``permission``, returning the
+    effective facility-name list to pass to downstream queries.
+
+    Semantics:
+    - **Unscoped users** (system-permission holders): ``requested``
+      wins; if empty, ``default`` applies; ``None`` means
+      "no restriction".
+    - **Scoped users**: returns the intersection of ``requested`` with
+      their allowed set. Falls back to the full allowed set when the
+      request is empty or the intersection is empty (clamp, don't
+      error — the user just asked for nothing they can see).
+    - **Users with an empty scope** (no entry at all): returns ``[]``.
+      Caller should treat as "no rows".
+
+    Used as the single source of truth for "what facility names do I
+    actually filter on, given this user + this request?" at both the
+    admin expirations/search routes and the allocations dashboard.
+    """
+    allowed = user_facility_scope(current_user, permission)
+    if allowed is None:
+        return list(requested) if requested else (list(default) if default else None)
+    if not allowed:
+        return []
+    if not requested:
+        return sorted(allowed)
+    intersected = [f for f in requested if f in allowed]
+    return intersected or sorted(allowed)
+
+
+def filter_rows_by_facility(rows, allowed):
+    """Drop rows whose ``'facility'`` key isn't in ``allowed``.
+
+    Pass ``None`` for ``allowed`` to skip filtering (unscoped / global
+    view). Used by the allocations dashboard's post-fetch scope filter
+    — every row returned by the summary / usage / transactions
+    queries carries a ``'facility'`` field."""
+    if allowed is None:
+        return rows
+    if not allowed:
+        return []
+    allowed_set = allowed if isinstance(allowed, (set, frozenset)) else set(allowed)
+    return [r for r in rows if r.get('facility') in allowed_set]
+
+
 def has_any_permission(user, *permissions: Permission) -> bool:
     """
     Check if user has any of the specified permissions.

--- a/src/webapp/utils/rbac.py
+++ b/src/webapp/utils/rbac.py
@@ -186,6 +186,47 @@ USER_PERMISSION_OVERRIDES: Dict[str, Set[Permission]] = {
 }
 
 
+# Per-user, per-facility permission grants — the third RBAC tier.
+#
+# A user is granted ``permission`` here only when the target project's
+# facility is in the configured set. Permissions held here are ADDITIVE
+# to whatever ``USER_PERMISSION_OVERRIDES`` / ``GROUP_PERMISSIONS``
+# confer (which apply unconditionally).
+#
+# Example — a WNA-scoped manager who may CRUD WNA projects/allocations
+# but has no authority anywhere else:
+#
+#     'sureshm': {
+#         'WNA': {
+#             Permission.CREATE_PROJECTS, Permission.EDIT_PROJECTS,
+#             Permission.CREATE_ALLOCATIONS, Permission.EDIT_ALLOCATIONS,
+#             ...
+#         },
+#     }
+#
+# Multi-facility entries are supported — the outer dict's value may
+# name any number of facilities, each mapping to its own permission set.
+#
+# Format: {username: {facility_name: {Permission, ...}}}
+USER_FACILITY_PERMISSIONS: Dict[str, Dict[str, Set[Permission]]] = {
+    # WNA-scoped admin — provisions and manages WNA projects and
+    # allocations. Holds no authority over NCAR/UNIV/CISL/CSL/XSEDE/ASD.
+    'sureshm': {
+        'WNA': {
+            Permission.ACCESS_ADMIN_DASHBOARD,
+            Permission.VIEW_PROJECTS,
+            Permission.EDIT_PROJECTS,
+            Permission.CREATE_PROJECTS,
+            Permission.VIEW_PROJECT_MEMBERS,
+            Permission.EDIT_PROJECT_MEMBERS,
+            Permission.VIEW_ALLOCATIONS,
+            Permission.EDIT_ALLOCATIONS,
+            Permission.CREATE_ALLOCATIONS,
+        },
+    },
+}
+
+
 def get_user_permissions(user) -> Set[Permission]:
     """
     Get all permissions for a user.
@@ -227,6 +268,94 @@ def has_permission(user, permission: Permission) -> bool:
         True if user has the permission, False otherwise
     """
     return permission in get_user_permissions(user)
+
+
+def has_permission_for_facility(user, permission: Permission,
+                                facility_name) -> bool:
+    """
+    Check if ``user`` holds ``permission`` for the given facility.
+
+    True iff either:
+    - The user has ``permission`` unconditionally (system grant via
+      groups or ``USER_PERMISSION_OVERRIDES``) — applies to any facility.
+    - ``USER_FACILITY_PERMISSIONS[user.username][facility_name]``
+      contains ``permission``.
+
+    Args:
+        user: AuthUser object (Flask-Login current_user). Unauthenticated
+            users always fail.
+        permission: Permission enum member to check.
+        facility_name: ``Facility.facility_name`` string, or ``None``
+            for orphan projects (no allocation_type chain). Orphans can
+            only be acted on by unscoped system-permission holders.
+
+    Returns:
+        True if the permission applies to this facility, else False.
+    """
+    # System grant — applies to every facility, including unknown ones.
+    if has_permission(user, permission):
+        return True
+    if facility_name is None:
+        # Orphan projects: only unscoped system-permission holders can act.
+        return False
+    if not getattr(user, 'is_authenticated', False):
+        return False
+    username = getattr(user, 'username', None)
+    if username is None:
+        return False
+    scoped = USER_FACILITY_PERMISSIONS.get(username, {})
+    return permission in scoped.get(facility_name, set())
+
+
+def has_permission_any_facility(user, permission: Permission) -> bool:
+    """True if ``user`` can exercise ``permission`` **somewhere** —
+    either unconditionally (system grant) or in at least one facility
+    via ``USER_FACILITY_PERMISSIONS``.
+
+    Use this for route-level gates that admit scoped users: they reach
+    the route, and the body intersects their scope against whatever
+    the request targeted (listing filter, create-target facility, …).
+
+    Contrast with ``has_permission``: that one answers "does the user
+    hold this unconditionally?" — the right question for routes that
+    must remain pure system-admin domain (impersonation, system
+    status, etc.)."""
+    if has_permission(user, permission):
+        return True
+    if not getattr(user, 'is_authenticated', False):
+        return False
+    username = getattr(user, 'username', None)
+    if username is None:
+        return False
+    scoped = USER_FACILITY_PERMISSIONS.get(username, {})
+    return any(permission in perms for perms in scoped.values())
+
+
+def user_facility_scope(user, permission: Permission):
+    """
+    Return the set of facility names where ``user`` may exercise
+    ``permission``, or ``None`` for "unscoped" (any facility, including
+    orphan projects).
+
+    Use at listing-filter call sites:
+      - ``None`` → skip the facility filter entirely (system-permission
+        holder; sees everything).
+      - ``set`` → constrain results to those facilities.
+      - empty ``set`` → user has no way to exercise this permission.
+
+    Args:
+        user: AuthUser object.
+        permission: Permission enum member.
+    """
+    if has_permission(user, permission):
+        return None
+    if not getattr(user, 'is_authenticated', False):
+        return set()
+    username = getattr(user, 'username', None)
+    if username is None:
+        return set()
+    scoped = USER_FACILITY_PERMISSIONS.get(username, {})
+    return {f for f, perms in scoped.items() if permission in perms}
 
 
 def has_any_permission(user, *permissions: Permission) -> bool:
@@ -328,6 +457,34 @@ def require_permission(permission: Permission):
     return decorator
 
 
+def require_permission_any_facility(permission: Permission):
+    """
+    Decorator that admits callers who hold ``permission`` either
+    unconditionally (system grant) **or** in at least one facility via
+    ``USER_FACILITY_PERMISSIONS``.
+
+    The route body is then responsible for intersecting the user's
+    facility scope against whatever the request targets. Use for admin
+    routes that a facility-scoped manager must be able to reach (e.g.
+    the admin dashboard, project search, expirations fragment,
+    project-create form) even though they don't hold the permission
+    globally.
+
+    For routes that must remain pure system-admin domain (impersonation,
+    global system administration), use ``require_permission`` instead.
+    """
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            if not current_user.is_authenticated:
+                abort(401)
+            if not has_permission_any_facility(current_user, permission):
+                abort(403)
+            return f(*args, **kwargs)
+        return decorated_function
+    return decorator
+
+
 def require_any_permission(*permissions: Permission):
     """
     Decorator to require any of the specified permissions.
@@ -410,6 +567,10 @@ def rbac_context_processor():
     return {
         'Permission': Permission,
         'has_permission': lambda p: has_permission(current_user, p) if current_user.is_authenticated else False,
+        'has_permission_any_facility': lambda p: (
+            has_permission_any_facility(current_user, p)
+            if current_user.is_authenticated else False
+        ),
         'has_role': lambda r: has_role(current_user, r) if current_user.is_authenticated else False,
         'user_permissions': get_user_permissions(current_user) if current_user.is_authenticated else set(),
         'can_act_on_project': _can_act_on_project,

--- a/tests/unit/test_allocations_performance.py
+++ b/tests/unit/test_allocations_performance.py
@@ -1024,3 +1024,250 @@ class TestShowUsageToggle:
         """Facilities with zero usage must not crash the chart renderer."""
         response = auth_client.get('/allocations/?show_usage=true&resources=Derecho')
         assert response.status_code == 200
+
+
+# ============================================================================
+# Facility-scoped RBAC on the allocations dashboard
+# ============================================================================
+
+class TestAllocationsDashboardFacilityScope:
+    """Route-level assertions for the facility-scope layer on
+    ``/allocations``. Runs against the snapshot DB via ``auth_client``;
+    scopes the benkirk test identity by emptying
+    ``USER_PERMISSION_OVERRIDES`` (drops his blanket admin grant) and
+    adding a ``USER_FACILITY_PERMISSIONS`` entry instead — the same
+    shape a real scoped user like ``sureshm`` would have."""
+
+    @staticmethod
+    def _scope_benkirk(monkeypatch, facilities):
+        """Re-cast the ``benkirk`` login as a facility-scoped user with
+        ``VIEW_PROJECTS`` on the given facilities."""
+        from webapp.utils import rbac
+        from webapp.utils.rbac import Permission
+
+        monkeypatch.setattr(rbac, 'USER_PERMISSION_OVERRIDES', {})
+        # Disable the 'admin-testing-only' bundle that the test conftest
+        # autoregisters — otherwise any POSIX-group membership on
+        # benkirk would leak full perms back in.
+        monkeypatch.setattr(rbac, 'GROUP_PERMISSIONS', {})
+        monkeypatch.setattr(
+            rbac, 'USER_FACILITY_PERMISSIONS',
+            {
+                'benkirk': {
+                    fn: {Permission.VIEW_PROJECTS}
+                    for fn in facilities
+                },
+            },
+        )
+
+    def test_index_renders_selector_for_scoped_user(self, auth_client, monkeypatch):
+        """Single-facility scoped user: selector is rendered and lists
+        only the granted facility, selected by default."""
+        self._scope_benkirk(monkeypatch, ['WNA'])
+        response = auth_client.get('/allocations/')
+        assert response.status_code == 200
+        html = response.data.decode()
+        # Selector form + one option (WNA), selected.
+        assert 'id="allocations-facility-filter-form"' in html
+        assert '<option value="WNA"' in html
+        assert 'selected' in html.split('<option value="WNA"', 1)[1].split('</option>', 1)[0]
+        # Other facilities must not appear as options.
+        assert '<option value="NCAR"' not in html
+        assert '<option value="UNIV"' not in html
+
+    def test_index_selector_lists_every_facility_for_unscoped_user(self, auth_client):
+        """Unscoped admin (benkirk default): selector shows the full
+        active-facility list, all selected by default."""
+        response = auth_client.get('/allocations/')
+        assert response.status_code == 200
+        html = response.data.decode()
+        assert 'id="allocations-facility-filter-form"' in html
+        # Snapshot has WNA and NCAR as active facilities.
+        assert '<option value="WNA"' in html
+        assert '<option value="NCAR"' in html
+
+    def test_index_clamps_out_of_scope_request_to_allowed_set(
+        self, auth_client, monkeypatch,
+    ):
+        """Forged ``?facilities=NCAR`` as a WNA-scoped user: the view
+        falls back to showing the allowed set (WNA) instead of 403ing
+        or rendering an empty page."""
+        self._scope_benkirk(monkeypatch, ['WNA'])
+        response = auth_client.get('/allocations/?facilities=NCAR')
+        assert response.status_code == 200
+        html = response.data.decode()
+        # WNA is still in the selected state.
+        assert '<option value="WNA"' in html
+        wna_frag = html.split('<option value="WNA"', 1)[1].split('</option>', 1)[0]
+        assert 'selected' in wna_frag
+
+    def test_projects_fragment_403s_out_of_scope_facility(
+        self, auth_client, monkeypatch,
+    ):
+        """The drill-down route rejects a forged out-of-scope facility
+        outright — single-facility param, no fallback."""
+        self._scope_benkirk(monkeypatch, ['WNA'])
+        response = auth_client.get(
+            '/allocations/projects?resource=Derecho&facility=NCAR'
+            '&allocation_type=Small'
+        )
+        assert response.status_code == 403
+
+    def test_projects_fragment_allows_in_scope_facility(
+        self, auth_client, monkeypatch,
+    ):
+        self._scope_benkirk(monkeypatch, ['WNA'])
+        response = auth_client.get(
+            '/allocations/projects?resource=Derecho&facility=WNA'
+            '&allocation_type=Small'
+        )
+        assert response.status_code == 200
+
+    def test_transactions_fragment_passes_facility_filter_to_query(
+        self, auth_client, monkeypatch,
+    ):
+        """When a scoped user hits the transactions fragment, the
+        query helper must receive a facility_name kwarg restricted to
+        the user's scope. Confirms the SQL-level filter is plumbed
+        through rather than Python-post-filtered."""
+        self._scope_benkirk(monkeypatch, ['WNA'])
+
+        captured = {}
+
+        def _stub(session, **kwargs):
+            captured.setdefault('get', []).append(kwargs.get('facility_name'))
+            return []
+
+        def _stub_count(session, **kwargs):
+            captured.setdefault('count', []).append(kwargs.get('facility_name'))
+            return 0
+
+        monkeypatch.setattr(
+            'webapp.dashboards.allocations.blueprint.get_recent_allocation_transactions',
+            _stub,
+        )
+        monkeypatch.setattr(
+            'webapp.dashboards.allocations.blueprint.count_recent_allocation_transactions',
+            _stub_count,
+        )
+
+        response = auth_client.get('/allocations/transactions_fragment')
+        assert response.status_code == 200
+        # Both the row query and the count query should have received
+        # WNA (or a list containing WNA) as their facility filter.
+        for calls in captured.values():
+            assert calls, 'query helper was not called'
+            arg = calls[0]
+            assert arg == ['WNA'] or arg == 'WNA' or (
+                isinstance(arg, list) and 'WNA' in arg
+            )
+
+    def test_empty_scope_user_gets_empty_dashboard(self, auth_client, monkeypatch):
+        """A user scoped to zero facilities for VIEW_PROJECTS — e.g.
+        a mis-configured entry — should render a functional page
+        with no rows rather than error."""
+        self._scope_benkirk(monkeypatch, [])  # entry exists but grants nothing
+        response = auth_client.get('/allocations/')
+        # The decorator admits any user with at least one facility grant
+        # of VIEW_PROJECTS; empty-dict entry leaves them unadmitted → 403.
+        assert response.status_code == 403
+
+
+# ============================================================================
+# Scope-aware cache key
+# ============================================================================
+
+class TestUserAwareCacheKeyScope:
+    """Two scoped users with disjoint facility grants must not share a
+    cached response slot, even at the same path with the same query
+    string."""
+
+    @staticmethod
+    def _make_stub(user_id, username):
+        """Minimal Flask-Login-compatible stub user.
+
+        ``login_user`` checks ``is_active`` and calls ``get_id()``; the
+        RBAC code reads ``is_authenticated``, ``user_id``, ``username``.
+        """
+        class _U:
+            pass
+
+        u = _U()
+        u.is_authenticated = True
+        u.is_active = True
+        u.is_anonymous = False
+        u.user_id = user_id
+        u.username = username
+        # ``get_user_permissions`` iterates user.roles to accumulate
+        # group-bundle grants. An empty set means "no bundle grants"
+        # — the scoped entries in USER_FACILITY_PERMISSIONS provide
+        # everything the tests need.
+        u.roles = set()
+        u.get_id = lambda: str(user_id)
+        return u
+
+    def test_key_varies_on_scope_tag(self, app, monkeypatch):
+        from webapp.extensions import user_aware_cache_key
+        from webapp.utils import rbac
+        from webapp.utils.rbac import Permission
+
+        monkeypatch.setattr(rbac, 'USER_PERMISSION_OVERRIDES', {})
+        monkeypatch.setattr(rbac, 'GROUP_PERMISSIONS', {})
+        monkeypatch.setattr(
+            rbac, 'USER_FACILITY_PERMISSIONS',
+            {
+                'alice': {'WNA': {Permission.VIEW_PROJECTS}},
+                'bob':   {'NCAR': {Permission.VIEW_PROJECTS}},
+            },
+        )
+
+        # Same user_id to isolate the scope-tag contribution; in
+        # practice user_id also partitions, but we want the scope tag
+        # itself to carry weight.
+        alice = self._make_stub(user_id=1, username='alice')
+        bob = self._make_stub(user_id=1, username='bob')
+
+        from flask_login import login_user, logout_user
+        with app.test_request_context('/allocations/'):
+            login_user(alice)
+            k_alice = user_aware_cache_key()
+            logout_user()
+        with app.test_request_context('/allocations/'):
+            login_user(bob)
+            k_bob = user_aware_cache_key()
+            logout_user()
+
+        assert k_alice != k_bob
+        assert 'WNA' in k_alice
+        assert 'NCAR' in k_bob
+
+    def test_key_is_stable_for_same_user_and_scope(self, app, monkeypatch):
+        from webapp.extensions import user_aware_cache_key
+        from webapp.utils import rbac
+        from webapp.utils.rbac import Permission
+
+        monkeypatch.setattr(rbac, 'USER_PERMISSION_OVERRIDES', {})
+        monkeypatch.setattr(rbac, 'GROUP_PERMISSIONS', {})
+        monkeypatch.setattr(
+            rbac, 'USER_FACILITY_PERMISSIONS',
+            {'scoped_user': {'WNA': {Permission.VIEW_PROJECTS}}},
+        )
+
+        from flask_login import login_user, logout_user
+        keys = []
+        for _ in range(2):
+            with app.test_request_context('/allocations/?foo=bar'):
+                login_user(self._make_stub(user_id=42, username='scoped_user'))
+                keys.append(user_aware_cache_key())
+                logout_user()
+        assert keys[0] == keys[1]
+
+    def test_unscoped_user_gets_all_tag(self, app):
+        from webapp.extensions import user_aware_cache_key
+        from flask_login import login_user, logout_user
+
+        with app.test_request_context('/allocations/'):
+            login_user(self._make_stub(user_id=99, username='benkirk'))
+            key = user_aware_cache_key()
+            logout_user()
+        assert '|s:all' in key

--- a/tests/unit/test_project_models.py
+++ b/tests/unit/test_project_models.py
@@ -14,10 +14,12 @@ from sam import (
     Facility,
     FosAoi,
     MnemonicCode,
+    Project,
     ProjectCode,
     ResponsibleParty,
     User,
 )
+from factories import make_project
 
 
 pytestmark = pytest.mark.unit
@@ -221,3 +223,37 @@ class TestResponsiblePartyModel:
         assert rp.creation_time is not None
         assert hasattr(rp, 'modified_time')
         session.rollback()
+
+
+# ============================================================================
+# Project.facility_name — derives via allocation_type → panel → facility
+# ============================================================================
+
+
+class TestProjectFacilityName:
+    """The facility-scoped RBAC layer keys off ``Project.facility_name``.
+    Verify the chain resolution and the ``None`` fallback for orphan
+    projects (no ``allocation_type``)."""
+
+    def test_full_chain_returns_facility_name(self, session):
+        # Pick any snapshot project that has the full chain.
+        project = (
+            session.query(Project)
+            .filter(Project.allocation_type_id.isnot(None))
+            .first()
+        )
+        if project is None:
+            pytest.skip("No projects with allocation_type in snapshot")
+        if project.allocation_type is None or project.allocation_type.panel is None:
+            pytest.skip("Snapshot project has a truncated chain")
+
+        expected = project.allocation_type.panel.facility.facility_name
+        assert project.facility_name == expected
+        assert isinstance(project.facility_name, str)
+
+    def test_orphan_project_returns_none(self, session):
+        # make_project leaves allocation_type_id=None by default — that
+        # is the exact orphan shape the RBAC layer needs to cover.
+        project = make_project(session)
+        assert project.allocation_type_id is None
+        assert project.facility_name is None

--- a/tests/unit/test_project_permissions.py
+++ b/tests/unit/test_project_permissions.py
@@ -25,12 +25,13 @@ from webapp.utils.rbac import Permission
 pytestmark = pytest.mark.unit
 
 
-def create_mock_user(user_id: int, roles: list = None):
+def create_mock_user(user_id: int, roles: list = None, username: str = 'stubuser'):
     """Create a mock user object for testing."""
     roles = roles or ['user']
     user = Mock()
     user.user_id = user_id
     user.roles = roles
+    user.username = username
     user.has_role = lambda r: r in roles
     user.has_any_role = lambda *rs: any(r in roles for r in rs)
     user.is_authenticated = True
@@ -38,16 +39,19 @@ def create_mock_user(user_id: int, roles: list = None):
 
 
 def create_mock_project(project_lead_user_id: int, project_admin_user_id: int = None,
-                        parent: Mock = None):
+                        parent: Mock = None, facility_name: str = None):
     """Create a mock project object for testing.
 
     ``parent`` is the Project ORM ``parent`` relationship — used by the
     Phase-2 ancestor-walk tests. Default None means root.
+    ``facility_name`` stubs the Phase-3 property that feeds
+    facility-scoped RBAC; default ``None`` = orphan project.
     """
     project = Mock()
     project.project_lead_user_id = project_lead_user_id
     project.project_admin_user_id = project_admin_user_id
     project.parent = parent
+    project.facility_name = facility_name
     return project
 
 
@@ -221,6 +225,78 @@ class TestIsProjectSteward:
         user.has_role = lambda r: False
         project = create_mock_project(project_lead_user_id=42)
         assert not _is_project_steward(user, project, Permission.EDIT_ALLOCATIONS)
+
+    def test_facility_scoped_user_passes_for_matching_facility(self, monkeypatch):
+        # A user with no system perms and no project role, but a scoped
+        # EDIT_PROJECTS grant for this project's facility, should pass.
+        from webapp.utils import rbac
+        monkeypatch.setattr(
+            rbac, 'USER_FACILITY_PERMISSIONS',
+            {'mgr': {'WNA': {Permission.EDIT_PROJECTS}}},
+        )
+        user = create_mock_user(user_id=77, roles=[], username='mgr')
+        project = create_mock_project(
+            project_lead_user_id=1, project_admin_user_id=2,
+            facility_name='WNA',
+        )
+        assert _is_project_steward(user, project, Permission.EDIT_PROJECTS)
+
+    def test_facility_scoped_user_blocked_for_other_facility(self, monkeypatch):
+        # Scoped to WNA but project is NCAR → no system perm, no role,
+        # no scope match → denied.
+        from webapp.utils import rbac
+        monkeypatch.setattr(
+            rbac, 'USER_FACILITY_PERMISSIONS',
+            {'mgr': {'WNA': {Permission.EDIT_PROJECTS}}},
+        )
+        user = create_mock_user(user_id=77, roles=[], username='mgr')
+        project = create_mock_project(
+            project_lead_user_id=1, project_admin_user_id=2,
+            facility_name='NCAR',
+        )
+        assert not _is_project_steward(user, project, Permission.EDIT_PROJECTS)
+
+    def test_facility_scoped_user_still_wins_via_lead_role(self, monkeypatch):
+        # Scope doesn't cover the facility, but user is the project lead
+        # → lead short-circuit still applies. Important: facility scope
+        # is additive, not replacement.
+        from webapp.utils import rbac
+        monkeypatch.setattr(
+            rbac, 'USER_FACILITY_PERMISSIONS',
+            {'mgr': {'WNA': {Permission.EDIT_PROJECTS}}},
+        )
+        user = create_mock_user(user_id=77, roles=[], username='mgr')
+        project = create_mock_project(
+            project_lead_user_id=77, project_admin_user_id=None,
+            facility_name='NCAR',
+        )
+        assert _is_project_steward(user, project, Permission.EDIT_PROJECTS)
+
+    def test_orphan_project_denies_scoped_user(self, monkeypatch):
+        # facility_name=None means no allocation_type chain exists;
+        # the facility-scoped user cannot act — only unscoped system
+        # holders may.
+        from webapp.utils import rbac
+        monkeypatch.setattr(
+            rbac, 'USER_FACILITY_PERMISSIONS',
+            {'mgr': {'WNA': {Permission.EDIT_PROJECTS}}},
+        )
+        user = create_mock_user(user_id=77, roles=[], username='mgr')
+        project = create_mock_project(
+            project_lead_user_id=1, project_admin_user_id=2,
+            facility_name=None,
+        )
+        assert not _is_project_steward(user, project, Permission.EDIT_PROJECTS)
+
+    def test_orphan_project_still_reachable_by_system_admin(self):
+        # Regression guard: orphan projects must remain manageable by
+        # users with the system-wide grant.
+        user = create_mock_user(user_id=100, roles=['admin-testing-only'])
+        project = create_mock_project(
+            project_lead_user_id=1, project_admin_user_id=2,
+            facility_name=None,
+        )
+        assert _is_project_steward(user, project, Permission.EDIT_PROJECTS)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_query_functions.py
+++ b/tests/unit/test_query_functions.py
@@ -366,7 +366,7 @@ EXPECTED_TXN_KEYS = {
     'transaction_amount', 'requested_amount', 'alloc_start_date', 'alloc_end_date',
     'transaction_comment', 'auth_at_panel_mtg', 'propagated',
     'projcode', 'project_id', 'resource_name', 'resource_id',
-    'facility_name', 'allocation_type',
+    'facility', 'allocation_type',
     'user_id', 'username', 'user_display_name',
 }
 
@@ -676,7 +676,7 @@ class TestRecentAllocationTransactions:
 EXPECTED_ADJ_KEYS = {
     'adjustment_id', 'account_id', 'amount', 'adjustment_date', 'comment',
     'adjustment_type',
-    'projcode', 'project_id', 'resource_name', 'resource_id', 'facility_name',
+    'projcode', 'project_id', 'resource_name', 'resource_id', 'facility',
     'user_id', 'username', 'user_display_name',
 }
 

--- a/tests/unit/test_query_functions.py
+++ b/tests/unit/test_query_functions.py
@@ -224,7 +224,7 @@ class TestDashboardQueries:
         )
         if result:
             assert isinstance(result, dict)
-            for field in ('project', 'resource', 'resource_summary', 'daily_charges'):
+            for field in ('project', 'resource_obj', 'resource_summary', 'daily_charges'):
                 assert field in result
 
     def test_user_dashboard_batched_matches_per_project(

--- a/tests/unit/test_rbac.py
+++ b/tests/unit/test_rbac.py
@@ -17,15 +17,18 @@ from webapp.utils.rbac import (
     has_all_permissions,
     has_any_permission,
     has_permission,
+    has_permission_for_facility,
+    user_facility_scope,
 )
 
 
 class _StubUser:
     """Minimal AuthUser-like stub: just `roles` (a set) and `username`."""
 
-    def __init__(self, *, roles=(), username='stubuser'):
+    def __init__(self, *, roles=(), username='stubuser', is_authenticated=True):
         self.roles = set(roles)
         self.username = username
+        self.is_authenticated = is_authenticated
 
     def has_role(self, name):
         return name in self.roles
@@ -248,3 +251,114 @@ class TestRbacContextProcessor:
     def test_returns_false_when_project_is_none(self, app):
         ctx = self._ctx(app)
         assert ctx['can_act_on_project'](Permission.EDIT_ALLOCATIONS, None) is False
+
+
+# ---------------------------------------------------------------------------
+# Facility-scoped permissions (third RBAC tier)
+# ---------------------------------------------------------------------------
+
+class TestFacilityScopedPermissions:
+    """``has_permission_for_facility`` and ``user_facility_scope`` add a
+    per-user, per-facility grant layer on top of system permissions.
+
+    Coverage matrix:
+    - System-permission holder → passes for any facility, including
+      orphan projects (``facility_name=None``).
+    - Scoped entry → passes only for named facilities, denies others.
+    - Scoped entry + orphan project → denies (system-only domain).
+    - Unauthenticated user → always denies.
+    - ``user_facility_scope`` returns ``None`` for system holders,
+      the configured set for scoped users, empty set otherwise.
+    """
+
+    def test_has_permission_for_facility_grants_via_system_perm(self, monkeypatch):
+        monkeypatch.setattr(
+            rbac, 'USER_PERMISSION_OVERRIDES',
+            {'alice': set(Permission)},
+        )
+        user = _StubUser(roles=[], username='alice')
+        # System grant applies regardless of facility.
+        assert has_permission_for_facility(user, Permission.EDIT_PROJECTS, 'NCAR')
+        assert has_permission_for_facility(user, Permission.EDIT_PROJECTS, 'WNA')
+        # Even orphan projects are reachable by system holders.
+        assert has_permission_for_facility(user, Permission.EDIT_PROJECTS, None)
+
+    def test_has_permission_for_facility_grants_via_scoped_entry(self, monkeypatch):
+        monkeypatch.setattr(
+            rbac, 'USER_FACILITY_PERMISSIONS',
+            {'mgr': {'WNA': {Permission.EDIT_PROJECTS, Permission.CREATE_PROJECTS}}},
+        )
+        user = _StubUser(roles=[], username='mgr')
+        assert has_permission_for_facility(user, Permission.EDIT_PROJECTS, 'WNA')
+        assert has_permission_for_facility(user, Permission.CREATE_PROJECTS, 'WNA')
+
+    def test_has_permission_for_facility_denies_other_facility(self, monkeypatch):
+        monkeypatch.setattr(
+            rbac, 'USER_FACILITY_PERMISSIONS',
+            {'mgr': {'WNA': {Permission.EDIT_PROJECTS}}},
+        )
+        user = _StubUser(roles=[], username='mgr')
+        # Scoped to WNA → must deny NCAR and UNIV.
+        assert not has_permission_for_facility(user, Permission.EDIT_PROJECTS, 'NCAR')
+        assert not has_permission_for_facility(user, Permission.EDIT_PROJECTS, 'UNIV')
+
+    def test_has_permission_for_facility_denies_permission_not_in_scope(self, monkeypatch):
+        monkeypatch.setattr(
+            rbac, 'USER_FACILITY_PERMISSIONS',
+            {'mgr': {'WNA': {Permission.VIEW_PROJECTS}}},
+        )
+        user = _StubUser(roles=[], username='mgr')
+        # WNA is in scope, but only for VIEW; EDIT must fail.
+        assert has_permission_for_facility(user, Permission.VIEW_PROJECTS, 'WNA')
+        assert not has_permission_for_facility(user, Permission.EDIT_PROJECTS, 'WNA')
+
+    def test_has_permission_for_facility_denies_orphan_project_for_scoped_user(self, monkeypatch):
+        monkeypatch.setattr(
+            rbac, 'USER_FACILITY_PERMISSIONS',
+            {'mgr': {'WNA': {Permission.EDIT_PROJECTS}}},
+        )
+        user = _StubUser(roles=[], username='mgr')
+        # facility_name=None means the target project has no
+        # allocation_type → panel → facility chain. Only unscoped
+        # system admins may act there.
+        assert not has_permission_for_facility(user, Permission.EDIT_PROJECTS, None)
+
+    def test_has_permission_for_facility_unauthenticated_returns_false(self):
+        user = _StubUser(roles=[], username='nobody', is_authenticated=False)
+        assert not has_permission_for_facility(user, Permission.EDIT_PROJECTS, 'WNA')
+        assert not has_permission_for_facility(user, Permission.EDIT_PROJECTS, None)
+
+    def test_user_facility_scope_returns_none_for_system_admin(self, monkeypatch):
+        monkeypatch.setattr(
+            rbac, 'USER_PERMISSION_OVERRIDES',
+            {'alice': set(Permission)},
+        )
+        user = _StubUser(roles=[], username='alice')
+        # None signals "no facility filter needed" — unscoped.
+        assert user_facility_scope(user, Permission.VIEW_PROJECTS) is None
+        assert user_facility_scope(user, Permission.EDIT_PROJECTS) is None
+
+    def test_user_facility_scope_returns_set_for_scoped_user(self, monkeypatch):
+        monkeypatch.setattr(
+            rbac, 'USER_FACILITY_PERMISSIONS',
+            {
+                'mgr': {
+                    'WNA': {Permission.VIEW_PROJECTS, Permission.EDIT_PROJECTS},
+                    'CISL': {Permission.VIEW_PROJECTS},
+                },
+            },
+        )
+        user = _StubUser(roles=[], username='mgr')
+        assert user_facility_scope(user, Permission.VIEW_PROJECTS) == {'WNA', 'CISL'}
+        assert user_facility_scope(user, Permission.EDIT_PROJECTS) == {'WNA'}
+        # A permission the user does not hold anywhere → empty set.
+        assert user_facility_scope(user, Permission.DELETE_PROJECTS) == set()
+
+    def test_user_facility_scope_empty_for_unauthenticated(self):
+        user = _StubUser(roles=[], username='nobody', is_authenticated=False)
+        assert user_facility_scope(user, Permission.VIEW_PROJECTS) == set()
+
+    def test_user_facility_scope_empty_for_user_without_entry(self, monkeypatch):
+        monkeypatch.setattr(rbac, 'USER_FACILITY_PERMISSIONS', {})
+        user = _StubUser(roles=[], username='no_entry')
+        assert user_facility_scope(user, Permission.VIEW_PROJECTS) == set()


### PR DESCRIPTION
## Purpose

Introduce a **third RBAC tier** — per-user, per-facility permission
grants — so that a "facility manager" (e.g. a WNA-scoped admin) can hold
`CREATE_PROJECTS`, `EDIT_PROJECTS`, `CREATE_ALLOCATIONS`, etc. **only
within their allowed facility set**, with no authority outside it.
Before this PR, the webapp had only two tiers: POSIX-group bundles
(`GROUP_PERMISSIONS`) and per-user overrides (`USER_PERMISSION_OVERRIDES`),
both global. Scoping was impossible.

First production user: **`sureshm`**, scoped to **WNA**.

## Authorization model (three tiers)

| Tier | Where | Semantics |
|---|---|---|
| 1. Group bundles | `GROUP_PERMISSIONS` (POSIX groups) | Global — applies anywhere |
| 2. Per-user overrides | `USER_PERMISSION_OVERRIDES` | Global — applies anywhere |
| 3. Facility-scoped (**new**) | `USER_FACILITY_PERMISSIONS[username][facility]` | Applies only when the target project's facility matches |

All three are **additive** — a user's effective permission set for a
given target is the union. Tier 3 is consulted by resolving the
target's `project.facility_name` (new property walking
`allocation_type → panel → facility`) and intersecting.

Core helpers (all in `webapp/utils/rbac.py`):

- `has_permission_for_facility(user, permission, facility_name)` —
  per-target check (union of tier-1/2 system grant + tier-3 scoped).
- `has_permission_any_facility(user, permission)` — admission gate:
  "holds `permission` **somewhere**?" Used by route decorators that
  admit scoped users into routes whose handlers then filter on scope.
- `user_facility_scope(user, permission)` — returns `None` (unscoped
  global), an empty `set` (none), or a `set` of allowed facility names.
- `apply_facility_scope(requested, permission, default)` — intersects
  a user-submitted facility filter against the allowed scope.
  Shared single source of truth for listing/search filters.
- `filter_rows_by_facility(rows, allowed)` — post-fetch Python filter
  keyed on each row dict's `'facility'` field.
- `@require_permission_any_facility(permission)` — decorator sibling
  of `require_permission`.

Stewardship (already existed, now correctly funnels through tier 3):
`_is_project_steward(user, project, permission, include_ancestors=?)`
returns True if the user has the permission for the project's
facility **or** is lead/admin of the project (optionally any ancestor).

## What lands, per surface

### Foundation (`ba26aab`)

- New `USER_FACILITY_PERMISSIONS` dict in `rbac.py`, keyed as
  `{username: {facility: {Permission, …}}}`.
- `Project.facility_name` hybrid property (walks
  `allocation_type → panel → facility`, returns `None` for orphans).
- `_is_project_steward` + API decorators (`require_project_permission`,
  `require_allocation_permission`, `require_project_access`,
  `require_project_member_access`) retrofitted onto
  `has_permission_for_facility` so the tier-3 grant flows into every
  project-scoped authorization check.
- Admin project routes re-decorated: `expirations_fragment`,
  `expirations_export`, `deactivate_expired`, `htmx_search_projects`,
  `htmx_project_create_form`, `htmx_project_create` (scope intersection
  applied to listings and validated at POST time), plus the
  cascading-dropdown helpers (`htmx_panels_for_facility`,
  `htmx_alloc_types_for_panel`).
- Admin dashboard: nav tab, post-login redirects (auth + `/`), create-
  project button, expirations "Deactivate" button, project card modals
  all gated on `has_permission_any_facility` so scoped users see admin
  chrome relevant to their scope and nothing else.
- Facility multi-select on admin dashboard Expirations form populated
  from `user_facility_scope` (sureshm sees only WNA; unscoped users see
  everything).
- Tests: `TestFacilityScopedPermissions` (10 cases), steward-tier cases
  on `TestIsProjectSteward`, `TestProjectFacilityName` (2 cases).

### Allocations dashboard (`a37a26e`, `33c37d6`)

- `/allocations` route admission swapped to
  `@require_permission_any_facility(VIEW_PROJECTS)` on the six
  read-only routes (`index`, `projects_fragment`, transactions /
  adjustments fragments + detail modals). `EDIT_ALLOCATIONS`-gated
  routes (purge cache, create-adjustment) left system-admin-only.
- **New facility selector UI** on `/allocations/`, rendered
  unconditionally to the left of the existing Resource selector.
  Defaults to the user's full allowed set; `?facilities=…` query param
  is clamped server-side against that set (scoped users cannot widen
  by forging the URL). Persists across tab/pagination clicks via
  `hx-include` and a new `extra_include` parameter on the shared
  pagination macro.
- **Two-stage scope filtering** in the route bodies:
  (a) hard-clamp user's request against their allowed set, then
  (b) `filter_rows_by_facility` on `summary_data` / `per_project_usage`
  rows at the index level; for transactions/adjustments the helpers
  already accept `facility_name`, so SQL-level filtering is used.
- `projects_fragment` 403s on a forged `?facility=<not-in-scope>`;
  detail modals deny inspection of out-of-scope rows.
- **Cache-key isolation**: `user_aware_cache_key` now appends a
  deterministic `|s:<scope_tag>` based on `sorted(user_facility_scope)`
  so two scoped users with disjoint scopes don't share a cache slot.
- Row-key standardization: every query emitting
  `get_allocation_summary` / `cached_allocation_usage` /
  `get_recent_allocation_transactions` / `get_recent_charge_adjustments`
  rows now uses a single `'facility'` key (was split between
  `'facility'` and `'facility_name'`). Templates + sort-column maps
  updated; `get_resource_detail_data` distinguishes its string
  `'resource'` row key from its ORM-object `'resource_obj'` emission.
- Tests: `TestAllocationsDashboardFacilityScope` (7 cases),
  `TestUserAwareCacheKeyScope` (3 cases).

### Admin reference-data tabs (`fe6c40c`)

Problem: the admin dashboard's Resources / Organizations / Facilities /
Users & Groups tabs all lazy-load their content via HTMX routes gated
on `@require_permission(VIEW_*)` — the tier-1/2-only gate. Scoped users
hit 403 on the card fragments even though the tabs themselves were
reachable.

- Swapped the admission gate on 8 read-only card/fragment loaders
  (`htmx_resources_card`, `htmx_organizations_card`,
  `htmx_institutions_fragment`, `htmx_facilities_card`,
  `htmx_queues_for_resource`, `user_card`, `group_card`,
  `htmx_search_groups`) to `require_permission_any_facility`.
- Relaxed the user-search endpoint's `impersonate` context gate from
  `IMPERSONATE_USERS` to `VIEW_USERS` (any-facility); the impersonate
  button itself is template-gated on `IMPERSONATE_USERS`, so scoped
  users see a plain directory listing.
- Tightened three `is_admin`-only blocks in `user_card.html`
  (Add/Edit Wallclock Exemption buttons + their column) to **also**
  require `has_permission(EDIT_USERS)` — preventing write chrome
  leakage to scoped viewers.
- Granted sureshm/WNA the read-only `VIEW_*` perms for these
  reference-data domains (directory lookup is inherently cross-facility
  — project membership spans facilities).
- Fixed a latent cache-isolation bug: two org-card fragments now use
  `user_aware_cache_key` instead of `query_string=True`.

### Project-edit allocation management (`672c467`)

Problem: on `/admin/project/<projcode>/edit`, the Allocations-tab
buttons were gated on `can_edit_governance` (system-only) and the
eleven backing HTMX routes used `@require_permission(EDIT_PROJECTS)`.
Neither consulted tier 3 or stewardship — so a WNA-scoped admin *who
was also the project admin* couldn't edit allocations.

- Template: Add/Extend/Renew buttons + per-row edit pencil now gated
  on `can_edit_allocations` (steward-aware).
- 6 `<projcode>`-keyed routes → `@require_project_permission(EDIT_ALLOCATIONS, include_ancestors=True)`,
  handlers receive `project` directly.
- 5 `<allocation_id>`-keyed routes → `@require_allocation_permission(EDIT_ALLOCATIONS)`,
  handlers receive `allocation` directly. URL param standardized
  from `<int:alloc_id>` to `<int:allocation_id>` (matching the
  parallel user-dashboard routes); six `url_for` call sites updated.
- `can_edit_governance` stays unconditional by design — the
  Details-tab governance fields remain system-admin only.

## Tests

Full suite green against `sam_test` (1642 passed, 22 skipped, 1 xfailed)
under xdist. New coverage:

- `TestFacilityScopedPermissions` (10 cases) — rbac helpers.
- `TestIsProjectSteward` (+5 facility-scoped cases).
- `TestProjectFacilityName` (2 cases) — ORM walk, orphan handling.
- `TestAllocationsDashboardFacilityScope` (7 cases) — index, projects
  drill-down (success + 403), transaction facility filter, unscoped
  default, multi-facility.
- `TestUserAwareCacheKeyScope` (3 cases) — cache-slot partitioning.

Existing tests stay green — system admins see no behavior change.

## Configuration landed

```python
# webapp/utils/rbac.py — USER_FACILITY_PERMISSIONS
'sureshm': {
    'WNA': {
        ACCESS_ADMIN_DASHBOARD,
        VIEW_PROJECTS, EDIT_PROJECTS, CREATE_PROJECTS,
        VIEW_PROJECT_MEMBERS, EDIT_PROJECT_MEMBERS,
        VIEW_ALLOCATIONS, EDIT_ALLOCATIONS, CREATE_ALLOCATIONS,
        # Directory + reference-data read access (globally read-only):
        VIEW_RESOURCES, VIEW_ORG_METADATA, VIEW_FACILITIES,
        VIEW_USERS, VIEW_GROUPS,
    },
}
```

## Manual verification to run before merge

1. Quick-login as `sureshm`:
   - Navbar shows Allocations + Admin tabs.
   - `/admin` loads: Resources / Organizations / Facilities /
     Users & Groups tabs render read-only (no Create/Edit/Delete
     buttons visible); facility multi-select on Expirations shows
     only "WNA".
   - `/admin/project/WYOM0078/edit` Allocations tab: Extend / Renew /
     Add Allocation buttons visible; per-row edit pencils visible;
     Add Allocation and Edit forms load (not 403).
   - `/allocations/` loads with facility selector pinned to WNA;
     transactions/adjustments tables show only WNA rows;
     `?facility=NCAR` in URL → 403.
   - `/admin/project/<NCAR projcode>/edit` → 403.
2. Quick-login as `benkirk` (unscoped): every surface behaves exactly
   as before — no regression.
3. Quick-login as a project-admin-only user on a non-WNA project:
   can edit allocations on that project via the steward tier.

## Out of scope (follow-ups)

- Charge-adjustment creation for scoped users (`htmx_create_adjustment_form`
  / `htmx_create_adjustment`) — needs FK picker scoping + POST
  facility validation.
- Cache-purge (`purge_cache`) — intentionally system-admin-only.
- Allocations API v1 (`/api/v1/allocations/...`) — per-allocation PUT
  already goes through `require_allocation_permission`.
- Six linked-elements admin routes (contracts/orgs/directories on the
  Details tab) remain `@require_permission(EDIT_PROJECTS)` — separate
  cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)