### PR TITLE
Admin UX polish (cont.): ProjectDirectory form refinements + bulk-deactivate

### DIFF
--- a/src/sam/schemas/forms/__init__.py
+++ b/src/sam/schemas/forms/__init__.py
@@ -171,6 +171,7 @@ from .projects import (
     AddLinkedContractForm,
     AddLinkedDirectoryForm,
     EditLinkedDirectoryForm,
+    BulkDeactivateProjectDirectoriesForm,
 )
 from .user import (
     AddMemberForm,
@@ -230,6 +231,7 @@ __all__ = [
     'AddLinkedContractForm',
     'AddLinkedDirectoryForm',
     'EditLinkedDirectoryForm',
+    'BulkDeactivateProjectDirectoriesForm',
     # User
     'AddMemberForm',
     'EditAllocationForm',

--- a/src/sam/schemas/forms/projects.py
+++ b/src/sam/schemas/forms/projects.py
@@ -103,7 +103,7 @@ class AddLinkedDirectoryForm(HtmxFormSchema):
     and assembles `directory_name = root.rstrip('/') + ('/' + suffix.lstrip('/') if suffix else '')`.
     """
     root_directory_id = f.Int(required=True)
-    directory_suffix = f.Str(load_default='', validate=v.Length(max=255))
+    directory_suffix = f.Str(required=True, validate=v.Length(min=1, max=255))
 
     @post_load
     def normalize(self, data, **kwargs):
@@ -118,7 +118,7 @@ class EditLinkedDirectoryForm(HtmxFormSchema):
     `project_id` -> Project) stay in the route since schemas don't touch the DB.
     """
     root_directory_id = f.Int(required=True)
-    directory_suffix = f.Str(load_default='', validate=v.Length(max=255))
+    directory_suffix = f.Str(required=True, validate=v.Length(min=1, max=255))
     project_id = f.Int(required=True)
 
     @post_load

--- a/src/sam/schemas/forms/projects.py
+++ b/src/sam/schemas/forms/projects.py
@@ -110,6 +110,25 @@ class AddLinkedDirectoryForm(HtmxFormSchema):
         return _normalize_directory_suffix(data)
 
 
+class BulkDeactivateProjectDirectoriesForm(HtmxFormSchema):
+    """Validate the prefix used for bulk-deactivation of project directories.
+
+    Match semantics live in the route, not here (schemas don't touch the DB).
+    The minimum length and not-equal-to-'/' guards prevent accidentally
+    matching every row in the table.
+    """
+    prefix = f.Str(required=True, validate=v.Length(min=4, max=255))
+
+    @post_load
+    def reject_root(self, data, **kwargs):
+        p = (data.get('prefix') or '').strip()
+        if not p or p == '/':
+            from marshmallow import ValidationError as _VE
+            raise _VE({'prefix': ['Prefix is required and cannot be just "/".']})
+        data['prefix'] = p
+        return data
+
+
 class EditLinkedDirectoryForm(HtmxFormSchema):
     """Edit a project_directory row: rename via root+suffix and/or re-link
     to a project.

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -1779,14 +1779,25 @@ _ORG_LINK_FACILITIES = {'NCAR', 'CISL', 'CSL', 'ASD'}
 
 
 def _disk_roots_for_picker():
-    """Return all DiskResourceRootDirectory rows except the catch-all '/'."""
+    """Return all DiskResourceRootDirectory rows except the catch-all '/',
+    sorted deepest-first (more path segments first, then alphabetically).
+
+    Deepest-first matches the longest-prefix matching used during
+    decomposition and avoids surprising users who expect a more specific
+    root like /glade/campaign to appear above the bare /glade in the
+    dropdown.
+    """
     from sam.resources.resources import DiskResourceRootDirectory
-    return (
+    rows = (
         db.session.query(DiskResourceRootDirectory)
         .filter(DiskResourceRootDirectory.root_directory != '/')
-        .order_by(DiskResourceRootDirectory.root_directory)
         .all()
     )
+    rows.sort(key=lambda r: (
+        -len([seg for seg in r.root_directory.strip('/').split('/') if seg]),
+        r.root_directory,
+    ))
+    return rows
 
 
 def _decompose_directory_name(directory_name, roots):

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -2101,11 +2101,16 @@ def htmx_remove_project_directory(projcode, pd_id):
 
 _PROJECT_DIRECTORIES_RELOAD_TRIGGERS = {
     'closeActiveModal': {},
+    # Both events are fired so the same admin route can refresh either
+    # context: the cross-project view (#projectDirectoriesSection) or
+    # the per-project linked-elements panel (#linkedElementsContainer).
+    # Each handler is a no-op when its target element isn't present.
     'reloadProjectDirectoriesCard': {},
+    'reloadProjectLinkedElements': {},
 }
 
 
-def _render_project_directories_card(*, show_inactive: bool):
+def _render_project_directories_card(*, active_only: bool):
     """Render the cross-project Project Directories card fragment.
 
     Groups rows by Resource via longest-prefix match of ``directory_name``
@@ -2131,7 +2136,7 @@ def _render_project_directories_card(*, show_inactive: bool):
         return None
 
     q = db.session.query(ProjectDirectory).join(Project)
-    if not show_inactive:
+    if active_only:
         q = q.filter(ProjectDirectory.is_active)
     rows = q.order_by(ProjectDirectory.directory_name).all()
 
@@ -2156,7 +2161,7 @@ def _render_project_directories_card(*, show_inactive: bool):
         'dashboards/admin/fragments/project_directories_card.html',
         ordered_groups=ordered_groups,
         total_rows=len(rows),
-        show_inactive=show_inactive,
+        active_only=active_only,
     )
 
 
@@ -2165,8 +2170,12 @@ def _render_project_directories_card(*, show_inactive: bool):
 @require_permission(Permission.EDIT_PROJECTS)
 def htmx_admin_project_directories():
     """Render the cross-project Project Directories table."""
-    show_inactive = request.args.get('show_inactive', '0') in ('1', 'true', 'on')
-    return _render_project_directories_card(show_inactive=show_inactive)
+    # Match the canonical "Active only" toggle pattern used by the
+    # Resources / Organizations / Facilities cards: when the checkbox is
+    # checked, hx-include sends active_only=1; when unchecked, no param,
+    # so we treat absence as False ("show all").
+    active_only = request.args.get('active_only') == '1'
+    return _render_project_directories_card(active_only=active_only)
 
 
 @bp.route('/htmx/admin/project-directories/new-form')

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -2362,3 +2362,110 @@ def htmx_admin_project_directory_deactivate(pd_id):
         {'reloadProjectDirectoriesCard': {}},
         'Project directory deactivated.',
     )
