### PR TITLE
Admin UX polish: Project Directories + Disk Roots + New-button shortcuts

### DIFF
--- a/src/cli/project/display.py
+++ b/src/cli/project/display.py
@@ -164,8 +164,16 @@ def display_project(ctx: Context, data: dict, extra_title_info: str = "",
             alloc_str = fmt.number(allocated)
             remaining_str = fmt.number(resource_usage['remaining'])
             used_str = fmt.number(resource_usage['used'])
+            # Shared (inheriting) allocation: annotate this project's
+            # contribution inline, e.g. "700 (200 yours)", and tag the
+            # resource cell so the user knows the pool is shared.
+            is_shared = resource_usage.get('is_inheriting', False)
+            self_used = resource_usage.get('self_used')
+            if is_shared and self_used is not None:
+                used_str = f"{used_str} [dim]({fmt.number(self_used)} yours)[/]"
+            shared_indicator = " [dim](shared)[/]" if is_shared else ""
             row = [
-                f"[{resource_style}]{resource_name}{expired_indicator}[/]",
+                f"[{resource_style}]{resource_name}{expired_indicator}[/]{shared_indicator}",
                 (f"[{resource_style}]{resource_usage['resource_type']}[/]"
                  if is_expired else resource_usage['resource_type']),
                 date_range,

--- a/src/sam/accounting/allocations.py
+++ b/src/sam/accounting/allocations.py
@@ -90,6 +90,17 @@ class Allocation(Base, TimestampMixin, SoftDeleteMixin, SessionMixin):
         """True if this allocation is a child node in the shared-allocation tree."""
         return self.parent_allocation_id is not None
 
+    @property
+    def root(self) -> 'Allocation':
+        """Walk parent links to the root allocation of the shared tree.
+
+        Returns self when this allocation is non-inheriting (already a root).
+        """
+        node = self
+        while node.parent is not None:
+            node = node.parent
+        return node
+
     def _walk_tree(self, action_func, *args, **kwargs) -> None:
         """
         Applies action_func to this node and recursively to all descendants.

--- a/src/sam/projects/projects.py
+++ b/src/sam/projects/projects.py
@@ -1344,6 +1344,21 @@ class ProjectDirectory(Base, TimestampMixin, DateRangeMixin, SessionMixin):
         session.flush()
         return obj
 
+    def update(self, *, directory_name=None, project_id=None) -> 'ProjectDirectory':
+        """Update this directory's name and/or linked project.
+
+        Does NOT commit; caller must wrap in management_transaction().
+        """
+        if directory_name is not None:
+            cleaned = directory_name.strip()
+            if not cleaned:
+                raise ValueError("directory_name cannot be blank")
+            self.directory_name = cleaned
+        if project_id is not None:
+            self.project_id = project_id
+        self.session.flush()
+        return self
+
     def deactivate(self) -> 'ProjectDirectory':
         """End this directory association by setting end_date to now.
 

--- a/src/sam/projects/projects.py
+++ b/src/sam/projects/projects.py
@@ -649,8 +649,33 @@ class Project(Base, TimestampMixin, ActiveFlagMixin, SessionMixin, NestedSetMixi
             allocated = float(query_alloc.amount)
             total_charges = sum(charges_by_type.values())
             effective_used = total_charges + adjustments
+            # `effective_used` here represents this project's subtree
+            # contribution to a (possibly shared) allocation pool. When the
+            # allocation is inheriting, the authoritative pool consumption
+            # lives at the root allocation's project subtree — compute it
+            # so the UI shows truth instead of just self-share.
+            self_used = effective_used
+            tree_used = effective_used
+            root_projcode = None
+            if query_alloc.is_inheriting:
+                root_alloc = query_alloc.root
+                root_account = root_alloc.account
+                root_project = root_account.project if root_account else None
+                if root_project is not None and root_project.tree_root \
+                        and root_project.tree_left and root_project.tree_right:
+                    root_charges = root_project.get_subtree_charges(
+                        account.resource_id, resource_type, start_date, end_date)
+                    root_total = sum(root_charges.values())
+                    if include_adjustments:
+                        root_total += root_project.get_subtree_adjustments(
+                            account.resource_id, start_date, end_date)
+                    tree_used = root_total
+                    root_projcode = root_project.projcode
+
+            effective_used = tree_used
             remaining = allocated - effective_used
             percent_used = (effective_used / allocated * 100) if allocated > 0 else 0
+            self_percent_used = (self_used / allocated * 100) if allocated > 0 else 0
 
             # Calculate time metrics
             days_elapsed = (now - query_alloc.start_date).days
@@ -690,6 +715,15 @@ class Project(Base, TimestampMixin, ActiveFlagMixin, SessionMixin, NestedSetMixi
                 'days_total': days_total,
                 'hierarchical': use_hierarchy
             }
+
+            # When the allocation is shared (inheriting), surface this
+            # project's own contribution and the root projcode so the UI
+            # can render a two-tone bar / inline annotation. Non-inheriting
+            # allocations keep the original shape.
+            if query_alloc.is_inheriting:
+                result['self_used'] = self_used
+                result['self_percent_used'] = self_percent_used
+                result['root_projcode'] = root_projcode
 
             if include_adjustments:
                 result['adjustments'] = adjustments

--- a/src/sam/queries/allocations.py
+++ b/src/sam/queries/allocations.py
@@ -1038,6 +1038,38 @@ def get_allocation_summary_with_usage(
             else:
                 account_infos.append(info)
 
+    # Tree-aware augmentation: for inheriting allocations, the per-allocation
+    # subtree charge does NOT match what users see in the project card —
+    # there `used` reflects the ROOT allocation's full subtree (the actual
+    # shared pool consumption). Collect anchors for the root projects so
+    # we can batch a parallel set of subtree queries keyed by ('root',
+    # allocation_id). Cheap when the row set is fully non-inheriting (no
+    # extra entries appended).
+    root_anchor_by_alloc_id: Dict[int, 'Project'] = {}
+    for alloc_list in alloc_by_key.values():
+        for alloc, res_name, res_type, project, account in alloc_list:
+            if not alloc.is_inheriting:
+                continue
+            root_alloc = alloc.root
+            root_account = root_alloc.account
+            root_project = root_account.project if root_account else None
+            if root_project is None:
+                continue
+            if not (root_project.tree_root and root_project.tree_left and root_project.tree_right):
+                continue
+            root_anchor_by_alloc_id[alloc.allocation_id] = root_project
+            subtree_infos.append({
+                'key':           ('root', alloc.allocation_id),
+                'resource_type': res_type,
+                'resource_id':   account.resource_id,
+                'account_id':    alloc.account_id,
+                'tree_root':     root_project.tree_root,
+                'tree_left':     root_project.tree_left,
+                'tree_right':    root_project.tree_right,
+                'start_date':    alloc.start_date,
+                'end_date':      alloc.end_date if alloc.end_date else check_date,
+            })
+
     # Batch compute all charges in O(charge_models × date_groups) SQL queries
     all_charges: Dict[Any, Dict] = {}
     if subtree_infos:
@@ -1050,27 +1082,64 @@ def get_allocation_summary_with_usage(
         key = _summary_item_key(item, resource_name, facility_name, allocation_type, projcode)
         item_allocations = alloc_by_key.get(key, [])
 
-        total_used = 0.0
+        self_used = 0.0
+        tree_used = 0.0
         charges_by_type_total: Dict[str, float] = {}
+
+        # Track inheriting state across the group: only surface tree-aware
+        # fields if EVERY allocation in this row is inheriting AND all
+        # share the same root project (e.g. one row per child project on
+        # one shared resource — the common case in the projects-tab).
+        all_inheriting = bool(item_allocations)
+        root_projcodes: set = set()
 
         for alloc, res_name, res_type, project, account in item_allocations:
             charge_result = all_charges.get(alloc.allocation_id, {'charges_by_type': {}, 'adjustment': 0.0})
 
             for charge_type, amount in charge_result['charges_by_type'].items():
                 charges_by_type_total[charge_type] = charges_by_type_total.get(charge_type, 0.0) + amount
-                total_used += amount
+                self_used += amount
 
             if include_adjustments:
                 adjustment_amount = charge_result['adjustment']
-                total_used += adjustment_amount
+                self_used += adjustment_amount
                 if adjustment_amount != 0:
                     charges_by_type_total['adjustments'] = (
                         charges_by_type_total.get('adjustments', 0.0) + adjustment_amount
                     )
 
-        item['total_used'] = total_used
+            if alloc.is_inheriting:
+                root_data = all_charges.get(('root', alloc.allocation_id),
+                                            {'charges_by_type': {}, 'adjustment': 0.0})
+                tree_used += sum(root_data['charges_by_type'].values())
+                if include_adjustments:
+                    tree_used += root_data['adjustment']
+                root_proj = root_anchor_by_alloc_id.get(alloc.allocation_id)
+                if root_proj is not None:
+                    root_projcodes.add(root_proj.projcode)
+            else:
+                all_inheriting = False
+                # Non-inheriting allocation contributes equally to self/tree.
+                tree_used += sum(charge_result['charges_by_type'].values())
+                if include_adjustments:
+                    tree_used += charge_result['adjustment']
+
+        # If this row represents a single shared pool (all inheriting,
+        # one common root), use the tree total as `total_used` so the
+        # bar reflects pool consumption, and expose `self_used`/
+        # `self_percent_used` for the two-tone overlay. Otherwise fall
+        # back to the legacy per-allocation sum.
         item['total_allocated'] = item['total_amount']  # Alias for clarity
-        item['percent_used'] = (total_used / item['total_allocated'] * 100) if item['total_allocated'] > 0 else 0
+        if all_inheriting and len(root_projcodes) == 1:
+            item['total_used'] = tree_used
+            item['percent_used'] = (tree_used / item['total_allocated'] * 100) if item['total_allocated'] > 0 else 0
+            item['self_used'] = self_used
+            item['self_percent_used'] = (self_used / item['total_allocated'] * 100) if item['total_allocated'] > 0 else 0
+            item['is_inheriting'] = True
+            item['root_projcode'] = next(iter(root_projcodes))
+        else:
+            item['total_used'] = self_used
+            item['percent_used'] = (self_used / item['total_allocated'] * 100) if item['total_allocated'] > 0 else 0
         item['charges_by_type'] = charges_by_type_total
 
     return summary

--- a/src/sam/queries/dashboard.py
+++ b/src/sam/queries/dashboard.py
@@ -55,7 +55,7 @@ case or complicate the N=many case — both are net losses for readers.
 """
 
 from datetime import datetime
-from typing import List, Dict, Optional, TypedDict
+from typing import Any, List, Dict, Optional, TypedDict
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload, selectinload
@@ -110,11 +110,19 @@ class DashboardResource(TypedDict):
     is_inheriting: bool
     account_id: Optional[int]
 
-    # Numeric usage
+    # Numeric usage. When `is_inheriting` (this is a shared/child
+    # allocation), `used`/`remaining`/`percent_used` reflect the FULL
+    # tree's consumption against the shared pool, and `self_used` /
+    # `self_percent_used` carry this project's own contribution so a
+    # two-tone bar can be rendered. For non-inheriting allocations,
+    # self_* are None.
     allocated: float
     used: float
     remaining: float
     percent_used: float
+    self_used: Optional[float]
+    self_percent_used: Optional[float]
+    root_projcode: Optional[str]
     charges_by_type: Dict[str, float]
     adjustments: float
 
@@ -231,6 +239,13 @@ def _build_project_resources_data(project: Project,
             'used': usage.get('used', 0.0),
             'remaining': usage.get('remaining', 0.0),
             'percent_used': usage.get('percent_used', 0.0),
+            # When `is_inheriting`, `used`/`percent_used` reflect the shared
+            # pool's full-tree consumption; `self_used`/`self_percent_used`
+            # carry this project's contribution so the UI can render a
+            # two-tone bar.
+            'self_used': usage.get('self_used'),
+            'self_percent_used': usage.get('self_percent_used'),
+            'root_projcode': usage.get('root_projcode'),
             'charges_by_type': usage.get('charges_by_type', {}),
             'adjustments': usage.get('adjustments', 0.0),
             'status': usage.get('status', 'Unknown'),
@@ -445,13 +460,44 @@ def _build_user_projects_resources_batched(
                 })
 
     # ------------------------------------------------------------------
+    # Phase 3.5: for each inheriting (shared) allocation, also compute the
+    # root allocation's project subtree usage. That total is the
+    # authoritative pool consumption — `used`/`percent_used` should
+    # reflect it, and the original per-project subtree number becomes
+    # `self_used`. We piggy-back on the same batch_get_subtree_charges
+    # primitive by adding parallel entries keyed with a ('root',) suffix.
+    # ------------------------------------------------------------------
+    root_project_by_key: Dict[tuple, 'Project'] = {}
+    for key, (project, account, query_alloc, resource_type, end_date) in chosen.items():
+        if not query_alloc.is_inheriting:
+            continue
+        root_alloc = query_alloc.root
+        root_account = root_alloc.account
+        root_project = root_account.project if root_account else None
+        if root_project is None:
+            continue
+        if not (root_project.tree_root and root_project.tree_left and root_project.tree_right):
+            continue
+        root_project_by_key[key] = root_project
+        subtree_infos.append({
+            'key':           ('root', key),
+            'resource_id':   account.resource_id,
+            'resource_type': resource_type,
+            'tree_root':     root_project.tree_root,
+            'tree_left':     root_project.tree_left,
+            'tree_right':    root_project.tree_right,
+            'start_date':    query_alloc.start_date,
+            'end_date':      end_date,
+        })
+
+    # ------------------------------------------------------------------
     # Phase 4: ONE batched fetch per partition (subtree / leaf). The
     # primitives live on Project and are already used by fstree — we are
     # the second, independent consumer. Each call issues
     # N_resource_types × N_charge_models queries (typically 5-20 total
     # for the whole user, regardless of project count).
     # ------------------------------------------------------------------
-    raw_charges: Dict[tuple, Dict] = {}
+    raw_charges: Dict[Any, Dict] = {}
     if subtree_infos:
         raw_charges.update(
             Project.batch_get_subtree_charges(session, subtree_infos, include_adjustments=True)
@@ -504,7 +550,25 @@ def _build_user_projects_resources_batched(
 
         allocated = float(query_alloc.amount)
         total_charges = sum(charges_by_type.values())
-        effective_used = total_charges + adjustments
+        self_used = total_charges + adjustments
+
+        # When this allocation is inheriting (shared), the authoritative
+        # pool consumption lives at the root allocation's project subtree
+        # — we batched it with a ('root', key) entry above. Use it as
+        # `used` so the UI shows the truth; expose self contribution as
+        # `self_used`.
+        tree_used = self_used
+        self_percent_used = None
+        root_projcode = None
+        if query_alloc.is_inheriting:
+            root_data = raw_charges.get(('root', key), {'charges_by_type': {}, 'adjustment': 0.0})
+            tree_used = sum(root_data['charges_by_type'].values()) + root_data['adjustment']
+            self_percent_used = (self_used / allocated * 100) if allocated > 0 else 0.0
+            root_proj = root_project_by_key.get(key)
+            if root_proj is not None:
+                root_projcode = root_proj.projcode
+
+        effective_used = tree_used
         remaining = allocated - effective_used
         percent_used = (effective_used / allocated * 100) if allocated > 0 else 0.0
 
@@ -546,6 +610,9 @@ def _build_user_projects_resources_batched(
             'used':                 effective_used,
             'remaining':            remaining,
             'percent_used':         percent_used,
+            'self_used':            self_used if query_alloc.is_inheriting else None,
+            'self_percent_used':    self_percent_used,
+            'root_projcode':        root_projcode,
             'charges_by_type':      charges_by_type,
             'adjustments':          adjustments,
             'status':               'Unknown',

--- a/src/sam/resources/resources.py
+++ b/src/sam/resources/resources.py
@@ -356,7 +356,7 @@ class ResourceShell(Base, TimestampMixin):
 
 
 #----------------------------------------------------------------------------
-class DiskResourceRootDirectory(Base):
+class DiskResourceRootDirectory(Base, SessionMixin):
     """Root directories for disk resources with charging exemption flags."""
     __tablename__ = 'disk_resource_root_directory'
 
@@ -375,6 +375,44 @@ class DiskResourceRootDirectory(Base):
     modified_time = Column(TIMESTAMP)  # DB: NULL default, no auto-update
 
     resource = relationship('Resource', back_populates='root_directories')
+
+    @classmethod
+    def create(cls, session, *, resource_id: int, root_directory: str,
+               charging_exempt: bool = False) -> 'DiskResourceRootDirectory':
+        """Create a new root directory entry for a disk resource.
+
+        Does NOT commit; caller must wrap in management_transaction().
+        Raises sqlalchemy IntegrityError on root_directory uniqueness collision.
+        """
+        cleaned = (root_directory or '').strip()
+        if not cleaned:
+            raise ValueError('root_directory is required')
+        obj = cls(resource_id=resource_id,
+                  root_directory=cleaned,
+                  charging_exempt=bool(charging_exempt))
+        session.add(obj)
+        session.flush()
+        return obj
+
+    def update(self, *, resource_id=None, root_directory=None,
+               charging_exempt=None) -> 'DiskResourceRootDirectory':
+        """Update one or more fields. Does NOT commit."""
+        if root_directory is not None:
+            cleaned = root_directory.strip()
+            if not cleaned:
+                raise ValueError('root_directory cannot be blank')
+            self.root_directory = cleaned
+        if resource_id is not None:
+            self.resource_id = resource_id
+        if charging_exempt is not None:
+            self.charging_exempt = bool(charging_exempt)
+        self.session.flush()
+        return self
+
+    def delete(self) -> None:
+        """Hard-delete this row. Does NOT commit."""
+        self.session.delete(self)
+        self.session.flush()
 
     def __str__(self):
         return f"{self.root_directory}"

--- a/src/sam/schemas/allocation.py
+++ b/src/sam/schemas/allocation.py
@@ -102,6 +102,13 @@ class AllocationWithUsageSchema(AllocationSchema):
             'percent_used',
             'charges_by_type',
             'adjustments',
+            # Shared-allocation tree fields. When `is_inheriting` is True,
+            # `used`/`percent_used` reflect the root subtree (the actual
+            # shared pool); these expose this project's contribution so
+            # consumers can render a two-tone bar.
+            'self_used',
+            'self_percent_used',
+            'root_projcode',
         )
 
     # Add resource details
@@ -113,6 +120,9 @@ class AllocationWithUsageSchema(AllocationSchema):
     percent_used = fields.Method('get_percent_used')
     charges_by_type = fields.Method('get_charges_by_type')
     adjustments = fields.Method('get_adjustments')
+    self_used = fields.Method('get_self_used')
+    self_percent_used = fields.Method('get_self_percent_used')
+    root_projcode = fields.Method('get_root_projcode')
 
     def get_resource(self, obj):
         """Get resource from account context."""
@@ -231,24 +241,96 @@ class AllocationWithUsageSchema(AllocationSchema):
         _, adjustments, _ = self._calculate_usage(obj)
         return adjustments
 
+    def _calculate_tree_usage(self, obj):
+        """For inheriting allocations, sum charges across the root project's
+        full subtree — that's the authoritative shared-pool consumption.
+
+        Returns (tree_used, root_project) or (None, None) for non-inheriting.
+        """
+        if not obj.is_inheriting:
+            return None, None
+        session = self.context.get('session')
+        include_adjustments = self.context.get('include_adjustments', True)
+        if not session:
+            return None, None
+        root_alloc = obj.root
+        root_account = root_alloc.account
+        root_project = root_account.project if root_account else None
+        if root_project is None or not (
+            root_project.tree_root and root_project.tree_left and root_project.tree_right
+        ):
+            return None, None
+        now = datetime.now()
+        start_date = obj.start_date
+        end_date = obj.end_date or now
+        resource_type = (
+            root_account.resource.resource_type.resource_type
+            if root_account.resource and root_account.resource.resource_type
+            else None
+        )
+        charges = root_project.get_subtree_charges(
+            root_account.resource_id, resource_type, start_date, end_date)
+        tree_used = sum(charges.values())
+        if include_adjustments:
+            tree_used += root_project.get_subtree_adjustments(
+                root_account.resource_id, start_date, end_date)
+        return tree_used, root_project
+
     def get_used(self, obj):
-        """Get total used amount (charges + adjustments)."""
+        """Total used amount. For inheriting allocations, this is the
+        root project's full subtree consumption (the actual shared pool
+        usage). For standalone allocations, this is the single-account
+        charges + adjustments.
+        """
+        tree_used, _ = self._calculate_tree_usage(obj)
+        if tree_used is not None:
+            return tree_used
         _, _, used = self._calculate_usage(obj)
         return used
 
     def get_remaining(self, obj):
-        """Get remaining allocation (amount - used)."""
-        _, _, used = self._calculate_usage(obj)
+        """Remaining = allocated - used (tree-aware when inheriting)."""
+        used = self.get_used(obj)
         allocated = float(obj.amount) if obj.amount else 0.0
         return allocated - used
 
     def get_percent_used(self, obj):
-        """Get percent of allocation used."""
+        """Percent used (tree-aware when inheriting)."""
+        used = self.get_used(obj)
+        allocated = float(obj.amount) if obj.amount else 0.0
+        if allocated > 0:
+            return (used / allocated) * 100.0
+        return 0.0
+
+    def get_self_used(self, obj):
+        """This project's contribution to the shared allocation pool.
+        None for non-inheriting allocations.
+        """
+        if not obj.is_inheriting:
+            return None
+        _, _, used = self._calculate_usage(obj)
+        return used
+
+    def get_self_percent_used(self, obj):
+        """This project's contribution as a percentage of the shared pool.
+        None for non-inheriting allocations.
+        """
+        if not obj.is_inheriting:
+            return None
         _, _, used = self._calculate_usage(obj)
         allocated = float(obj.amount) if obj.amount else 0.0
         if allocated > 0:
             return (used / allocated) * 100.0
         return 0.0
+
+    def get_root_projcode(self, obj):
+        """Projcode of the project owning the root allocation. None for
+        non-inheriting allocations.
+        """
+        if not obj.is_inheriting:
+            return None
+        _, root_project = self._calculate_tree_usage(obj)
+        return root_project.projcode if root_project else None
 
 
 class AccountSchema(BaseSchema):

--- a/src/sam/schemas/forms/__init__.py
+++ b/src/sam/schemas/forms/__init__.py
@@ -142,6 +142,8 @@ from .resources import (
     EditMachineForm,
     CreateMachineForm,
     EditQueueForm,
+    CreateDiskResourceRootDirectoryForm,
+    EditDiskResourceRootDirectoryForm,
 )
 from .orgs import (
     EditOrganizationForm,
@@ -201,6 +203,8 @@ __all__ = [
     'EditMachineForm',
     'CreateMachineForm',
     'EditQueueForm',
+    'CreateDiskResourceRootDirectoryForm',
+    'EditDiskResourceRootDirectoryForm',
     # Organizations
     'EditOrganizationForm',
     'CreateOrganizationForm',

--- a/src/sam/schemas/forms/__init__.py
+++ b/src/sam/schemas/forms/__init__.py
@@ -168,6 +168,7 @@ from .projects import (
     AddLinkedOrganizationForm,
     AddLinkedContractForm,
     AddLinkedDirectoryForm,
+    EditLinkedDirectoryForm,
 )
 from .user import (
     AddMemberForm,
@@ -224,6 +225,7 @@ __all__ = [
     'AddLinkedOrganizationForm',
     'AddLinkedContractForm',
     'AddLinkedDirectoryForm',
+    'EditLinkedDirectoryForm',
     # User
     'AddMemberForm',
     'EditAllocationForm',

--- a/src/sam/schemas/forms/projects.py
+++ b/src/sam/schemas/forms/projects.py
@@ -93,3 +93,21 @@ class AddLinkedDirectoryForm(HtmxFormSchema):
             from marshmallow import ValidationError as _VE
             raise _VE({'directory_name': ['Directory name cannot be blank.']})
         return data
+
+
+class EditLinkedDirectoryForm(HtmxFormSchema):
+    """Edit a project_directory row: rename and/or re-link to a project.
+
+    FK existence check (project_id -> Project) stays in the route since
+    schemas don't touch the DB.
+    """
+    directory_name = f.Str(required=True, validate=v.Length(min=1, max=255))
+    project_id = f.Int(required=True)
+
+    @post_load
+    def normalize(self, data, **kwargs):
+        data['directory_name'] = data['directory_name'].strip()
+        if not data['directory_name']:
+            from marshmallow import ValidationError as _VE
+            raise _VE({'directory_name': ['Directory name cannot be blank.']})
+        return data

--- a/src/sam/schemas/forms/projects.py
+++ b/src/sam/schemas/forms/projects.py
@@ -82,32 +82,45 @@ class AddLinkedContractForm(HtmxFormSchema):
     contract_id = f.Int(required=True)
 
 
+def _normalize_directory_suffix(data):
+    """Strip + reject any '..' path segment in the directory_suffix field.
+
+    The full directory_name is assembled in the route from the chosen
+    DiskResourceRootDirectory + this suffix; the schema doesn't touch the DB.
+    """
+    suffix = (data.get('directory_suffix') or '').strip()
+    if suffix and any(seg == '..' for seg in suffix.split('/')):
+        from marshmallow import ValidationError as _VE
+        raise _VE({'directory_suffix': ['Suffix cannot contain ".." segments.']})
+    data['directory_suffix'] = suffix
+    return data
+
+
 class AddLinkedDirectoryForm(HtmxFormSchema):
-    """Validate the directory name field when adding a project directory."""
-    directory_name = f.Str(required=True, validate=v.Length(min=1, max=255))
+    """Add a project_directory: pick a registered disk root + a suffix.
+
+    The route looks up `root_directory_id` (must exist and not equal '/')
+    and assembles `directory_name = root.rstrip('/') + ('/' + suffix.lstrip('/') if suffix else '')`.
+    """
+    root_directory_id = f.Int(required=True)
+    directory_suffix = f.Str(load_default='', validate=v.Length(max=255))
 
     @post_load
     def normalize(self, data, **kwargs):
-        data['directory_name'] = data['directory_name'].strip()
-        if not data['directory_name']:
-            from marshmallow import ValidationError as _VE
-            raise _VE({'directory_name': ['Directory name cannot be blank.']})
-        return data
+        return _normalize_directory_suffix(data)
 
 
 class EditLinkedDirectoryForm(HtmxFormSchema):
-    """Edit a project_directory row: rename and/or re-link to a project.
+    """Edit a project_directory row: rename via root+suffix and/or re-link
+    to a project.
 
-    FK existence check (project_id -> Project) stays in the route since
-    schemas don't touch the DB.
+    FK existence checks (`root_directory_id` -> DiskResourceRootDirectory,
+    `project_id` -> Project) stay in the route since schemas don't touch the DB.
     """
-    directory_name = f.Str(required=True, validate=v.Length(min=1, max=255))
+    root_directory_id = f.Int(required=True)
+    directory_suffix = f.Str(load_default='', validate=v.Length(max=255))
     project_id = f.Int(required=True)
 
     @post_load
     def normalize(self, data, **kwargs):
-        data['directory_name'] = data['directory_name'].strip()
-        if not data['directory_name']:
-            from marshmallow import ValidationError as _VE
-            raise _VE({'directory_name': ['Directory name cannot be blank.']})
-        return data
+        return _normalize_directory_suffix(data)

--- a/src/sam/schemas/forms/resources.py
+++ b/src/sam/schemas/forms/resources.py
@@ -6,7 +6,7 @@ Covers: Resources, Resource Types, Machines, Queues.
 
 import marshmallow.fields as f
 import marshmallow.validate as v
-from marshmallow import post_load
+from marshmallow import post_load, ValidationError
 
 from . import HtmxFormSchema
 
@@ -82,3 +82,28 @@ class EditQueueForm(HtmxFormSchema):
     # Note: queue start_date is on the ORM object, not in the form. The route
     # checks end_date > queue.start_date inline after schema.load() since it
     # requires the existing DB value.
+
+
+class CreateDiskResourceRootDirectoryForm(HtmxFormSchema):
+    """Validate creation of a DiskResourceRootDirectory.
+
+    FK existence check (resource_id -> Resource of DISK type) stays in the
+    route since schemas do not touch the DB. Uniqueness on root_directory is
+    enforced by the DB and surfaced as a route-level error.
+    """
+    resource_id = f.Int(required=True)
+    root_directory = f.Str(required=True, validate=v.Length(min=1, max=64))
+    charging_exempt = f.Bool(load_default=False)
+
+    @post_load
+    def normalize(self, data, **kwargs):
+        data["root_directory"] = data["root_directory"].strip()
+        if not data["root_directory"]:
+            raise ValidationError({"root_directory": ["Root directory cannot be blank."]})
+        return data
+
+
+class EditDiskResourceRootDirectoryForm(CreateDiskResourceRootDirectoryForm):
+    """Same shape as create. root_directory is editable; uniqueness collisions
+    surface as a route-level error."""
+

--- a/src/webapp/dashboards/admin/blueprint.py
+++ b/src/webapp/dashboards/admin/blueprint.py
@@ -878,6 +878,133 @@ def htmx_add_exemption(username):
     )
 
 
+@bp.route('/htmx/admin/exemption-form')
+@login_required
+@require_permission(Permission.EDIT_USERS)
+def htmx_admin_exemption_form():
+    """Return the add-exemption form fragment for the admin "New" button on
+    the Wallclock Exemptions card row (no preselected user)."""
+    from sam.resources.resources import Resource
+
+    resources = (
+        db.session.query(Resource)
+        .filter(Resource.is_active)
+        .order_by(Resource.resource_name)
+        .all()
+    )
+    resources = [r for r in resources if r.queues]
+
+    return render_template(
+        'dashboards/admin/fragments/add_exemption_form_htmx.html',
+        sam_user=None,
+        resources=resources,
+        today=datetime.now().strftime('%Y-%m-%d')
+    )
+
+
+@bp.route('/htmx/admin/exemption/create', methods=['POST'])
+@login_required
+@require_permission(Permission.EDIT_USERS)
+def htmx_admin_exemption_create():
+    """Create a wallclock exemption from the admin "New" button.
+
+    Reads user_id from the FK picker; otherwise mirrors htmx_add_exemption.
+    """
+    from sam.resources.resources import Resource
+    from sam.operational import WallclockExemption
+    from sam.manage import management_transaction
+
+    def _reload_form(errors):
+        resources = (
+            db.session.query(Resource)
+            .filter(Resource.is_active)
+            .order_by(Resource.resource_name)
+            .all()
+        )
+        resources = [r for r in resources if r.queues]
+        return render_template(
+            'dashboards/admin/fragments/add_exemption_form_htmx.html',
+            sam_user=None,
+            resources=resources,
+            today=datetime.now().strftime('%Y-%m-%d'),
+            errors=errors,
+            form=request.form,
+        )
+
+    errors = []
+    user_id_str = request.form.get('user_id', '').strip()
+    queue_id = request.form.get('queue_id', '').strip()
+    start_date_str = request.form.get('start_date', '').strip()
+    end_date_str = request.form.get('end_date', '').strip()
+    limit_str = request.form.get('time_limit_hours', '').strip()
+    comment = request.form.get('comment', '').strip()
+
+    if not user_id_str:
+        errors.append('User is required.')
+    if not queue_id:
+        errors.append('Queue is required.')
+    if not start_date_str:
+        errors.append('Start date is required.')
+    if not end_date_str:
+        errors.append('End date is required.')
+
+    time_limit_hours = None
+    if not limit_str:
+        errors.append('Time limit (hours) is required.')
+    else:
+        try:
+            time_limit_hours = float(limit_str)
+            if time_limit_hours <= 0:
+                errors.append('Time limit must be a positive number.')
+        except ValueError:
+            errors.append('Time limit must be a number.')
+
+    start_date = end_date = None
+    if start_date_str:
+        try:
+            start_date = datetime.strptime(start_date_str, '%Y-%m-%d')
+        except ValueError:
+            errors.append('Invalid start date format.')
+    if end_date_str:
+        try:
+            end_date = parse_input_end_date(end_date_str)
+        except ValueError:
+            errors.append('Invalid end date format.')
+    if start_date and end_date and end_date <= start_date:
+        errors.append('End date must be after start date.')
+
+    sam_user = None
+    if user_id_str:
+        try:
+            sam_user = db.session.get(User, int(user_id_str))
+        except ValueError:
+            sam_user = None
+        if not sam_user:
+            errors.append('Selected user does not exist.')
+
+    if errors:
+        return _reload_form(errors)
+
+    try:
+        with management_transaction(db.session):
+            WallclockExemption.create(
+                db.session,
+                user_id=sam_user.user_id,
+                queue_id=int(queue_id),
+                start_date=start_date,
+                end_date=end_date,
+                time_limit_hours=time_limit_hours,
+                comment=comment or None,
+            )
+    except Exception as e:
+        return _reload_form([f'Error creating exemption: {e}'])
+
+    return htmx_success_message(
+        {'closeActiveModal': {}, 'reloadResourcesCard': {}},
+        'Exemption saved successfully.',
+    )
+
+
 @bp.route('/htmx/exemption-edit-form/<int:exemption_id>')
 @login_required
 @require_permission(Permission.EDIT_USERS)

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -1778,6 +1778,39 @@ def htmx_propagate_to_remaining(allocation):
 _ORG_LINK_FACILITIES = {'NCAR', 'CISL', 'CSL', 'ASD'}
 
 
+def _disk_roots_for_picker():
+    """Return all DiskResourceRootDirectory rows except the catch-all '/'."""
+    from sam.resources.resources import DiskResourceRootDirectory
+    return (
+        db.session.query(DiskResourceRootDirectory)
+        .filter(DiskResourceRootDirectory.root_directory != '/')
+        .order_by(DiskResourceRootDirectory.root_directory)
+        .all()
+    )
+
+
+def _decompose_directory_name(directory_name, roots):
+    """Split a stored ProjectDirectory.directory_name back into (root, suffix).
+
+    Longest-prefix match wins. Returns (None, original_path) when no
+    root in the supplied list is a prefix of the path.
+    """
+    for r in sorted(roots, key=lambda r: len(r.root_directory), reverse=True):
+        base = r.root_directory.rstrip('/')
+        if directory_name == r.root_directory or directory_name == base:
+            return r, ''
+        if directory_name.startswith(base + '/'):
+            return r, directory_name[len(base) + 1:]
+    return None, directory_name
+
+
+def _assemble_directory_name(root, suffix):
+    """Combine a root + suffix into a stored directory_name string."""
+    suffix = (suffix or '').strip()
+    base = root.root_directory.rstrip('/')
+    return base + ('/' + suffix.lstrip('/') if suffix else '')
+
+
 def _linked_elements_context(project):
     """Build the template context dict for the linked-elements fragment."""
     facility_name = None
@@ -1792,6 +1825,7 @@ def _linked_elements_context(project):
         active_organizations=[po for po in project.organizations if po.is_active],
         contracts=project.contracts,
         active_directories=[pd for pd in project.directories if pd.is_active],
+        disk_roots=_disk_roots_for_picker(),
         can_edit_governance=can_edit_project_governance(current_user, project),
         errors=[],
     )
@@ -1981,10 +2015,15 @@ def htmx_remove_project_contract(projcode, pc_id):
 @login_required
 @require_permission(Permission.EDIT_PROJECTS)
 def htmx_add_project_directory(projcode):
-    """Associate a filesystem directory with a project."""
+    """Associate a filesystem directory with a project.
+
+    Input is now (root_directory_id, directory_suffix); the route looks up
+    the chosen root, rejects '/', and assembles the final directory_name.
+    """
     from marshmallow import ValidationError
     from sam.schemas.forms.projects import AddLinkedDirectoryForm
     from sam.projects.projects import Project, ProjectDirectory
+    from sam.resources.resources import DiskResourceRootDirectory
 
     project = Project.get_by_projcode(db.session, projcode)
     if not project:
@@ -1995,7 +2034,11 @@ def htmx_add_project_directory(projcode):
     except ValidationError as e:
         return _render_linked_elements(project, errors=AddLinkedDirectoryForm.flatten_errors(e.messages))
 
-    directory_name = form_data['directory_name']
+    root = db.session.get(DiskResourceRootDirectory, form_data['root_directory_id'])
+    if not root or root.root_directory == '/':
+        return _render_linked_elements(project, errors=['Selected disk root is invalid.'])
+
+    directory_name = _assemble_directory_name(root, form_data['directory_suffix'])
 
     # Prevent duplicate active entries
     existing = [pd for pd in project.directories if pd.directory_name == directory_name and pd.is_active]
@@ -2122,6 +2165,7 @@ def htmx_admin_project_directory_new_form():
     """Return the create-form fragment loaded into the add modal."""
     return render_template(
         'dashboards/admin/fragments/project_directory_new_form_htmx.html',
+        disk_roots=_disk_roots_for_picker(),
     )
 
 
@@ -2129,53 +2173,58 @@ def htmx_admin_project_directory_new_form():
 @login_required
 @require_permission(Permission.EDIT_PROJECTS)
 def htmx_admin_project_directory_create():
-    """Create a new project_directory row from the admin add modal."""
+    """Create a new project_directory row from the admin add modal.
+
+    Input shape: (root_directory_id, directory_suffix, project_id).
+    The route validates the chosen root (must exist and not equal '/'),
+    assembles the final directory_name, and creates the row.
+    """
     from marshmallow import ValidationError
     from sam.schemas.forms.projects import EditLinkedDirectoryForm
     from sam.projects.projects import Project, ProjectDirectory
+    from sam.resources.resources import DiskResourceRootDirectory
+
+    disk_roots = _disk_roots_for_picker()
+
+    def _reload(errors):
+        return render_template(
+            'dashboards/admin/fragments/project_directory_new_form_htmx.html',
+            disk_roots=disk_roots,
+            errors=errors,
+            form=request.form,
+        )
 
     try:
         form_data = EditLinkedDirectoryForm().load(request.form)
     except ValidationError as e:
-        return render_template(
-            'dashboards/admin/fragments/project_directory_new_form_htmx.html',
-            errors=EditLinkedDirectoryForm.flatten_errors(e.messages),
-            form=request.form,
-        )
+        return _reload(EditLinkedDirectoryForm.flatten_errors(e.messages))
+
+    root = db.session.get(DiskResourceRootDirectory, form_data['root_directory_id'])
+    if not root or root.root_directory == '/':
+        return _reload(['Selected disk root is invalid.'])
 
     target_project = db.session.get(Project, form_data['project_id'])
     if not target_project:
-        return render_template(
-            'dashboards/admin/fragments/project_directory_new_form_htmx.html',
-            errors=['Selected project does not exist.'],
-            form=request.form,
-        )
+        return _reload(['Selected project does not exist.'])
 
-    # Prevent duplicate active entries on the target project
+    directory_name = _assemble_directory_name(root, form_data['directory_suffix'])
+
     duplicates = [
         pd for pd in target_project.directories
-        if pd.directory_name == form_data['directory_name'] and pd.is_active
+        if pd.directory_name == directory_name and pd.is_active
     ]
     if duplicates:
-        return render_template(
-            'dashboards/admin/fragments/project_directory_new_form_htmx.html',
-            errors=[f'Directory "{form_data["directory_name"]}" is already linked to {target_project.projcode}.'],
-            form=request.form,
-        )
+        return _reload([f'Directory "{directory_name}" is already linked to {target_project.projcode}.'])
 
     try:
         with management_transaction(db.session):
             ProjectDirectory.create(
                 db.session,
                 project_id=form_data['project_id'],
-                directory_name=form_data['directory_name'],
+                directory_name=directory_name,
             )
     except Exception as e:
-        return render_template(
-            'dashboards/admin/fragments/project_directory_new_form_htmx.html',
-            errors=[f'Error creating directory: {e}'],
-            form=request.form,
-        )
+        return _reload([f'Error creating directory: {e}'])
 
     return htmx_success_message(
         _PROJECT_DIRECTORIES_RELOAD_TRIGGERS,
@@ -2187,16 +2236,28 @@ def htmx_admin_project_directory_create():
 @login_required
 @require_permission(Permission.EDIT_PROJECTS)
 def htmx_admin_project_directory_edit_form(pd_id):
-    """Return the edit-form fragment loaded into the edit modal."""
+    """Return the edit-form fragment loaded into the edit modal.
+
+    Pre-populates root_directory_id + directory_suffix by decomposing the
+    existing directory_name; renders an orphaned banner if no registered
+    non-'/' root matches.
+    """
     from sam.projects.projects import ProjectDirectory
 
     pd = db.session.get(ProjectDirectory, pd_id)
     if not pd:
         return '<div class="alert alert-danger">Directory not found.</div>', 404
 
+    disk_roots = _disk_roots_for_picker()
+    default_root, default_suffix = _decompose_directory_name(pd.directory_name, disk_roots)
+
     return render_template(
         'dashboards/admin/fragments/project_directory_edit_form_htmx.html',
         pd=pd,
+        disk_roots=disk_roots,
+        default_root=default_root,
+        default_suffix=default_suffix,
+        is_orphaned=(default_root is None),
     )
 
 
@@ -2208,43 +2269,51 @@ def htmx_admin_project_directory_edit(pd_id):
     from marshmallow import ValidationError
     from sam.schemas.forms.projects import EditLinkedDirectoryForm
     from sam.projects.projects import Project, ProjectDirectory
+    from sam.resources.resources import DiskResourceRootDirectory
 
     pd = db.session.get(ProjectDirectory, pd_id)
     if not pd:
         return '<div class="alert alert-danger">Directory not found.</div>', 404
 
-    try:
-        form_data = EditLinkedDirectoryForm().load(request.form)
-    except ValidationError as e:
+    disk_roots = _disk_roots_for_picker()
+
+    def _reload(errors):
+        # Decompose afresh so banner state stays consistent on re-render.
+        default_root, default_suffix = _decompose_directory_name(pd.directory_name, disk_roots)
         return render_template(
             'dashboards/admin/fragments/project_directory_edit_form_htmx.html',
             pd=pd,
-            errors=EditLinkedDirectoryForm.flatten_errors(e.messages),
+            disk_roots=disk_roots,
+            default_root=default_root,
+            default_suffix=default_suffix,
+            is_orphaned=(default_root is None),
+            errors=errors,
             form=request.form,
         )
 
+    try:
+        form_data = EditLinkedDirectoryForm().load(request.form)
+    except ValidationError as e:
+        return _reload(EditLinkedDirectoryForm.flatten_errors(e.messages))
+
+    root = db.session.get(DiskResourceRootDirectory, form_data['root_directory_id'])
+    if not root or root.root_directory == '/':
+        return _reload(['Selected disk root is invalid.'])
+
     target_project = db.session.get(Project, form_data['project_id'])
     if not target_project:
-        return render_template(
-            'dashboards/admin/fragments/project_directory_edit_form_htmx.html',
-            pd=pd,
-            errors=['Selected project does not exist.'],
-            form=request.form,
-        )
+        return _reload(['Selected project does not exist.'])
+
+    directory_name = _assemble_directory_name(root, form_data['directory_suffix'])
 
     try:
         with management_transaction(db.session):
             pd.update(
-                directory_name=form_data['directory_name'],
+                directory_name=directory_name,
                 project_id=form_data['project_id'],
             )
     except Exception as e:
-        return render_template(
-            'dashboards/admin/fragments/project_directory_edit_form_htmx.html',
-            pd=pd,
-            errors=[f'Error updating directory: {e}'],
-            form=request.form,
-        )
+        return _reload([f'Error updating directory: {e}'])
 
     return htmx_success_message(
         _PROJECT_DIRECTORIES_RELOAD_TRIGGERS,

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -2115,6 +2115,74 @@ def htmx_admin_project_directories():
     return _render_project_directories_card(show_inactive=show_inactive)
 
 
+@bp.route('/htmx/admin/project-directories/new-form')
+@login_required
+@require_permission(Permission.EDIT_PROJECTS)
+def htmx_admin_project_directory_new_form():
+    """Return the create-form fragment loaded into the add modal."""
+    return render_template(
+        'dashboards/admin/fragments/project_directory_new_form_htmx.html',
+    )
+
+
+@bp.route('/htmx/admin/project-directories/create', methods=['POST'])
+@login_required
+@require_permission(Permission.EDIT_PROJECTS)
+def htmx_admin_project_directory_create():
+    """Create a new project_directory row from the admin add modal."""
+    from marshmallow import ValidationError
+    from sam.schemas.forms.projects import EditLinkedDirectoryForm
+    from sam.projects.projects import Project, ProjectDirectory
+
+    try:
+        form_data = EditLinkedDirectoryForm().load(request.form)
+    except ValidationError as e:
+        return render_template(
+            'dashboards/admin/fragments/project_directory_new_form_htmx.html',
+            errors=EditLinkedDirectoryForm.flatten_errors(e.messages),
+            form=request.form,
+        )
+
+    target_project = db.session.get(Project, form_data['project_id'])
+    if not target_project:
+        return render_template(
+            'dashboards/admin/fragments/project_directory_new_form_htmx.html',
+            errors=['Selected project does not exist.'],
+            form=request.form,
+        )
+
+    # Prevent duplicate active entries on the target project
+    duplicates = [
+        pd for pd in target_project.directories
+        if pd.directory_name == form_data['directory_name'] and pd.is_active
+    ]
+    if duplicates:
+        return render_template(
+            'dashboards/admin/fragments/project_directory_new_form_htmx.html',
+            errors=[f'Directory "{form_data["directory_name"]}" is already linked to {target_project.projcode}.'],
+            form=request.form,
+        )
+
+    try:
+        with management_transaction(db.session):
+            ProjectDirectory.create(
+                db.session,
+                project_id=form_data['project_id'],
+                directory_name=form_data['directory_name'],
+            )
+    except Exception as e:
+        return render_template(
+            'dashboards/admin/fragments/project_directory_new_form_htmx.html',
+            errors=[f'Error creating directory: {e}'],
+            form=request.form,
+        )
+
+    return htmx_success_message(
+        _PROJECT_DIRECTORIES_RELOAD_TRIGGERS,
+        'Project directory created.',
+    )
+
+
 @bp.route('/htmx/admin/project-directories/<int:pd_id>/edit-form')
 @login_required
 @require_permission(Permission.EDIT_PROJECTS)

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -2039,3 +2039,169 @@ def htmx_remove_project_directory(projcode, pd_id):
 
     db.session.refresh(project)
     return _render_linked_elements(project)
+
+
+# ---------------------------------------------------------------------------
+# Admin: cross-project Project Directories view
+# ---------------------------------------------------------------------------
+
+_PROJECT_DIRECTORIES_RELOAD_TRIGGERS = {
+    'closeActiveModal': {},
+    'reloadProjectDirectoriesCard': {},
+}
+
+
+def _render_project_directories_card(*, show_inactive: bool):
+    """Render the cross-project Project Directories card fragment.
+
+    Groups rows by Resource via longest-prefix match of ``directory_name``
+    against ``DiskResourceRootDirectory.root_directory``. Unmatched rows
+    fall into a final "No Resource Identified" group.
+    """
+    from collections import defaultdict
+    from sam.projects.projects import ProjectDirectory, Project
+    from sam.resources.resources import DiskResourceRootDirectory
+
+    roots = (
+        db.session.query(DiskResourceRootDirectory)
+        .order_by(DiskResourceRootDirectory.root_directory)
+        .all()
+    )
+    # Longest prefix wins so /glade/campaign beats /glade
+    roots_by_len = sorted(roots, key=lambda r: len(r.root_directory), reverse=True)
+
+    def _resolve_resource(directory_name: str):
+        for r in roots_by_len:
+            if directory_name.startswith(r.root_directory):
+                return r.resource
+        return None
+
+    q = db.session.query(ProjectDirectory).join(Project)
+    if not show_inactive:
+        q = q.filter(ProjectDirectory.is_active)
+    rows = q.order_by(ProjectDirectory.directory_name).all()
+
+    groups = defaultdict(list)  # resource_id (or None) -> list[ProjectDirectory]
+    resources_by_id = {}        # resource_id -> Resource
+    for pd in rows:
+        res = _resolve_resource(pd.directory_name)
+        rid = res.resource_id if res is not None else None
+        groups[rid].append(pd)
+        if res is not None and rid not in resources_by_id:
+            resources_by_id[rid] = res
+
+    # Ordered list: real resources alphabetically, then Unmatched (None) last
+    ordered_groups = sorted(
+        ((rid, resources_by_id[rid], groups[rid]) for rid in resources_by_id),
+        key=lambda t: t[1].resource_name.lower(),
+    )
+    if None in groups:
+        ordered_groups.append((None, None, groups[None]))
+
+    return render_template(
+        'dashboards/admin/fragments/project_directories_card.html',
+        ordered_groups=ordered_groups,
+        total_rows=len(rows),
+        show_inactive=show_inactive,
+    )
+
+
+@bp.route('/htmx/admin/project-directories')
+@login_required
+@require_permission(Permission.EDIT_PROJECTS)
+def htmx_admin_project_directories():
+    """Render the cross-project Project Directories table."""
+    show_inactive = request.args.get('show_inactive', '0') in ('1', 'true', 'on')
+    return _render_project_directories_card(show_inactive=show_inactive)
+
+
+@bp.route('/htmx/admin/project-directories/<int:pd_id>/edit-form')
+@login_required
+@require_permission(Permission.EDIT_PROJECTS)
+def htmx_admin_project_directory_edit_form(pd_id):
+    """Return the edit-form fragment loaded into the edit modal."""
+    from sam.projects.projects import ProjectDirectory
+
+    pd = db.session.get(ProjectDirectory, pd_id)
+    if not pd:
+        return '<div class="alert alert-danger">Directory not found.</div>', 404
+
+    return render_template(
+        'dashboards/admin/fragments/project_directory_edit_form_htmx.html',
+        pd=pd,
+    )
+
+
+@bp.route('/htmx/admin/project-directories/<int:pd_id>/edit', methods=['POST'])
+@login_required
+@require_permission(Permission.EDIT_PROJECTS)
+def htmx_admin_project_directory_edit(pd_id):
+    """Update a project_directory row's directory_name and/or linked project."""
+    from marshmallow import ValidationError
+    from sam.schemas.forms.projects import EditLinkedDirectoryForm
+    from sam.projects.projects import Project, ProjectDirectory
+
+    pd = db.session.get(ProjectDirectory, pd_id)
+    if not pd:
+        return '<div class="alert alert-danger">Directory not found.</div>', 404
+
+    try:
+        form_data = EditLinkedDirectoryForm().load(request.form)
+    except ValidationError as e:
+        return render_template(
+            'dashboards/admin/fragments/project_directory_edit_form_htmx.html',
+            pd=pd,
+            errors=EditLinkedDirectoryForm.flatten_errors(e.messages),
+            form=request.form,
+        )
+
+    target_project = db.session.get(Project, form_data['project_id'])
+    if not target_project:
+        return render_template(
+            'dashboards/admin/fragments/project_directory_edit_form_htmx.html',
+            pd=pd,
+            errors=['Selected project does not exist.'],
+            form=request.form,
+        )
+
+    try:
+        with management_transaction(db.session):
+            pd.update(
+                directory_name=form_data['directory_name'],
+                project_id=form_data['project_id'],
+            )
+    except Exception as e:
+        return render_template(
+            'dashboards/admin/fragments/project_directory_edit_form_htmx.html',
+            pd=pd,
+            errors=[f'Error updating directory: {e}'],
+            form=request.form,
+        )
+
+    return htmx_success_message(
+        _PROJECT_DIRECTORIES_RELOAD_TRIGGERS,
+        'Project directory updated.',
+    )
+
+
+@bp.route('/htmx/admin/project-directories/<int:pd_id>/deactivate', methods=['POST'])
+@login_required
+@require_permission(Permission.EDIT_PROJECTS)
+def htmx_admin_project_directory_deactivate(pd_id):
+    """Deactivate (soft-delete) a project_directory row."""
+    from sam.projects.projects import ProjectDirectory
+
+    pd = db.session.get(ProjectDirectory, pd_id)
+    if not pd:
+        return '<div class="alert alert-danger">Directory not found.</div>', 404
+
+    try:
+        with management_transaction(db.session):
+            pd.deactivate()
+    except Exception as e:
+        return f'<div class="alert alert-danger">Error: {e}</div>', 500
+
+    return htmx_success_message(
+        {'reloadProjectDirectoriesCard': {}},
+        'Project directory deactivated.',
+    )

--- a/src/webapp/dashboards/admin/resources_routes.py
+++ b/src/webapp/dashboards/admin/resources_routes.py
@@ -23,6 +23,7 @@ from sam.schemas.forms.resources import (
     EditResourceForm, CreateResourceForm,
     EditResourceTypeForm, CreateResourceTypeForm,
     EditMachineForm, CreateMachineForm, EditQueueForm,
+    CreateDiskResourceRootDirectoryForm, EditDiskResourceRootDirectoryForm,
 )
 
 from .blueprint import bp
@@ -98,6 +99,16 @@ def htmx_resources_card():
         exemption_q = exemption_q.filter(WallclockExemption.is_active)
     exemptions = exemption_q.all()
 
+    # Disk resources (with their root_directories collection) for the
+    # "Disk Resource Root Directories" section in the Resources sub-tab.
+    disk_resources_with_roots = (
+        db.session.query(Resource)
+        .join(ResourceType)
+        .filter(ResourceType.resource_type == 'DISK')
+        .order_by(Resource.resource_name)
+        .all()
+    )
+
     return render_template(
         'dashboards/admin/fragments/resources_card.html',
         resources=resources,
@@ -105,6 +116,7 @@ def htmx_resources_card():
         machines=machines,
         queues=queues,
         exemptions=exemptions,
+        disk_resources_with_roots=disk_resources_with_roots,
         is_admin=True,
         now=now,
         active_only=active_only,
@@ -543,3 +555,159 @@ def htmx_search_organizations():
         'dashboards/admin/fragments/org_search_results_fk_htmx.html',
         orgs=orgs,
     )
+
+
+# ---------------------------------------------------------------------------
+# Admin: Disk Resource Root Directories CRUD
+# ---------------------------------------------------------------------------
+
+def _disk_resources():
+    """Return all DISK-type resources, ordered by name (used for the
+    resource_id select on add/edit forms)."""
+    from sam.resources.resources import Resource, ResourceType
+    return (
+        db.session.query(Resource)
+        .join(ResourceType)
+        .filter(ResourceType.resource_type == 'DISK')
+        .order_by(Resource.resource_name)
+        .all()
+    )
+
+
+@bp.route('/htmx/admin/disk-roots/new-form')
+@login_required
+@require_permission(Permission.EDIT_RESOURCES)
+def htmx_admin_disk_root_new_form():
+    """Return the create-disk-root form fragment for the modal."""
+    return render_template(
+        'dashboards/admin/fragments/disk_root_new_form_htmx.html',
+        disk_resources=_disk_resources(),
+    )
+
+
+@bp.route('/htmx/admin/disk-roots/create', methods=['POST'])
+@login_required
+@require_permission(Permission.EDIT_RESOURCES)
+def htmx_admin_disk_root_create():
+    """Create a new DiskResourceRootDirectory row."""
+    from marshmallow import ValidationError
+    from sqlalchemy.exc import IntegrityError
+    from sam.resources.resources import Resource, ResourceType, DiskResourceRootDirectory
+
+    def _reload(errors, form=None):
+        return render_template(
+            'dashboards/admin/fragments/disk_root_new_form_htmx.html',
+            disk_resources=_disk_resources(),
+            errors=errors,
+            form=form if form is not None else request.form,
+        )
+
+    try:
+        data = CreateDiskResourceRootDirectoryForm().load(request.form)
+    except ValidationError as e:
+        return _reload(CreateDiskResourceRootDirectoryForm.flatten_errors(e.messages))
+
+    target = db.session.get(Resource, data['resource_id'])
+    if not target or not target.resource_type or target.resource_type.resource_type != 'DISK':
+        return _reload(['Selected resource does not exist or is not a disk resource.'])
+
+    try:
+        with management_transaction(db.session):
+            DiskResourceRootDirectory.create(
+                db.session,
+                resource_id=data['resource_id'],
+                root_directory=data['root_directory'],
+                charging_exempt=data['charging_exempt'],
+            )
+    except IntegrityError:
+        db.session.rollback()
+        return _reload([f'Root directory "{data["root_directory"]}" already exists.'])
+    except Exception as e:
+        return _reload([f'Error creating root directory: {e}'])
+
+    return htmx_success_message(_RESOURCES_TRIGGERS, 'Root directory created.')
+
+
+@bp.route('/htmx/admin/disk-roots/<int:dr_id>/edit-form')
+@login_required
+@require_permission(Permission.EDIT_RESOURCES)
+def htmx_admin_disk_root_edit_form(dr_id):
+    """Return the edit-disk-root form fragment for the modal."""
+    from sam.resources.resources import DiskResourceRootDirectory
+
+    dr = db.session.get(DiskResourceRootDirectory, dr_id)
+    if not dr:
+        return '<div class="alert alert-danger">Root directory not found.</div>', 404
+
+    return render_template(
+        'dashboards/admin/fragments/disk_root_edit_form_htmx.html',
+        dr=dr,
+        disk_resources=_disk_resources(),
+    )
+
+
+@bp.route('/htmx/admin/disk-roots/<int:dr_id>/edit', methods=['POST'])
+@login_required
+@require_permission(Permission.EDIT_RESOURCES)
+def htmx_admin_disk_root_edit(dr_id):
+    """Update a DiskResourceRootDirectory row."""
+    from marshmallow import ValidationError
+    from sqlalchemy.exc import IntegrityError
+    from sam.resources.resources import Resource, DiskResourceRootDirectory
+
+    dr = db.session.get(DiskResourceRootDirectory, dr_id)
+    if not dr:
+        return '<div class="alert alert-danger">Root directory not found.</div>', 404
+
+    def _reload(errors, form=None):
+        return render_template(
+            'dashboards/admin/fragments/disk_root_edit_form_htmx.html',
+            dr=dr,
+            disk_resources=_disk_resources(),
+            errors=errors,
+            form=form if form is not None else request.form,
+        )
+
+    try:
+        data = EditDiskResourceRootDirectoryForm().load(request.form)
+    except ValidationError as e:
+        return _reload(EditDiskResourceRootDirectoryForm.flatten_errors(e.messages))
+
+    target = db.session.get(Resource, data['resource_id'])
+    if not target or not target.resource_type or target.resource_type.resource_type != 'DISK':
+        return _reload(['Selected resource does not exist or is not a disk resource.'])
+
+    try:
+        with management_transaction(db.session):
+            dr.update(
+                resource_id=data['resource_id'],
+                root_directory=data['root_directory'],
+                charging_exempt=data['charging_exempt'],
+            )
+    except IntegrityError:
+        db.session.rollback()
+        return _reload([f'Root directory "{data["root_directory"]}" already exists.'])
+    except Exception as e:
+        return _reload([f'Error updating root directory: {e}'])
+
+    return htmx_success_message(_RESOURCES_TRIGGERS, 'Root directory updated.')
+
+
+@bp.route('/htmx/admin/disk-roots/<int:dr_id>/delete', methods=['POST'])
+@login_required
+@require_permission(Permission.DELETE_RESOURCES)
+def htmx_admin_disk_root_delete(dr_id):
+    """Hard-delete a DiskResourceRootDirectory row."""
+    from sam.resources.resources import DiskResourceRootDirectory
+
+    dr = db.session.get(DiskResourceRootDirectory, dr_id)
+    if not dr:
+        return '<div class="alert alert-danger">Root directory not found.</div>', 404
+
+    try:
+        with management_transaction(db.session):
+            dr.delete()
+    except Exception as e:
+        return f'<div class="alert alert-danger">Error: {e}</div>', 500
+
+    return htmx_success_message({'reloadResourcesCard': {}}, 'Root directory deleted.')

--- a/src/webapp/static/js/htmx-config.js
+++ b/src/webapp/static/js/htmx-config.js
@@ -100,6 +100,21 @@ document.body.addEventListener('reloadResourcesCard', function() {
     _reloadAdminCard('resourcesSection', 'resourcesCardActiveOnly');
 });
 
+// Reload the cross-project Project Directories table after an edit/deactivate.
+// Uses the show_inactive checkbox state if present (note: opposite of active_only).
+document.body.addEventListener('reloadProjectDirectoriesCard', function() {
+    var section = document.getElementById('projectDirectoriesSection');
+    if (!section) return;
+    var url = (section.getAttribute('hx-get') || '').split('?')[0];
+    if (!url) return;
+    var cb = document.getElementById('projectDirectoriesShowInactive');
+    var qs = (cb && cb.checked) ? '?show_inactive=1' : '';
+    setTimeout(function() {
+        htmx.ajax('GET', url + qs,
+                  {target: '#projectDirectoriesSection', swap: 'innerHTML'});
+    }, 300);
+});
+
 // Load the newly-created project card into #projectCardContainer so the admin
 // can immediately see the result without re-searching.
 document.body.addEventListener('loadNewProject', function(evt) {

--- a/src/webapp/templates/dashboards/admin/dashboard.html
+++ b/src/webapp/templates/dashboards/admin/dashboard.html
@@ -58,6 +58,30 @@
     <!-- Tab 1: Projects -->
     <div class="tab-pane fade show active" id="tab-projects" role="tabpanel" aria-labelledby="projects-tab">
 
+        <!-- Projects sub-tab navigation -->
+        <ul class="nav nav-pills mb-3" id="projectsSubTabs" role="tablist">
+            <li class="nav-item" role="presentation">
+                <button class="nav-link active" id="projects-manage-tab"
+                        data-bs-toggle="pill" data-bs-target="#tab-projects-manage"
+                        type="button" role="tab" aria-controls="tab-projects-manage" aria-selected="true">
+                    <i class="fas fa-folder-open me-1"></i> Manage
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="projects-directories-tab"
+                        data-bs-toggle="pill" data-bs-target="#tab-projects-directories"
+                        type="button" role="tab" aria-controls="tab-projects-directories" aria-selected="false">
+                    <i class="fas fa-folder-tree me-1"></i> Project Directories
+                </button>
+            </li>
+        </ul>
+
+        <div class="tab-content" id="projectsSubTabsContent">
+
+        <!-- Sub-tab: Manage (existing content) -->
+        <div class="tab-pane fade show active" id="tab-projects-manage"
+             role="tabpanel" aria-labelledby="projects-manage-tab">
+
         <div class="row">
             <!-- Search Projects Section -->
             <div class="col-md-6">
@@ -230,6 +254,26 @@
                 </div>
             </div>
         </div>
+
+        </div><!-- /#tab-projects-manage -->
+
+        <!-- Sub-tab: Project Directories -->
+        <div class="tab-pane fade" id="tab-projects-directories"
+             role="tabpanel" aria-labelledby="projects-directories-tab">
+            <div id="projectDirectoriesSection"
+                 hx-get="{{ url_for('admin_dashboard.htmx_admin_project_directories') }}"
+                 hx-trigger="load once"
+                 hx-target="this"
+                 hx-swap="innerHTML">
+                <div class="text-center py-4">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="sr-only">Loading...</span>
+                    </div>
+                </div>
+            </div>
+        </div><!-- /#tab-projects-directories -->
+
+        </div><!-- /#projectsSubTabsContent -->
 
     </div><!-- /#tab-projects -->
 
@@ -443,6 +487,8 @@
 </div>
 
 {% include 'dashboards/admin/fragments/exemption_modals.html' %}
+
+{% include 'dashboards/admin/fragments/project_directory_modals.html' %}
 
 {% include 'dashboards/admin/fragments/resources_modals.html' %}
 

--- a/src/webapp/templates/dashboards/admin/dashboard.html
+++ b/src/webapp/templates/dashboards/admin/dashboard.html
@@ -59,17 +59,17 @@
     <div class="tab-pane fade show active" id="tab-projects" role="tabpanel" aria-labelledby="projects-tab">
 
         <!-- Projects sub-tab navigation -->
-        <ul class="nav nav-pills mb-3" id="projectsSubTabs" role="tablist">
+        <ul class="nav nav-tabs mb-3" id="projectsSubTabs" role="tablist">
             <li class="nav-item" role="presentation">
                 <button class="nav-link active" id="projects-manage-tab"
-                        data-bs-toggle="pill" data-bs-target="#tab-projects-manage"
+                        data-bs-toggle="tab" data-bs-target="#tab-projects-manage"
                         type="button" role="tab" aria-controls="tab-projects-manage" aria-selected="true">
                     <i class="fas fa-folder-open me-1"></i> Manage
                 </button>
             </li>
             <li class="nav-item" role="presentation">
                 <button class="nav-link" id="projects-directories-tab"
-                        data-bs-toggle="pill" data-bs-target="#tab-projects-directories"
+                        data-bs-toggle="tab" data-bs-target="#tab-projects-directories"
                         type="button" role="tab" aria-controls="tab-projects-directories" aria-selected="false">
                     <i class="fas fa-folder-tree me-1"></i> Project Directories
                 </button>

--- a/src/webapp/templates/dashboards/admin/fragments/add_exemption_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/add_exemption_form_htmx.html
@@ -1,17 +1,27 @@
 {% from 'dashboards/fragments/modal_form.html' import htmx_form with context %}
-{% from 'dashboards/fragments/form_fields.html' import number_field, date_field, textarea_field with context %}
+{% from 'dashboards/fragments/form_fields.html' import number_field, date_field, textarea_field, fk_search_field with context %}
 {#
   htmx: Add Wallclock Exemption Form (loaded into #addExemptionFormContainer)
   Resource → Queue cascading via HTMX (kept inline).
+
+  When ``sam_user`` is provided (per-user add from a user card), the user is
+  shown as static text and posted with the username embedded in the URL.
+  When ``sam_user`` is None (admin "New" button on the Wallclock Exemptions
+  row of the resources card), the form renders an FK picker for user_id and
+  posts to the admin-wide create endpoint.
 #}
 
+{% set _post_url = url_for('admin_dashboard.htmx_add_exemption', username=sam_user.username) if sam_user
+                   else url_for('admin_dashboard.htmx_admin_exemption_create') %}
+
 {% call htmx_form(
-    url_for('admin_dashboard.htmx_add_exemption', username=sam_user.username),
+    _post_url,
     '#addExemptionFormContainer',
     'Add Exemption',
     submit_icon='plus',
     errors=errors
 ) %}
+        {% if sam_user %}
         <div class="mb-3">
             <label class="form-label">User</label>
             <div class="form-control-plaintext">
@@ -19,6 +29,13 @@
                 <span class="text-muted">({{ sam_user.username }})</span>
             </div>
         </div>
+        {% else %}
+        {{ fk_search_field('user_id', 'User',
+                           search_url=url_for('admin_dashboard.htmx_search_users', context='fk'),
+                           required=True,
+                           placeholder='Search by username, first, or last name…',
+                           id_prefix='addExemptionUser') }}
+        {% endif %}
 
         {# Resource → Queue cascading select kept inline — dependent options
            are populated via HTMX; the dependent select is dynamic. #}

--- a/src/webapp/templates/dashboards/admin/fragments/disk_root_directories_section.html
+++ b/src/webapp/templates/dashboards/admin/fragments/disk_root_directories_section.html
@@ -1,0 +1,119 @@
+{% from 'dashboards/fragments/action_buttons.html' import edit_modal_button with context %}
+{#
+  Admin: Disk Resource Root Directories section.
+
+  Mirrors the Wallclock Exemptions structure (resources_card.html:306-401).
+  Sits at the bottom of the Resources sub-tab pane.
+
+  Context:
+    disk_resources_with_roots : list[Resource] with .root_directories collection
+#}
+
+<div class="border-top mt-2 pt-2 px-3 pb-1 d-flex align-items-center justify-content-between">
+    <div class="d-flex align-items-center">
+        <i class="fas fa-folder-tree me-2 text-muted"></i>
+        <span class="fw-semibold">Disk Resource Root Directories</span>
+        <span class="text-muted small ms-2">
+            prefix mappings used to associate project directories with disk resources
+        </span>
+    </div>
+    {% if has_permission(Permission.EDIT_RESOURCES) %}
+    <button type="button" class="btn btn-sm btn-success"
+            data-bs-toggle="modal"
+            data-bs-target="#addDiskRootModal"
+            hx-get="{{ url_for('admin_dashboard.htmx_admin_disk_root_new_form') }}"
+            hx-target="#addDiskRootFormContainer"
+            hx-trigger="click">
+        <i class="fas fa-plus"></i> New
+    </button>
+    {% endif %}
+</div>
+
+<div class="table-responsive">
+    <table class="table table-sm mb-0">
+        <thead class="table-light">
+            <tr>
+                <th>Root Directory</th>
+                <th>Charging Exempt</th>
+                <th class="text-end">Actions</th>
+            </tr>
+        </thead>
+        {% set _total_roots = namespace(n=0) %}
+        {% if disk_resources_with_roots %}
+        {% for r in disk_resources_with_roots %}
+        {% set _total_roots.n = _total_roots.n + r.root_directories|length %}
+        {# ── Resource row (clickable trigger) ── #}
+        <tbody>
+            <tr class="cursor-pointer table-light fw-semibold"
+                data-bs-toggle="collapse"
+                data-bs-target="#disk-root-res-{{ r.resource_id }}"
+                aria-expanded="false">
+                <td>
+                    <i class="fas fa-chevron-right small text-muted me-1 disk-root-collapse-icon"
+                       style="transition: transform 0.2s;"></i>
+                    {{ r.resource_name }}
+                </td>
+                <td class="text-muted small" colspan="2">
+                    {{ r.root_directories|length }} root director{{ 'ies' if r.root_directories|length != 1 else 'y' }}
+                </td>
+            </tr>
+        </tbody>
+        {# ── Root-directory child rows (collapsed by default) ── #}
+        <tbody class="collapse" id="disk-root-res-{{ r.resource_id }}">
+            {% if r.root_directories %}
+            {% for dr in r.root_directories|sort(attribute='root_directory') %}
+            <tr class="table-secondary">
+                <td class="ps-4 font-monospace small">{{ dr.root_directory }}</td>
+                <td>
+                    {% if dr.charging_exempt %}
+                    <span class="badge bg-warning text-dark">
+                        <i class="fas fa-shield-alt"></i> exempt
+                    </span>
+                    {% else %}
+                    <span class="text-muted small">—</span>
+                    {% endif %}
+                </td>
+                <td class="text-end">
+                    {{ edit_modal_button(
+                        url_for('admin_dashboard.htmx_admin_disk_root_edit_form', dr_id=dr.root_directory_id),
+                        modal_id='editDiskRootModal',
+                        target_id='editDiskRootFormContainer',
+                        title='Edit root directory',
+                        stop_propagation=True,
+                        permission=Permission.EDIT_RESOURCES) }}
+                    {% if has_permission(Permission.DELETE_RESOURCES) %}
+                    <button class="btn btn-sm btn-outline-danger ms-1"
+                            title="Delete root directory"
+                            hx-post="{{ url_for('admin_dashboard.htmx_admin_disk_root_delete', dr_id=dr.root_directory_id) }}"
+                            hx-swap="none"
+                            hx-confirm="Permanently delete root directory &quot;{{ dr.root_directory }}&quot;? This cannot be undone."
+                            data-confirm-title="Delete root directory"
+                            data-confirm-variant="danger"
+                            data-confirm-label="Delete"
+                            onclick="event.stopPropagation()">
+                        <i class="fas fa-trash-alt"></i>
+                    </button>
+                    {% endif %}
+                </td>
+            </tr>
+            {% endfor %}
+            {% else %}
+            <tr class="table-secondary">
+                <td colspan="3" class="ps-4 text-muted fst-italic small">
+                    No root directories configured for this resource.
+                </td>
+            </tr>
+            {% endif %}
+        </tbody>
+        {% endfor %}
+        {% else %}
+        <tbody>
+            <tr><td colspan="3" class="text-center text-muted py-3">No disk resources found.</td></tr>
+        </tbody>
+        {% endif %}
+    </table>
+</div>
+<div class="text-muted small px-3 py-2">
+    Showing {{ _total_roots.n }} root director{{ 'ies' if _total_roots.n != 1 else 'y' }}
+    across {{ disk_resources_with_roots|length }} disk resource{{ 's' if disk_resources_with_roots|length != 1 else '' }}.
+</div>

--- a/src/webapp/templates/dashboards/admin/fragments/disk_root_edit_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/disk_root_edit_form_htmx.html
@@ -1,0 +1,40 @@
+{% from 'dashboards/fragments/modal_form.html' import htmx_form with context %}
+{% from 'dashboards/fragments/form_fields.html' import text_field, select_field, checkbox_field with context %}
+{#
+  htmx: Edit Disk Root Directory form (loaded into #editDiskRootFormContainer).
+
+  Context:
+    dr             : DiskResourceRootDirectory instance
+    disk_resources : list[Resource] of DISK type (drives the resource_id select)
+    errors : optional list[str]
+    form   : optional ImmutableMultiDict (re-render after validation error)
+#}
+
+{% call htmx_form(
+    url_for('admin_dashboard.htmx_admin_disk_root_edit', dr_id=dr.root_directory_id),
+    '#editDiskRootFormContainer',
+    'Save Changes',
+    is_edit=True,
+    errors=errors
+) %}
+        {{ select_field('resource_id', 'Disk Resource',
+                        items=disk_resources,
+                        value_attr='resource_id',
+                        label_attr='resource_name',
+                        required=True,
+                        default=dr.resource_id,
+                        id='editDiskRootResource') }}
+
+        {{ text_field('root_directory', 'Root Directory',
+                      required=True,
+                      maxlength=64,
+                      default=dr.root_directory,
+                      placeholder='/glade/...',
+                      help='Must be unique across all disk resources.',
+                      id='editDiskRootPath') }}
+
+        {{ checkbox_field('charging_exempt', 'Charging exempt',
+                          default=dr.charging_exempt,
+                          help='If checked, directories under this root do not incur disk charges.',
+                          id='editDiskRootExempt') }}
+{% endcall %}

--- a/src/webapp/templates/dashboards/admin/fragments/disk_root_new_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/disk_root_new_form_htmx.html
@@ -1,0 +1,37 @@
+{% from 'dashboards/fragments/modal_form.html' import htmx_form with context %}
+{% from 'dashboards/fragments/form_fields.html' import text_field, select_field, checkbox_field with context %}
+{#
+  htmx: New Disk Root Directory form (loaded into #addDiskRootFormContainer).
+
+  Context:
+    disk_resources : list[Resource] of DISK type (drives the resource_id select)
+    errors : optional list[str]
+    form   : optional ImmutableMultiDict (re-render after validation error)
+#}
+
+{% call htmx_form(
+    url_for('admin_dashboard.htmx_admin_disk_root_create'),
+    '#addDiskRootFormContainer',
+    'Create',
+    submit_icon='plus',
+    errors=errors
+) %}
+        {{ select_field('resource_id', 'Disk Resource',
+                        items=disk_resources,
+                        value_attr='resource_id',
+                        label_attr='resource_name',
+                        required=True,
+                        placeholder='-- Select a disk resource --',
+                        id='addDiskRootResource') }}
+
+        {{ text_field('root_directory', 'Root Directory',
+                      required=True,
+                      maxlength=64,
+                      placeholder='/glade/...',
+                      help='Filesystem prefix used to map project directories to this disk resource. Must be unique.',
+                      id='addDiskRootPath') }}
+
+        {{ checkbox_field('charging_exempt', 'Charging exempt',
+                          help='If checked, directories under this root do not incur disk charges.',
+                          id='addDiskRootExempt') }}
+{% endcall %}

--- a/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
@@ -15,6 +15,7 @@
       - All rows share the same <colgroup> → progress bars align perfectly
 #}
 {% from 'dashboards/shared/project_tree.html' import render_project_tree, render_project_tree_rows with context %}
+{% from 'dashboards/shared/usage_bar.html' import render_usage_bar with context %}
 
 {# ── Active at date picker ───────────────────────────────────────────── #}
 <div class="d-flex align-items-center gap-2 mb-3">
@@ -122,16 +123,10 @@
           {# Cols 2+3: progress bar with % overlaid on the bar #}
           <td colspan="2" style="padding:0.25rem 0.6rem; vertical-align:middle;">
             {% if root_alloc %}
-            <div class="progress" style="height:18px;">
-              <div class="progress-bar
-                   {%- if root_alloc.percent_used >= 90 %} bg-danger
-                   {%- elif root_alloc.percent_used >= 75 %} bg-warning
-                   {%- else %} bg-success{% endif %}"
-                   role="progressbar"
-                   style="width:{{ pct }}%;">
-                {{ root_alloc.percent_used | fmt_pct(decimals=0) }}
-              </div>
-            </div>
+            {{ render_usage_bar(root_alloc.percent_used,
+                                root_alloc.self_percent_used if root_alloc.is_inheriting else none,
+                                height='18px',
+                                show_label=True) }}
             {% else %}
             <span class="text-muted small"><em>— no allocation —</em></span>
             {% endif %}
@@ -182,13 +177,9 @@
           {# Col 2: progress bar — same column as tree rows #}
           <td style="padding:0.25rem 0.4rem; vertical-align:middle;">
             {% if root_alloc %}
-            <div class="progress" style="height:8px;">
-              <div class="progress-bar
-                   {%- if root_alloc.percent_used >= 90 %} bg-danger
-                   {%- elif root_alloc.percent_used >= 75 %} bg-warning
-                   {%- else %} bg-success{% endif %}"
-                   role="progressbar" style="width:{{ pct }}%;"></div>
-            </div>
+            {{ render_usage_bar(root_alloc.percent_used,
+                                root_alloc.self_percent_used if root_alloc.is_inheriting else none,
+                                height='8px') }}
             {% endif %}
           </td>
 

--- a/src/webapp/templates/dashboards/admin/fragments/project_directories_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directories_card.html
@@ -22,19 +22,31 @@
                 Filesystem directories linked to projects, grouped by resource.
             </span>
         </div>
-        <div class="form-check mb-0">
-            <input type="checkbox" class="form-check-input"
-                   id="projectDirectoriesShowInactive"
-                   name="show_inactive" value="1"
-                   {% if show_inactive %}checked{% endif %}
-                   hx-get="{{ url_for('admin_dashboard.htmx_admin_project_directories') }}"
-                   hx-trigger="change"
-                   hx-target="#projectDirectoriesSection"
-                   hx-swap="innerHTML"
-                   hx-include="this">
-            <label class="form-check-label" for="projectDirectoriesShowInactive">
-                Show inactive
-            </label>
+        <div class="d-flex align-items-center gap-3">
+            <div class="form-check mb-0">
+                <input type="checkbox" class="form-check-input"
+                       id="projectDirectoriesShowInactive"
+                       name="show_inactive" value="1"
+                       {% if show_inactive %}checked{% endif %}
+                       hx-get="{{ url_for('admin_dashboard.htmx_admin_project_directories') }}"
+                       hx-trigger="change"
+                       hx-target="#projectDirectoriesSection"
+                       hx-swap="innerHTML"
+                       hx-include="this">
+                <label class="form-check-label" for="projectDirectoriesShowInactive">
+                    Show inactive
+                </label>
+            </div>
+            {% if has_permission(Permission.EDIT_PROJECTS) %}
+            <button type="button" class="btn btn-sm btn-success"
+                    data-bs-toggle="modal"
+                    data-bs-target="#addProjectDirectoryModal"
+                    hx-get="{{ url_for('admin_dashboard.htmx_admin_project_directory_new_form') }}"
+                    hx-target="#addProjectDirectoryFormContainer"
+                    hx-trigger="click">
+                <i class="fas fa-plus"></i> New
+            </button>
+            {% endif %}
         </div>
     </div>
 

--- a/src/webapp/templates/dashboards/admin/fragments/project_directories_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directories_card.html
@@ -1,0 +1,167 @@
+{% from 'dashboards/fragments/action_buttons.html' import edit_modal_button with context %}
+{#
+  Admin: Cross-project Project Directories card.
+
+  Groups ProjectDirectory rows by Resource via longest-prefix match of
+  directory_name against DiskResourceRootDirectory.root_directory.
+  Unmatched rows fall into a "No Resource Identified" group at the bottom.
+
+  Context:
+    ordered_groups : list[(resource_id|None, Resource|None, list[ProjectDirectory])]
+    total_rows     : int
+    show_inactive  : bool
+#}
+
+<div class="card mb-3">
+    <div class="card-header d-flex flex-wrap align-items-center justify-content-between">
+        <div>
+            <h5 class="mb-0 d-inline-block">
+                <i class="fas fa-folder-tree"></i> Project Directories
+            </h5>
+            <span class="text-muted small ms-2">
+                Filesystem directories linked to projects, grouped by resource.
+            </span>
+        </div>
+        <div class="form-check mb-0">
+            <input type="checkbox" class="form-check-input"
+                   id="projectDirectoriesShowInactive"
+                   name="show_inactive" value="1"
+                   {% if show_inactive %}checked{% endif %}
+                   hx-get="{{ url_for('admin_dashboard.htmx_admin_project_directories') }}"
+                   hx-trigger="change"
+                   hx-target="#projectDirectoriesSection"
+                   hx-swap="innerHTML"
+                   hx-include="this">
+            <label class="form-check-label" for="projectDirectoriesShowInactive">
+                Show inactive
+            </label>
+        </div>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-sm mb-0">
+            <thead class="table-light">
+                <tr>
+                    <th>Directory</th>
+                    <th>Project</th>
+                    <th>Start</th>
+                    <th>End</th>
+                    <th class="text-end">Actions</th>
+                </tr>
+            </thead>
+            {% if ordered_groups %}
+            {% for rid, resource, rows in ordered_groups %}
+            {% set group_id = 'pd-res-' ~ (rid if rid is not none else 'none') %}
+            {# ── Resource row (clickable trigger) ── #}
+            <tbody>
+                <tr class="cursor-pointer table-light fw-semibold"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#{{ group_id }}"
+                    aria-expanded="false">
+                    <td>
+                        <i class="fas fa-chevron-right small text-muted me-1 pd-res-collapse-icon"
+                           style="transition: transform 0.2s;"></i>
+                        {% if resource %}
+                            {{ resource.resource_name }}
+                            {% if resource.resource_type %}
+                            <small class="text-muted ms-1">({{ resource.resource_type.resource_type }})</small>
+                            {% endif %}
+                        {% else %}
+                            <span class="text-warning">
+                                <i class="fas fa-exclamation-triangle"></i> No Resource Identified
+                            </span>
+                        {% endif %}
+                    </td>
+                    <td class="text-muted small" colspan="4">
+                        {{ rows|length }} director{{ 'ies' if rows|length != 1 else 'y' }}
+                        {%- set _orphans = rows|selectattr('is_active')|rejectattr('project.is_active')|list|length %}
+                        {% if _orphans %}
+                        <span class="badge bg-warning text-dark ms-2"
+                              title="Active directories whose project is inactive">
+                            <i class="fas fa-unlink"></i> {{ _orphans }} orphaned
+                        </span>
+                        {% endif %}
+                    </td>
+                </tr>
+            </tbody>
+            {# ── Directory child rows (collapsed by default) ── #}
+            <tbody class="collapse" id="{{ group_id }}">
+                {% for pd in rows %}
+                {% set _orphan = pd.is_active and not pd.project.is_active %}
+                <tr class="table-secondary{% if not pd.is_active %} opacity-50{% endif %}{% if _orphan %} table-warning{% endif %}"
+                    {% if _orphan %}title="Active directory linked to an inactive project"{% endif %}>
+                    <td class="ps-4 font-monospace small">
+                        {% if _orphan %}
+                        <i class="fas fa-unlink text-warning me-1"
+                           title="Orphaned: project is inactive"></i>
+                        {% endif %}
+                        {{ pd.directory_name }}
+                    </td>
+                    <td>
+                        <button type="button"
+                                class="btn btn-link p-0 align-baseline"
+                                title="View project details"
+                                hx-get="{{ url_for('user_dashboard.project_details_modal', projcode=pd.project.projcode) }}"
+                                hx-target="#projectDetailsModalBody"
+                                hx-swap="innerHTML"
+                                data-bs-toggle="modal"
+                                data-bs-target="#projectDetailsModal"
+                                onclick="event.stopPropagation()">
+                            <strong>{{ pd.project.projcode }}</strong>
+                        </button>
+                        {% if _orphan %}
+                        <span class="badge bg-warning text-dark ms-1" title="Project is inactive">inactive project</span>
+                        {% endif %}
+                        <div class="text-muted small">{{ pd.project.title | truncate(60) }}</div>
+                    </td>
+                    <td class="text-nowrap small">{{ pd.start_date | fmt_date }}</td>
+                    <td class="text-nowrap small">{{ pd.end_date | fmt_date }}</td>
+                    <td class="text-end">
+                        {{ edit_modal_button(
+                            url_for('admin_dashboard.htmx_admin_project_directory_edit_form', pd_id=pd.project_directory_id),
+                            modal_id='editProjectDirectoryModal',
+                            target_id='editProjectDirectoryFormContainer',
+                            title='Edit directory',
+                            stop_propagation=True,
+                            permission=Permission.EDIT_PROJECTS) }}
+                        {% if has_permission(Permission.EDIT_PROJECTS) and pd.is_active %}
+                        <button class="btn btn-sm btn-outline-warning ms-1"
+                                title="Deactivate directory"
+                                hx-post="{{ url_for('admin_dashboard.htmx_admin_project_directory_deactivate', pd_id=pd.project_directory_id) }}"
+                                hx-swap="none"
+                                hx-confirm="Deactivate directory &quot;{{ pd.directory_name }}&quot; on project {{ pd.project.projcode }}? This sets the end date to today."
+                                data-confirm-title="Deactivate directory"
+                                data-confirm-variant="warning"
+                                data-confirm-label="Deactivate"
+                                onclick="event.stopPropagation()">
+                            <i class="fas fa-ban"></i>
+                        </button>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+            {% endfor %}
+            {% else %}
+            <tbody>
+                <tr><td colspan="5" class="text-center text-muted py-3">
+                    No project directories
+                    {% if not show_inactive %}(active){% endif %} found.
+                </td></tr>
+            </tbody>
+            {% endif %}
+        </table>
+    </div>
+    <div class="text-muted small px-3 py-2">
+        Showing {{ total_rows }} director{{ 'ies' if total_rows != 1 else 'y' }}
+        across {{ ordered_groups|length }} group{{ 's' if ordered_groups|length != 1 else '' }}.
+    </div>
+</div>
+
+<script>
+(function() {
+    if (window.SamCollapseChevron) {
+        SamCollapseChevron.attach('#projectDirectoriesSection', '.pd-res-collapse-icon');
+    }
+})();
+</script>

--- a/src/webapp/templates/dashboards/admin/fragments/project_directory_edit_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directory_edit_form_htmx.html
@@ -1,0 +1,42 @@
+{% from 'dashboards/fragments/modal_form.html' import htmx_form with context %}
+{% from 'dashboards/fragments/form_fields.html' import text_field, fk_search_field, readonly_display with context %}
+{#
+  htmx: Edit Project Directory form (loaded into #editProjectDirectoryFormContainer).
+
+  Fields:
+    - directory_name : free-text, required (1-255).
+    - project_id     : FK picker (search by projcode/title), required.
+
+  Read-only:
+    - start_date (creation timestamp; not editable here — use deactivate to end-date).
+
+  Context:
+    pd     : ProjectDirectory
+    errors : optional list[str]
+    form   : optional ImmutableMultiDict (re-render after validation error)
+#}
+
+{% call htmx_form(
+    url_for('admin_dashboard.htmx_admin_project_directory_edit', pd_id=pd.project_directory_id),
+    '#editProjectDirectoryFormContainer',
+    'Save Changes',
+    is_edit=True,
+    errors=errors
+) %}
+        {{ readonly_display('Start Date', pd.start_date | fmt_date, muted=True) }}
+
+        {{ text_field('directory_name', 'Directory Name',
+                      required=True,
+                      maxlength=255,
+                      default=pd.directory_name,
+                      placeholder='/glade/...',
+                      id='editProjectDirectoryName') }}
+
+        {{ fk_search_field('project_id', 'Linked Project',
+                           search_url=url_for('admin_dashboard.htmx_project_search_for_parent'),
+                           required=True,
+                           placeholder='Search by project code or title…',
+                           selected_id=pd.project.project_id,
+                           selected_label=pd.project.projcode ~ ' — ' ~ (pd.project.title | truncate(60)),
+                           id_prefix='editProjectDirectoryProject') }}
+{% endcall %}

--- a/src/webapp/templates/dashboards/admin/fragments/project_directory_edit_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directory_edit_form_htmx.html
@@ -1,19 +1,25 @@
 {% from 'dashboards/fragments/modal_form.html' import htmx_form with context %}
-{% from 'dashboards/fragments/form_fields.html' import text_field, fk_search_field, readonly_display with context %}
+{% from 'dashboards/fragments/form_fields.html' import text_field, select_field, fk_search_field, readonly_display with context %}
 {#
   htmx: Edit Project Directory form (loaded into #editProjectDirectoryFormContainer).
 
   Fields:
-    - directory_name : free-text, required (1-255).
-    - project_id     : FK picker (search by projcode/title), required.
+    - root_directory_id  : registered disk root (excludes '/'), required.
+    - directory_suffix   : path under the chosen root, optional.
+    - project_id         : FK picker (search by projcode/title), required.
 
   Read-only:
-    - start_date (creation timestamp; not editable here — use deactivate to end-date).
+    - Current full directory_name (assembled).
+    - start_date (creation timestamp).
 
   Context:
-    pd     : ProjectDirectory
-    errors : optional list[str]
-    form   : optional ImmutableMultiDict (re-render after validation error)
+    pd             : ProjectDirectory
+    disk_roots     : list[DiskResourceRootDirectory] (excludes '/')
+    default_root   : DiskResourceRootDirectory or None (longest-prefix match for pd.directory_name)
+    default_suffix : str (path remainder after the matching root, or full path when orphaned)
+    is_orphaned    : bool (default_root is None)
+    errors         : optional list[str]
+    form           : optional ImmutableMultiDict (re-render after validation error)
 #}
 
 {% call htmx_form(
@@ -23,14 +29,36 @@
     is_edit=True,
     errors=errors
 ) %}
+        {% if is_orphaned %}
+        <div class="alert alert-warning mb-3">
+            <i class="fas fa-exclamation-triangle"></i>
+            <strong>This directory doesn't match any registered disk root.</strong>
+            The current path <code>{{ pd.directory_name }}</code> was created
+            before validation was added, or its root has since been deleted.
+            To save any change you must first select a valid root and adjust
+            the sub-path. To remove this entry instead, close this modal and
+            click Delete on the row.
+        </div>
+        {% endif %}
+
+        {{ readonly_display('Current path', pd.directory_name, muted=False, strong=True) }}
         {{ readonly_display('Start Date', pd.start_date | fmt_date, muted=True) }}
 
-        {{ text_field('directory_name', 'Directory Name',
-                      required=True,
+        {{ select_field('root_directory_id', 'Disk Root',
+                        items=disk_roots,
+                        value_attr='root_directory_id',
+                        label_attr='root_directory',
+                        required=True,
+                        default=(default_root.root_directory_id if default_root else ''),
+                        placeholder='-- Select a disk root --',
+                        id='editProjectDirectoryRoot') }}
+
+        {{ text_field('directory_suffix', 'Sub-path',
                       maxlength=255,
-                      default=pd.directory_name,
-                      placeholder='/glade/...',
-                      id='editProjectDirectoryName') }}
+                      default=default_suffix or '',
+                      placeholder='subpath/under/the/root  (or leave blank for the root itself)',
+                      help='Path under the chosen root. ".." segments are not allowed.',
+                      id='editProjectDirectorySuffix') }}
 
         {{ fk_search_field('project_id', 'Linked Project',
                            search_url=url_for('admin_dashboard.htmx_project_search_for_parent'),

--- a/src/webapp/templates/dashboards/admin/fragments/project_directory_modals.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directory_modals.html
@@ -1,0 +1,12 @@
+{% from 'dashboards/fragments/modals.html' import modal_scaffold %}
+{#
+  Admin: Project Directory edit modal scaffold.
+
+  The form fragment is loaded into #editProjectDirectoryFormContainer
+  by the edit_modal_button macro on each row.
+#}
+
+{{ modal_scaffold('editProjectDirectoryModal', 'Edit Project Directory',
+                  icon='edit',
+                  container_id='editProjectDirectoryFormContainer',
+                  variant='edit') }}

--- a/src/webapp/templates/dashboards/admin/fragments/project_directory_modals.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directory_modals.html
@@ -6,6 +6,10 @@
   by the edit_modal_button macro on each row.
 #}
 
+{{ modal_scaffold('addProjectDirectoryModal', 'New Project Directory',
+                  icon='folder-plus',
+                  container_id='addProjectDirectoryFormContainer') }}
+
 {{ modal_scaffold('editProjectDirectoryModal', 'Edit Project Directory',
                   icon='edit',
                   container_id='editProjectDirectoryFormContainer',

--- a/src/webapp/templates/dashboards/admin/fragments/project_directory_new_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directory_new_form_htmx.html
@@ -1,11 +1,13 @@
 {% from 'dashboards/fragments/modal_form.html' import htmx_form with context %}
-{% from 'dashboards/fragments/form_fields.html' import text_field, fk_search_field with context %}
+{% from 'dashboards/fragments/form_fields.html' import text_field, select_field, fk_search_field with context %}
 {#
   htmx: New Project Directory form (loaded into #addProjectDirectoryFormContainer).
 
-  Shares EditLinkedDirectoryForm validation: directory_name + project_id.
+  Shares EditLinkedDirectoryForm validation: root_directory_id + directory_suffix + project_id.
+  Final directory_name is assembled server-side from the chosen root + suffix.
 
   Context:
+    disk_roots : list[DiskResourceRootDirectory] (excludes the catch-all '/')
     errors : optional list[str]
     form   : optional ImmutableMultiDict (re-render after validation error)
 #}
@@ -17,11 +19,27 @@
     submit_icon='plus',
     errors=errors
 ) %}
-        {{ text_field('directory_name', 'Directory Name',
-                      required=True,
+        {% if not disk_roots %}
+        <div class="alert alert-warning">
+            <i class="fas fa-exclamation-triangle"></i>
+            No registered disk root directories available.
+            Configure them under <strong>Admin &rarr; Resources</strong> first.
+        </div>
+        {% endif %}
+
+        {{ select_field('root_directory_id', 'Disk Root',
+                        items=disk_roots,
+                        value_attr='root_directory_id',
+                        label_attr='root_directory',
+                        required=True,
+                        placeholder='-- Select a disk root --',
+                        id='addProjectDirectoryRoot') }}
+
+        {{ text_field('directory_suffix', 'Sub-path',
                       maxlength=255,
-                      placeholder='/glade/...',
-                      id='addProjectDirectoryName') }}
+                      placeholder='subpath/under/the/root  (or leave blank for the root itself)',
+                      help='Path under the chosen root. ".." segments are not allowed.',
+                      id='addProjectDirectorySuffix') }}
 
         {{ fk_search_field('project_id', 'Linked Project',
                            search_url=url_for('admin_dashboard.htmx_project_search_for_parent'),

--- a/src/webapp/templates/dashboards/admin/fragments/project_directory_new_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directory_new_form_htmx.html
@@ -1,0 +1,31 @@
+{% from 'dashboards/fragments/modal_form.html' import htmx_form with context %}
+{% from 'dashboards/fragments/form_fields.html' import text_field, fk_search_field with context %}
+{#
+  htmx: New Project Directory form (loaded into #addProjectDirectoryFormContainer).
+
+  Shares EditLinkedDirectoryForm validation: directory_name + project_id.
+
+  Context:
+    errors : optional list[str]
+    form   : optional ImmutableMultiDict (re-render after validation error)
+#}
+
+{% call htmx_form(
+    url_for('admin_dashboard.htmx_admin_project_directory_create'),
+    '#addProjectDirectoryFormContainer',
+    'Create',
+    submit_icon='plus',
+    errors=errors
+) %}
+        {{ text_field('directory_name', 'Directory Name',
+                      required=True,
+                      maxlength=255,
+                      placeholder='/glade/...',
+                      id='addProjectDirectoryName') }}
+
+        {{ fk_search_field('project_id', 'Linked Project',
+                           search_url=url_for('admin_dashboard.htmx_project_search_for_parent'),
+                           required=True,
+                           placeholder='Search by project code or title…',
+                           id_prefix='addProjectDirectoryProject') }}
+{% endcall %}

--- a/src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html
@@ -213,14 +213,23 @@
 
       {# ── Add form (hidden by default) ── #}
       <div id="addDirForm" style="display:none;" class="p-3 border-bottom bg-light">
+        {% if disk_roots %}
         <form hx-post="{{ url_for('admin_dashboard.htmx_add_project_directory', projcode=project.projcode) }}"
               hx-target="#linkedElementsContainer"
               hx-swap="innerHTML">
           <div class="d-flex gap-2 align-items-center flex-wrap">
+            <select name="root_directory_id" required
+                    class="form-select form-select-sm"
+                    style="max-width:14em;">
+              <option value="">-- Select a disk root --</option>
+              {% for r in disk_roots %}
+              <option value="{{ r.root_directory_id }}">{{ r.root_directory }}</option>
+              {% endfor %}
+            </select>
             <input type="text"
-                   name="directory_name"
+                   name="directory_suffix"
                    class="form-control form-control-sm flex-grow-1"
-                   placeholder="/glade/path/to/directory"
+                   placeholder="sub/path  (or leave blank for the root itself)"
                    autocomplete="off"
                    style="min-width:200px;">
             <button type="submit" class="btn btn-sm btn-success">
@@ -231,7 +240,19 @@
               Cancel
             </button>
           </div>
+          <small class="text-muted d-block mt-1">
+            Final path is assembled as
+            <code>&lt;root&gt;/&lt;sub-path&gt;</code>; <code>".."</code>
+            segments are not allowed.
+          </small>
         </form>
+        {% else %}
+        <div class="text-muted small">
+          <i class="fas fa-exclamation-triangle text-warning"></i>
+          No registered disk root directories.
+          Configure them under <strong>Admin &rarr; Resources</strong> first.
+        </div>
+        {% endif %}
       </div>
 
       {# ── Table of active directories ── #}

--- a/src/webapp/templates/dashboards/admin/fragments/resources_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/resources_card.html
@@ -304,12 +304,24 @@
             </div>
 
             {# ── Wallclock Exemptions ────────────────────────────────────── #}
-            <div class="border-top mt-2 pt-2 px-3 pb-1 d-flex align-items-center">
-                <i class="fas fa-clock me-2 text-muted"></i>
-                <span class="fw-semibold">Wallclock Exemptions</span>
-                <span class="text-muted small ms-2">
-                    per-user overrides of queue wallclock limits
-                </span>
+            <div class="border-top mt-2 pt-2 px-3 pb-1 d-flex align-items-center justify-content-between">
+                <div class="d-flex align-items-center">
+                    <i class="fas fa-clock me-2 text-muted"></i>
+                    <span class="fw-semibold">Wallclock Exemptions</span>
+                    <span class="text-muted small ms-2">
+                        per-user overrides of queue wallclock limits
+                    </span>
+                </div>
+                {% if has_permission(Permission.EDIT_USERS) %}
+                <button type="button" class="btn btn-sm btn-success"
+                        data-bs-toggle="modal"
+                        data-bs-target="#addExemptionModal"
+                        hx-get="{{ url_for('admin_dashboard.htmx_admin_exemption_form') }}"
+                        hx-target="#addExemptionFormContainer"
+                        hx-trigger="click">
+                    <i class="fas fa-plus"></i> New
+                </button>
+                {% endif %}
             </div>
             <div class="table-responsive">
                 <table class="table table-sm mb-0">

--- a/src/webapp/templates/dashboards/admin/fragments/resources_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/resources_card.html
@@ -145,6 +145,8 @@
                 </div>
                 {% endif %}
             </div>
+
+            {% include 'dashboards/admin/fragments/disk_root_directories_section.html' %}
         </div>
 
         <!-- ── Machines tab ────────────────────────────────────────────── -->
@@ -450,6 +452,7 @@
     document.querySelectorAll('#resourcesTabsContent table').forEach(attachSorting);
 
     SamCollapseChevron.attach('#resources-pane', '.res-type-collapse-icon');
+    SamCollapseChevron.attach('#resources-pane', '.disk-root-collapse-icon');
     SamCollapseChevron.attach('#queues-pane',    '.queue-res-collapse-icon');
     SamCollapseChevron.attach('#queues-pane',    '.exemption-res-collapse-icon');
 })();

--- a/src/webapp/templates/dashboards/admin/fragments/resources_modals.html
+++ b/src/webapp/templates/dashboards/admin/fragments/resources_modals.html
@@ -18,6 +18,11 @@
                   icon='plus', container_id='createMachineFormContainer') }}
 {% endif %}
 
+{% if has_permission(Permission.EDIT_RESOURCES) %}
+{{ modal_scaffold('addDiskRootModal', 'New Disk Root Directory',
+                  icon='folder-plus', container_id='addDiskRootFormContainer') }}
+{% endif %}
+
 {# ══════════════════════════════════════════════════════════ EDIT MODALS #}
 
 {{ modal_scaffold('editResourceModal', 'Edit Resource',
@@ -31,3 +36,6 @@
 
 {{ modal_scaffold('editQueueModal', 'Edit Queue',
                   icon='list-ol', container_id='editQueueFormContainer', variant='edit') }}
+
+{{ modal_scaffold('editDiskRootModal', 'Edit Disk Root Directory',
+                  icon='folder-tree', container_id='editDiskRootFormContainer', variant='edit') }}

--- a/src/webapp/templates/dashboards/allocations/partials/project_table.html
+++ b/src/webapp/templates/dashboards/allocations/partials/project_table.html
@@ -1,4 +1,5 @@
 {% from 'dashboards/fragments/badges.html' import status_badge %}
+{% from 'dashboards/shared/usage_bar.html' import render_usage_bar with context %}
 <!-- Project Details Table -->
 <table class="table table-sm table-striped">
     <thead class="align-top">
@@ -98,13 +99,10 @@
                     </div>
                     {% endif %}
                     <div class="position-relative">
-                        <div class="progress progress-large">
-                            <div class="progress-bar {% if pct >= 90 %}bg-danger{% elif pct >= 75 %}bg-warning{% else %}bg-success{% endif %}"
-                                 role="progressbar"
-                                 style="width: {{ [pct, 100]|min }}%">
-                                {{ pct | fmt_pct(decimals=0) }}
-                            </div>
-                        </div>
+                        {{ render_usage_bar(pct,
+                                            project.get('self_percent_used'),
+                                            size_class='progress-large',
+                                            show_label=True) }}
                         {% if bar_state == 'active' %}
                         <div class="position-absolute"
                              style="left: {{ elapsed_pct }}%; top: -2px; bottom: -2px; width: 2px; background: rgba(33,37,41,0.55); z-index: 2; pointer-events: none;"
@@ -112,7 +110,11 @@
                         {% endif %}
                     </div>
                     <div class="d-flex justify-content-between small mt-1">
-                        <span class="text-warning">{{ project['total_used'] | fmt_number }} used</span>
+                        <span class="text-warning">
+                            {{ project['total_used'] | fmt_number }} used{% if project.get('is_inheriting') and project.get('self_used') is not none %}
+                            <span class="text-muted" title="This project's contribution to the shared pool">({{ project['self_used'] | fmt_number }} yours)</span>
+                            {% endif %}
+                        </span>
                         <span class="text-success">{{ (project['total_amount'] - project['total_used']) | fmt_number }} remaining</span>
                     </div>
                 {% else %}

--- a/src/webapp/templates/dashboards/allocations/partials/usage_modal.html
+++ b/src/webapp/templates/dashboards/allocations/partials/usage_modal.html
@@ -1,4 +1,5 @@
 {% from 'dashboards/fragments/badges.html' import status_badge %}
+{% from 'dashboards/shared/usage_bar.html' import render_usage_bar with context %}
 <!-- Usage Details Modal Content -->
 {% if allocation %}
 <div class="usage-details">
@@ -79,14 +80,10 @@
             </div>
 
             <!-- Progress Bar -->
-            <div class="progress progress-xxlarge">
-                {% set percent = allocation.percent_used %}
-                <div class="progress-bar {% if percent >= 90 %}bg-danger{% elif percent >= 75 %}bg-warning{% else %}bg-success{% endif %}"
-                     role="progressbar"
-                     style="width: {{ percent }}%">
-                    {{ "%.1f"|format(percent) }}%
-                </div>
-            </div>
+            {{ render_usage_bar(allocation.percent_used,
+                                allocation.get('self_percent_used'),
+                                size_class='progress-xxlarge',
+                                show_label=True) }}
         </div>
     </div>
 

--- a/src/webapp/templates/dashboards/shared/project_tree.html
+++ b/src/webapp/templates/dashboards/shared/project_tree.html
@@ -35,6 +35,7 @@
 #}
 
 {% from 'dashboards/fragments/badges.html' import status_badge %}
+{% from 'dashboards/shared/usage_bar.html' import render_usage_bar with context %}
 
 {% macro render_project_tree(nodes,
                               current_projcode='',
@@ -82,15 +83,12 @@
       {%- set res = alloc_by_projcode.get(node.projcode) -%}
       {%- if res -%}
       <div class="d-flex align-items-center gap-2 small flex-shrink-0">
-        {%- set pct = [res.percent_used, 100] | min -%}
         <div style="width:100px;flex-shrink:0;">
-          <div class="progress" style="height:8px;">
-            <div class="progress-bar
-                 {%- if res.percent_used >= usage_critical_threshold %} bg-danger
-                 {%- elif res.percent_used >= usage_warning_threshold %} bg-warning
-                 {%- else %} bg-success{% endif %}"
-                 role="progressbar" style="width:{{ pct }}%;"></div>
-          </div>
+          {{ render_usage_bar(res.percent_used,
+                              res.self_percent_used if res.is_inheriting else none,
+                              height='8px',
+                              warning_threshold=usage_warning_threshold,
+                              critical_threshold=usage_critical_threshold) }}
         </div>
         <span class="text-muted" style="width:40px;flex-shrink:0;text-align:right;">{{ res.percent_used | fmt_pct }}</span>
         <span class="text-muted" style="width:80px;flex-shrink:0;text-align:right;">{{ res.allocated | fmt_number }}</span>
@@ -186,7 +184,6 @@
 {%- if not active_only or is_active -%}
 {%- set is_current = (node.projcode == current_projcode) -%}
 {%- set res = alloc_by_projcode.get(node.projcode) if alloc_by_projcode is not none else none -%}
-{%- set pct = [res.percent_used, 100] | min if res else 0 -%}
 
 <tr style="
   {%- if is_current %}background:#fff3cd;font-weight:bold;{% endif %}
@@ -218,13 +215,11 @@
   {# ── Col 2: progress bar — anchored by table column, always aligned ── #}
   <td style="padding: 0.25rem 0.4rem; vertical-align:middle;">
     {%- if res %}
-    <div class="progress" style="height:8px;">
-      <div class="progress-bar
-           {%- if res.percent_used >= usage_critical_threshold %} bg-danger
-           {%- elif res.percent_used >= usage_warning_threshold %} bg-warning
-           {%- else %} bg-success{% endif %}"
-           role="progressbar" style="width:{{ pct }}%;"></div>
-    </div>
+    {{ render_usage_bar(res.percent_used,
+                        res.self_percent_used if res.is_inheriting else none,
+                        height='8px',
+                        warning_threshold=usage_warning_threshold,
+                        critical_threshold=usage_critical_threshold) }}
     {%- endif %}
   </td>
 

--- a/src/webapp/templates/dashboards/shared/usage_bar.html
+++ b/src/webapp/templates/dashboards/shared/usage_bar.html
@@ -1,0 +1,67 @@
+{#
+  Shared macro: render_usage_bar
+  ==============================
+  Renders an allocation-usage progress bar. When `self_percent_used` is
+  given (i.e. the allocation is shared/inheriting), the consumed portion
+  is split into two tones: an outer "rest of tree" segment (other
+  projects in the shared tree) and an inner "self" segment (this
+  project's contribution). Empty portion is the bar's neutral track.
+
+  Color uses thresholds against `percent_used` (the authoritative full
+  pool consumption). The "self" segment is rendered with a striped
+  modifier so it reads as part of the same colored fill.
+
+  Usage:
+    {% from 'dashboards/shared/usage_bar.html' import render_usage_bar with context %}
+    {{ render_usage_bar(percent_used, self_percent_used,
+                        height='8px', show_label=False,
+                        warning_threshold=75, critical_threshold=90) }}
+
+  Parameters
+  ----------
+  percent_used        Total % consumed against allocated (drives bar width and color).
+  self_percent_used   This project's % contribution; None or 0 → single-tone bar.
+  height              CSS height for .progress (default 8px).
+  show_label          If True, show the percent value as text inside the bar.
+  warning_threshold   Color turns yellow above this % (default 75).
+  critical_threshold  Color turns red above this %    (default 90).
+#}
+{% macro render_usage_bar(percent_used,
+                           self_percent_used=none,
+                           height=none,
+                           size_class=none,
+                           show_label=False,
+                           warning_threshold=75,
+                           critical_threshold=90) %}
+{%- set total_pct = [percent_used or 0, 100] | min -%}
+{%- set self_pct = [self_percent_used or 0, total_pct] | min -%}
+{%- set rest_pct = total_pct - self_pct -%}
+{%- if percent_used and percent_used >= critical_threshold -%}
+  {%- set color_class = 'bg-danger' -%}
+{%- elif percent_used and percent_used >= warning_threshold -%}
+  {%- set color_class = 'bg-warning' -%}
+{%- else -%}
+  {%- set color_class = 'bg-success' -%}
+{%- endif -%}
+<div class="progress{% if size_class %} {{ size_class }}{% endif %}"
+     {%- if height %} style="height:{{ height }};"{% endif %}>
+  {%- if self_percent_used is not none and self_pct > 0 and rest_pct > 0 -%}
+  <div class="progress-bar {{ color_class }} progress-bar-rest"
+       role="progressbar"
+       style="width:{{ rest_pct }}%;opacity:0.55;"
+       title="Rest of tree: {{ rest_pct | round(1) }}%"></div>
+  <div class="progress-bar {{ color_class }} progress-bar-striped progress-bar-self"
+       role="progressbar"
+       style="width:{{ self_pct }}%;"
+       title="This project: {{ self_pct | round(1) }}%">
+    {%- if show_label %}{{ self_pct | fmt_pct(decimals=0) }}{% endif -%}
+  </div>
+  {%- else -%}
+  <div class="progress-bar {{ color_class }}"
+       role="progressbar"
+       style="width:{{ total_pct }}%;">
+    {%- if show_label %}{{ percent_used | fmt_pct(decimals=0) }}{% endif -%}
+  </div>
+  {%- endif -%}
+</div>
+{% endmacro %}

--- a/src/webapp/templates/dashboards/user/partials/project_card.html
+++ b/src/webapp/templates/dashboards/user/partials/project_card.html
@@ -1,4 +1,5 @@
 {% from 'dashboards/fragments/badges.html' import status_badge %}
+{% from 'dashboards/shared/usage_bar.html' import render_usage_bar with context %}
 
 {# Macro: Project Information Section #}
 {% macro render_project_info(project) %}
@@ -140,15 +141,6 @@
 
                     {# ── Resource rows (no date columns) ──────────────────────────── #}
                     {% for resource in group_resources %}
-                        {% set percent = resource.percent_used | round(1) %}
-                        {% if percent >= 90 %}
-                            {% set progress_class = 'bg-danger' %}
-                        {% elif percent >= 75 %}
-                            {% set progress_class = 'bg-warning' %}
-                        {% else %}
-                            {% set progress_class = 'bg-success' %}
-                        {% endif %}
-
                         {# Check if resource is expired #}
                         {% set is_expired = resource.days_until_expiration is not none and resource.days_until_expiration < 0 %}
                         {% set row_class = 'text-muted' if is_expired else '' %}
@@ -168,16 +160,10 @@
                                     {% endif %}
                                 </div>
                                 <div class="position-relative">
-                                    <div class="progress progress-large">
-                                        <div class="progress-bar {{ progress_class }}"
-                                             role="progressbar"
-                                             style="width: {{ [0, [percent, 100] | min] | max }}%"
-                                             aria-valuenow="{{ percent }}"
-                                             aria-valuemin="0"
-                                             aria-valuemax="100">
-                                            {{ percent | fmt_pct(decimals=0) }}
-                                        </div>
-                                    </div>
+                                    {{ render_usage_bar(resource.percent_used,
+                                                        resource.self_percent_used if resource.is_inheriting else none,
+                                                        size_class='progress-large',
+                                                        show_label=True) }}
                                     {% if first.bar_state == 'active' and resource.resource_type in ['HPC', 'DAV'] %}
                                     <div class="position-absolute"
                                          style="left: {{ first.elapsed_pct }}%; top: -2px; bottom: -2px; width: 2px; background: rgba(33,37,41,0.55); z-index: 2; pointer-events: none;"
@@ -185,7 +171,11 @@
                                     {% endif %}
                                 </div>
                                 <div class="d-flex justify-content-between small mt-1">
-                                    <span class="{% if not is_expired %}text-warning{% endif %}">{{ resource.used | fmt_number }} used</span>
+                                    <span class="{% if not is_expired %}text-warning{% endif %}">
+                                        {{ resource.used | fmt_number }} used{% if resource.is_inheriting and resource.self_used is not none %}
+                                        <span class="text-muted" title="This project's contribution to the shared pool">({{ resource.self_used | fmt_number }} yours)</span>
+                                        {% endif %}
+                                    </span>
                                     <span class="{% if not is_expired %}text-success{% endif %}">{{ resource.remaining | fmt_number }} remaining</span>
                                 </div>
                                 {% if not is_expired and (

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -1,4 +1,5 @@
 {% extends 'dashboards/base.html' %}
+{% from 'dashboards/shared/usage_bar.html' import render_usage_bar with context %}
 
 {% block title %}Resource Details - {{ resource_name }} - SAM{% endblock %}
 
@@ -227,33 +228,22 @@
                 </thead>
                 <tbody>
                     {% set summary = detail_data.resource_summary %}
-                    {% set percent = summary.percent_used | round(1) %}
-                    {% if percent >= 90 %}
-                        {% set progress_class = 'bg-danger' %}
-                    {% elif percent >= 75 %}
-                        {% set progress_class = 'bg-warning' %}
-                    {% else %}
-                        {% set progress_class = 'bg-success' %}
-                    {% endif %}
-
                     <tr>
                         <td><strong>{{ resource_name }}</strong></td>
                         <td>{{ summary.start_date | fmt_date }}</td>
                         <td>{{ summary.end_date | fmt_date }}</td>
                         <td class="text-primary">{{ summary.allocated | fmt_number }}</td>
-                        <td class="text-warning">{{ summary.used | fmt_number }}</td>
+                        <td class="text-warning">
+                            {{ summary.used | fmt_number }}{% if summary.is_inheriting and summary.self_used is not none %}
+                            <span class="text-muted small" title="This project's contribution to the shared pool">({{ summary.self_used | fmt_number }} yours)</span>
+                            {% endif %}
+                        </td>
                         <td class="text-success">{{ summary.remaining | fmt_number }}</td>
                         <td>
-                            <div class="progress progress-large">
-                                <div class="progress-bar {{ progress_class }}"
-                                     role="progressbar"
-                                     style="width: {{ [0, [percent, 100] | min] | max }}%"
-                                     aria-valuenow="{{ percent }}"
-                                     aria-valuemin="0"
-                                     aria-valuemax="100">
-                                    {{ percent | fmt_pct }}
-                                </div>
-                            </div>
+                            {{ render_usage_bar(summary.percent_used,
+                                                summary.self_percent_used if summary.is_inheriting else none,
+                                                size_class='progress-large',
+                                                show_label=True) }}
                         </td>
                         {% if has_permission and Permission and has_permission(Permission.EDIT_ALLOCATIONS) %}
                         <td class="text-center">

--- a/tests/unit/test_query_functions.py
+++ b/tests/unit/test_query_functions.py
@@ -246,12 +246,14 @@ class TestDashboardQueries:
             'resource_name', 'allocation_id', 'parent_allocation_id',
             'is_inheriting', 'account_id', 'status', 'start_date', 'end_date',
             'days_until_expiration', 'date_group_key', 'bar_state',
-            'resource_type',
+            'resource_type', 'root_projcode',
         )
         FLOAT_FIELDS = (
             'allocated', 'used', 'remaining', 'percent_used',
             'adjustments', 'elapsed_pct',
         )
+        # Optional float fields: present-and-equal, or None on both sides.
+        OPTIONAL_FLOAT_FIELDS = ('self_used', 'self_percent_used')
         FLOAT_TOL = 1e-6
 
         for project in projects:
@@ -273,6 +275,15 @@ class TestDashboardQueries:
                     assert abs(float(pp[f]) - float(bb[f])) < FLOAT_TOL, (
                         f"{ctx}: {f} differs ({pp[f]} vs {bb[f]})"
                     )
+                for f in OPTIONAL_FLOAT_FIELDS:
+                    if pp[f] is None or bb[f] is None:
+                        assert pp[f] == bb[f], (
+                            f"{ctx}: {f} differs ({pp[f]!r} vs {bb[f]!r})"
+                        )
+                    else:
+                        assert abs(float(pp[f]) - float(bb[f])) < FLOAT_TOL, (
+                            f"{ctx}: {f} differs ({pp[f]} vs {bb[f]})"
+                        )
                 assert set(pp['charges_by_type'].keys()) == set(bb['charges_by_type'].keys())
                 for k in pp['charges_by_type']:
                     assert abs(pp['charges_by_type'][k] - bb['charges_by_type'][k]) < FLOAT_TOL

--- a/tests/unit/test_shared_allocation_usage.py
+++ b/tests/unit/test_shared_allocation_usage.py
@@ -1,0 +1,148 @@
+"""Tree-aware usage for shared (inheriting) allocations.
+
+When an allocation tree is shared across a project hierarchy
+(parent → child → grandchild), child projects must surface the
+*root* tree's full usage as `used`/`remaining`/`percent_used`, plus
+their own contribution as `self_used`/`self_percent_used`. The UI
+needs both to render a two-tone progress bar.
+"""
+from datetime import date, datetime, timedelta
+
+import pytest
+
+from sam.summaries.comp_summaries import CompChargeSummary
+
+from factories import (
+    make_account,
+    make_allocation,
+    make_project,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def shared_tree(session, hpc_resource):
+    """Three-deep project tree sharing one allocation pool.
+
+        root  (allocation root, amount=1000)
+         └── mid (inheriting child)
+              └── leaf (inheriting grandchild)
+
+    Each project has its own Account on the HPC resource. Charges live
+    only on the leaf (200) and the mid project (300); root has none —
+    so the tree total is 500 against an allocation of 1000.
+    """
+    root_p = make_project(session)
+    mid_p = make_project(session, parent=root_p)
+    leaf_p = make_project(session, parent=mid_p)
+
+    root_acct = make_account(session, project=root_p, resource=hpc_resource)
+    mid_acct = make_account(session, project=mid_p, resource=hpc_resource)
+    leaf_acct = make_account(session, project=leaf_p, resource=hpc_resource)
+
+    start = datetime.now() - timedelta(days=30)
+    end = datetime.now() + timedelta(days=365)
+
+    root_alloc = make_allocation(
+        session, account=root_acct, amount=1000.0,
+        start_date=start, end_date=end,
+    )
+    mid_alloc = make_allocation(
+        session, account=mid_acct, amount=1000.0,
+        start_date=start, end_date=end, parent=root_alloc,
+    )
+    leaf_alloc = make_allocation(
+        session, account=leaf_acct, amount=1000.0,
+        start_date=start, end_date=end, parent=mid_alloc,
+    )
+
+    today = date.today()
+    session.add(CompChargeSummary(
+        account_id=mid_acct.account_id, activity_date=today, charges=300.0,
+        machine='test-mach', queue='test-queue',
+    ))
+    session.add(CompChargeSummary(
+        account_id=leaf_acct.account_id, activity_date=today, charges=200.0,
+        machine='test-mach', queue='test-queue',
+    ))
+    session.flush()
+
+    # NestedSetMixin._ns_place_in_tree() updates ancestor tree_right via
+    # raw SQL when descendants are added — refresh the in-memory rows so
+    # subsequent get_subtree_charges() queries see the current coords.
+    session.refresh(root_p)
+    session.refresh(mid_p)
+
+    return {
+        'root': root_p, 'mid': mid_p, 'leaf': leaf_p,
+        'resource': hpc_resource,
+        'root_alloc': root_alloc, 'mid_alloc': mid_alloc, 'leaf_alloc': leaf_alloc,
+    }
+
+
+class TestAllocationRoot:
+    def test_root_of_root_is_self(self, shared_tree):
+        assert shared_tree['root_alloc'].root is shared_tree['root_alloc']
+
+    def test_root_of_grandchild_walks_to_top(self, shared_tree):
+        assert shared_tree['leaf_alloc'].root is shared_tree['root_alloc']
+
+
+class TestSharedAllocationUsage:
+    """Verify get_detailed_allocation_usage() returns tree-truth on
+    inheriting allocations and self contribution alongside it.
+    """
+
+    def test_root_sees_full_tree_usage(self, shared_tree):
+        usage = shared_tree['root'].get_detailed_allocation_usage(
+            include_adjustments=True,
+        )
+        rname = shared_tree['resource'].resource_name
+        row = usage[rname]
+        assert row['is_inheriting'] is False
+        assert row['used'] == pytest.approx(500.0)
+        assert row['remaining'] == pytest.approx(500.0)
+        # Non-inheriting: no self_* fields surfaced.
+        assert 'self_used' not in row
+
+    def test_leaf_used_reflects_root_tree(self, shared_tree):
+        usage = shared_tree['leaf'].get_detailed_allocation_usage(
+            include_adjustments=True,
+        )
+        rname = shared_tree['resource'].resource_name
+        row = usage[rname]
+        assert row['is_inheriting'] is True
+        # `used` is the full tree consumption — same number the root sees.
+        assert row['used'] == pytest.approx(500.0)
+        assert row['remaining'] == pytest.approx(500.0)
+        # `self_used` is just leaf's own subtree (it's a leaf → just itself).
+        assert row['self_used'] == pytest.approx(200.0)
+        assert row['root_projcode'] == shared_tree['root'].projcode
+
+    def test_mid_self_used_includes_descendants(self, shared_tree):
+        """`self_used` is the project's OWN subtree contribution — for a
+        non-leaf, that includes its descendants.
+        """
+        usage = shared_tree['mid'].get_detailed_allocation_usage(
+            include_adjustments=True,
+        )
+        rname = shared_tree['resource'].resource_name
+        row = usage[rname]
+        assert row['is_inheriting'] is True
+        # Mid's subtree = mid (300) + leaf (200) = 500
+        assert row['self_used'] == pytest.approx(500.0)
+        # `used` (the root tree) is also 500 here because the root
+        # itself has no charges; matches the parent's view.
+        assert row['used'] == pytest.approx(500.0)
+
+    def test_self_percent_used_present_only_when_inheriting(self, shared_tree):
+        rname = shared_tree['resource'].resource_name
+        leaf_row = shared_tree['leaf'].get_detailed_allocation_usage(
+            include_adjustments=True,
+        )[rname]
+        root_row = shared_tree['root'].get_detailed_allocation_usage(
+            include_adjustments=True,
+        )[rname]
+        assert leaf_row['self_percent_used'] == pytest.approx(20.0)
+        assert 'self_percent_used' not in root_row


### PR DESCRIPTION
## Summary

Four admin UX features on the Resources / Projects tabs, plus the
in-flight tree-aware allocation display that came along on the branch.

1. **Cross-project Project Directories view** — new Admin → Projects subtab letting admins audit and manage every `ProjectDirectory` row in one place, grouped by Resource (longest-prefix match against `DiskResourceRootDirectory.root_directory`). Existing Projects-tab content moves into a new Manage subtab.
2. **"New" buttons that reuse existing forms** — green New buttons in the Project Directories toolbar *and* the existing Wallclock Exemptions card row. Both wire to the same modal/form templates the Edit and per-user Add flows already use; the Wallclock add form is now polymorphic (FK picker for user when invoked admin-wide).
3. **Disk Resource Root Directories CRUD** — `DiskResourceRootDirectory` had zero discoverable UI before. A new collapsible-by-resource section is appended to Admin → Resources → Resources sub-tab, mirroring the Wallclock Exemptions placement. Full CRUD: create / rename / re-link / toggle `charging_exempt` / hard delete (the model has no soft-delete columns; UI confirms accordingly). New ORM methods + form schemas. RBAC: `EDIT_RESOURCES` for create/edit, `DELETE_RESOURCES` for delete.
4. **ProjectDirectory CRUD must use a registered disk root** — every new or edited `ProjectDirectory` now picks a root from a dropdown (excluding the catch-all `/`) and supplies an optional sub-path; the server assembles the final `directory_name`. Legacy orphaned rows (created before this validation, or whose root has since been deleted) are **blocked from edit** until corrected — the edit modal renders a banner with the fix path. Validation applies in all three entry points: per-project linked-elements panel, admin New, admin Edit.

Plus carry-over commit `99b2dc2`: tree-aware shared-allocation usage display (two-tone bars + "(N yours)").

---

## Why each change

- **Cross-project Project Directories view** — admins previously had to walk every project to find a stale or orphaned directory link. The grouping makes the relationship between project directories and disk resources legible at a glance, including an "active directory linked to inactive project" orphan flag with per-group orphan counts.
- **"New" buttons** — both Project Directories and Wallclock Exemptions had no admin-wide entry point for creating rows, only per-project / per-user buttons buried in cards. The New buttons reuse the existing form templates (the Wallclock add form was made polymorphic via an `sam_user`-is-None branch that adds a user FK picker) so we don't duplicate validation or markup.
- **Disk Resource Root Directories CRUD** — the new Project Directories grouping silently misclassifies any directory whose root isn't in this table. Without an admin UI, every change to root mappings was a DBA task. The new section sits alongside Resources / Machines / Queues so admins see it where they already manage resource metadata.
- **ProjectDirectory CRUD validation** — the cross-project view's "No Resource Identified" group exists for legacy data debt; it shouldn't keep growing. Validating against registered roots at create / edit time means new entries always group under a meaningful resource. Legacy rows still render in read mode but require correction (or deletion) before any edit can save.

---

## Notable model + schema changes

- `ProjectDirectory.update(directory_name=, project_id=)` instance method added (per CLAUDE.md §7).
- `DiskResourceRootDirectory` gains `SessionMixin` plus `create()` / `update()` / `delete()` instance/class methods.
- New form schemas: `EditLinkedDirectoryForm` (admin Project Directories edit/create), `CreateDiskResourceRootDirectoryForm`, `EditDiskResourceRootDirectoryForm`.
- `AddLinkedDirectoryForm` and `EditLinkedDirectoryForm` field shape changes from `directory_name` to `root_directory_id` + `directory_suffix`. Server assembles the final stored string.
- **No DB migrations** — every change is at the form / route / template layer.

---

## RBAC

- Project Directories admin routes: `EDIT_PROJECTS`.
- Disk Roots admin routes: `EDIT_RESOURCES` for create/edit; `DELETE_RESOURCES` for delete.
- Wallclock Exemptions admin "New" route: `EDIT_USERS` (matches the per-user route).
- All permission checks reuse existing `Permission.*` enum values; no new permissions introduced.

---

## Test plan

- [ ] `pytest` passes (no new failures; existing exemption / project / resource routes unaffected).
- [ ] **Project Directories**: Manage subtab unchanged; Project Directories subtab loads, groups by resource, "No Resource Identified" appears last; Show inactive toggle works; orphan flag (active directory + inactive project) renders the warning row, unlink icon, and per-group count; projcode opens `#projectDetailsModal`.
- [ ] **New** (Project Directories): dropdown lists all non-`/` roots; suffix builds an assembled path; duplicate-active-on-same-project case shows a clear error.
- [ ] **Edit** (Project Directories) — non-orphaned: dropdown pre-selects the matching root, suffix shows the remainder; rename + re-link both work.
- [ ] **Edit** (Project Directories) — legacy orphaned: alert banner renders; saving without a root fails; saving with a valid root + suffix normalizes the path and the row leaves "No Resource Identified".
- [ ] **Per-project Linked Elements**: Add Directory now uses the dropdown + suffix shape; submit creates the row.
- [ ] **Disk Roots**: section appears below the resource-types table; New + Edit + Delete all work; unique-collision on `root_directory` shows a clean form error; `EDIT_RESOURCES` but not `DELETE_RESOURCES` hides Delete and 403s the POST.
- [ ] **Wallclock Exemptions admin "New"**: opens existing modal with user FK picker; resource→queue cascade works; per-user Add Exemption from user card still works (regression).
- [ ] **RBAC**: log in without `EDIT_PROJECTS` — admin Project Directories edit/delete/new routes return 403; same for `EDIT_RESOURCES` and disk-root routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
