### PR TITLE
RBAC: reserve allocation Add/Extend/Renew/Edit for base RBAC

### DIFF
--- a/src/webapp/api/access_control.py
+++ b/src/webapp/api/access_control.py
@@ -288,3 +288,90 @@ def require_allocation_permission(permission: Permission) -> Callable:
 
         return decorated_function
     return decorator
+
+
+def require_project_facility_permission(permission: Permission) -> Callable:
+    """
+    Decorator factory for project-mutating routes that require **base
+    RBAC only** — no steward override.
+
+    Identical URL contract to ``require_project_permission`` (resolves
+    ``<projcode>`` and passes the ``project`` object), but grants
+    access only when the user holds ``permission`` system-wide or
+    facility-scoped for the project's facility. Project lead/admin
+    status does NOT grant access.
+
+    Use for allocation mutations that should not be available to
+    project leads (Add / Extend / Renew). For within-tree redistribution
+    that leads should be able to perform, use
+    ``require_project_permission`` instead.
+
+    Usage:
+        @bp.route('/<projcode>/extend', methods=['POST'])
+        @login_required
+        @require_project_facility_permission(Permission.EDIT_ALLOCATIONS)
+        def extend(project):
+            ...
+    """
+    def decorator(f: Callable) -> Callable:
+        @wraps(f)
+        def decorated_function(projcode: str, *args, **kwargs):
+            project, error = get_project_or_404(db.session, projcode)
+            if error:
+                return error
+
+            if not has_permission_for_facility(
+                current_user, permission, project.facility_name
+            ):
+                abort(403)
+
+            return f(project, *args, **kwargs)
+
+        return decorated_function
+    return decorator
+
+
+def require_allocation_facility_permission(permission: Permission) -> Callable:
+    """
+    Decorator factory for allocation-mutating routes that require
+    **base RBAC only** — no steward override.
+
+    Resolves ``<allocation_id>`` (or ``<int:allocation_id>``), walks
+    to ``allocation.account.project``, and grants access only when
+    the user holds ``permission`` system-wide or facility-scoped for
+    that project's facility. Project lead/admin status does NOT
+    grant access.
+
+    Passes the ``allocation`` object to the decorated function in
+    place of ``allocation_id``.
+
+    Usage:
+        @bp.route('/<int:allocation_id>', methods=['PUT'])
+        @login_required
+        @require_allocation_facility_permission(Permission.EDIT_ALLOCATIONS)
+        def update_allocation(allocation):
+            ...
+    """
+    from sam.accounting.allocations import Allocation
+
+    def decorator(f: Callable) -> Callable:
+        @wraps(f)
+        def decorated_function(allocation_id: int, *args, **kwargs):
+            allocation = db.session.get(Allocation, int(allocation_id))
+            if allocation is None:
+                abort(404)
+
+            account = allocation.account
+            project = account.project if account is not None else None
+            if project is None:
+                abort(403)
+
+            if not has_permission_for_facility(
+                current_user, permission, project.facility_name
+            ):
+                abort(403)
+
+            return f(allocation, *args, **kwargs)
+
+        return decorated_function
+    return decorator

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -20,10 +20,13 @@ from webapp.utils.rbac import (
 )
 from webapp.api.access_control import (
     require_project_permission, require_allocation_permission,
+    require_project_facility_permission,
+    require_allocation_facility_permission,
 )
 from webapp.utils.project_permissions import (
     can_edit_project_governance,
-    can_edit_allocations,
+    can_modify_allocations,
+    can_exchange_allocations,
 )
 from sam.manage import management_transaction
 
@@ -452,7 +455,7 @@ def edit_project_page(project):
     form_data = _project_form_data(form=pre_fill or None)
 
     can_edit_governance = can_edit_project_governance(current_user, project)
-    can_edit_allocs = can_edit_allocations(current_user, project)
+    can_modify_allocs = can_modify_allocations(current_user, project)
     from webapp.utils.rbac import has_permission_any_facility
     can_access_admin = has_permission_any_facility(current_user, Permission.ACCESS_ADMIN_DASHBOARD)
 
@@ -463,7 +466,7 @@ def edit_project_page(project):
         current_facility_id=current_facility_id,
         current_panel_id=current_panel_id,
         can_edit_governance=can_edit_governance,
-        can_edit_allocations=can_edit_allocs,
+        can_modify_allocations=can_modify_allocs,
         can_access_admin=can_access_admin,
         **form_data,
     )