+
+
+# ---------------------------------------------------------------------------
+# Admin: bulk-deactivate Project Directories under a path prefix
+# ---------------------------------------------------------------------------
+
+def _project_dirs_matching_prefix(prefix: str, *, active_only: bool = True):
+    """Return ProjectDirectory rows whose directory_name is `prefix`
+    (with an optional trailing slash) or any descendant of it.
+
+    The match must consume a full path segment, so `/glade/p` does NOT
+    match `/glade/pp/foo`. Caller is responsible for any 'minimum length'
+    sanity checks (the schema enforces >= 4 chars and != '/').
+    """
+    from sam.projects.projects import ProjectDirectory
+    base = prefix.rstrip('/')
+    q = db.session.query(ProjectDirectory).filter(
+        (ProjectDirectory.directory_name == base) |
+        (ProjectDirectory.directory_name.like(base + '/%'))
+    )
+    if active_only:
+        q = q.filter(ProjectDirectory.is_active)
+    return q.order_by(ProjectDirectory.directory_name).all()
+
+
+@bp.route('/htmx/admin/project-directories/bulk-deactivate-form')
+@login_required
+@require_permission(Permission.DELETE_PROJECTS)
+def htmx_admin_project_directory_bulk_deactivate_form():
+    """Step 1: render the prefix-input form fragment in the bulk modal."""
+    return render_template(
+        'dashboards/admin/fragments/bulk_deactivate_project_directories_form_htmx.html',
+    )
+
+
+@bp.route('/htmx/admin/project-directories/bulk-deactivate-preview', methods=['POST'])
+@login_required
+@require_permission(Permission.DELETE_PROJECTS)
+def htmx_admin_project_directory_bulk_deactivate_preview():
+    """Step 2: show count + sample of paths that would be deactivated."""
+    from marshmallow import ValidationError
+    from sam.schemas.forms.projects import BulkDeactivateProjectDirectoriesForm
+
+    try:
+        form_data = BulkDeactivateProjectDirectoriesForm().load(request.form)
+    except ValidationError as e:
+        return render_template(
+            'dashboards/admin/fragments/bulk_deactivate_project_directories_form_htmx.html',
+            errors=BulkDeactivateProjectDirectoriesForm.flatten_errors(e.messages),
+            form=request.form,
+        )
+
+    matches = _project_dirs_matching_prefix(form_data['prefix'], active_only=True)
+    return render_template(
+        'dashboards/admin/fragments/bulk_deactivate_project_directories_preview_htmx.html',
+        prefix=form_data['prefix'],
+        matches=matches,
+    )
+
+
+@bp.route('/htmx/admin/project-directories/bulk-deactivate', methods=['POST'])
+@login_required
+@require_permission(Permission.DELETE_PROJECTS)
+def htmx_admin_project_directory_bulk_deactivate():
+    """Step 3: commit. Re-runs the query (in case data changed since
+    preview) and deactivates all active matches inside one transaction."""
+    from marshmallow import ValidationError
+    from sam.schemas.forms.projects import BulkDeactivateProjectDirectoriesForm
+
+    try:
+        form_data = BulkDeactivateProjectDirectoriesForm().load(request.form)
+    except ValidationError as e:
+        # Bounce back to the step-1 form with the error.
+        return render_template(
+            'dashboards/admin/fragments/bulk_deactivate_project_directories_form_htmx.html',
+            errors=BulkDeactivateProjectDirectoriesForm.flatten_errors(e.messages),
+            form=request.form,
+        )
+
+    prefix = form_data['prefix']
+    matches = _project_dirs_matching_prefix(prefix, active_only=True)
+
+    if not matches:
+        return render_template(
+            'dashboards/admin/fragments/bulk_deactivate_project_directories_preview_htmx.html',
+            prefix=prefix,
+            matches=[],
+            errors=['No active directories match — nothing to do.'],
+        )
+
+    try:
+        with management_transaction(db.session):
+            for pd in matches:
+                pd.deactivate()
+    except Exception as e:
+        return render_template(
+            'dashboards/admin/fragments/bulk_deactivate_project_directories_preview_htmx.html',
+            prefix=prefix,
+            matches=matches,
+            errors=[f'Error during bulk deactivation: {e}'],
+        )
+
+    n = len(matches)
+    return htmx_success_message(
+        _PROJECT_DIRECTORIES_RELOAD_TRIGGERS,
+        f'Deactivated {n} project director{"ies" if n != 1 else "y"} under "{prefix}".',
+    )

--- a/src/webapp/static/js/htmx-config.js
+++ b/src/webapp/static/js/htmx-config.js
@@ -101,17 +101,22 @@ document.body.addEventListener('reloadResourcesCard', function() {
 });
 
 // Reload the cross-project Project Directories table after an edit/deactivate.
