### PR TITLE
Tree-aware resource details + status-dashboard timezone overhaul

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,37 +178,6 @@ Schemas follow a consistent pattern for optimal performance:
 - Fetching 10-100 objects → Use List Schema (e.g., user listing, search results)
 - Showing related object → Use Summary Schema (e.g., project's lead within project detail)
 
-**Concrete Example - User Schemas:**
-```python
-# UserSchema (Full) - Returns everything
-{
-    "user_id": 12345,
-    "username": "benkirk",
-    "first_name": "Benjamin",
-    "last_name": "Kirk",
-    "email_addresses": [{"email_address": "benkirk@ucar.edu", "is_primary": true}],
-    "active_projects": [{"projcode": "SCSG0001", "title": "..."}],
-    "institutions": [...],
-    "organizations": [...]
-}
-
-# UserListSchema - Just core fields
-{
-    "user_id": 12345,
-    "username": "benkirk",
-    "first_name": "Benjamin",
-    "last_name": "Kirk",
-    "primary_email": "benkirk@ucar.edu"
-}
-
-# UserSummarySchema - Minimal identifier
-{
-    "user_id": 12345,
-    "username": "benkirk",
-    "full_name": "Benjamin Shelton Kirk"
-}
-```
-
 ### Usage Examples
 ```python
 from sam.schemas import UserSchema, ProjectListSchema, AllocationWithUsageSchema
@@ -876,19 +845,6 @@ for project, allocation, resource_name, days_since in expired:
 
 ## Git Workflow
 
-### Recent Commits
-1. **cfbf846**: Refactor SAM CLI into modular, class-based architecture ⭐ NEW
-   - Split 1043-line monolith into 17 modular files
-   - Added sam-admin CLI with validation and reconciliation
-   - 100% backward compatibility, all 437 tests pass
-2. **aa83b9b**: Enable parallel test execution with pytest-xdist (3x faster)
-3. **c92972b**: Add targeted tests for query functions (+41 tests, +5% coverage)
-4. **df4d317**: Admin functionality (#13)
-
-### Branches
-- **Current**: `admin-cli`
-- **Main branch**: `main`
-
 ### Commit Guidelines
 - Use detailed commit messages with markdown formatting
 - Include "## Summary" section
@@ -1055,7 +1011,3 @@ sam-search --format json accounting --last 7d
 ✅ **DO** use `@require_project_access` or `@require_project_member_access(Permission.X)` on all project-scoped GET routes — function receives `project`, not `projcode`
 ✅ **DO** use `FormSchema().load(data)` for POST mutations, `FormSchema().load(data, partial=True)` for PUT — gate the `updates` dict on keys present in the original `data` dict, not the form output
 
----
-
-*Last Updated: 2026-04-15*
-*Current Branch: tests_refactor*

--- a/collectors/lib/parsers/reservations.py
+++ b/collectors/lib/parsers/reservations.py
@@ -2,11 +2,23 @@
 PBS reservation parser.
 
 Parses output from 'pbs_rstat -f' to extract reservation information.
+
+Time zones: PBS reports `reserve_start` / `reserve_end` in the cluster's
+local time (e.g. 'Wed Nov 12 12:00:00 2025'), with no zone marker.  The
+parser anchors that to the supplied ``cluster_tz`` (default
+'America/Denver' since both Derecho and Casper sit at NCAR-Wyoming) and
+converts to naive-UTC before stringifying, matching the project-wide
+naive-UTC storage convention.
 """
 
 import logging
 from typing import List, Optional
 from datetime import datetime
+from zoneinfo import ZoneInfo
+
+
+_UTC = ZoneInfo('UTC')
+_DEFAULT_CLUSTER_TZ = 'America/Denver'
 
 
 class ReservationParser:
@@ -16,7 +28,11 @@ class ReservationParser:
         self.logger = logging.getLogger(__name__)
 
     @staticmethod
-    def parse_reservations(rstat_output: str, system_name: str) -> List[dict]:
+    def parse_reservations(
+        rstat_output: str,
+        system_name: str,
+        cluster_tz: str = _DEFAULT_CLUSTER_TZ,
+    ) -> List[dict]:
         """
         Parse PBS pbs_rstat -f output into reservation records.
 
@@ -83,7 +99,8 @@ class ReservationParser:
                 continue
 
             try:
-                resv_data = ReservationParser._parse_reservation_block(block, system_name)
+                resv_data = ReservationParser._parse_reservation_block(
+                    block, system_name, cluster_tz)
                 if resv_data:
                     reservations.append(resv_data)
             except Exception as e:
@@ -95,7 +112,11 @@ class ReservationParser:
         return reservations
 
     @staticmethod
-    def _parse_reservation_block(block: str, system_name: str) -> Optional[dict]:
+    def _parse_reservation_block(
+        block: str,
+        system_name: str,
+        cluster_tz: str = _DEFAULT_CLUSTER_TZ,
+    ) -> Optional[dict]:
         """
         Parse a single reservation block.
 
@@ -143,8 +164,8 @@ class ReservationParser:
             return None
 
         try:
-            start_time = ReservationParser._parse_pbs_datetime(start_time_str)
-            end_time = ReservationParser._parse_pbs_datetime(end_time_str)
+            start_time = ReservationParser._parse_pbs_datetime(start_time_str, cluster_tz)
+            end_time = ReservationParser._parse_pbs_datetime(end_time_str, cluster_tz)
         except ValueError as e:
             logger.warning(f"Skipping reservation {reservation_name}: datetime parse error: {e}")
             return None
@@ -169,25 +190,28 @@ class ReservationParser:
         }
 
     @staticmethod
-    def _parse_pbs_datetime(time_str: str) -> str:
+    def _parse_pbs_datetime(time_str: str, cluster_tz: str = _DEFAULT_CLUSTER_TZ) -> str:
         """
-        Parse PBS datetime string to ISO format.
+        Parse a PBS datetime string and return naive-UTC ISO.
 
-        PBS format: "Wed Nov 12 12:00:00 2025"
-        Output: "2025-11-12T12:00:00"
+        PBS format: "Wed Nov 12 12:00:00 2025" — TZ-blind, but understood
+        by convention to be the cluster's local time.  Anchor it to
+        ``cluster_tz`` so DST math is correct, then convert to naive-UTC
+        for storage (matching the project-wide convention).
 
         Args:
-            time_str: PBS datetime string
+            time_str:    PBS datetime string.
+            cluster_tz:  IANA name of the cluster's local TZ.
 
         Returns:
-            ISO format datetime string
+            Naive-UTC ISO datetime string (no offset suffix).
 
         Raises:
-            ValueError: If datetime format is invalid
+            ValueError: If datetime format is invalid.
         """
-        # PBS datetime format: "Wed Nov 12 12:00:00 2025"
         dt = datetime.strptime(time_str, "%a %b %d %H:%M:%S %Y")
-        return dt.isoformat()
+        dt = dt.replace(tzinfo=ZoneInfo(cluster_tz))
+        return dt.astimezone(_UTC).replace(tzinfo=None).isoformat()
 
     @staticmethod
     def _extract_node_count(data: dict) -> Optional[int]:

--- a/collectors/run_collectors.sh
+++ b/collectors/run_collectors.sh
@@ -5,6 +5,14 @@
 
 set -e
 
+# Force collectors to write naive-UTC timestamps regardless of host TZ.
+# The webapp (in a container) reads with datetime.now() in UTC, so a
+# host running MDT/MST would write timestamps 6–7 hours behind, causing
+# the most recent records to fall just outside short read windows
+# (e.g. 6h on the status dashboard).  TZ=UTC keeps writers and readers
+# on the same naive-UTC clock per the project-wide convention.
+export TZ=UTC
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 

--- a/src/sam/fmt.py
+++ b/src/sam/fmt.py
@@ -348,6 +348,9 @@ def register_jinja_filters(app) -> None:
     app.jinja_env.filters['fmt_date']     = date_str
     app.jinja_env.filters['fmt_size']     = size
     app.jinja_env.filters['to_local_dt']  = to_local_dt
+    # Global (not a filter) so templates can render "{{ local_tz_label() }}"
+    # alongside naive-local timestamps that don't go through to_local_dt.
+    app.jinja_env.globals['local_tz_label'] = local_tz_label
 
 
 def mpl_number_formatter(sig_figs: Optional[int] = None):

--- a/src/sam/fmt.py
+++ b/src/sam/fmt.py
@@ -73,6 +73,30 @@ def local_tz_label() -> str:
     abbr = datetime.now(_DISPLAY_TZ).strftime('%Z')
     return abbr or _DISPLAY_TZ_NAME
 
+
+def naive_local_to_utc(
+    dt: Optional[datetime],
+    tz_name: Optional[str] = None,
+) -> Optional[datetime]:
+    """Treat a naive datetime as wall-clock time in `tz_name` and return the
+    equivalent naive-UTC datetime.  Used at form-submit time to normalize
+    operator-entered values (browser-local) into the project's naive-UTC
+    storage convention.
+
+    None passes through.  An already-aware datetime is converted directly.
+    A bad / missing tz_name falls back to STATUS_DISPLAY_TZ."""
+    if dt is None:
+        return None
+    tz = _DISPLAY_TZ
+    if tz_name:
+        try:
+            tz = ZoneInfo(tz_name)
+        except Exception:
+            tz = _DISPLAY_TZ
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=tz)
+    return dt.astimezone(_UTC).replace(tzinfo=None)
+
 # ── Constants ─────────────────────────────────────────────────────────────────
 
 # Numbers ≤ this are shown exactly with thousands separators ("99,999").

--- a/src/sam/fmt.py
+++ b/src/sam/fmt.py
@@ -30,10 +30,48 @@ Quick reference
     ax.yaxis.set_major_formatter(fmt.mpl_number_formatter())
 """
 import math
+import os
 from datetime import date, datetime
 from typing import Optional, Union
+from zoneinfo import ZoneInfo
 
 from config import SAMConfig
+
+
+# ── Display timezone for naive-UTC datetimes ────────────────────────────────
+#
+# Database / collector convention is naive-UTC (CLAUDE.md).  When rendering
+# datetimes for human eyes, convert to the configured display TZ.  Default
+# is America/Denver since the systems and most users are in NCAR's TZ.
+# Override with STATUS_DISPLAY_TZ for other deployments.
+
+_DISPLAY_TZ_NAME = os.environ.get('STATUS_DISPLAY_TZ', 'America/Denver')
+_DISPLAY_TZ = ZoneInfo(_DISPLAY_TZ_NAME)
+_UTC = ZoneInfo('UTC')
+
+
+def to_local_dt(dt: Optional[datetime]) -> Optional[datetime]:
+    """Convert a naive-UTC datetime to a tz-aware datetime in the display TZ.
+
+    Returns None unchanged.  `date` (no time) is returned unchanged since
+    a calendar date has no time-of-day to localise.  Already-aware
+    datetimes are converted to the display TZ; naive datetimes are
+    assumed to be UTC (the project-wide convention).
+    """
+    if dt is None:
+        return None
+    if not isinstance(dt, datetime):
+        return dt  # pure date — leave alone
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=_UTC)
+    return dt.astimezone(_DISPLAY_TZ)
+
+
+def local_tz_label() -> str:
+    """DST-aware short abbreviation for the active display TZ (e.g. 'MDT'/'MST').
+    Falls back to the IANA name if the platform doesn't supply an abbrev."""
+    abbr = datetime.now(_DISPLAY_TZ).strftime('%Z')
+    return abbr or _DISPLAY_TZ_NAME
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -305,10 +343,11 @@ def register_jinja_filters(app) -> None:
                       {{ value | fmt_date(fmt='%b %Y') }}
         fmt_size    — {{ value | fmt_size }}
     """
-    app.jinja_env.filters['fmt_number'] = number
-    app.jinja_env.filters['fmt_pct']    = pct
-    app.jinja_env.filters['fmt_date']   = date_str
-    app.jinja_env.filters['fmt_size']   = size
+    app.jinja_env.filters['fmt_number']   = number
+    app.jinja_env.filters['fmt_pct']      = pct
+    app.jinja_env.filters['fmt_date']     = date_str
+    app.jinja_env.filters['fmt_size']     = size
+    app.jinja_env.filters['to_local_dt']  = to_local_dt
 
 
 def mpl_number_formatter(sig_figs: Optional[int] = None):

--- a/src/sam/queries/rolling_usage.py
+++ b/src/sam/queries/rolling_usage.py
@@ -221,10 +221,22 @@ def get_project_rolling_usage(
             allocated        – allocation amount (float, AU)
             start_date       – allocation start (datetime)
             end_date         – allocation end (datetime | None)
+            is_inheriting    – True if this project's allocation is a child node
+                               in a shared-allocation tree (charges roll up
+                               across peers)
+            root_projcode    – projcode of the master allocation's project when
+                               inheriting; None otherwise
             windows          – dict keyed by window_days (int), each with:
-                charges          – total charges in window (float, AU)
+                charges          – total charges in window (float, AU).  When
+                                   ``is_inheriting`` is True this is the
+                                   *pool* burn (root allocation's project
+                                   subtree); otherwise this project's own.
+                self_charges     – this project's own contribution to the
+                                   pool when inheriting; None otherwise.
                 prorated_alloc   – prorated allocation for this period (float, AU)
                 pct_of_prorated  – charges / prorated_alloc × 100 (float, %)
+                                   — pool burn vs prorated when inheriting,
+                                   so this is the runway-meaningful number.
                 threshold_pct    – configured threshold % from account (int | None)
                                    30d window → account.first_threshold
                                    90d window → account.second_threshold
@@ -270,10 +282,15 @@ def get_project_rolling_usage(
     account_meta: Dict[int, Dict] = {}
     # account_id → (alloc_start, alloc_end) for window clamping
     alloc_windows: Dict[int, tuple] = {}
-    # leaf account_ids (direct charge lookup)
+    # leaf account_ids (direct charge lookup) — yields *self* charges
     leaf_ids: List[int] = []
-    # non-leaf account_id → MPTT info (subtree rollup)
+    # non-leaf account_id → MPTT info (subtree rollup) — yields *self* charges
     subtree_map: Dict[int, Dict] = {}
+    # Inheriting accounts: account_id → MPTT info for the *root* allocation's
+    # project subtree.  Used to compute pool charges in parallel with the
+    # self-charge query above.  The pool MPTT info uses a different anchor
+    # (the master parent's tree coordinates) and the same window clamp.
+    pool_subtree_map: Dict[int, Dict] = {}
 
     for acct in project.accounts:
         if acct.deleted:
@@ -297,11 +314,38 @@ def get_project_rolling_usage(
 
         aid = acct.account_id
         alloc_windows[aid] = (active_alloc.start_date, active_alloc.end_date)
+
+        # Pool detection — when the active allocation is inheriting, walk to
+        # the root allocation and prepare a parallel subtree query against
+        # the *root project's* tree, so this window's `charges` reflects
+        # pool burn (the rate that actually depletes the shared allocation).
+        # Mirrors Project.get_detailed_allocation_usage (projects.py:660-673).
+        is_inheriting = False
+        root_projcode = None
+        if active_alloc.is_inheriting:
+            root_alloc = active_alloc.root
+            root_account = root_alloc.account if root_alloc is not None else None
+            root_project = root_account.project if root_account is not None else None
+            if (root_project is not None
+                    and root_project.tree_root is not None
+                    and root_project.tree_left is not None
+                    and root_project.tree_right is not None):
+                is_inheriting = True
+                root_projcode = root_project.projcode
+                pool_subtree_map[aid] = {
+                    'tree_root':   root_project.tree_root,
+                    'tree_left':   root_project.tree_left,
+                    'tree_right':  root_project.tree_right,
+                    'resource_id': acct.resource_id,
+                }
+
         account_meta[aid] = {
             'resource_name':    res.resource_name,
             'allocated':        float(active_alloc.amount) if active_alloc.amount is not None else 0.0,
             'start_date':       active_alloc.start_date,
             'end_date':         active_alloc.end_date,
+            'is_inheriting':    is_inheriting,
+            'root_projcode':    root_projcode,
             # Threshold percentages from account — may be None for most accounts.
             # first_threshold → 30d window, second_threshold → 90d window
             # (matching DefaultAccountStatusCalculator.java convention)
@@ -309,7 +353,7 @@ def get_project_rolling_usage(
             'threshold_90': acct.second_threshold,
         }
 
-        # Leaf vs. non-leaf determines charge rollup strategy.
+        # Leaf vs. non-leaf determines self-charge rollup strategy.
         # project.is_leaf() uses NestedSetMixin (base.py:303): tree_right == tree_left + 1
         if project.is_leaf():
             leaf_ids.append(aid)
@@ -330,23 +374,45 @@ def get_project_rolling_usage(
     result: Dict[str, Dict] = {}
 
     for w in windows:
-        window_charges: Dict[int, float] = {}
+        # Self-charges: this project's own contribution (existing logic).
+        self_charges_by_aid: Dict[int, float] = {}
         if leaf_ids:
-            window_charges.update(_query_window_charges(session, leaf_ids, w, now, alloc_windows))
+            self_charges_by_aid.update(_query_window_charges(session, leaf_ids, w, now, alloc_windows))
         if subtree_map:
-            window_charges.update(_query_window_subtree_charges(session, subtree_map, w, now, alloc_windows))
+            self_charges_by_aid.update(_query_window_subtree_charges(session, subtree_map, w, now, alloc_windows))
 
-        for aid, charges in window_charges.items():
+        # Pool charges: root allocation's project subtree, only for inheriting
+        # accounts.  Empty dict when no inheriting accounts in this resource set.
+        pool_charges_by_aid: Dict[int, float] = {}
+        if pool_subtree_map:
+            pool_charges_by_aid.update(
+                _query_window_subtree_charges(session, pool_subtree_map, w, now, alloc_windows)
+            )
+
+        for aid, self_charges in self_charges_by_aid.items():
             meta = account_meta[aid]
             rname = meta['resource_name']
+            inheriting = meta['is_inheriting']
 
             if rname not in result:
                 result[rname] = {
-                    'allocated':  meta['allocated'],
-                    'start_date': meta['start_date'],
-                    'end_date':   meta['end_date'],
-                    'windows':    {},
+                    'allocated':     meta['allocated'],
+                    'start_date':    meta['start_date'],
+                    'end_date':      meta['end_date'],
+                    'is_inheriting': inheriting,
+                    'root_projcode': meta['root_projcode'],
+                    'windows':       {},
                 }
+
+            # `charges` is pool burn for inheriting allocations, this project's
+            # own otherwise.  `self_charges_value` is the project-only number,
+            # surfaced separately for "(N yours)" annotation in the UI.
+            if inheriting:
+                charges = pool_charges_by_aid.get(aid, 0.0)
+                self_charges_value: Optional[float] = self_charges
+            else:
+                charges = self_charges
+                self_charges_value = None
 
             alloc_start = meta['start_date']
             alloc_end   = meta['end_date']
@@ -373,6 +439,7 @@ def get_project_rolling_usage(
 
             result[rname]['windows'][w] = {
                 'charges':         charges,
+                'self_charges':    self_charges_value,  # None when not inheriting
                 'prorated_alloc':  prorated,
                 'pct_of_prorated': pct,
                 'threshold_pct':   threshold_pct,   # None when not configured

--- a/src/webapp/dashboards/admin/blueprint.py
+++ b/src/webapp/dashboards/admin/blueprint.py
@@ -80,11 +80,17 @@ def index():
     # (UNIV and WNA). Keep them only if they survive the allowed set.
     default_selected = [f for f in ('UNIV', 'WNA') if f in allowed_facility_names]
 
+    # Optional re-hydration: when arriving from a back-link like
+    # /admin/?projcode=SCSG0001, auto-render the project card via HTMX
+    # on page load so the user lands where they left off.
+    auto_load_projcode = (request.args.get('projcode') or '').strip() or None
+
     return render_template(
         'dashboards/admin/dashboard.html',
         user=current_user,
         allowed_facility_names=allowed_facility_names,
         default_selected_facilities=default_selected,
+        auto_load_projcode=auto_load_projcode,
     )
 
 

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -32,6 +32,13 @@ import numpy as np
 from sam import fmt
 
 
+def _to_display_tz(naive_utc_ts: datetime) -> datetime:
+    """Naive-UTC → naive-local for matplotlib axis rendering.  Strips tzinfo
+    after conversion so the existing naive-datetime plotting path is
+    unchanged (matplotlib renders the local-clock values directly)."""
+    return fmt.to_local_dt(naive_utc_ts).replace(tzinfo=None)
+
+
 # ---------------------------------------------------------------------------
 # Cache infrastructure
 # ---------------------------------------------------------------------------
@@ -189,7 +196,7 @@ def generate_nodetype_history_matplotlib(history_data: List[Dict]) -> str:
     if not history_data:
         return '<div class="text-center text-muted">No history data available for this node type</div>'
 
-    timestamps = [d['timestamp'] for d in history_data]
+    timestamps = [_to_display_tz(d['timestamp']) for d in history_data]
     nodes_available = [d.get('nodes_available', 0) for d in history_data]
     nodes_down = [d.get('nodes_down', 0) for d in history_data]
     nodes_allocated = [d.get('nodes_allocated', 0) for d in history_data]
@@ -218,7 +225,7 @@ def generate_nodetype_history_matplotlib(history_data: List[Dict]) -> str:
         ax2.plot(mem_times, mem_vals, 'c', linewidth=3, label='Memory Utilization')
 
     ax2.set_ylabel('Utilization', fontsize=11)
-    ax2.set_xlabel('Time', fontsize=11)
+    ax2.set_xlabel(f'Time ({fmt.local_tz_label()})', fontsize=11)
     ax2.set_ylim(0, 100)
     ax2.yaxis.set_major_formatter(fmt.mpl_pct_formatter())
     ax2.legend(loc='best', fontsize=10)
@@ -252,7 +259,7 @@ def generate_queue_history_matplotlib(history_data: List[Dict]) -> str:
     if not history_data:
         return '<div class="text-center text-muted">No history data available for this queue</div>'
 
-    timestamps = [d['timestamp'] for d in history_data]
+    timestamps = [_to_display_tz(d['timestamp']) for d in history_data]
     running_jobs = [d.get('running_jobs', 0) for d in history_data]
     pending_jobs = [d.get('pending_jobs', 0) for d in history_data]
     held_jobs = [d.get('held_jobs', 0) for d in history_data]
@@ -285,7 +292,7 @@ def generate_queue_history_matplotlib(history_data: List[Dict]) -> str:
 
     ax2.set_ylim([0, None])
     ax2.set_ylabel('Resources', fontsize=11)
-    ax2.set_xlabel('Time', fontsize=11)
+    ax2.set_xlabel(f'Time ({fmt.local_tz_label()})', fontsize=11)
     ax2.yaxis.set_major_formatter(fmt.mpl_number_formatter())
     ax2.legend(loc=2, fontsize=10)
     ax2.grid(True, alpha=0.3)

--- a/src/webapp/dashboards/status/blueprint.py
+++ b/src/webapp/dashboards/status/blueprint.py
@@ -277,8 +277,15 @@ def queue_history(system, queue_name):
 @login_required
 @require_permission(Permission.EDIT_SYSTEM_STATUS)
 def htmx_create_outage():
-    """Create an outage and redirect back to the status page."""
+    """Create an outage and redirect back to the status page.
+
+    Form datetime-local values are TZ-blind on the wire. The companion
+    `tz` hidden field carries the operator's browser TZ (IANA name) so
+    we can normalize the entered wall-clock time to naive-UTC for
+    storage. `tz` falls back to the configured display TZ if missing
+    (older clients, scripted POSTs)."""
     from system_status.models import SystemOutage
+    from sam.fmt import naive_local_to_utc
 
     system_name = request.form.get('system_name', '').strip()
     title = request.form.get('title', '').strip()
@@ -288,6 +295,8 @@ def htmx_create_outage():
         flash('System, title, and severity are required.', 'error')
         return redirect(url_for('status_dashboard.index'))
 
+    operator_tz = request.form.get('tz', '').strip() or None
+
     outage = SystemOutage(
         system_name=system_name,
         title=title,
@@ -295,20 +304,22 @@ def htmx_create_outage():
         component=request.form.get('component', '').strip() or None,
         description=request.form.get('description', '').strip() or None,
         status='investigating',
-        start_time=datetime.now(),
+        start_time=datetime.now(),  # already UTC under TZ=UTC
     )
 
     start_time_str = request.form.get('start_time', '').strip()
     if start_time_str:
         try:
-            outage.start_time = datetime.fromisoformat(start_time_str)
+            outage.start_time = naive_local_to_utc(
+                datetime.fromisoformat(start_time_str), operator_tz)
         except ValueError:
             pass
 
     est_res_str = request.form.get('estimated_resolution', '').strip()
     if est_res_str:
         try:
-            outage.estimated_resolution = datetime.fromisoformat(est_res_str)
+            outage.estimated_resolution = naive_local_to_utc(
+                datetime.fromisoformat(est_res_str), operator_tz)
         except ValueError:
             pass
 
@@ -350,10 +361,14 @@ def htmx_update_outage(outage_id):
 
     outage.description = request.form.get('description', '').strip() or None
 
+    # Naive-UTC conversion mirrors htmx_create_outage; see its docstring.
+    from sam.fmt import naive_local_to_utc
+    operator_tz = request.form.get('tz', '').strip() or None
     est_res_str = request.form.get('estimated_resolution', '').strip()
     if est_res_str:
         try:
-            outage.estimated_resolution = datetime.fromisoformat(est_res_str)
+            outage.estimated_resolution = naive_local_to_utc(
+                datetime.fromisoformat(est_res_str), operator_tz)
         except ValueError:
             pass
     else:

--- a/src/webapp/dashboards/status/blueprint.py
+++ b/src/webapp/dashboards/status/blueprint.py
@@ -24,8 +24,26 @@ def index():
     Queries latest status from all systems and renders server-side.
     Status models are routed to the `system_status` bind via
     `__bind_key__`, so `db.session` handles both reads and writes.
+
+    The optional ``hours`` (or legacy ``days``) query param doesn't change
+    what the dashboard queries — it's a stateless passthrough so drill-down
+    row clicks inherit the user's last-set time range, and the back link
+    on detail pages can carry it through. ``selected_hours`` is None when
+    the param is absent (matches today's row-click URLs bit-for-bit).
     """
     session = db.session
+
+    selected_hours = None
+    if request.args.get('hours'):
+        try:
+            selected_hours = int(request.args['hours'])
+        except ValueError:
+            selected_hours = None
+    elif request.args.get('days'):
+        try:
+            selected_hours = int(request.args['days']) * 24
+        except ValueError:
+            selected_hours = None
 
     # Get latest Derecho status
     derecho_status = status_queries.get_latest_derecho_status(session)
@@ -77,6 +95,7 @@ def index():
         reservations=reservations,
         google_calendar_embed_url=current_app.config.get('GOOGLE_CALENDAR_EMBED_URL', ''),
         now=datetime.now(),
+        selected_hours=selected_hours,
     )
 
 

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -369,11 +369,17 @@ def resource_details():
         flash('Invalid date format. Please use YYYY-MM-DD.', 'error')
         return redirect(url_for('user_dashboard.index'))
 
-    # Fetch 30d/90d rolling window usage (HPC/DAV only; None for DISK/ARCHIVE)
+    # Fetch 30d/90d rolling window usage (HPC/DAV only; None for DISK/ARCHIVE).
+    # When the allocation is inheriting, `charges` reported here is *pool burn*
+    # across the whole shared-allocation tree (the runway-meaningful number);
+    # `self_charges` on each window surfaces the per-project slice.
     rolling_usage = get_project_rolling_usage(db.session, projcode, resource_name=resource_name)
-    rolling_windows = rolling_usage.get(resource_name, {}).get('windows', {})
+    rolling_resource = rolling_usage.get(resource_name, {})
+    rolling_windows = rolling_resource.get('windows', {})
     rolling_30 = rolling_windows.get(30)
     rolling_90 = rolling_windows.get(90)
+    rolling_is_inheriting = rolling_resource.get('is_inheriting', False)
+    rolling_root_projcode = rolling_resource.get('root_projcode')
 
     # Load root project
     project = Project.get_by_projcode(db.session, projcode)
@@ -480,6 +486,8 @@ def resource_details():
         usage_chart=usage_chart,
         rolling_30=rolling_30,
         rolling_90=rolling_90,
+        rolling_is_inheriting=rolling_is_inheriting,
+        rolling_root_projcode=rolling_root_projcode,
         can_edit_threshold=can_edit_threshold,
         has_children=has_children,
         scope=scope,
@@ -713,7 +721,8 @@ def htmx_rolling_section(projcode, resource_name):
         return '<div class="alert alert-danger">Project not found</div>', 404
 
     rolling_usage = get_project_rolling_usage(db.session, projcode, resource_name=resource_name)
-    windows = rolling_usage.get(resource_name, {}).get('windows', {})
+    rolling_resource = rolling_usage.get(resource_name, {})
+    windows = rolling_resource.get('windows', {})
 
     return render_template(
         'dashboards/user/fragments/rolling_rate_htmx.html',
@@ -721,6 +730,8 @@ def htmx_rolling_section(projcode, resource_name):
         resource_name=resource_name,
         rolling_30=windows.get(30),
         rolling_90=windows.get(90),
+        rolling_is_inheriting=rolling_resource.get('is_inheriting', False),
+        rolling_root_projcode=rolling_resource.get('root_projcode'),
         can_edit_threshold=can_edit_consumption_threshold(current_user, project),
     )
 
@@ -793,7 +804,8 @@ def htmx_save_threshold(projcode, resource_name, window):
             account.update_thresholds(second_threshold=new_val)
 
     rolling_usage = get_project_rolling_usage(db.session, projcode, resource_name=resource_name)
-    windows = rolling_usage.get(resource_name, {}).get('windows', {})
+    rolling_resource = rolling_usage.get(resource_name, {})
+    windows = rolling_resource.get('windows', {})
 
     return render_template(
         'dashboards/user/fragments/rolling_rate_htmx.html',
@@ -801,5 +813,7 @@ def htmx_save_threshold(projcode, resource_name, window):
         resource_name=resource_name,
         rolling_30=windows.get(30),
         rolling_90=windows.get(90),
+        rolling_is_inheriting=rolling_resource.get('is_inheriting', False),
+        rolling_root_projcode=rolling_resource.get('root_projcode'),
         can_edit_threshold=True,
     )

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -683,3 +683,19 @@ body {
         margin-bottom: 20px;
     }
 }
+
+/* ===================================================================
+   Chart container — global centering for SVG charts.
+   Allocations dashboard further constrains pies to 720px in
+   allocations.css, which is loaded after this file on those pages.
+   =================================================================== */
+.chart-container {
+    text-align: center;
+}
+
+.chart-container svg {
+    display: block;
+    margin: 0 auto;
+    max-width: 100%;
+    height: auto;
+}

--- a/src/webapp/templates/dashboards/admin/dashboard.html
+++ b/src/webapp/templates/dashboards/admin/dashboard.html
@@ -130,7 +130,12 @@
         <div class="row">
             <div class="col-12">
                 <div id="projectCardContainer"
-                     data-reload-url="{{ url_for('admin_dashboard.project_card', projcode='') }}"></div>
+                     data-reload-url="{{ url_for('admin_dashboard.project_card', projcode='') }}"
+                     {% if auto_load_projcode %}
+                     hx-get="{{ url_for('admin_dashboard.project_card', projcode=auto_load_projcode) }}"
+                     hx-trigger="load"
+                     hx-swap="innerHTML"
+                     {% endif %}></div>
             </div>
         </div>
 

--- a/src/webapp/templates/dashboards/admin/edit_project.html
+++ b/src/webapp/templates/dashboards/admin/edit_project.html
@@ -24,7 +24,9 @@
     </ol>
   </nav>
   {% if can_access_admin %}
-  <a href="{{ url_for('admin_dashboard.index') }}" class="btn btn-outline-secondary btn-sm ms-auto">
+  {# Pass projcode so the admin index re-renders this project's card on
+     return — otherwise the user lands on a blank search page. #}
+  <a href="{{ url_for('admin_dashboard.index', projcode=project.projcode) }}" class="btn btn-outline-secondary btn-sm ms-auto">
     <i class="fas fa-arrow-left"></i> Back to Admin
   </a>
   {% else %}

--- a/src/webapp/templates/dashboards/admin/fragments/project_card_wrapper.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_card_wrapper.html
@@ -6,5 +6,6 @@
     user,
     usage_warning_threshold,
     usage_critical_threshold,
-    is_expanded=true
+    is_expanded=true,
+    admin_origin=true
 ) }}

--- a/src/webapp/templates/dashboards/fragments/time_range_picker.html
+++ b/src/webapp/templates/dashboards/fragments/time_range_picker.html
@@ -27,9 +27,10 @@
                 {% endfor %}
             </div>
 
-            <!-- Current range display -->
+            <!-- Current range display (TZ-converted to user-local for readability;
+                 underlying query uses naive-UTC against the collector's UTC writes). -->
             <small class="text-muted ms-auto">
-                {{ start_date | fmt_date(fmt='%Y-%m-%d %H:%M') }} – {{ end_date | fmt_date(fmt='%Y-%m-%d %H:%M') }}
+                {{ start_date | to_local_dt | fmt_date(fmt='%Y-%m-%d %H:%M %Z') }} – {{ end_date | to_local_dt | fmt_date(fmt='%Y-%m-%d %H:%M %Z') }}
             </small>
         </div>
     </div>

--- a/src/webapp/templates/dashboards/status/casper.html
+++ b/src/webapp/templates/dashboards/status/casper.html
@@ -122,6 +122,9 @@
                     </div>
                 </div>
                 <div class="text-end">
+                    {# PBS-sourced reservations are stored as naive cluster-local
+                       time (`pbs_rstat -f` output, parsed via strptime in
+                       collectors/lib/parsers/reservations.py) — render as-is. #}
                     <div class="fw-bold">{{ res.start_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} - {{ res.end_time | fmt_date(fmt='%Y-%m-%d %H:%M') }}</div>
                 </div>
             </div>

--- a/src/webapp/templates/dashboards/status/casper.html
+++ b/src/webapp/templates/dashboards/status/casper.html
@@ -124,8 +124,9 @@
                 <div class="text-end">
                     {# PBS-sourced reservations are stored as naive cluster-local
                        time (`pbs_rstat -f` output, parsed via strptime in
-                       collectors/lib/parsers/reservations.py) — render as-is. #}
-                    <div class="fw-bold">{{ res.start_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} - {{ res.end_time | fmt_date(fmt='%Y-%m-%d %H:%M') }}</div>
+                       collectors/lib/parsers/reservations.py) — render as-is
+                       and tag with the display TZ for clarity. #}
+                    <div class="fw-bold">{{ res.start_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} - {{ res.end_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} {{ local_tz_label() }}</div>
                 </div>
             </div>
         </div>

--- a/src/webapp/templates/dashboards/status/casper.html
+++ b/src/webapp/templates/dashboards/status/casper.html
@@ -99,7 +99,7 @@
         <!-- Queues -->
         {% if casper_queues %}
         <h6 class="mb-3"><i class="fas fa-list"></i> Queue Status</h6>
-        {{ queues.queue_table(casper_queues, show_gpus=true, system='casper') }}
+        {{ queues.queue_table(casper_queues, show_gpus=true, system='casper', hours=selected_hours) }}
         {% endif %}
 
         <!-- Reservations -->
@@ -132,7 +132,7 @@
         <!-- Node Types -->
         {% if casper_node_types %}
         <h6 class="mb-3"><i class="fas fa-server"></i> Node Type Status</h6>
-        {{ nodetypes.nodetype_table(casper_node_types, 'casper') }}
+        {{ nodetypes.nodetype_table(casper_node_types, 'casper', hours=selected_hours) }}
         {% endif %}
 
         <!-- Filesystems -->

--- a/src/webapp/templates/dashboards/status/casper.html
+++ b/src/webapp/templates/dashboards/status/casper.html
@@ -122,11 +122,10 @@
                     </div>
                 </div>
                 <div class="text-end">
-                    {# PBS-sourced reservations are stored as naive cluster-local
-                       time (`pbs_rstat -f` output, parsed via strptime in
-                       collectors/lib/parsers/reservations.py) — render as-is
-                       and tag with the display TZ for clarity. #}
-                    <div class="fw-bold">{{ res.start_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} - {{ res.end_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} {{ local_tz_label() }}</div>
+                    {# PBS reservations are stored naive-UTC (parser anchors
+                       cluster-local PBS output to America/Denver and converts
+                       to UTC).  Convert back to display TZ for human reading. #}
+                    <div class="fw-bold">{{ res.start_time | to_local_dt | fmt_date(fmt='%Y-%m-%d %H:%M %Z') }} - {{ res.end_time | to_local_dt | fmt_date(fmt='%Y-%m-%d %H:%M %Z') }}</div>
                 </div>
             </div>
         </div>

--- a/src/webapp/templates/dashboards/status/dashboard.html
+++ b/src/webapp/templates/dashboards/status/dashboard.html
@@ -40,6 +40,9 @@
                     </span>
                 </div>
                 <div class="d-flex align-items-center gap-2">
+                    {# Outages are entered via <input type="datetime-local"> →
+                       fromisoformat → stored as naive browser-local time
+                       (see status/blueprint.py:304).  Render as-is. #}
                     <span class="text-muted small">{{ outage.start_time | fmt_date(fmt='%Y-%m-%d %H:%M') }}</span>
                     {% if has_permission(Permission.EDIT_SYSTEM_STATUS) %}
                     <div class="btn-group btn-group-sm ms-2">
@@ -77,6 +80,7 @@
             {% endif %}
             {% if outage.estimated_resolution %}
             <div class="text-muted small mt-1">
+                {# Same naive browser-local convention as outage.start_time above. #}
                 <i class="fas fa-clock"></i> Estimated resolution: {{ outage.estimated_resolution | fmt_date(fmt='%Y-%m-%d %H:%M') }}
             </div>
             {% endif %}

--- a/src/webapp/templates/dashboards/status/dashboard.html
+++ b/src/webapp/templates/dashboards/status/dashboard.html
@@ -40,17 +40,18 @@
                     </span>
                 </div>
                 <div class="d-flex align-items-center gap-2">
-                    {# Outages are entered via <input type="datetime-local"> →
-                       fromisoformat → stored as naive browser-local time
-                       (see status/blueprint.py:304).  Render as-is, but tag
-                       with the configured display TZ so viewers don't have
-                       to guess the zone. #}
-                    <span class="text-muted small">{{ outage.start_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} {{ local_tz_label() }}</span>
+                    {# Outages are stored naive-UTC (form-side TZ capture +
+                       server-side conversion in htmx_create/update_outage).
+                       Convert back to display TZ for human reading. #}
+                    <span class="text-muted small">{{ outage.start_time | to_local_dt | fmt_date(fmt='%Y-%m-%d %H:%M %Z') }}</span>
                     {% if has_permission(Permission.EDIT_SYSTEM_STATUS) %}
                     <div class="btn-group btn-group-sm ms-2">
                         <button class="btn btn-outline-secondary btn-sm"
                                 title="Edit outage"
-                                onclick='openEditOutageModal({{ outage.outage_id }}, {{ outage.status|tojson }}, {{ outage.severity|tojson }}, {{ outage.description|tojson }}, {{ outage.estimated_resolution.isoformat()|tojson if outage.estimated_resolution else "null" }}, {{ outage.title|tojson }})'>
+                                {# estimated_resolution is naive-UTC; mark with 'Z' so JS can
+                                   parse it as a real instant and convert to operator-local
+                                   for the datetime-local input. #}
+                                onclick='openEditOutageModal({{ outage.outage_id }}, {{ outage.status|tojson }}, {{ outage.severity|tojson }}, {{ outage.description|tojson }}, {{ (outage.estimated_resolution.isoformat() + "Z")|tojson if outage.estimated_resolution else "null" }}, {{ outage.title|tojson }})'>
                             <i class="fas fa-edit"></i>
                         </button>
                         <button class="btn btn-outline-success btn-sm"
@@ -82,8 +83,8 @@
             {% endif %}
             {% if outage.estimated_resolution %}
             <div class="text-muted small mt-1">
-                {# Same naive browser-local convention as outage.start_time above. #}
-                <i class="fas fa-clock"></i> Estimated resolution: {{ outage.estimated_resolution | fmt_date(fmt='%Y-%m-%d %H:%M') }} {{ local_tz_label() }}
+                {# Same naive-UTC convention as outage.start_time above. #}
+                <i class="fas fa-clock"></i> Estimated resolution: {{ outage.estimated_resolution | to_local_dt | fmt_date(fmt='%Y-%m-%d %H:%M %Z') }}
             </div>
             {% endif %}
         </div>

--- a/src/webapp/templates/dashboards/status/dashboard.html
+++ b/src/webapp/templates/dashboards/status/dashboard.html
@@ -42,8 +42,10 @@
                 <div class="d-flex align-items-center gap-2">
                     {# Outages are entered via <input type="datetime-local"> →
                        fromisoformat → stored as naive browser-local time
-                       (see status/blueprint.py:304).  Render as-is. #}
-                    <span class="text-muted small">{{ outage.start_time | fmt_date(fmt='%Y-%m-%d %H:%M') }}</span>
+                       (see status/blueprint.py:304).  Render as-is, but tag
+                       with the configured display TZ so viewers don't have
+                       to guess the zone. #}
+                    <span class="text-muted small">{{ outage.start_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} {{ local_tz_label() }}</span>
                     {% if has_permission(Permission.EDIT_SYSTEM_STATUS) %}
                     <div class="btn-group btn-group-sm ms-2">
                         <button class="btn btn-outline-secondary btn-sm"
@@ -81,7 +83,7 @@
             {% if outage.estimated_resolution %}
             <div class="text-muted small mt-1">
                 {# Same naive browser-local convention as outage.start_time above. #}
-                <i class="fas fa-clock"></i> Estimated resolution: {{ outage.estimated_resolution | fmt_date(fmt='%Y-%m-%d %H:%M') }}
+                <i class="fas fa-clock"></i> Estimated resolution: {{ outage.estimated_resolution | fmt_date(fmt='%Y-%m-%d %H:%M') }} {{ local_tz_label() }}
             </div>
             {% endif %}
         </div>

--- a/src/webapp/templates/dashboards/status/derecho.html
+++ b/src/webapp/templates/dashboards/status/derecho.html
@@ -85,6 +85,9 @@
                     </div>
                 </div>
                 <div class="text-end">
+                    {# PBS-sourced reservations are stored as naive cluster-local
+                       time (`pbs_rstat -f` output, parsed via strptime in
+                       collectors/lib/parsers/reservations.py) — render as-is. #}
                     <div class="fw-bold">{{ res.start_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} - {{ res.end_time | fmt_date(fmt='%Y-%m-%d %H:%M') }}</div>
                 </div>
             </div>

--- a/src/webapp/templates/dashboards/status/derecho.html
+++ b/src/webapp/templates/dashboards/status/derecho.html
@@ -85,11 +85,10 @@
                     </div>
                 </div>
                 <div class="text-end">
-                    {# PBS-sourced reservations are stored as naive cluster-local
-                       time (`pbs_rstat -f` output, parsed via strptime in
-                       collectors/lib/parsers/reservations.py) — render as-is
-                       and tag with the display TZ for clarity. #}
-                    <div class="fw-bold">{{ res.start_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} - {{ res.end_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} {{ local_tz_label() }}</div>
+                    {# PBS reservations are stored naive-UTC (parser anchors
+                       cluster-local PBS output to America/Denver and converts
+                       to UTC).  Convert back to display TZ for human reading. #}
+                    <div class="fw-bold">{{ res.start_time | to_local_dt | fmt_date(fmt='%Y-%m-%d %H:%M %Z') }} - {{ res.end_time | to_local_dt | fmt_date(fmt='%Y-%m-%d %H:%M %Z') }}</div>
                 </div>
             </div>
         </div>

--- a/src/webapp/templates/dashboards/status/derecho.html
+++ b/src/webapp/templates/dashboards/status/derecho.html
@@ -87,8 +87,9 @@
                 <div class="text-end">
                     {# PBS-sourced reservations are stored as naive cluster-local
                        time (`pbs_rstat -f` output, parsed via strptime in
-                       collectors/lib/parsers/reservations.py) — render as-is. #}
-                    <div class="fw-bold">{{ res.start_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} - {{ res.end_time | fmt_date(fmt='%Y-%m-%d %H:%M') }}</div>
+                       collectors/lib/parsers/reservations.py) — render as-is
+                       and tag with the display TZ for clarity. #}
+                    <div class="fw-bold">{{ res.start_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} - {{ res.end_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} {{ local_tz_label() }}</div>
                 </div>
             </div>
         </div>

--- a/src/webapp/templates/dashboards/status/derecho.html
+++ b/src/webapp/templates/dashboards/status/derecho.html
@@ -62,7 +62,7 @@
         <!-- Queues -->
         {% if derecho_queues %}
         <h6 class="mb-3"><i class="fas fa-list"></i> Queue Status</h6>
-        {{ queues.queue_table(derecho_queues, show_gpus=true, system='derecho') }}
+        {{ queues.queue_table(derecho_queues, show_gpus=true, system='derecho', hours=selected_hours) }}
         {% endif %}
 
         <!-- Reservations -->

--- a/src/webapp/templates/dashboards/status/fragments/outage_modals.html
+++ b/src/webapp/templates/dashboards/status/fragments/outage_modals.html
@@ -15,6 +15,9 @@
             </div>
             <form hx-post="{{ url_for('status_dashboard.htmx_create_outage') }}"
                   hx-disabled-elt="find button[type='submit']">
+                {# Captured at submit-time by JS so the server can convert the
+                   naive datetime-local values into naive-UTC for storage. #}
+                <input type="hidden" name="tz" id="createTz">
                 <div class="modal-body">
                     <div class="mb-3">
                         <label for="createSystem" class="form-label">System <span class="text-danger">*</span></label>
@@ -54,7 +57,10 @@
                     <div class="mb-3">
                         <label for="createStartTime" class="form-label">Start Time</label>
                         <input type="datetime-local" class="form-control" id="createStartTime" name="start_time">
-                        <small class="form-text text-muted">Adjust if the outage started earlier</small>
+                        <small class="form-text text-muted">
+                            Enter in your local time. Stored as UTC; displayed back in {{ local_tz_label() }}.
+                            Adjust if the outage started earlier.
+                        </small>
                     </div>
                     <div class="mb-3">
                         <label for="createEstimatedResolution" class="form-label">Estimated Resolution <span class="text-muted">(optional)</span></label>
@@ -89,6 +95,8 @@
             <form id="editOutageForm"
                   hx-disabled-elt="find button[type='submit']">
                 <input type="hidden" id="editOutageId" name="outage_id">
+                {# Browser TZ — same purpose as on the create form. #}
+                <input type="hidden" name="tz" id="editTz">
                 <div class="modal-body">
                     <div class="mb-3">
                         <label for="editTitle" class="form-label">Title</label>
@@ -119,7 +127,9 @@
                     <div class="mb-3">
                         <label for="editEstimatedResolution" class="form-label">Estimated Resolution <span class="text-muted">(optional)</span></label>
                         <input type="datetime-local" class="form-control" id="editEstimatedResolution" name="estimated_resolution">
-                        <small class="form-text text-muted">Clear to remove estimated resolution time</small>
+                        <small class="form-text text-muted">
+                            Times shown in your local TZ. Clear to remove estimated resolution time.
+                        </small>
                     </div>
                 </div>
                 <div class="modal-footer">
@@ -135,33 +145,63 @@
 
 {#
   Inline JS for:
-  1. Pre-filling start time on create modal open
-  2. Populating edit form fields from button data attributes
+  1. Pre-filling start time on create modal open + capturing browser TZ
+  2. Converting UTC ISO from server → operator-local datetime-local input
+     when populating the edit form
   3. Setting the edit form's hx-post URL dynamically
-  The delete confirmation is handled by hx-confirm on the delete buttons.
+
+  Time-zone strategy: datetime-local inputs are TZ-blind. The browser TZ
+  is captured into a hidden `tz` field at modal-show time so the server
+  can convert the submitted naive datetime into naive-UTC for storage.
+  When pre-filling the edit form, the server emits UTC ISO with a 'Z'
+  suffix; JS converts to the operator's local naive ISO (the format
+  datetime-local inputs require).
 #}
 <script>
-/* Pre-fill create start time */
-document.getElementById('createOutageModal').addEventListener('show.bs.modal', function() {
-    var now = new Date();
-    var pad = function(n) { return String(n).padStart(2, '0'); };
-    document.getElementById('createStartTime').value =
-        now.getFullYear() + '-' + pad(now.getMonth()+1) + '-' + pad(now.getDate()) +
-        'T' + pad(now.getHours()) + ':' + pad(now.getMinutes());
-});
+(function () {
+    function pad(n) { return String(n).padStart(2, '0'); }
 
-/* Populate edit form from button click */
-function openEditOutageModal(id, status, severity, description, estimatedResolution, title) {
-    document.getElementById('editOutageId').value = id;
-    document.getElementById('editTitle').value = title || '';
-    document.getElementById('editStatus').value = status || 'investigating';
-    document.getElementById('editSeverity').value = severity || 'minor';
-    document.getElementById('editDescription').value = description || '';
-    document.getElementById('editEstimatedResolution').value = estimatedResolution ? estimatedResolution.substring(0, 16) : '';
-    /* Set the form's hx-post URL dynamically based on the outage ID */
-    document.getElementById('editOutageForm').setAttribute('hx-post',
-        '/status/htmx/outage/' + id + '/edit');
-    htmx.process(document.getElementById('editOutageForm'));
-    bootstrap.Modal.getOrCreateInstance(document.getElementById('editOutageModal')).show();
-}
+    /* Format a Date as a naive local ISO suitable for <input type="datetime-local">. */
+    function toLocalNaiveISO(d) {
+        return d.getFullYear() + '-' + pad(d.getMonth()+1) + '-' + pad(d.getDate()) +
+               'T' + pad(d.getHours()) + ':' + pad(d.getMinutes());
+    }
+
+    function browserTzName() {
+        try { return Intl.DateTimeFormat().resolvedOptions().timeZone || ''; }
+        catch (e) { return ''; }
+    }
+
+    /* Pre-fill create start time + capture browser TZ. */
+    document.getElementById('createOutageModal').addEventListener('show.bs.modal', function() {
+        document.getElementById('createStartTime').value = toLocalNaiveISO(new Date());
+        document.getElementById('createTz').value = browserTzName();
+    });
+
+    /* Populate edit form from button click. */
+    window.openEditOutageModal = function (id, status, severity, description, estimatedResolutionUtcIso, title) {
+        document.getElementById('editOutageId').value = id;
+        document.getElementById('editTitle').value = title || '';
+        document.getElementById('editStatus').value = status || 'investigating';
+        document.getElementById('editSeverity').value = severity || 'minor';
+        document.getElementById('editDescription').value = description || '';
+        document.getElementById('editTz').value = browserTzName();
+
+        /* Server emits estimated_resolution as a UTC ISO with 'Z' suffix.
+           Parse that as a real instant, then format as operator-local naive. */
+        var resInput = document.getElementById('editEstimatedResolution');
+        if (estimatedResolutionUtcIso) {
+            var d = new Date(estimatedResolutionUtcIso);
+            resInput.value = isNaN(d.getTime()) ? '' : toLocalNaiveISO(d);
+        } else {
+            resInput.value = '';
+        }
+
+        /* Set the form's hx-post URL dynamically based on the outage ID. */
+        document.getElementById('editOutageForm').setAttribute('hx-post',
+            '/status/htmx/outage/' + id + '/edit');
+        htmx.process(document.getElementById('editOutageForm'));
+        bootstrap.Modal.getOrCreateInstance(document.getElementById('editOutageModal')).show();
+    };
+})();
 </script>

--- a/src/webapp/templates/dashboards/status/fragments/reservations.html
+++ b/src/webapp/templates/dashboards/status/fragments/reservations.html
@@ -9,6 +9,8 @@
                 </h6>
             </div>
             <div class="text-muted">
+                {# PBS reservations are stored as naive cluster-local time;
+                   render as-is (do NOT apply to_local_dt — it would shift 6h). #}
                 {{ res.start_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} - {{ res.end_time | fmt_date(fmt='%Y-%m-%d %H:%M') }}
             </div>
         </div>

--- a/src/webapp/templates/dashboards/status/fragments/reservations.html
+++ b/src/webapp/templates/dashboards/status/fragments/reservations.html
@@ -9,10 +9,10 @@
                 </h6>
             </div>
             <div class="text-muted">
-                {# PBS reservations are stored as naive cluster-local time;
-                   render as-is (do NOT apply to_local_dt — it would shift 6h)
-                   but tag with the display TZ for clarity. #}
-                {{ res.start_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} - {{ res.end_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} {{ local_tz_label() }}
+                {# PBS reservations are stored naive-UTC (parser anchors
+                   cluster-local PBS output to America/Denver and converts
+                   to UTC).  Convert back to display TZ for human reading. #}
+                {{ res.start_time | to_local_dt | fmt_date(fmt='%Y-%m-%d %H:%M %Z') }} - {{ res.end_time | to_local_dt | fmt_date(fmt='%Y-%m-%d %H:%M %Z') }}
             </div>
         </div>
         {% if res.description %}

--- a/src/webapp/templates/dashboards/status/fragments/reservations.html
+++ b/src/webapp/templates/dashboards/status/fragments/reservations.html
@@ -10,8 +10,9 @@
             </div>
             <div class="text-muted">
                 {# PBS reservations are stored as naive cluster-local time;
-                   render as-is (do NOT apply to_local_dt — it would shift 6h). #}
-                {{ res.start_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} - {{ res.end_time | fmt_date(fmt='%Y-%m-%d %H:%M') }}
+                   render as-is (do NOT apply to_local_dt — it would shift 6h)
+                   but tag with the display TZ for clarity. #}
+                {{ res.start_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} - {{ res.end_time | fmt_date(fmt='%Y-%m-%d %H:%M') }} {{ local_tz_label() }}
             </div>
         </div>
         {% if res.description %}

--- a/src/webapp/templates/dashboards/status/nodetype_history.html
+++ b/src/webapp/templates/dashboards/status/nodetype_history.html
@@ -3,8 +3,11 @@
 {% block title %}Node Type History - {{ node_type }} - SAM{% endblock %}
 
 {% block content %}
+{# Forward `hours` to the dashboard so sideways navigation between node
+   types inherits the user's chosen time range. #}
+{% set _idx_kwargs = {'hours': hours} if hours else {} %}
 <div class="back-link mb-3">
-    <a href="{{ url_for('status_dashboard.index') }}" class="btn btn-sm btn-outline-secondary">
+    <a href="{{ url_for('status_dashboard.index', **_idx_kwargs) }}" class="btn btn-sm btn-outline-secondary">
         <i class="fas fa-arrow-left"></i> <span class="back-link-text">Back to Status Dashboard</span>
     </a>
 </div>

--- a/src/webapp/templates/dashboards/status/partials/nodetype_table.html
+++ b/src/webapp/templates/dashboards/status/partials/nodetype_table.html
@@ -1,4 +1,6 @@
-{% macro nodetype_table(node_types, system='casper') %}
+{% macro nodetype_table(node_types, system='casper', hours=None) %}
+{# `hours`, when set, flows through into the row-click drill-down URL so the
+   user's chosen time range survives sideways navigation between node types. #}
 <div class="table-responsive">
     <table class="table table-sm table-bordered nodetype-table">
         <thead class="thead-light">
@@ -14,7 +16,9 @@
         </thead>
         <tbody>
             {% for nt in node_types %}
-            <tr class="clickable-row" onclick="window.location='{{ url_for('status_dashboard.nodetype_history', system=system, node_type=nt.node_type) }}';" title="Click to view history for {{ nt.node_type }}">
+            {% set _nh_kwargs = {'system': system, 'node_type': nt.node_type} %}
+            {% if hours %}{% set _ = _nh_kwargs.update({'hours': hours}) %}{% endif %}
+            <tr class="clickable-row" onclick="window.location='{{ url_for('status_dashboard.nodetype_history', **_nh_kwargs) }}';" title="Click to view history for {{ nt.node_type }}">
                 <td><strong>{{ nt.node_type }}</strong></td>
                 <td>
                     <small>

--- a/src/webapp/templates/dashboards/status/partials/queue_table.html
+++ b/src/webapp/templates/dashboards/status/partials/queue_table.html
@@ -1,4 +1,6 @@
-{% macro queue_table(queues, show_gpus=false, system='derecho') %}
+{% macro queue_table(queues, show_gpus=false, system='derecho', hours=None) %}
+{# `hours`, when set, flows through into the row-click drill-down URL so the
+   user's chosen time range survives sideways navigation between queues. #}
 <div class="table-responsive">
     <table class="table table-sm table-bordered queue-table">
         <thead class="thead-dark">
@@ -29,7 +31,9 @@
         </thead>
         <tbody>
             {% for queue in queues %}
-            <tr class="clickable-row" onclick="window.location='{{ url_for('status_dashboard.queue_history', system=system, queue_name=queue.queue_name) }}';" title="Click to view history for {{ queue.queue_name }}">
+            {% set _qh_kwargs = {'system': system, 'queue_name': queue.queue_name} %}
+            {% if hours %}{% set _ = _qh_kwargs.update({'hours': hours}) %}{% endif %}
+            <tr class="clickable-row" onclick="window.location='{{ url_for('status_dashboard.queue_history', **_qh_kwargs) }}';" title="Click to view history for {{ queue.queue_name }}">
                 <td><strong>{{ queue.queue_name }}</strong></td>
                 <td>{{ queue.active_users | fmt_number }}</td>
                 <td>{{ queue.running_jobs | fmt_number }}</td>

--- a/src/webapp/templates/dashboards/status/partials/system_header.html
+++ b/src/webapp/templates/dashboards/status/partials/system_header.html
@@ -3,7 +3,7 @@
     <h5>
         {{ title|safe }}
         <span class="float-end last-updated">
-            Last updated: {{ timestamp | fmt_date(fmt='%Y-%m-%d %H:%M:%S') }}
+            Last updated: {{ timestamp | to_local_dt | fmt_date(fmt='%Y-%m-%d %H:%M:%S %Z') }}
         </span>
     </h5>
 </div>

--- a/src/webapp/templates/dashboards/status/queue_history.html
+++ b/src/webapp/templates/dashboards/status/queue_history.html
@@ -25,7 +25,7 @@
 <div class="card mb-4">
     <div class="card-header">
         <h5 class="mb-0"><i class="fas fa-clock"></i> Current Status</h5>
-        <small class="text-muted">Last Updated: {{ latest_status.timestamp | fmt_date(fmt='%Y-%m-%d %H:%M') }}</small>
+        <small class="text-muted">Last Updated: {{ latest_status.timestamp | to_local_dt | fmt_date(fmt='%Y-%m-%d %H:%M %Z') }}</small>
     </div>
     <div class="card-body">
         <div class="row">

--- a/src/webapp/templates/dashboards/status/queue_history.html
+++ b/src/webapp/templates/dashboards/status/queue_history.html
@@ -3,10 +3,14 @@
 {% block title %}Queue History - {{ queue_name }} ({{ system|upper }}) - SAM{% endblock %}
 
 {% block content %}
+{# Forward `hours` to the dashboard so sideways navigation between queues
+   inherits the user's chosen time range. Also passed by the back button
+   below; both use the same kwargs pattern. #}
+{% set _idx_kwargs = {'hours': hours} if hours else {} %}
 <!-- Breadcrumb -->
 <nav aria-label="breadcrumb" class="mb-3">
     <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="{{ url_for('status_dashboard.index') }}">System Status</a></li>
+        <li class="breadcrumb-item"><a href="{{ url_for('status_dashboard.index', **_idx_kwargs) }}">System Status</a></li>
         <li class="breadcrumb-item active">{{ system|upper }} - {{ queue_name }} Queue History</li>
     </ol>
 </nav>
@@ -94,7 +98,7 @@
 
 <!-- Back Button -->
 <div class="back-link mb-4">
-    <a href="{{ url_for('status_dashboard.index') }}" class="btn btn-secondary">
+    <a href="{{ url_for('status_dashboard.index', **_idx_kwargs) }}" class="btn btn-secondary">
         <i class="fas fa-arrow-left"></i> <span class="back-link-text">Back to Status Dashboard</span>
     </a>
 </div>

--- a/src/webapp/templates/dashboards/user/fragments/rolling_rate_htmx.html
+++ b/src/webapp/templates/dashboards/user/fragments/rolling_rate_htmx.html
@@ -2,11 +2,18 @@
   Rolling Consumption Rate section fragment.
 
   Context variables:
-    rolling_30         — 30-day window dict (or None)
-    rolling_90         — 90-day window dict (or None)
-    projcode           — project code string
-    resource_name      — resource name string
-    can_edit_threshold — bool: show Add/Edit Limit buttons
+    rolling_30             — 30-day window dict (or None)
+    rolling_90             — 90-day window dict (or None)
+    rolling_is_inheriting  — bool: this project's allocation inherits from a
+                             shared-allocation root.  When True, win.charges
+                             reflects pool burn (across all peers); each
+                             window's win.self_charges holds the per-project
+                             slice for the "(N yours)" annotation.
+    rolling_root_projcode  — projcode of the master allocation's project
+                             when inheriting; None otherwise.
+    projcode               — project code string
+    resource_name          — resource name string
+    can_edit_threshold     — bool: show Add/Edit Limit buttons
 #}
 
 <div class="mt-3 pt-3 border-top">
@@ -14,6 +21,10 @@
     <p class="text-muted small mb-2">
         Charges over the last 30 and 90 days vs. the prorated steady-state rate.
         <strong>100% = steady state</strong>; left of center is cold, right is hot.
+        {% if rolling_is_inheriting and rolling_root_projcode %}
+        <br><i class="fas fa-share-alt me-1"></i>Pool shared with master project
+        <strong>{{ rolling_root_projcode }}</strong> — rate covers the whole shared allocation.
+        {% endif %}
     </p>
 
     {% set scale_max = 200 %}
@@ -106,8 +117,18 @@
             <span class="badge bg-danger"><i class="fas fa-exclamation-triangle me-1"></i>over {{ win.threshold_pct }}% lim</span>
             {% endif %}
             <span class="badge {{ badge_class }}">{{ pct | fmt_pct }}</span>
-            <span class="text-muted" style="font-size:0.78rem;">{{ win.charges | fmt_number }} AU &middot; {{ state_label }}</span>
-            {% if can_edit_threshold %}
+            <span class="text-muted" style="font-size:0.78rem;">
+                {{ win.charges | fmt_number }} AU
+                {% if rolling_is_inheriting and win.self_charges is not none %}
+                <span title="This project's own contribution to the shared pool">({{ win.self_charges | fmt_number }} yours)</span>
+                {% endif %}
+                &middot; {{ state_label }}
+            </span>
+            {# Threshold edit lives on the master allocation's account, not the
+               child's — the displayed pct is pool burn, so a child-side
+               threshold is never compared against. Hide the edit button on
+               inheriting projects; users edit via the master parent project. #}
+            {% if can_edit_threshold and not rolling_is_inheriting %}
             <span id="threshold-btn-{{ win_days }}d-{{ projcode }}">
                 {% if win.threshold_pct is none %}
                 <button class="btn btn-outline-secondary py-0 px-1"

--- a/src/webapp/templates/dashboards/user/partials/project_card.html
+++ b/src/webapp/templates/dashboards/user/partials/project_card.html
@@ -92,7 +92,7 @@
 {% endmacro %}
 
 {# Macro: Resources Table #}
-{% macro render_project_resources(project, resources, usage_warning_threshold, usage_critical_threshold, show_clickable_rows=true, can_edit_allocations=false) %}
+{% macro render_project_resources(project, resources, usage_warning_threshold, usage_critical_threshold, show_clickable_rows=true, can_edit_allocations=false, admin_origin=false) %}
 {% if resources %}
 <div class="mt-3">
     <h6 class="mb-2"><i class="fas fa-server"></i> Resources:</h6>
@@ -145,8 +145,13 @@
                         {% set is_expired = resource.days_until_expiration is not none and resource.days_until_expiration < 0 %}
                         {% set row_class = 'text-muted' if is_expired else '' %}
 
+                        {# When the card is rendered from the admin origin, mark the
+                           resource-detail link with ?from=admin so its back button can
+                           land back on the admin index with this projcode auto-loaded. #}
+                        {% set _detail_kwargs = {'projcode': project.projcode, 'resource': resource.resource_name} %}
+                        {% if admin_origin %}{% set _ = _detail_kwargs.update({'from': 'admin'}) %}{% endif %}
                         <tr class="{% if show_clickable_rows %}resource-row cursor-pointer {% endif %}{{ row_class }}{% if is_expired %} expired-allocation{% endif %}"
-                            {% if show_clickable_rows %}onclick="location.href='{{ url_for('user_dashboard.resource_details', projcode=project.projcode, resource=resource.resource_name) }}'"{% endif %}>
+                            {% if show_clickable_rows %}onclick="location.href='{{ url_for('user_dashboard.resource_details', **_detail_kwargs) }}'"{% endif %}>
                             <td><strong>{{ resource.resource_name }}</strong></td>
                             <td>
                                 <div class="d-flex justify-content-between small mb-1">
@@ -249,7 +254,7 @@
 {% endmacro %}
 
 {# Macro: Project Card Wrapper #}
-{% macro render_project_card(project_data, loop_index, user, usage_warning_threshold, usage_critical_threshold, is_expanded=false) %}
+{% macro render_project_card(project_data, loop_index, user, usage_warning_threshold, usage_critical_threshold, is_expanded=false, admin_origin=false) %}
     {% set project = project_data.project %}
     {% set resources = project_data.resources %}
     {% set card_id = 'project-' ~ loop_index %}
@@ -344,7 +349,7 @@
                 {{ render_project_info(project) }}
 
                 <!-- Resources Section -->
-                {{ render_project_resources(project, resources, usage_warning_threshold, usage_critical_threshold, true, user_can_edit_allocations) }}
+                {{ render_project_resources(project, resources, usage_warning_threshold, usage_critical_threshold, true, user_can_edit_allocations, admin_origin) }}
 
                 <!-- Members Section (Lazy Loaded) -->
                 {{ render_project_members(project, card_id) }}

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -310,9 +310,15 @@
         <span class="{% if is_clickable %}text-muted{% endif %} fw-normal text-truncate" style="max-width: 35ch;">- {{ node.title }}</span>
         {% endif %}
         {% if node.subtree_charges > 0 %}
-        <span class="badge {{ 'bg-warning text-dark' if is_selected else 'bg-secondary' }} ms-auto flex-shrink-0">
+        {% if is_selected %}
+        <span class="badge bg-warning text-dark ms-auto flex-shrink-0">
             {{ node.subtree_charges | fmt_number }}
         </span>
+        {% else %}
+        <span class="text-muted small ms-auto flex-shrink-0 font-monospace">
+            {{ node.subtree_charges | fmt_number }}
+        </span>
+        {% endif %}
         {% endif %}
     {% if is_clickable %}
     </a>

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -184,10 +184,21 @@
 {# ── Page content ──────────────────────────────────────────────────────────── #}
 
 {% block content %}
+{# When the visit was launched from an admin project card, the URL carries
+   ?from=admin so we can return the user to the admin index with this
+   projcode pre-loaded into the card slot, instead of dumping them on the
+   blank user dashboard. #}
+{% set _from_admin = request.args.get('from') == 'admin' %}
 <div class="back-link mb-3">
+    {% if _from_admin %}
+    <a href="{{ url_for('admin_dashboard.index', projcode=projcode) }}" class="btn btn-sm btn-outline-secondary">
+        <i class="fas fa-arrow-left"></i> <span class="back-link-text">Back to Admin</span>
+    </a>
+    {% else %}
     <a href="{{ url_for('user_dashboard.index') }}" class="btn btn-sm btn-outline-secondary">
         <i class="fas fa-arrow-left"></i> <span class="back-link-text">Back to Dashboard</span>
     </a>
+    {% endif %}
 </div>
 
 <div class="page-header">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -606,6 +606,52 @@ def subtree_project(session, _subtree_project_id):
     return session.get(Project, _subtree_project_id)
 
 
+@pytest.fixture(scope="session")
+def _inheriting_project_lookup(engine):
+    """(project_id, resource_name) for any project whose active HPC/DAV allocation
+    on an active resource is inheriting (parent_allocation_id IS NOT NULL).
+
+    Used by tests that need to verify pool-aware rolling charges. Returns
+    None if the snapshot has no inheriting allocations.
+    """
+    from sqlalchemy import text as _text
+    with _session_for_setup(engine) as s:
+        row = s.execute(_text("""
+            SELECT p.project_id, r.resource_name
+            FROM project p
+            JOIN account a ON a.project_id = p.project_id
+            JOIN allocation al ON al.account_id = a.account_id
+            JOIN resources r ON r.resource_id = a.resource_id
+            JOIN resource_type rt ON rt.resource_type_id = r.resource_type_id
+            WHERE p.active = 1
+              AND a.deleted = 0
+              AND al.parent_allocation_id IS NOT NULL
+              AND al.start_date <= NOW()
+              AND (al.end_date IS NULL OR al.end_date >= NOW())
+              AND rt.resource_type IN ('HPC', 'DAV')
+              AND (r.commission_date IS NULL OR r.commission_date <= NOW())
+              AND (r.decommission_date IS NULL OR r.decommission_date >= NOW())
+            ORDER BY p.project_id
+            LIMIT 1
+        """)).first()
+    if row is None:
+        return None
+    return (row[0], row[1])
+
+
+@pytest.fixture
+def inheriting_project(session, _inheriting_project_lookup):
+    """A (Project, resource_name) pair where the project has an inheriting
+    allocation on the named resource. Skips the test if the snapshot has
+    no inheriting allocations.
+    """
+    if _inheriting_project_lookup is None:
+        pytest.skip("snapshot has no inheriting allocations")
+    project_id, resource_name = _inheriting_project_lookup
+    from sam import Project
+    return session.get(Project, project_id), resource_name
+
+
 # ---- "any row of X" fixtures ----------------------------------------------
 #
 # Simple function-scoped lookups used by the `.update()` contract tests in

--- a/tests/integration/test_status_dashboard.py
+++ b/tests/integration/test_status_dashboard.py
@@ -164,3 +164,85 @@ class TestStatusDashboard:
         response = auth_client.get('/status/queue-history/derecho/main')
         assert response.status_code == 200
         assert b'main Queue History' in response.data
+
+    # ------------------------------------------------------------------
+    # `hours` filter passthrough — sideways navigation between detail
+    # pages should inherit the user's chosen time range via the dashboard.
+    # ------------------------------------------------------------------
+
+    def test_dashboard_accepts_hours_param(self, auth_client, status_session):
+        """`/status/?hours=720` renders without crashing."""
+        seed_data(status_session)
+        response = auth_client.get('/status/?hours=720')
+        assert response.status_code == 200
+        assert b'System Status' in response.data
+
+    def test_dashboard_forwards_hours_to_drill_down_links(self, auth_client, status_session):
+        """When `hours` is set, queue/nodetype row-click URLs must carry it."""
+        seed_data(status_session)
+        response = auth_client.get('/status/?hours=720')
+        assert response.status_code == 200
+        # Drill-down URLs are emitted as window.location='...' onclick handlers.
+        assert b'hours=720' in response.data, (
+            'Expected hours=720 to appear in row-click URLs on the dashboard'
+        )
+
+    def test_dashboard_forwards_legacy_days_as_hours(self, auth_client, status_session):
+        """`?days=30` (legacy) is normalized to hours=720 in row-click URLs."""
+        seed_data(status_session)
+        response = auth_client.get('/status/?days=30')
+        assert response.status_code == 200
+        assert b'hours=720' in response.data
+
+    def test_dashboard_no_hours_means_no_hours_in_links(self, auth_client, status_session):
+        """No `hours` param → drill-down URLs are clean (no `hours=` query string).
+
+        Regression guard: ensures the param-absent path matches today's URLs
+        bit-for-bit so users without the param see the original behavior.
+        """
+        seed_data(status_session)
+        response = auth_client.get('/status/')
+        assert response.status_code == 200
+        # The dashboard renders many things; we only care that drill-down URLs
+        # in queue/nodetype tables don't have hours= appended. Look at the
+        # specific onclick URLs.
+        assert b'queue-history/derecho' in response.data
+        # The URL preceding the queue_name shouldn't carry an `hours=` param
+        # in any of the row-click handlers when none was requested.
+        # (A bare `hours=` somewhere else like a script comment would be a
+        # false positive; restrict to the drill-down URL prefix.)
+        assert b'queue-history/derecho/' in response.data
+        # Permissive substring check — no row-click should contain hours=:
+        for url_prefix in (b'queue-history/derecho/', b'queue-history/casper/',
+                           b'nodetype-history/casper/'):
+            # Find every occurrence of the prefix and verify the surrounding
+            # 200 bytes don't include hours=
+            idx = 0
+            while True:
+                pos = response.data.find(url_prefix, idx)
+                if pos == -1:
+                    break
+                snippet = response.data[pos:pos + 200]
+                assert b'hours=' not in snippet, (
+                    f'Unexpected hours= near {url_prefix!r} in dashboard '
+                    f'rendered with no params: {snippet!r}'
+                )
+                idx = pos + len(url_prefix)
+
+    def test_queue_history_back_link_carries_hours(self, auth_client, status_session):
+        """Detail-page back links forward `hours` to the dashboard so the
+        user's range survives a back-then-forward cycle.
+        """
+        seed_data(status_session)
+        response = auth_client.get('/status/queue-history/derecho/main?hours=720')
+        assert response.status_code == 200
+        assert b'/status/?hours=720' in response.data, (
+            'Expected back-link to forward hours=720 to status_dashboard.index'
+        )
+
+    def test_nodetype_history_back_link_carries_hours(self, auth_client, status_session):
+        """Same forwarding for nodetype detail page."""
+        seed_data(status_session)
+        response = auth_client.get('/status/nodetype-history/casper/cpu?hours=720')
+        assert response.status_code == 200
+        assert b'/status/?hours=720' in response.data

--- a/tests/unit/test_fmt.py
+++ b/tests/unit/test_fmt.py
@@ -13,10 +13,12 @@ from sam.fmt import (
     COMPACT_THRESHOLD,
     configure,
     date_str,
+    naive_local_to_utc,
     number,
     pct,
     round_to_sig_figs,
     size,
+    to_local_dt,
 )
 
 
@@ -297,3 +299,72 @@ class TestConfigure:
         configure(raw=False, sig_figs=3)
         assert number(68_567_808) == '68.6M'
         assert pct(0.4) == '0.4%'
+
+
+# ============================================================================
+# Timezone helpers — to_local_dt / naive_local_to_utc
+#
+# Form values arrive naive in the operator's browser TZ; storage is naive-UTC;
+# display shifts back to the configured display TZ.  These tests pin the
+# round-trip math against real IANA zones so DST-window changes don't bit-rot
+# silently.
+# ============================================================================
+
+
+class TestNaiveLocalToUTC:
+    """Operator-entered naive datetimes → naive-UTC for storage."""
+
+    def test_none_passes_through(self):
+        assert naive_local_to_utc(None) is None
+
+    def test_browser_eastern_summer_to_utc(self):
+        # 2026-07-15 14:30 EDT (UTC-4) → 18:30 UTC
+        dt = datetime(2026, 7, 15, 14, 30)
+        utc = naive_local_to_utc(dt, 'America/New_York')
+        assert utc == datetime(2026, 7, 15, 18, 30)
+        assert utc.tzinfo is None
+
+    def test_browser_mountain_summer_to_utc(self):
+        # 2026-07-15 14:30 MDT (UTC-6) → 20:30 UTC
+        dt = datetime(2026, 7, 15, 14, 30)
+        utc = naive_local_to_utc(dt, 'America/Denver')
+        assert utc == datetime(2026, 7, 15, 20, 30)
+
+    def test_browser_mountain_winter_to_utc(self):
+        # 2026-01-15 14:30 MST (UTC-7) → 21:30 UTC — DST off
+        dt = datetime(2026, 1, 15, 14, 30)
+        utc = naive_local_to_utc(dt, 'America/Denver')
+        assert utc == datetime(2026, 1, 15, 21, 30)
+
+    def test_missing_tz_falls_back_to_display(self):
+        # No tz_name → uses STATUS_DISPLAY_TZ default (America/Denver).
+        dt = datetime(2026, 7, 15, 14, 30)
+        assert naive_local_to_utc(dt) == naive_local_to_utc(dt, 'America/Denver')
+
+    def test_invalid_tz_falls_back_to_display(self):
+        dt = datetime(2026, 7, 15, 14, 30)
+        assert naive_local_to_utc(dt, 'Not/A_Zone') == naive_local_to_utc(dt, 'America/Denver')
+
+
+class TestRoundTrip:
+    """An operator-entered datetime stored and re-displayed must come back
+    looking like what they typed (in their TZ)."""
+
+    def test_eastern_round_trip(self):
+        operator_typed = datetime(2026, 7, 15, 14, 30)  # 2:30 PM EDT
+        stored_utc = naive_local_to_utc(operator_typed, 'America/New_York')
+        # …and to_local_dt converts back to the *display* TZ (Mountain).
+        # Different operator viewing in Mountain sees 12:30 PM MDT.
+        viewed = to_local_dt(stored_utc)
+        assert viewed.hour == 12
+        assert viewed.minute == 30
+        # 14:30 EDT == 18:30 UTC == 12:30 MDT — sanity.
+
+    def test_mountain_round_trip_idempotent(self):
+        # When operator and viewer are both in Mountain (the default),
+        # stored value displays back exactly as typed.
+        operator_typed = datetime(2026, 7, 15, 14, 30)
+        stored_utc = naive_local_to_utc(operator_typed, 'America/Denver')
+        viewed = to_local_dt(stored_utc)
+        assert viewed.hour == 14
+        assert viewed.minute == 30

--- a/tests/unit/test_rolling_usage.py
+++ b/tests/unit/test_rolling_usage.py
@@ -51,7 +51,8 @@ class TestRollingUsageStructure:
 
     def test_each_entry_has_required_fields(self, session, active_project):
         result = get_project_rolling_usage(session, active_project.projcode)
-        required = {'allocated', 'start_date', 'end_date', 'windows'}
+        required = {'allocated', 'start_date', 'end_date', 'windows',
+                    'is_inheriting', 'root_projcode'}
         for rname, data in result.items():
             assert not (required - data.keys()), f'{rname}: missing {required - data.keys()}'
 
@@ -63,7 +64,7 @@ class TestRollingUsageStructure:
 
     def test_window_entry_has_required_fields(self, session, active_project):
         result = get_project_rolling_usage(session, active_project.projcode)
-        required = {'charges', 'prorated_alloc', 'pct_of_prorated',
+        required = {'charges', 'self_charges', 'prorated_alloc', 'pct_of_prorated',
                     'threshold_pct', 'use_limit', 'pct_of_limit'}
         for rname, data in result.items():
             for wdays, winfo in data['windows'].items():
@@ -296,6 +297,102 @@ class TestEdgeCases:
         result = get_project_rolling_usage(session, active_project.projcode, windows=[])
         for _rname, data in result.items():
             assert data['windows'] == {}
+
+
+# ============================================================================
+# Inherited (shared-pool) allocations
+#
+# When a project's allocation on a resource is inheriting (parent_allocation_id
+# IS NOT NULL), `charges` and the derived percentages must reflect *pool burn*
+# across the whole shared-allocation tree — that's the rate that depletes the
+# allocation. Each window also carries `self_charges` so the UI can surface
+# the per-project slice as "(N yours)".
+# ============================================================================
+
+
+class TestInheritedAllocation:
+
+    def test_resource_dict_flags_inheriting(self, session, inheriting_project):
+        project, resource_name = inheriting_project
+        result = get_project_rolling_usage(
+            session, project.projcode, resource_name=resource_name
+        )
+        if not result or resource_name not in result:
+            pytest.skip(
+                f'{project.projcode}/{resource_name}: no rolling data '
+                f'(allocation may be excluded by HPC/DAV/active filter)'
+            )
+        data = result[resource_name]
+        assert data['is_inheriting'] is True
+        assert isinstance(data.get('root_projcode'), str)
+        assert data['root_projcode'], 'root_projcode must be a non-empty projcode'
+
+    def test_windows_carry_self_charges(self, session, inheriting_project):
+        project, resource_name = inheriting_project
+        result = get_project_rolling_usage(
+            session, project.projcode, resource_name=resource_name
+        )
+        if not result or resource_name not in result:
+            pytest.skip(f'{project.projcode}/{resource_name}: no rolling data')
+        for wdays, winfo in result[resource_name]['windows'].items():
+            assert 'self_charges' in winfo, f'window {wdays}: missing self_charges'
+            assert winfo['self_charges'] is not None, (
+                f'window {wdays}: self_charges must be set when inheriting'
+            )
+            assert isinstance(winfo['self_charges'], float)
+
+    def test_pool_charges_gte_self(self, session, inheriting_project):
+        """Pool burn must include self-burn — invariant `charges >= self_charges`."""
+        project, resource_name = inheriting_project
+        result = get_project_rolling_usage(
+            session, project.projcode, resource_name=resource_name
+        )
+        if not result or resource_name not in result:
+            pytest.skip(f'{project.projcode}/{resource_name}: no rolling data')
+        for wdays, winfo in result[resource_name]['windows'].items():
+            assert winfo['charges'] >= winfo['self_charges'], (
+                f'window {wdays}: pool charges ({winfo["charges"]}) '
+                f'must be >= self_charges ({winfo["self_charges"]})'
+            )
+
+    def test_threshold_math_holds_on_pool(self, session, inheriting_project):
+        """`pct_of_limit == charges / use_limit * 100` — same formula as the
+        non-inheriting path, applied to pool numbers. Skips if no threshold
+        configured on the inheriting project's account.
+        """
+        project, resource_name = inheriting_project
+        result = get_project_rolling_usage(
+            session, project.projcode, resource_name=resource_name
+        )
+        if not result or resource_name not in result:
+            pytest.skip(f'{project.projcode}/{resource_name}: no rolling data')
+        any_threshold = False
+        for wdays, winfo in result[resource_name]['windows'].items():
+            if winfo['threshold_pct'] is None or not winfo['use_limit']:
+                continue
+            any_threshold = True
+            expected = round(winfo['charges'] / winfo['use_limit'] * 100.0, 1)
+            assert abs(winfo['pct_of_limit'] - expected) < 1.0
+        if not any_threshold:
+            pytest.skip(
+                f'{project.projcode}/{resource_name}: no threshold configured'
+            )
+
+    def test_non_inheriting_has_null_self_charges(self, session, active_project):
+        """Regression guard: non-inheriting allocations don't leak the new
+        `self_charges` value (must be None to keep the UI annotation gated).
+        """
+        result = get_project_rolling_usage(session, active_project.projcode)
+        for rname, data in result.items():
+            if data.get('is_inheriting'):
+                continue  # inheriting case is covered by tests above
+            assert data.get('is_inheriting') is False
+            assert data.get('root_projcode') is None
+            for wdays, winfo in data['windows'].items():
+                assert winfo.get('self_charges') is None, (
+                    f'{rname}/window {wdays}: non-inheriting must have '
+                    f'self_charges=None, got {winfo.get("self_charges")}'
+                )
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

A bundle of UX and correctness fixes layered onto the resource-details / status-dashboard surfaces. Two major themes:

1. **Tree-aware resource utilization** — pool-aware rolling consumption, less noisy tree usage, back-link state preservation.
2. **System-status timezone consistency** — collectors and dashboards now share the project-wide naive-UTC convention; operator-entered values are TZ-captured at submit time.

Each commit is self-contained with its own focused test plan; merging in order is safe.

## Commits

### UX polish on the project tree
- **732e68d** — Quiet non-selected usage numbers in the project-tree "Resource Usage Details" view: keep the prominent yellow badge on the selected node only; sibling rows render their `subtree_charges` as muted monospace text instead of competing badges.
- **8308f57** — Trim `CLAUDE.md` to stay under the 40k-char performance threshold (drops three stale/redundant blocks).

### Pool-aware Rolling Consumption Rate
- **e72e1c4** — `get_project_rolling_usage` now detects `Allocation.is_inheriting` and reports **pool burn** (root allocation's project subtree) for inherited allocations, instead of just this project's own slice. Each window also carries `self_charges` so the UI can surface the per-project contribution as `(N yours)`. The `pct_of_prorated` / threshold math now reflects runway-correct pool numbers. Threshold edit buttons are hidden on inheriting projects (the threshold lives on the master). New `inheriting_project` snapshot fixture + `TestInheritedAllocation` covering pool-≥-self invariant, threshold formula on pool numbers, and a regression guard that non-inheriting allocations leave `self_charges=None`.

### Back-link state preservation
- **b4bea42** — Admin → search project → resource detail → "Back to Admin" no longer dumps the user on a blank `/admin/`. The admin index now accepts `?projcode=X` and auto-renders the card via the existing `/admin/project/<X>` HTMX endpoint on page load. Resource-details rows from admin-origin cards carry `?from=admin`, which the back link honors. `edit_project.html`'s admin branch picks up the same projcode pass-through.
- **2916794** — Same pattern for the status dashboard: drilling into queue A with `?hours=720`, hitting back, and clicking queue B used to revert to the default 168h. Index route now accepts `?hours=` (with legacy `?days=` normalization), forwards through row-click URLs and detail-page back links. 6 integration tests cover accept/forward/legacy/regression/round-trip.

### Status-dashboard timezone consistency

The four commits below tackle a bug spotted on a 6h history chart that said "No data" while collection was actively running.

- **74e7a32** — Force `TZ=UTC` at the top of `run_collectors.sh`. Collectors were running on a host in MDT/MST and writing timestamps 6–7h behind the webapp's UTC reads, causing the latest record to fall just outside short read windows.
- **a62a84a** — Add `to_local_dt()` and `local_tz_label()` to `sam.fmt`, registered as a Jinja filter. Apply only to fields that are genuinely naive-UTC: collector-written `*Status.timestamp`. Audit complete: PBS reservations and operator-entered outages are naive-local on this commit and rendered raw with explanatory comments. Also hoist `.chart-container` centering rules from `allocations.css` to global `dashboard.css` (the tighter SVG bbox after localization exposed missing centering on status pages).
- **373935d** — Tag naive-local reservation/outage timestamps with the display TZ label (`local_tz_label()` registered as a Jinja global) so they at least carry an honest abbreviation alongside the heartbeat timestamps.
- **04b973e** — Capture the operator's browser TZ on outage submit (`Intl.DateTimeFormat().resolvedOptions().timeZone` into a hidden `tz` field). Server normalizes the entered wall-clock time to naive-UTC via a new `sam.fmt.naive_local_to_utc(dt, tz_name)` helper. Reservation parser gains a `cluster_tz='America/Denver'` parameter and converts PBS cluster-local timestamps to naive-UTC at parse time. Display layer re-applies `to_local_dt` for outages and reservations now that their storage matches the project-wide naive-UTC convention. 7 new test cases pin EDT/MDT/MST conversions, fallbacks, and the East Coast operator → Mountain viewer round trip.

## Caveats / migration notes

- **Pre-existing `*Status.timestamp` rows** were written in MDT before `74e7a32`. Going forward they will display 6h "early" relative to wall clock. Self-heals as old rows age out of viewing windows.
- **Pre-existing outage rows** are still naive-local. Under the new filter they'll display 6h late. Operational dataset is small enough for a one-off SQL nudge if desired (`UPDATE system_outages SET start_time = CONVERT_TZ(start_time, 'America/Denver', 'UTC') WHERE start_time < '<commit-date>'`); not auto-migrating to avoid double-shifting.
- **Pre-existing reservation rows** self-heal — the collector overwrites them on the next PBS sync.

## Test plan

- [ ] `pytest tests/unit/test_fmt.py -v` — passes with the 7 new TZ round-trip cases.
- [ ] `pytest tests/unit/test_rolling_usage.py -v` — passes with the new `TestInheritedAllocation` plus tightened structure tests.
- [ ] `pytest tests/integration/test_status_dashboard.py -v` — passes with the 6 new `?hours=` round-trip cases.
- [ ] Manual: visit `/admin/?projcode=SCSG0001` → card auto-renders.
- [ ] Manual: from admin card → resource detail → "Back to Admin" → card returns.
- [ ] Manual: `/user/resource-details?projcode=CESM0023&resource=Casper` → Rolling Consumption Rate is present, shows pool burn with `(N yours)` annotation; subtitle mentions the master parent project; threshold buttons absent.
- [ ] Manual: status detail charts show `Time (MDT)` axis and consistent local-time x-axis values; range header tagged `MDT`/`MST`.
- [ ] Manual: outage create form populates the hidden `tz` field; submit a value while in a non-Mountain TZ and verify it displays correctly (Mountain) on the dashboard.
- [ ] Manual: outage edit modal pre-fills correctly when the stored value is naive-UTC (`Z` suffix → operator-local in `<input type="datetime-local">`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)