@@ -618,7 +621,8 @@ def htmx_project_allocation_tree(project):
     # hold a dedicated (non-inheriting) allocation for it. The root is
     # never a valid exchange endpoint — see ``_exchange_candidates``.
     # Computed from the data already loaded above; no extra DB trips.
-    can_exchange = can_edit_allocations(current_user, project)
+    can_exchange = can_exchange_allocations(current_user, project)
+    can_modify_allocs = can_modify_allocations(current_user, project)
     descendant_projcodes = {
         p.projcode for p in project.get_descendants(include_self=False)
         if p.active
@@ -656,7 +660,7 @@ def htmx_project_allocation_tree(project):
         active_at=active_at_str,
         now_str=now_str,
         can_edit_governance=can_edit_project_governance(current_user, project),
-        can_edit_allocations=can_exchange,
+        can_modify_allocations=can_modify_allocs,
         can_exchange=can_exchange,
         exchange_eligible_resources=exchange_eligible_resources,
         resource_id_by_name=resource_id_by_name,
@@ -665,7 +669,7 @@ def htmx_project_allocation_tree(project):
 
 @bp.route('/htmx/add-allocation-form/<projcode>')
 @login_required
-@require_project_permission(Permission.EDIT_ALLOCATIONS, include_ancestors=True)
+@require_project_facility_permission(Permission.EDIT_ALLOCATIONS)
 def htmx_add_allocation_form(project):
     """Return the add-allocation sub-form (loaded into modal on button click)."""
     import calendar
@@ -708,7 +712,7 @@ def htmx_add_allocation_form(project):
 
 @bp.route('/htmx/add-allocation/<projcode>', methods=['POST'])
 @login_required
-@require_project_permission(Permission.EDIT_ALLOCATIONS, include_ancestors=True)
+@require_project_facility_permission(Permission.EDIT_ALLOCATIONS)
 def htmx_add_allocation(project):
     """Create a new account + allocation for the project."""
     from sam.resources.resources import Resource
@@ -1142,7 +1146,7 @@ def _build_renew_candidates(project, source_active_at):
 
 @bp.route('/htmx/renew-allocations-form/<projcode>')
 @login_required
-@require_project_permission(Permission.EDIT_ALLOCATIONS, include_ancestors=True)
+@require_project_facility_permission(Permission.EDIT_ALLOCATIONS)
 def htmx_renew_allocations_form(project):
     """Return the Renew Allocations modal form fragment.
 
@@ -1172,7 +1176,7 @@ def htmx_renew_allocations_form(project):
 
 @bp.route('/htmx/renew-allocations/<projcode>', methods=['POST'])
 @login_required
-@require_project_permission(Permission.EDIT_ALLOCATIONS, include_ancestors=True)
+@require_project_facility_permission(Permission.EDIT_ALLOCATIONS)
 def htmx_renew_allocations(project):
     """Create renewed allocations for the selected resources."""
     from sam.resources.resources import Resource
@@ -1384,7 +1388,7 @@ def _build_extend_candidates(project, source_active_at):
 
 @bp.route('/htmx/extend-allocations-form/<projcode>')
 @login_required
-@require_project_permission(Permission.EDIT_ALLOCATIONS, include_ancestors=True)
+@require_project_facility_permission(Permission.EDIT_ALLOCATIONS)
 def htmx_extend_allocations_form(project):
     """Return the Extend Allocations modal form fragment."""
     root = project.get_root() if hasattr(project, 'get_root') else project
@@ -1408,7 +1412,7 @@ def htmx_extend_allocations_form(project):
 
 @bp.route('/htmx/extend-allocations/<projcode>', methods=['POST'])
 @login_required
-@require_project_permission(Permission.EDIT_ALLOCATIONS, include_ancestors=True)
+@require_project_facility_permission(Permission.EDIT_ALLOCATIONS)
 def htmx_extend_allocations(project):
     """Push end_date forward on the selected allocations."""
     from sam.manage.extend import extend_project_allocations
@@ -1505,7 +1509,7 @@ def htmx_extend_allocations(project):
 
 @bp.route('/htmx/edit-allocation-form/<int:allocation_id>')
 @login_required
-@require_allocation_permission(Permission.EDIT_ALLOCATIONS)
+@require_allocation_facility_permission(Permission.EDIT_ALLOCATIONS)
 def htmx_edit_allocation_form(allocation):
     """Return the edit-allocation form fragment (loaded into modal)."""
     from sam.manage.allocations import get_partitioned_descendant_sum, date_ranges_overlap
@@ -1585,7 +1589,7 @@ def htmx_edit_allocation_form(allocation):
 
 @bp.route('/htmx/edit-allocation/<int:allocation_id>', methods=['POST'])
 @login_required
-@require_allocation_permission(Permission.EDIT_ALLOCATIONS)
+@require_allocation_facility_permission(Permission.EDIT_ALLOCATIONS)
 def htmx_edit_allocation(allocation):
     """Validate and apply allocation edits with cascade + audit logging."""
     from sam.accounting.allocations import InheritingAllocationException

--- a/src/webapp/templates/dashboards/admin/edit_project.html
+++ b/src/webapp/templates/dashboards/admin/edit_project.html
@@ -101,7 +101,7 @@
 
   <!-- ── Tab 2: Allocations ─────────────────────────────────────────── -->
   <div class="tab-pane fade" id="tab-allocations" role="tabpanel">
-    {% if can_edit_allocations %}
+    {% if can_modify_allocations %}
     <div class="d-flex justify-content-end gap-2 mb-3">
       <button class="btn btn-sm btn-warning"
               hx-get="{{ url_for('admin_dashboard.htmx_extend_allocations_form', projcode=project.projcode) }}"

--- a/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
@@ -139,7 +139,7 @@
 
           {# Col 5: edit pencil (or shared badge for inherited allocations) #}
           <td style="vertical-align:middle;">
-            {% if can_edit_allocations and root_alloc and root_alloc.allocation_id and not root_alloc.is_inheriting %}
+            {% if can_modify_allocations and root_alloc and root_alloc.allocation_id and not root_alloc.is_inheriting %}
             <button class="btn btn-xs btn-outline-warning py-0 px-1"
                     style="font-size:0.7rem;"
                     hx-get="{{ url_for('admin_dashboard.htmx_edit_allocation_form', allocation_id=root_alloc.allocation_id) }}"
@@ -228,7 +228,7 @@
                                      current_projcode=projcode,
                                      alloc_by_projcode=alloc_by_projcode,
                                      can_view=true,
-                                     can_edit_allocations=can_edit_governance,
+                                     can_edit_allocations=can_modify_allocations,
                                      active_only=true,
                                      usage_warning_threshold=75,
                                      usage_critical_threshold=90,

--- a/src/webapp/utils/project_permissions.py
+++ b/src/webapp/utils/project_permissions.py
@@ -150,25 +150,37 @@ def can_view_project_members(user, project) -> bool:
     return True
 
 
-def can_edit_allocations(user, project) -> bool:
+def can_modify_allocations(user, project) -> bool:
     """
-    Edit allocation values (amount, dates, description).
+    Mutate allocation quotas — Add / Extend / Renew / per-allocation
+    Edit (amount, start, end).
+
+    Granted to: system EDIT_ALLOCATIONS holders only (facility-scoped
+    via ``USER_FACILITY_PERMISSIONS`` counts as a system grant for
+    that project's facility). **No steward override** — project lead
+    / admin do NOT inherit this. These operations create or alter
+    quota and are reserved for base RBAC.
+
+    For within-tree redistribution use ``can_exchange_allocations``.
+    """
+    return has_permission_for_facility(
+        user, Permission.EDIT_ALLOCATIONS, project.facility_name
+    )
+
+
+def can_exchange_allocations(user, project) -> bool:
+    """
+    Exchange (redistribute) allocations across a project subtree.
 
     Granted to: system EDIT_ALLOCATIONS holders, OR project lead/admin
     of this project OR any ancestor in the project tree. The
     ancestor walk supports redistribution within a subtree the user
-    leads — e.g. a lead of project A can edit allocations on its
-    children A1, A2.
+    leads — a lead of project A can exchange allocations among its
+    children A1, A2 without acquiring new quota.
     """
     return _is_project_steward(
         user, project, Permission.EDIT_ALLOCATIONS, include_ancestors=True
     )
-
-
-# Allocation redistribution is a specialization of allocation editing
-# (same authorization, distinct UI/API surface). The alias exists so
-# callers can use the name that reads best at the call site.
-can_redistribute_allocations = can_edit_allocations
 
 
 def can_edit_consumption_threshold(user, project) -> bool:

--- a/tests/unit/test_project_permissions.py
+++ b/tests/unit/test_project_permissions.py
@@ -12,10 +12,10 @@ import pytest
 from webapp.utils.project_permissions import (
     _is_project_steward,
     can_change_admin,
-    can_edit_allocations,
     can_edit_consumption_threshold,
+    can_exchange_allocations,
     can_manage_project_members,
-    can_redistribute_allocations,
+    can_modify_allocations,
     can_view_project_members,
     get_user_role_in_project,
 )
@@ -300,46 +300,94 @@ class TestIsProjectSteward:
 
 
 # ---------------------------------------------------------------------------
-# Phase 2: can_edit_allocations BEHAVIOR CHANGE
+# can_exchange_allocations — steward-aware (lead/admin can redistribute
+# within a subtree they own; ancestor walk supports parent-of-subtree)
 # ---------------------------------------------------------------------------
 
-class TestCanEditAllocations:
-    """``can_edit_allocations`` previously short-circuited to
-    ``has_permission(EDIT_ALLOCATIONS)`` only — i.e. system admins only.
-    Phase 2 grants project lead/admin (and ancestor lead/admin) too,
-    enabling allocation redistribution within a project subtree."""
+class TestCanExchangeAllocations:
+    """Exchange (redistribution) keeps quota fixed and rebalances within
+    a subtree. Project lead/admin — including any ancestor lead/admin —
+    can perform it without holding system EDIT_ALLOCATIONS."""
 
-    def test_lead_can_edit_their_allocation(self):
-        # Regression target — used to return False for non-system users.
+    def test_lead_can_exchange_their_allocation(self):
         user = create_mock_user(user_id=42, roles=[])
         project = create_mock_project(project_lead_user_id=42)
-        assert can_edit_allocations(user, project)
+        assert can_exchange_allocations(user, project)
 
-    def test_admin_can_edit_their_allocation(self):
+    def test_admin_can_exchange_their_allocation(self):
         user = create_mock_user(user_id=42, roles=[])
         project = create_mock_project(project_lead_user_id=999, project_admin_user_id=42)
-        assert can_edit_allocations(user, project)
+        assert can_exchange_allocations(user, project)
 
-    def test_ancestor_lead_can_edit_descendant_allocation(self):
-        # The redistribution-within-tree use case.
+    def test_ancestor_lead_can_exchange_descendant_allocation(self):
         parent = create_mock_project(project_lead_user_id=42)
         child = create_mock_project(project_lead_user_id=998, parent=parent)
         user = create_mock_user(user_id=42, roles=[])
-        assert can_edit_allocations(user, child)
+        assert can_exchange_allocations(user, child)
 
-    def test_outsider_still_blocked(self):
+    def test_outsider_blocked(self):
         user = create_mock_user(user_id=42, roles=[])
         project = create_mock_project(project_lead_user_id=999, project_admin_user_id=998)
-        assert not can_edit_allocations(user, project)
+        assert not can_exchange_allocations(user, project)
 
     def test_facility_manager_grants_via_system_permission(self):
         user = create_mock_user(user_id=99, roles=['nusd'])
         project = create_mock_project(project_lead_user_id=999, project_admin_user_id=998)
-        assert can_edit_allocations(user, project)
+        assert can_exchange_allocations(user, project)
 
-    def test_redistribute_is_alias(self):
-        # Same authorization, different name at the call site.
-        assert can_redistribute_allocations is can_edit_allocations
+
+# ---------------------------------------------------------------------------
+# can_modify_allocations — base RBAC only (no steward override)
+# ---------------------------------------------------------------------------
+
+class TestCanModifyAllocations:
+    """Add / Extend / Renew / per-allocation Edit are reserved for base
+    RBAC holders of ``EDIT_ALLOCATIONS``. Project lead / admin / ancestor
+    lead are explicitly NOT granted — they create or extend quota."""
+
+    def test_lead_cannot_modify(self):
+        user = create_mock_user(user_id=42, roles=[])
+        project = create_mock_project(project_lead_user_id=42)
+        assert not can_modify_allocations(user, project)
+
+    def test_admin_cannot_modify(self):
+        user = create_mock_user(user_id=42, roles=[])
+        project = create_mock_project(project_lead_user_id=999, project_admin_user_id=42)
+        assert not can_modify_allocations(user, project)
+
+    def test_ancestor_lead_cannot_modify(self):
+        parent = create_mock_project(project_lead_user_id=42)
+        child = create_mock_project(project_lead_user_id=998, parent=parent)
+        user = create_mock_user(user_id=42, roles=[])
+        assert not can_modify_allocations(user, child)
+
+    def test_outsider_cannot_modify(self):
+        user = create_mock_user(user_id=42, roles=[])
+        project = create_mock_project(project_lead_user_id=999, project_admin_user_id=998)
+        assert not can_modify_allocations(user, project)
+
+    def test_system_permission_grants_modify(self):
+        # 'nusd' carries Permission.EDIT_ALLOCATIONS unconditionally.
+        user = create_mock_user(user_id=99, roles=['nusd'])
+        project = create_mock_project(project_lead_user_id=999, project_admin_user_id=998)
+        assert can_modify_allocations(user, project)
+
+    def test_facility_scoped_grants_for_matching_facility(self, monkeypatch):
+        from webapp.utils import rbac
+        user = create_mock_user(user_id=77, roles=[], username='wna_admin')
+        monkeypatch.setitem(
+            rbac.USER_FACILITY_PERMISSIONS,
+            'wna_admin',
+            {'WNA': {Permission.EDIT_ALLOCATIONS}},
+        )
+        wna_project = create_mock_project(
+            project_lead_user_id=999, facility_name='WNA',
+        )
+        univ_project = create_mock_project(
+            project_lead_user_id=999, facility_name='UNIV',
+        )
+        assert can_modify_allocations(user, wna_project)
+        assert not can_modify_allocations(user, univ_project)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Project leads/admins were inheriting \`Permission.EDIT_ALLOCATIONS\` via the
\`_is_project_steward\` short-circuit, which let them submit **Add
Allocation**, **Extend**, **Renew**, and the per-allocation pencil **Edit**
on \`/admin/project/<projcode>/edit\`. Those operations create or alter
quota and should be reserved for users who hold the permission system-wide
(or facility-scoped via \`USER_FACILITY_PERMISSIONS\`).

**Exchange** — a within-tree redistribution that keeps total quota fixed —
remains a steward operation. Leads can still rebalance across their
subtree without acquiring new quota.

## Changes

- \`webapp/utils/project_permissions.py\`: split \`can_edit_allocations\` into:
  - \`can_modify_allocations\` — base RBAC only (Add/Extend/Renew/Edit)
  - \`can_exchange_allocations\` — steward-aware, ancestor-walking (Exchange)
  - dropped the \`can_redistribute_allocations\` alias.
- \`webapp/api/access_control.py\`: added \`require_project_facility_permission\`
  and \`require_allocation_facility_permission\` — strict no-steward variants
  of the existing project / allocation decorators.
- \`webapp/dashboards/admin/projects_routes.py\`: swapped the strict
  decorators onto \`htmx_add_allocation_*\`, \`htmx_renew_allocations_*\`,
  \`htmx_extend_allocations_*\`, \`htmx_edit_allocation_*\`. Left
  \`htmx_exchange_allocation_*\` on the steward-aware decorator.
- Templates (\`edit_project.html\`, \`project_allocation_tree_htmx.html\`):
  the four mutating affordances gate on \`can_modify_allocations\`; the
  Exchange URL stays on \`can_exchange\`. Descendant-row pencils now also
  gate on \`can_modify_allocations\` (was \`can_edit_governance\`, which
  carried \`EDIT_PROJECTS\` semantics — wrong permission for editing
  allocation values).

## Net effect

For a project lead like \`dlawren\` (CESM0002):

- ❌ **Extend / Renew / Add Allocation** buttons no longer render; POSTs return 403.
- ❌ Per-allocation pencil edit no longer renders; PUT returns 403.
- ✅ **Exchange** still works for within-subtree redistribution.

System and facility-scoped \`EDIT_ALLOCATIONS\` holders are unaffected.

## Test plan

- [x] \`pytest tests/unit/test_project_permissions.py\` — refactored
  \`TestCanEditAllocations\` → \`TestCanExchangeAllocations\`; added
  \`TestCanModifyAllocations\` covering lead/admin/ancestor denial,
  system-permission grant, and facility-scoped match/non-match.
- [ ] Manual: log in as \`dlawren\`, visit \`/admin/project/CESM0002/edit\` →
  Allocations tab; confirm Extend/Renew/Add and pencil are gone, Exchange
  remains visible and functional.
- [ ] Manual: log in as a system \`EDIT_ALLOCATIONS\` holder; confirm all
  four affordances + Exchange render and submit successfully.
- [ ] Manual: log in as a facility-scoped admin (\`sureshm\`/WNA); confirm
  affordances render on a WNA project and not on a UNIV project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)