-// Uses the show_inactive checkbox state if present (note: opposite of active_only).
+// Honors the canonical "Active only" toggle (active_only=1 when checked).
 document.body.addEventListener('reloadProjectDirectoriesCard', function() {
-    var section = document.getElementById('projectDirectoriesSection');
-    if (!section) return;
-    var url = (section.getAttribute('hx-get') || '').split('?')[0];
+    _reloadAdminCard('projectDirectoriesSection', 'projectDirectoriesActiveOnly');
+});
+
+// Reload the per-project Linked Elements panel (#linkedElementsContainer
+// on the admin edit-project page) after a directory edit. The container
+// carries its own hx-get URL; we just re-fire it. No-op when the page
+// doesn't host the container.
+document.body.addEventListener('reloadProjectLinkedElements', function() {
+    var c = document.getElementById('linkedElementsContainer');
+    if (!c) return;
+    var url = c.getAttribute('hx-get');
     if (!url) return;
-    var cb = document.getElementById('projectDirectoriesShowInactive');
-    var qs = (cb && cb.checked) ? '?show_inactive=1' : '';
     setTimeout(function() {
-        htmx.ajax('GET', url + qs,
-                  {target: '#projectDirectoriesSection', swap: 'innerHTML'});
+        htmx.ajax('GET', url, {target: '#linkedElementsContainer', swap: 'innerHTML'});
     }, 300);
 });
 

--- a/src/webapp/static/js/path-preview.js
+++ b/src/webapp/static/js/path-preview.js
@@ -1,0 +1,75 @@
+/**
+ * Path Preview
+ *
+ * Live preview for the (disk-root dropdown + sub-path text-input) pair
+ * used by ProjectDirectory create/edit forms. Assembles the final stored
+ * directory_name with duplicate slashes collapsed, mirroring the
+ * server-side _assemble_directory_name().
+ *
+ * Usage (in a Jinja fragment):
+ *
+ *   <div class="input-group" data-path-preview-group>
+ *     <select name="root_directory_id" data-path-preview-root>
+ *       <option value="">-- root --</option>
+ *       <option value="1" data-root-path="/glade/campaign">/glade/campaign</option>
+ *     </select>
+ *     <input type="text" name="directory_suffix" data-path-preview-suffix>
+ *   </div>
+ *   <div class="form-text">
+ *     Final path: <code class="path-preview text-primary"></code>
+ *   </div>
+ *
+ * The `data-root-path` attribute on each <option> carries the root path
+ * string (the form `value` is the FK id, not the path). The preview span
+ * is found by climbing to the nearest `.mb-3` / `.form-group` / parent
+ * and looking for `.path-preview`.
+ *
+ * Listens with delegation on `input` and `change`, so dynamically
+ * inserted groups (htmx swaps, modal re-renders) work automatically.
+ */
+(function () {
+    'use strict';
+
+    function dedupeSlashes(s) {
+        return s.replace(/\/+/g, '/');
+    }
+
+    function compute(group) {
+        var sel = group.querySelector('[data-path-preview-root]');
+        var inp = group.querySelector('[data-path-preview-suffix]');
+        if (!sel) return '';
+        var opt = sel.options[sel.selectedIndex];
+        var root = (opt && opt.dataset && opt.dataset.rootPath) || '';
+        if (!root) return '';
+        var suffix = inp ? (inp.value || '').trim() : '';
+        var combined = suffix
+            ? root.replace(/\/+$/, '') + '/' + suffix.replace(/^\/+/, '')
+            : (root.replace(/\/+$/, '') || '/');
+        return dedupeSlashes(combined);
+    }
+
+    function updatePreview(group) {
+        var container = group.closest('.mb-3') || group.closest('.form-group') || group.parentElement;
+        if (!container) return;
+        var target = container.querySelector('.path-preview');
+        if (!target) return;
+        var path = compute(group);
+        target.textContent = path || '—';
+    }
+
+    function primeAll(root) {
+        (root || document).querySelectorAll('[data-path-preview-group]').forEach(updatePreview);
+    }
+
+    function handle(e) {
+        var g = e.target && e.target.closest && e.target.closest('[data-path-preview-group]');
+        if (g) updatePreview(g);
+    }
+    document.addEventListener('input', handle);
+    document.addEventListener('change', handle);
+
+    document.addEventListener('DOMContentLoaded', function () { primeAll(document); });
+    document.addEventListener('htmx:afterSettle', function (evt) {
+        primeAll(evt.detail && evt.detail.elt);
+    });
+})();

--- a/src/webapp/templates/dashboards/admin/dashboard.html
+++ b/src/webapp/templates/dashboards/admin/dashboard.html
@@ -261,7 +261,7 @@
         <div class="tab-pane fade" id="tab-projects-directories"
              role="tabpanel" aria-labelledby="projects-directories-tab">
             <div id="projectDirectoriesSection"
-                 hx-get="{{ url_for('admin_dashboard.htmx_admin_project_directories') }}"
+                 hx-get="{{ url_for('admin_dashboard.htmx_admin_project_directories') }}?active_only=1"
                  hx-trigger="load once"
                  hx-target="this"
                  hx-swap="innerHTML">

--- a/src/webapp/templates/dashboards/admin/edit_project.html
+++ b/src/webapp/templates/dashboards/admin/edit_project.html
@@ -266,6 +266,10 @@
 <!-- Include member management modals (reused from user dashboard) -->
 {% include 'project_members/fragments/member_modals_htmx.html' %}
 
+<!-- Edit ProjectDirectory modal scaffold (loaded by the pencil button on
+     each row of the Directories panel inside #linkedElementsContainer). -->
+{% include 'dashboards/admin/fragments/project_directory_modals.html' %}
+
 <!-- ═══════════════════════════════════════════════ HTMX event handlers -->
 <script>
   // After a successful project details save, the success fragment is shown

--- a/src/webapp/templates/dashboards/admin/fragments/bulk_deactivate_project_directories_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/bulk_deactivate_project_directories_form_htmx.html
@@ -1,0 +1,43 @@
+{% from 'dashboards/fragments/form_fields.html' import text_field with context %}
+{#
+  Step-1: prefix-input form for bulk-deactivating ProjectDirectory rows.
+
+  Loaded into #bulkDeactivateProjectDirectoriesFormContainer when the
+  toolbar "Bulk deactivate" button is clicked. POSTs to the preview
+  endpoint and replaces itself with the step-2 fragment.
+
+  Context:
+    errors : optional list[str]
+    form   : optional ImmutableMultiDict (re-render after validation error)
+#}
+
+<form hx-post="{{ url_for('admin_dashboard.htmx_admin_project_directory_bulk_deactivate_preview') }}"
+      hx-target="#bulkDeactivateProjectDirectoriesFormContainer"
+      hx-swap="innerHTML">
+    <div class="modal-body">
+        <p class="text-muted small mb-3">
+            Enter a path prefix below to find every <strong>active</strong>
+            project directory beneath it. The next step shows the count
+            and a sample of matching paths before you commit.
+        </p>
+
+        {{ text_field('prefix', 'Path prefix',
+                      required=True,
+                      maxlength=255,
+                      placeholder='/glade/p/',
+                      help='Example: /glade/p/  → matches /glade/p and any directory under it. Path-segment-aware: /glade/p does NOT match /glade/pp/foo.',
+                      id='bulkDeactivatePrefix') }}
+
+        {% if errors %}
+        <div class="alert alert-danger mt-2 mb-0">
+            {% for e in errors %}<p class="mb-0"><i class="fas fa-exclamation-circle"></i> {{ e }}</p>{% endfor %}
+        </div>
+        {% endif %}
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="submit" class="btn btn-primary">
+            <i class="fas fa-search"></i> Preview matches
+        </button>
+    </div>
+</form>

--- a/src/webapp/templates/dashboards/admin/fragments/bulk_deactivate_project_directories_preview_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/bulk_deactivate_project_directories_preview_htmx.html
@@ -1,0 +1,82 @@
+{#
+  Step-2: preview + commit fragment for bulk-deactivation.
+
+  Replaces step 1 inside #bulkDeactivateProjectDirectoriesFormContainer.
+  Shows the count + sample of matched paths and a red "Deactivate N"
+  button that POSTs to the commit endpoint.
+
+  Context:
+    prefix  : str (the prefix entered in step 1)
+    matches : list[ProjectDirectory] (active rows that match)
+    errors  : optional list[str]
+#}
+
+<form hx-post="{{ url_for('admin_dashboard.htmx_admin_project_directory_bulk_deactivate') }}"
+      hx-target="#bulkDeactivateProjectDirectoriesFormContainer"
+      hx-swap="innerHTML">
+    <input type="hidden" name="prefix" value="{{ prefix }}">
+
+    <div class="modal-body">
+        {% if not prefix.endswith('/') %}
+        <div class="alert alert-warning">
+            <i class="fas fa-exclamation-triangle"></i>
+            Prefix <code>{{ prefix }}</code> doesn't end with a trailing slash.
+            Match semantics still respect path segments
+            (so <code>{{ prefix }}/...</code> patterns are matched, but
+            <code>{{ prefix }}foo</code>-style siblings are not), but a
+            trailing slash is the safer convention.
+        </div>
+        {% endif %}
+
+        {% if matches %}
+        <p class="mb-2">
+            <strong>{{ matches|length }} active director{{ 'ies' if matches|length != 1 else 'y' }}</strong>
+            match prefix <code>{{ prefix }}</code>:
+        </p>
+        <ul class="font-monospace small mb-3" style="max-height: 18em; overflow-y: auto;">
+            {% for pd in matches[:25] %}
+            <li>
+                {{ pd.directory_name }}
+                <span class="text-muted ms-1">— {{ pd.project.projcode }}</span>
+            </li>
+            {% endfor %}
+            {% if matches|length > 25 %}
+            <li class="text-muted">… and {{ matches|length - 25 }} more.</li>
+            {% endif %}
+        </ul>
+        <div class="alert alert-danger mb-0">
+            <i class="fas fa-exclamation-triangle"></i>
+            Are you sure you want to deactivate
+            <strong>{{ matches|length }}</strong>
+            director{{ 'ies' if matches|length != 1 else 'y' }}
+            under <code>{{ prefix }}</code>?
+            This action cannot be undone.
+        </div>
+        {% else %}
+        <div class="alert alert-info mb-0">
+            No active directories match prefix <code>{{ prefix }}</code>.
+        </div>
+        {% endif %}
+
+        {% if errors %}
+        <div class="alert alert-danger mt-2 mb-0">
+            {% for e in errors %}<p class="mb-0"><i class="fas fa-exclamation-circle"></i> {{ e }}</p>{% endfor %}
+        </div>
+        {% endif %}
+    </div>
+
+    <div class="modal-footer">
+        <button type="button" class="btn btn-secondary"
+                hx-get="{{ url_for('admin_dashboard.htmx_admin_project_directory_bulk_deactivate_form') }}"
+                hx-target="#bulkDeactivateProjectDirectoriesFormContainer"
+                hx-swap="innerHTML">
+            <i class="fas fa-arrow-left"></i> Back
+        </button>
+        {% if matches %}
+        <button type="submit" class="btn btn-danger">
+            <i class="fas fa-trash-alt"></i>
+            Deactivate {{ matches|length }} director{{ 'ies' if matches|length != 1 else 'y' }}
+        </button>
+        {% endif %}
+    </div>
+</form>

--- a/src/webapp/templates/dashboards/admin/fragments/project_directories_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directories_card.html
@@ -48,6 +48,17 @@
                 <i class="fas fa-plus"></i> New
             </button>
             {% endif %}
+            {% if has_permission(Permission.DELETE_PROJECTS) %}
+            <button type="button" class="btn btn-sm btn-outline-warning"
+                    data-bs-toggle="modal"
+                    data-bs-target="#bulkDeactivateProjectDirectoriesModal"
+                    hx-get="{{ url_for('admin_dashboard.htmx_admin_project_directory_bulk_deactivate_form') }}"
+                    hx-target="#bulkDeactivateProjectDirectoriesFormContainer"
+                    hx-trigger="click"
+                    title="Bulk-deactivate directories under a path prefix">
+                <i class="fas fa-broom"></i> Bulk deactivate
+            </button>
+            {% endif %}
         </div>
     </div>
 

--- a/src/webapp/templates/dashboards/admin/fragments/project_directories_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directories_card.html
@@ -9,7 +9,7 @@
   Context:
     ordered_groups : list[(resource_id|None, Resource|None, list[ProjectDirectory])]
     total_rows     : int
-    show_inactive  : bool
+    active_only    : bool
 #}
 
 <div class="card mb-3">
@@ -23,18 +23,19 @@
             </span>
         </div>
         <div class="d-flex align-items-center gap-3">
-            <div class="form-check mb-0">
+            <div class="form-check form-switch mb-0">
                 <input type="checkbox" class="form-check-input"
-                       id="projectDirectoriesShowInactive"
-                       name="show_inactive" value="1"
-                       {% if show_inactive %}checked{% endif %}
+                       id="projectDirectoriesActiveOnly"
+                       name="active_only" value="1"
+                       {% if active_only %}checked{% endif %}
                        hx-get="{{ url_for('admin_dashboard.htmx_admin_project_directories') }}"
                        hx-trigger="change"
                        hx-target="#projectDirectoriesSection"
                        hx-swap="innerHTML"
                        hx-include="this">
-                <label class="form-check-label" for="projectDirectoriesShowInactive">
-                    Show inactive
+                <label class="form-check-label small text-muted fw-normal"
+                       for="projectDirectoriesActiveOnly">
+                    Active only
                 </label>
             </div>
             {% if has_permission(Permission.EDIT_PROJECTS) %}
@@ -137,7 +138,7 @@
                             stop_propagation=True,
                             permission=Permission.EDIT_PROJECTS) }}
                         {% if has_permission(Permission.EDIT_PROJECTS) and pd.is_active %}
-                        <button class="btn btn-sm btn-outline-warning ms-1"
+                        <button class="btn btn-sm btn-outline-danger ms-1"
                                 title="Deactivate directory"
                                 hx-post="{{ url_for('admin_dashboard.htmx_admin_project_directory_deactivate', pd_id=pd.project_directory_id) }}"
                                 hx-swap="none"
@@ -146,7 +147,7 @@
                                 data-confirm-variant="warning"
                                 data-confirm-label="Deactivate"
                                 onclick="event.stopPropagation()">
-                            <i class="fas fa-ban"></i>
+                            <i class="fas fa-trash-alt"></i>
                         </button>
                         {% endif %}
                     </td>
@@ -158,7 +159,7 @@
             <tbody>
                 <tr><td colspan="5" class="text-center text-muted py-3">
                     No project directories
-                    {% if not show_inactive %}(active){% endif %} found.
+                    {% if active_only %}(active){% endif %} found.
                 </td></tr>
             </tbody>
             {% endif %}

--- a/src/webapp/templates/dashboards/admin/fragments/project_directory_edit_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directory_edit_form_htmx.html
@@ -1,5 +1,5 @@
 {% from 'dashboards/fragments/modal_form.html' import htmx_form with context %}
-{% from 'dashboards/fragments/form_fields.html' import text_field, select_field, fk_search_field, readonly_display with context %}
+{% from 'dashboards/fragments/form_fields.html' import fk_search_field, readonly_display with context %}
 {#
   htmx: Edit Project Directory form (loaded into #editProjectDirectoryFormContainer).
 
@@ -44,21 +44,43 @@
         {{ readonly_display('Current path', pd.directory_name, muted=False, strong=True) }}
         {{ readonly_display('Start Date', pd.start_date | fmt_date, muted=True) }}
 
-        {{ select_field('root_directory_id', 'Disk Root',
-                        items=disk_roots,
-                        value_attr='root_directory_id',
-                        label_attr='root_directory',
-                        required=True,
-                        default=(default_root.root_directory_id if default_root else ''),
-                        placeholder='-- Select a disk root --',
-                        id='editProjectDirectoryRoot') }}
-
-        {{ text_field('directory_suffix', 'Sub-path',
-                      maxlength=255,
-                      default=default_suffix or '',
-                      placeholder='subpath/under/the/root  (or leave blank for the root itself)',
-                      help='Path under the chosen root. ".." segments are not allowed.',
-                      id='editProjectDirectorySuffix') }}
+        {%- set _selected_root_id = form.get('root_directory_id') if form else (default_root.root_directory_id if default_root else '') -%}
+        {%- set _selected_suffix = form.get('directory_suffix') if form else (default_suffix or '') -%}
+        <div class="mb-3">
+            <label for="editProjectDirectoryRoot" class="form-label">
+                Directory <span class="text-danger">*</span>
+            </label>
+            <div class="input-group" data-path-preview-group>
+                <select class="form-select" id="editProjectDirectoryRoot"
+                        name="root_directory_id" required
+                        data-path-preview-root
+                        style="max-width: 18em;">
+                    <option value="">-- Select a disk root --</option>
+                    {% for r in disk_roots %}
+                    <option value="{{ r.root_directory_id }}"
+                            data-root-path="{{ r.root_directory }}"
+                            {% if _selected_root_id|string == r.root_directory_id|string %}selected{% endif %}>
+                        {{ r.root_directory }}
+                    </option>
+                    {% endfor %}
+                </select>
+                <span class="input-group-text">/</span>
+                <input type="text" class="form-control"
+                       id="editProjectDirectorySuffix"
+                       name="directory_suffix"
+                       maxlength="255"
+                       required
+                       placeholder="sub-path"
+                       autocomplete="off"
+                       data-path-preview-suffix
+                       value="{{ _selected_suffix }}">
+            </div>
+            <div class="form-text">
+                Final path:
+                <code class="path-preview text-primary fw-semibold">—</code>
+                <span class="text-muted">— <code>".."</code> segments are not allowed.</span>
+            </div>
+        </div>
 
         {{ fk_search_field('project_id', 'Linked Project',
                            search_url=url_for('admin_dashboard.htmx_project_search_for_parent'),

--- a/src/webapp/templates/dashboards/admin/fragments/project_directory_edit_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directory_edit_form_htmx.html
@@ -75,10 +75,12 @@
                        data-path-preview-suffix
                        value="{{ _selected_suffix }}">
             </div>
+            <div class="form-text text-muted">
+                <code>".."</code> segments are not allowed.
+            </div>
             <div class="form-text">
                 Final path:
                 <code class="path-preview text-primary fw-semibold">—</code>
-                <span class="text-muted">— <code>".."</code> segments are not allowed.</span>
             </div>
         </div>
 

--- a/src/webapp/templates/dashboards/admin/fragments/project_directory_modals.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directory_modals.html
@@ -14,3 +14,12 @@
                   icon='edit',
                   container_id='editProjectDirectoryFormContainer',
                   variant='edit') }}
+
+{% if has_permission(Permission.DELETE_PROJECTS) %}
+{{ modal_scaffold('bulkDeactivateProjectDirectoriesModal',
+                  'Bulk-deactivate Project Directories',
+                  icon='broom',
+                  container_id='bulkDeactivateProjectDirectoriesFormContainer',
+                  variant='edit',
+                  size='lg') }}
+{% endif %}

--- a/src/webapp/templates/dashboards/admin/fragments/project_directory_new_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directory_new_form_htmx.html
@@ -1,10 +1,14 @@
 {% from 'dashboards/fragments/modal_form.html' import htmx_form with context %}
-{% from 'dashboards/fragments/form_fields.html' import text_field, select_field, fk_search_field with context %}
+{% from 'dashboards/fragments/form_fields.html' import fk_search_field with context %}
 {#
   htmx: New Project Directory form (loaded into #addProjectDirectoryFormContainer).
 
   Shares EditLinkedDirectoryForm validation: root_directory_id + directory_suffix + project_id.
   Final directory_name is assembled server-side from the chosen root + suffix.
+
+  The root dropdown + suffix input render as a single Bootstrap input-group
+  so the user sees them as one path; static/js/path-preview.js renders the
+  assembled (slash-deduplicated) result live below.
 
   Context:
     disk_roots : list[DiskResourceRootDirectory] (excludes the catch-all '/')
@@ -27,19 +31,41 @@
         </div>
         {% endif %}
 
-        {{ select_field('root_directory_id', 'Disk Root',
-                        items=disk_roots,
-                        value_attr='root_directory_id',
-                        label_attr='root_directory',
-                        required=True,
-                        placeholder='-- Select a disk root --',
-                        id='addProjectDirectoryRoot') }}
-
-        {{ text_field('directory_suffix', 'Sub-path',
-                      maxlength=255,
-                      placeholder='subpath/under/the/root  (or leave blank for the root itself)',
-                      help='Path under the chosen root. ".." segments are not allowed.',
-                      id='addProjectDirectorySuffix') }}
+        <div class="mb-3">
+            <label for="addProjectDirectoryRoot" class="form-label">
+                Directory <span class="text-danger">*</span>
+            </label>
+            <div class="input-group" data-path-preview-group>
+                <select class="form-select" id="addProjectDirectoryRoot"
+                        name="root_directory_id" required
+                        data-path-preview-root
+                        style="max-width: 18em;">
+                    <option value="">-- Select a disk root --</option>
+                    {% for r in disk_roots %}
+                    <option value="{{ r.root_directory_id }}"
+                            data-root-path="{{ r.root_directory }}"
+                            {% if form and form.get('root_directory_id') == r.root_directory_id|string %}selected{% endif %}>
+                        {{ r.root_directory }}
+                    </option>
+                    {% endfor %}
+                </select>
+                <span class="input-group-text">/</span>
+                <input type="text" class="form-control"
+                       id="addProjectDirectorySuffix"
+                       name="directory_suffix"
+                       maxlength="255"
+                       required
+                       placeholder="sub-path"
+                       autocomplete="off"
+                       data-path-preview-suffix
+                       value="{{ form.get('directory_suffix') if form else '' }}">
+            </div>
+            <div class="form-text">
+                Final path:
+                <code class="path-preview text-primary fw-semibold">—</code>
+                <span class="text-muted">— <code>".."</code> segments are not allowed.</span>
+            </div>
+        </div>
 
         {{ fk_search_field('project_id', 'Linked Project',
                            search_url=url_for('admin_dashboard.htmx_project_search_for_parent'),

--- a/src/webapp/templates/dashboards/admin/fragments/project_directory_new_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directory_new_form_htmx.html
@@ -60,10 +60,12 @@
                        data-path-preview-suffix
                        value="{{ form.get('directory_suffix') if form else '' }}">
             </div>
+            <div class="form-text text-muted">
+                <code>".."</code> segments are not allowed.
+            </div>
             <div class="form-text">
                 Final path:
                 <code class="path-preview text-primary fw-semibold">—</code>
-                <span class="text-muted">— <code>".."</code> segments are not allowed.</span>
             </div>
         </div>
 

--- a/src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html
@@ -269,7 +269,7 @@
             <th>Directory</th>
             <th style="width:9em;">Since</th>
             <th style="width:9em;">Until</th>
-            <th style="width:3em;"></th>
+            <th style="width:5em;"></th>
           </tr>
         </thead>
         <tbody>
@@ -280,9 +280,18 @@
             <td class="text-muted small">
               {% if pd.end_date %}{{ pd.end_date | fmt_date }}{% else %}—{% endif %}
             </td>
-            <td class="text-end">
+            <td class="text-end text-nowrap">
               {% if can_edit_governance %}
-              <button class="btn btn-xs btn-outline-danger"
+              <button class="btn btn-xs btn-outline-secondary"
+                      title="Edit directory"
+                      data-bs-toggle="modal"
+                      data-bs-target="#editProjectDirectoryModal"
+                      hx-get="{{ url_for('admin_dashboard.htmx_admin_project_directory_edit_form', pd_id=pd.project_directory_id) }}"
+                      hx-target="#editProjectDirectoryFormContainer"
+                      hx-trigger="click">
+                <i class="fas fa-edit"></i>
+              </button>
+              <button class="btn btn-xs btn-outline-danger ms-1"
                       title="Remove directory"
                       hx-post="{{ url_for('admin_dashboard.htmx_remove_project_directory', projcode=project.projcode, pd_id=pd.project_directory_id) }}"
                       hx-target="#linkedElementsContainer"

--- a/src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html
@@ -217,33 +217,37 @@
         <form hx-post="{{ url_for('admin_dashboard.htmx_add_project_directory', projcode=project.projcode) }}"
               hx-target="#linkedElementsContainer"
               hx-swap="innerHTML">
-          <div class="d-flex gap-2 align-items-center flex-wrap">
+          <div class="input-group input-group-sm" data-path-preview-group>
             <select name="root_directory_id" required
-                    class="form-select form-select-sm"
+                    class="form-select"
+                    data-path-preview-root
                     style="max-width:14em;">
               <option value="">-- Select a disk root --</option>
               {% for r in disk_roots %}
-              <option value="{{ r.root_directory_id }}">{{ r.root_directory }}</option>
+              <option value="{{ r.root_directory_id }}"
+                      data-root-path="{{ r.root_directory }}">{{ r.root_directory }}</option>
               {% endfor %}
             </select>
+            <span class="input-group-text">/</span>
             <input type="text"
                    name="directory_suffix"
-                   class="form-control form-control-sm flex-grow-1"
-                   placeholder="sub/path  (or leave blank for the root itself)"
+                   class="form-control"
+                   required
+                   placeholder="sub-path"
                    autocomplete="off"
-                   style="min-width:200px;">
-            <button type="submit" class="btn btn-sm btn-success">
+                   data-path-preview-suffix>
+            <button type="submit" class="btn btn-success">
               <i class="fas fa-check"></i> Add
             </button>
-            <button type="button" class="btn btn-sm btn-outline-secondary"
+            <button type="button" class="btn btn-outline-secondary"
                     onclick="leToggleAddForm('addDirForm')">
               Cancel
             </button>
           </div>
           <small class="text-muted d-block mt-1">
-            Final path is assembled as
-            <code>&lt;root&gt;/&lt;sub-path&gt;</code>; <code>".."</code>
-            segments are not allowed.
+            Final path:
+            <code class="path-preview text-primary fw-semibold">—</code>
+            — <code>".."</code> segments are not allowed.
           </small>
         </form>
         {% else %}

--- a/src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html
@@ -245,9 +245,11 @@
             </button>
           </div>
           <small class="text-muted d-block mt-1">
+            <code>".."</code> segments are not allowed.
+          </small>
+          <small class="d-block">
             Final path:
             <code class="path-preview text-primary fw-semibold">—</code>
-            — <code>".."</code> segments are not allowed.
           </small>
         </form>
         {% else %}

--- a/src/webapp/templates/dashboards/base.html
+++ b/src/webapp/templates/dashboards/base.html
@@ -169,6 +169,7 @@
     <script src="{{ url_for('static', filename='js/lazy-loading.js') }}"></script>
     <script src="{{ url_for('static', filename='js/nav-view-persistence.js') }}"></script>
     <script src="{{ url_for('static', filename='js/number-preview.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/path-preview.js') }}"></script>
     <script src="{{ url_for('static', filename='js/fk-picker.js') }}"></script>
     <script src="{{ url_for('static', filename='js/htmx-config.js') }}"></script>
     <script src="{{ url_for('static', filename='js/collapse-chevron.js') }}"></script>


### PR DESCRIPTION
## Summary

Two things on top of the merged PR #198 (`Admin UX polish: Project
Directories + Disk Roots + New-button shortcuts`):

1. **ProjectDirectory form refinements** — the create/edit forms got
   sharper inline ergonomics so the root dropdown + sub-path input read
   as a single path with a live preview, the sub-path is required, and
   the dropdown surfaces the most-specific roots first.
2. **Bulk-deactivate by path prefix** — new toolbar action on the
   cross-project Project Directories card that batches the soft-delete
   used by the per-row deactivate, gated for filesystem-decommission
   scenarios.

---

## 1. ProjectDirectory form refinements

Across three commits (`3c1a83c`, `3361778`, `6f526d8`):

- **One-line layout.** Disk-root `<select>` + sub-path `<input>` now
  render as a single Bootstrap `input-group` with a `/` separator. The
  user sees the form as one path, not two stacked fields. Applied in
  the admin New modal, the admin Edit modal, and the per-project
  linked-elements panel.
- **Live preview.** New `static/js/path-preview.js` (modeled on the
  existing `number-preview.js`) renders the assembled `directory_name`
  with duplicate slashes collapsed into a sibling `.path-preview` span,
  exactly mirroring the server-side `_assemble_directory_name()`.
  Reads each `<option>`'s `data-root-path` attribute since the form
  value is the FK id, not the path string. Listens via event delegation
  on `input` / `change` and re-primes on `htmx:afterSettle` for modal
  re-renders.
- **Sub-path required.** Marshmallow field `directory_suffix` is now
  `required=True, validate=Length(min=1, max=255)`; templates also add
  the HTML5 `required` attribute. An empty suffix would yield a
  `directory_name` equal to the bare root, which is essentially never
  the intent.
- **Deepest-first sort.** `_disk_roots_for_picker()` now sorts by
  number of path segments (descending), then alphabetically — so
  `/glade/campaign` appears above `/glade` in the dropdown, matching
  the longest-prefix logic used during decomposition on edit.
- Replaced the bespoke "Show inactive" checkbox with the canonical
  `form-switch` "Active only" toggle used by the Resources /
  Organizations / Facilities cards (semantics inverted, default
  active-only). The reload event handler now delegates to the existing
  `_reloadAdminCard('projectDirectoriesSection', 'projectDirectoriesActiveOnly')`.
- Added a pencil edit icon on the per-project Linked Elements panel's
  Directories table, immediately before the existing X delete button,
  reusing the cross-project edit modal. Modal scaffold included on
  `edit_project.html`. The admin edit POST's success triggers gained
  `reloadProjectLinkedElements` so both the cross-project view and the
  per-project panel refresh after a save (each handler no-ops when its
  target element isn't on the page).
- Project Directories rows now use the `btn-outline-danger` +
  `fa-trash-alt` styling (matching the Organizations card and the new
  Disk Roots section) instead of the prior `btn-outline-warning` +
  `fa-ban` combination.

---

## 2. Bulk-deactivate by path prefix

Single commit `5ff4749`. New toolbar button on the Project Directories
card header, right of the existing **New** button, gated by
`Permission.DELETE_PROJECTS`. Opens a two-step modal:

- **Step 1**: prefix text input (e.g. `/glade/p/`) + Preview button.
- **Step 2**: revealed after preview, shows the count, the first 25
  matched paths with their projcodes, a yellow warning if the prefix
  doesn't end with a trailing slash, and a red **Deactivate N
  directories** commit button. Confirm wording uses the user-supplied
  text: *"Are you sure you want to deactivate N directories under
  &lt;prefix&gt;? This action cannot be undone."*

### Match semantics

Path-segment-aware: `directory_name == prefix.rstrip('/')` OR
`directory_name LIKE prefix.rstrip('/') + '/%'`. So `/glade/p` does
**not** match `/glade/pp/foo`. Only active rows are considered. The
commit route re-runs the query (race-safety) and iterates
`pd.deactivate()` inside one `management_transaction`, then fires the
existing `closeActiveModal` + `reloadProjectDirectoriesCard` +
`reloadProjectLinkedElements` triggers.

### Schema

`BulkDeactivateProjectDirectoriesForm`: `prefix` required, length
∈ [4, 255]; explicitly rejects `/` and whitespace-only prefixes to
prevent accidentally matching every row in the table.

### RBAC

`Permission.DELETE_PROJECTS` — stronger than per-row deactivate
(`EDIT_PROJECTS`). Today only the `nusd` group has this. Toolbar
button, modal scaffold, and all three routes (form GET, preview POST,
commit POST) all enforce it.

---

## Files of note

- `src/sam/schemas/forms/projects.py` — `BulkDeactivateProjectDirectoriesForm`; `directory_suffix` becomes required on the existing add/edit schemas.
- `src/webapp/dashboards/admin/projects_routes.py` — `_disk_roots_for_picker` deepest-first sort; `_project_dirs_matching_prefix` helper; three new bulk-deactivate routes; existing edit success-trigger payload extended.
- `src/webapp/templates/dashboards/admin/fragments/project_directories_card.html` — toolbar gains the Bulk deactivate button; canonical "Active only" toggle.
- `src/webapp/templates/dashboards/admin/fragments/project_directory_{new,edit}_form_htmx.html` — inline `input-group` layout, live preview, required suffix.
- `src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html` — same inline shape; pencil edit button.
- `src/webapp/templates/dashboards/admin/fragments/bulk_deactivate_project_directories_{form,preview}_htmx.html` — NEW two-step modal fragments.
- `src/webapp/templates/dashboards/admin/fragments/project_directory_modals.html` — added `bulkDeactivateProjectDirectoriesModal` scaffold.
- `src/webapp/static/js/path-preview.js` — NEW; loaded from `base.html`.

**No DB migrations.** Every change is at the form / route / template / static-asset layer.

---

## Test plan

- [ ] `pytest` passes (no new failures; existing project-directory routes unaffected).
- [ ] **Inline form layout**: in all three entry points (admin New, admin Edit, per-project Linked Elements add) the dropdown and sub-path appear on one row with a `/` separator and a `Final path: <preview>` line below; ".." segments rejected with a clean error.
- [ ] **Required sub-path**: empty submit blocked client-side and (if bypassed) server-side.
- [ ] **Deepest-first dropdown**: `/glade/campaign` appears above `/glade`.
- [ ] **Active-only toggle**: matches the visual style of the other admin cards; checkbox state preserved across reloads.
- [ ] **Pencil edit on per-project page**: clicking it opens the cross-project edit modal pre-populated; saving refreshes the per-project Linked Elements panel.
- [ ] **Bulk deactivate**: button appears only with `DELETE_PROJECTS`; preview shows the count and first 25 matches with the trailing-slash warning when applicable; commit batches the soft-delete and the table refreshes; 0-match commit stays in step 2 with a clear message; `/`, `/a`, empty all blocked at step 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
