### PR TITLE
Disk Charging

### DIFF
--- a/docs/plans/DISK_BILLING_REFACTOR.md
+++ b/docs/plans/DISK_BILLING_REFACTOR.md
@@ -1,0 +1,202 @@
+# Disk Billing Refactor — Future Work
+
+This is the deferred follow-up to the disk-charging cutover landed
+in `docs/plans/DISK_CHARGING.md`. That plan delivered **Option 2**
+(current-snapshot read path + epoch cutover to TiB-years for new
+rows) and noted a deeper redesign of cumulative billing as Option 3.
+
+After re-evaluation, **Option 3 collapses to a single targeted
+change**: infer the reporting interval per row from the prior
+successful snapshot for the same account, instead of using the
+hard-coded `--reporting-interval=7` constant. The originally-proposed
+`LAG()`-based read-time integration is dropped.
+
+---
+
+## Why we are not doing the read-time integration anymore
+
+The original Option 3 draft proposed:
+
+1. Stop pre-multiplying `terabyte_years` at ingest.
+2. Replace every `SUM(charges)` call site with a `LAG(activity_date)`
+   integration query.
+3. Bump the DB minimum version.
+4. Rename the `terabyte_years` column.
+
+That design was motivated by three real edge cases — cadence
+changes, missing snapshots, backfills — none of which the current
+hard-coded-`7`-at-ingest path handles correctly.
+
+But every one of those edge cases can be fixed at *write* time by
+inferring the interval from the prior snapshot. If we do that:
+
+- The six existing SUM call sites are correct without any change.
+- No DB version bump is required.
+- No column rename is required.
+- No second epoch is required.
+- No consumer-side defensive code is required.
+
+The read-time integration's only remaining value-add is
+**partial-period interrogation between snapshots** (today vs the
+last snapshot, before the next one lands). That question is already
+answered by Option 2's `Account.current_disk_usage()` and the
+schema's `current_used_*` fields — in TiB rather than TiB-years,
+which is what dashboards actually want.
+
+**Decision**: drop the `LAG()` rewrite as a workstream. Keep the
+integration logic in mind as an optional debug helper in
+`sam.queries.charges` if a real use case shows up.
+
+---
+
+## What this plan does
+
+### Where the magic constant lives today
+
+```
+src/cli/cmds/admin.py          --reporting-interval default 7
+src/cli/accounting/commands.py reporting_interval: int = 7
+                               tib_years(bytes, reporting_interval)  ← uniform across rows
+```
+
+Every row of a single import gets the same interval. The legacy
+SAM doc itself flagged the fragility:
+
+> *"If the snapshot frequency changes (e.g., to daily), this value
+> must be updated to `1` to prevent 7× over-billing."*
+
+A single hard-coded constant is the entire defense against under- or
+over-billing.
+
+### Write-time inferred interval
+
+Replace the per-import constant with a per-row lookup at write time.
+For each row in `_run_disk`:
+
+```python
+# Pre-load once per import (one query per chunk, populated lazily by account_id).
+prior_date = (
+    session.query(func.max(DiskChargeSummary.activity_date))
+    .filter(
+        DiskChargeSummary.account_id == acct_id,
+        DiskChargeSummary.activity_date < snap_date,
+    )
+    .scalar()
+)
+interval_days = (snap_date - prior_date).days if prior_date else fallback_interval
+terabyte_years = tib_years(bytes, interval_days)
+charges        = terabyte_years
+```
+
+The `< snap_date` filter is critical: the existing `_run_disk`
+deletes all `(resource, snap_date)` rows before the chunked insert,
+so the lookup needs to find the snapshot *before* the one being
+imported, not the row about to be overwritten.
+
+### Properties under each cadence case
+
+| case                                     | behavior                                                                                         |
+|---                                       |---                                                                                               |
+| Steady weekly cadence                    | Every interval = 7 → identical to today's hard-coded path.                                       |
+| Steady daily cadence (operator forgot to flip flag) | Every interval = 1 → correct without operator action.                                  |
+| Cadence change (weekly → daily)           | First daily snapshot's interval = 7 (covers the prior week); subsequent rows = 1.                |
+| Missed snapshot day                      | Next snapshot's interval = (gap-with-missed-day) → bytes count for the missed window.            |
+| Backfill out of order (Apr 11 imported after Apr 18) | The `< :snap_date` filter makes Apr 11's prior = Apr 04 (or earlier), not Apr 18.       |
+| Bootstrap (first ever row for account)   | Falls back to `--reporting-interval` default (7). One-shot operator concern only.                |
+| New account joining mid-stream           | First row uses bootstrap interval. Bytes-for-the-prior-period are genuinely unknown — bootstrap is honest. |
+| Idempotent re-import (same date)         | `_run_disk` deletes existing rows for `(resource, snap_date)` before insert; the lookup then sees the actually-prior snapshot. |
+
+---
+
+## Implementation outline
+
+### Files to touch
+
+- `src/cli/accounting/commands.py` — modify `_run_disk` to pre-load
+  `prior_date_by_account: dict[int, date]` from
+  `disk_charge_summary` for the accounts the import will touch,
+  then compute `interval_days` per row inside the chunk loop.
+- `src/cli/cmds/admin.py` — update `--reporting-interval` help text
+  to clarify it is a bootstrap-only fallback (not a per-row constant
+  anymore).
+- `src/sam/summaries/disk_summaries.py` — no signature change;
+  `tib_years(bytes_, reporting_interval_days)` is unchanged. The
+  caller selects the interval per row.
+
+### Tests to add
+
+- `tests/unit/test_disk_inferred_interval.py` — new:
+  - Steady weekly cadence: imports across 4 weeks, all intervals = 7.
+  - Steady daily cadence: imports across 4 days, all intervals = 1.
+  - Cadence change: weekly snapshots followed by daily; first daily
+    interval = 7, subsequent = 1.
+  - Missed day: weekly snapshot, then a 14-day gap; the second
+    snapshot's interval = 14.
+  - Backfill out of order: import Apr 18, then Apr 11; Apr 11's
+    interval is the gap to its actual predecessor (Apr 04 or
+    bootstrap), NOT a negative number from Apr 18.
+  - Bootstrap: first-ever row for a fresh account uses
+    `--reporting-interval` default.
+  - Re-import idempotency: re-running Apr 18 finds Apr 11 (not the
+    deleted Apr 18 row) as prior, interval stays 7.
+- `tests/unit/test_accounting_disk_admin.py` — extend with a
+  multi-import scenario that verifies the second snapshot's rows
+  use `(date2 - date1).days` as the interval.
+
+### What is NOT changing
+
+- The cumulative-billing query path (six SUM call sites surveyed
+  in `DISK_CHARGING.md`) — no consumer touches required.
+- The `disk_charge_summary.terabyte_years` column name — column
+  rename to `tebibyte_years` is a separate, smaller, future PR.
+- The `DISK_CHARGING_TIB_EPOCH = 2026-04-18` cutover — unchanged.
+- The `Allocation.amount` ↔ `terabyte_years` unit alignment — unchanged.
+
+---
+
+## Verification
+
+### Unit-level
+
+```python
+# Worked example: weekly cadence with one missed week
+seed(account=A, date=2026-04-11, bytes=B)
+seed(account=A, date=2026-04-25, bytes=B)   # 14 days later, missed Apr 18
+import the second snapshot via _run_disk
+assert row.terabyte_years == B * 14 / 365 / 1024**4
+```
+
+### Live cross-check
+
+After landing this change, on the next `--disk` import:
+
+```sql
+SELECT activity_date,
+       terabyte_years,
+       ROUND(terabyte_years * 365 * POW(1024,4) / bytes) AS inferred_interval_days
+FROM disk_charge_summary
+WHERE activity_date >= '<post-feature-date>'
+ORDER BY activity_date DESC, account_id LIMIT 20;
+```
+
+`inferred_interval_days` should equal the actual gap between
+snapshot dates (typically 7; whatever the snapshot cadence is in
+practice).
+
+### Idempotency
+
+Re-running the same date twice must produce identical
+`terabyte_years` values across both runs (no off-by-one from
+seeing the deleted-and-replaced row as "prior").
+
+---
+
+## Out of scope
+
+- The pure `LAG()` read-time integration query. Demoted from
+  primary recommendation to optional debug helper if a future use
+  case demands it.
+- The `terabyte_years` → `tebibyte_years` column rename. Separate
+  PR, untouched here.
+- Backfilling pre-epoch (decimal-TB-yr) rows. Per
+  `DISK_CHARGING.md`, those stay in legacy units forever.

--- a/docs/plans/DISK_BILLING_REFACTOR.md
+++ b/docs/plans/DISK_BILLING_REFACTOR.md
@@ -1,156 +1,218 @@
-# Disk Billing Refactor — Future Work
+# Disk Billing Refactor — Execution Plan
 
-This is the deferred follow-up to the disk-charging cutover landed
-in `docs/plans/DISK_CHARGING.md`. That plan delivered **Option 2**
-(current-snapshot read path + epoch cutover to TiB-years for new
-rows) and noted a deeper redesign of cumulative billing as Option 3.
+## Context
 
-After re-evaluation, **Option 3 collapses to a single targeted
-change**: infer the reporting interval per row from the prior
-successful snapshot for the same account, instead of using the
-hard-coded `--reporting-interval=7` constant. The originally-proposed
-`LAG()`-based read-time integration is dropped.
+`docs/plans/DISK_BILLING_REFACTOR.md` already lays out the *what* and the
+*why* for the deferred Option-3 follow-up to the disk-charging cutover.
+Today every row of a `sam-admin accounting --disk` import is multiplied
+by the same hard-coded `--reporting-interval=7`. That is the entire
+defense against under- or over-billing on cadence changes, missed
+snapshots, and out-of-order backfills.
 
----
+This plan turns that doc into an execution-ready PR: replace the
+per-import constant with a per-row interval inferred at write time
+from the prior `disk_charge_summary.activity_date` for the same
+account, falling back to `--reporting-interval` only when no prior
+row exists (bootstrap).
 
-## Why we are not doing the read-time integration anymore
-
-The original Option 3 draft proposed:
-
-1. Stop pre-multiplying `terabyte_years` at ingest.
-2. Replace every `SUM(charges)` call site with a `LAG(activity_date)`
-   integration query.
-3. Bump the DB minimum version.
-4. Rename the `terabyte_years` column.
-
-That design was motivated by three real edge cases — cadence
-changes, missing snapshots, backfills — none of which the current
-hard-coded-`7`-at-ingest path handles correctly.
-
-But every one of those edge cases can be fixed at *write* time by
-inferring the interval from the prior snapshot. If we do that:
-
-- The six existing SUM call sites are correct without any change.
-- No DB version bump is required.
-- No column rename is required.
-- No second epoch is required.
-- No consumer-side defensive code is required.
-
-The read-time integration's only remaining value-add is
-**partial-period interrogation between snapshots** (today vs the
-last snapshot, before the next one lands). That question is already
-answered by Option 2's `Account.current_disk_usage()` and the
-schema's `current_used_*` fields — in TiB rather than TiB-years,
-which is what dashboards actually want.
-
-**Decision**: drop the `LAG()` rewrite as a workstream. Keep the
-integration logic in mind as an optional debug helper in
-`sam.queries.charges` if a real use case shows up.
+The goal of this document is to specify the implementation precisely
+enough to execute (file:line landings, function shapes, test cases)
+without further design discussion. On approval, port the plan back
+to `docs/plans/DISK_BILLING_REFACTOR.md`, replace the implementation
+outline in §"What this plan does" with the concrete steps below, and
+proceed to coding.
 
 ---
 
-## What this plan does
+## Design
 
-### Where the magic constant lives today
+### Where the math moves
 
-```
-src/cli/cmds/admin.py          --reporting-interval default 7
-src/cli/accounting/commands.py reporting_interval: int = 7
-                               tib_years(bytes, reporting_interval)  ← uniform across rows
-```
-
-Every row of a single import gets the same interval. The legacy
-SAM doc itself flagged the fragility:
-
-> *"If the snapshot frequency changes (e.g., to daily), this value
-> must be updated to `1` to prevent 7× over-billing."*
-
-A single hard-coded constant is the entire defense against under- or
-over-billing.
-
-### Write-time inferred interval
-
-Replace the per-import constant with a per-row lookup at write time.
-For each row in `_run_disk`:
+Today, charging math runs **once before the chunk loop** at
+`src/cli/accounting/commands.py:482–485`:
 
 ```python
-# Pre-load once per import (one query per chunk, populated lazily by account_id).
+# ---- 6. Charging math ------------------------------------------
+for e in entries:
+    e.terabyte_years = tib_years(e.bytes, reporting_interval)
+    e.charges = e.terabyte_years
+```
+
+For normal rows, `account_id` is **not** known at that point — it is
+resolved lazily inside the chunk loop via `_resolve_for_row()` at
+line 620. The interval depends on `account_id` (each account has its
+own prior snapshot), so the math has to move.
+
+**Move the per-row math into the chunk loop, immediately after
+account resolution.** The pre-loop block becomes a no-op and is
+deleted; the chunk loop computes `terabyte_years` per row using a
+lazy `prior_date_by_account` cache.
+
+### Lookup query
+
+```python
 prior_date = (
-    session.query(func.max(DiskChargeSummary.activity_date))
+    self.session.query(func.max(DiskChargeSummary.activity_date))
     .filter(
         DiskChargeSummary.account_id == acct_id,
-        DiskChargeSummary.activity_date < snap_date,
+        DiskChargeSummary.activity_date < snap_date,   # critical: <, not <=
     )
     .scalar()
 )
 interval_days = (snap_date - prior_date).days if prior_date else fallback_interval
-terabyte_years = tib_years(bytes, interval_days)
-charges        = terabyte_years
 ```
 
-The `< snap_date` filter is critical: the existing `_run_disk`
-deletes all `(resource, snap_date)` rows before the chunked insert,
-so the lookup needs to find the snapshot *before* the one being
-imported, not the row about to be overwritten.
+The `< snap_date` filter is the safety bar against the idempotency
+delete: `_run_disk` block 7b at lines 538–572 removes all
+`(resource, snap_date)` rows **before** the chunk loop runs, so a
+re-import sees the actually-prior snapshot, not the row about to be
+overwritten. `<` (strict) instead of `<=` is also what protects
+backfill out of order — importing Apr 11 *after* Apr 18 has been
+imported finds Apr 11's prior as Apr 04, not Apr 18.
 
-### Properties under each cadence case
+### Cache shape
 
-| case                                     | behavior                                                                                         |
-|---                                       |---                                                                                               |
-| Steady weekly cadence                    | Every interval = 7 → identical to today's hard-coded path.                                       |
-| Steady daily cadence (operator forgot to flip flag) | Every interval = 1 → correct without operator action.                                  |
-| Cadence change (weekly → daily)           | First daily snapshot's interval = 7 (covers the prior week); subsequent rows = 1.                |
-| Missed snapshot day                      | Next snapshot's interval = (gap-with-missed-day) → bytes count for the missed window.            |
-| Backfill out of order (Apr 11 imported after Apr 18) | The `< :snap_date` filter makes Apr 11's prior = Apr 04 (or earlier), not Apr 18.       |
-| Bootstrap (first ever row for account)   | Falls back to `--reporting-interval` default (7). One-shot operator concern only.                |
-| New account joining mid-stream           | First row uses bootstrap interval. Bytes-for-the-prior-period are genuinely unknown — bootstrap is honest. |
-| Idempotent re-import (same date)         | `_run_disk` deletes existing rows for `(resource, snap_date)` before insert; the lookup then sees the actually-prior snapshot. |
+```python
+prior_date_by_account: dict[int, Optional[date]] = {}
+# Sentinel: presence in the dict means "we asked"; value None means
+# "no prior" (use fallback).
+
+def _interval_for(account_id: int) -> int:
+    if account_id not in prior_date_by_account:
+        prior_date_by_account[account_id] = (
+            self.session.query(func.max(DiskChargeSummary.activity_date))
+            .filter(
+                DiskChargeSummary.account_id == account_id,
+                DiskChargeSummary.activity_date < snap_date,
+            )
+            .scalar()
+        )
+    prior = prior_date_by_account[account_id]
+    return (snap_date - prior).days if prior else reporting_interval
+```
+
+Lazy because account_ids for normal rows are not known up-front.
+Multiple users on the same project share an account, so the cache
+deduplicates queries within an import — typical Campaign_Store
+imports (~2000 rows, ~150 distinct accounts) will issue ~150 lookups
+instead of 2000.
+
+### Gap rows
+
+`_build_unidentified_disk_rows` at `commands.py:678–823` constructs
+`DiskUsageEntry` instances with `account_override=account` already
+set (line 812). It currently passes `reporting_interval` through to
+the entry (line 808) but the value is overwritten by the now-deleted
+block 6 anyway — so the field is effectively dead.
+
+Gap rows flow through the same chunk loop as normal rows. They take
+the `account_override` path at `commands.py:609–613` which sets
+`account_for_upsert = row.account_override` before the upsert. The
+new per-row math runs after that branch, using
+`account_for_upsert.account_id` to populate the same cache. No
+special-case logic.
+
+**Cleanup**: drop the unused `reporting_interval` argument from
+`_build_unidentified_disk_rows` (the kwarg at line 686, the call site
+at line 469, and the constructor field on `DiskUsageEntry`). One
+fewer dead parameter to confuse future readers.
+
+### Flag semantics
+
+`--reporting-interval` (admin.py:204–206) goes from "uniform per-row
+interval" to "bootstrap fallback used only on the first-ever row for
+an account." Keep the flag and default of `7`; rewrite the help text:
+
+```
+'[disk] Bootstrap interval in days, used only when no prior '
+'snapshot exists for an account. Steady-state imports infer the '
+'per-row interval from the gap to the previous snapshot.'
+```
 
 ---
 
-## Implementation outline
+## Files to change
 
-### Files to touch
+### `src/cli/accounting/commands.py`
 
-- `src/cli/accounting/commands.py` — modify `_run_disk` to pre-load
-  `prior_date_by_account: dict[int, date]` from
-  `disk_charge_summary` for the accounts the import will touch,
-  then compute `interval_days` per row inside the chunk loop.
-- `src/cli/cmds/admin.py` — update `--reporting-interval` help text
-  to clarify it is a bootstrap-only fallback (not a per-row constant
-  anymore).
-- `src/sam/summaries/disk_summaries.py` — no signature change;
-  `tib_years(bytes_, reporting_interval_days)` is unchanged. The
-  caller selects the interval per row.
+1. **Delete** block 6 at lines 482–485 (the pre-loop `for e in entries`).
+2. **Inside `_run_disk`**, before the chunk loop (around line 574),
+   declare `prior_date_by_account: dict[int, Optional[date]] = {}` and
+   define a small `_interval_for(account_id)` closure that reads /
+   populates the cache. `from sqlalchemy import func` if not already.
+3. **Inside the chunk loop**, after `_resolve_for_row()` succeeds (or
+   `account_override` is taken — i.e., right after the
+   `account_for_upsert` assignment at lines 613 and 620), compute:
+   ```python
+   interval_days = _interval_for(account_for_upsert.account_id)
+   row.terabyte_years = tib_years(row.bytes, interval_days)
+   row.charges = row.terabyte_years
+   ```
+   Then call `upsert_disk_charge_summary(...)` as today.
+4. **Drop the `reporting_interval` argument** to
+   `_build_unidentified_disk_rows` (parameter at line 686, call site at
+   line 469, field on `DiskUsageEntry`).
 
-### Tests to add
+### `src/cli/cmds/admin.py`
 
-- `tests/unit/test_disk_inferred_interval.py` — new:
-  - Steady weekly cadence: imports across 4 weeks, all intervals = 7.
-  - Steady daily cadence: imports across 4 days, all intervals = 1.
-  - Cadence change: weekly snapshots followed by daily; first daily
-    interval = 7, subsequent = 1.
-  - Missed day: weekly snapshot, then a 14-day gap; the second
-    snapshot's interval = 14.
-  - Backfill out of order: import Apr 18, then Apr 11; Apr 11's
-    interval is the gap to its actual predecessor (Apr 04 or
-    bootstrap), NOT a negative number from Apr 18.
-  - Bootstrap: first-ever row for a fresh account uses
-    `--reporting-interval` default.
-  - Re-import idempotency: re-running Apr 18 finds Apr 11 (not the
-    deleted Apr 18 row) as prior, interval stays 7.
-- `tests/unit/test_accounting_disk_admin.py` — extend with a
-  multi-import scenario that verifies the second snapshot's rows
-  use `(date2 - date1).days` as the interval.
+Update the help text on the `--reporting-interval` Click option at
+lines 204–206 to the bootstrap-fallback wording above.
 
-### What is NOT changing
+### `src/sam/summaries/disk_summaries.py`
 
-- The cumulative-billing query path (six SUM call sites surveyed
-  in `DISK_CHARGING.md`) — no consumer touches required.
-- The `disk_charge_summary.terabyte_years` column name — column
-  rename to `tebibyte_years` is a separate, smaller, future PR.
-- The `DISK_CHARGING_TIB_EPOCH = 2026-04-18` cutover — unchanged.
-- The `Allocation.amount` ↔ `terabyte_years` unit alignment — unchanged.
+No change. `tib_years(bytes_, reporting_interval_days)` keeps its
+signature; the caller selects the interval per row.
+
+### `src/cli/accounting/disk_usage/base.py`
+
+Remove the `reporting_interval` field from `DiskUsageEntry` (the
+field is set at `commands.py:808` when constructing gap rows; once
+the math moves into the chunk loop, the field is dead).
+
+---
+
+## Tests
+
+### New: `tests/unit/test_disk_inferred_interval.py`
+
+End-to-end tests against `_run_disk` via `CliRunner`. Reuse
+`_build_campaign_store_graph`, `_write_acct`, `_write_quotas`,
+`runner`, and `mock_db_session` from
+`tests/unit/test_accounting_disk_admin.py:36–103`. Each case seeds
+prior `DiskChargeSummary` rows directly via `session.add()` (not via
+the CLI) so the test pins one variable at a time, then runs one CLI
+invocation and asserts the resulting `terabyte_years`.
+
+| case | seed | import | expected `terabyte_years` |
+|---|---|---|---|
+| Steady weekly | row at `snap-7` | snap | `bytes × 7 / 365 / 1024⁴` |
+| Steady daily | row at `snap-1` | snap | `bytes × 1 / 365 / 1024⁴` |
+| Cadence change weekly→daily | row at `snap-7` | snap | `bytes × 7 / 365 / 1024⁴` (first daily after weekly covers prior week) |
+| Missed week | row at `snap-14` | snap | `bytes × 14 / 365 / 1024⁴` |
+| Backfill out of order | row at `snap+7` (later snapshot already imported), row at `snap-7` | snap | `bytes × 7 / 365 / 1024⁴` (must NOT pick up `snap+7`) |
+| Bootstrap (no prior) | none | snap | `bytes × 7 / 365 / 1024⁴` (fallback to flag default) |
+| Bootstrap with non-default flag | none | snap, `--reporting-interval=3` | `bytes × 3 / 365 / 1024⁴` |
+| Re-import idempotency | row at `snap-7`, row at `snap` | snap (re-import) | `bytes × 7 / 365 / 1024⁴` (the `snap` row is deleted before the lookup runs) |
+
+The "backfill out of order" case is the load-bearing one — it proves
+the strict `<` filter. The "re-import idempotency" case proves the
+delete-then-lookup ordering at lines 538–572 is preserved.
+
+Use `pytest.approx(expected, abs=1e-7)` for the `terabyte_years`
+comparison (DB column is FLOAT, ~7 decimal digits) — match the
+existing tolerance at `test_accounting_disk_admin.py:148`.
+
+### Extend: `tests/unit/test_accounting_disk_admin.py`
+
+Add one multi-import test that runs the CLI twice with different
+snapshot dates 8 days apart and asserts the second import's row uses
+interval = 8, not 7. Exercises the full CLI path twice rather than
+mixing seeded rows with one CLI run.
+
+### `tests/unit/test_disk_charging_math.py`
+
+No change. Pure formula tests for `tib_years()` are already pinned;
+this refactor does not touch `tib_years`.
 
 ---
 
@@ -158,45 +220,85 @@ imported, not the row about to be overwritten.
 
 ### Unit-level
 
-```python
-# Worked example: weekly cadence with one missed week
-seed(account=A, date=2026-04-11, bytes=B)
-seed(account=A, date=2026-04-25, bytes=B)   # 14 days later, missed Apr 18
-import the second snapshot via _run_disk
-assert row.terabyte_years == B * 14 / 365 / 1024**4
 ```
+pytest tests/unit/test_disk_inferred_interval.py \
+       tests/unit/test_accounting_disk_admin.py \
+       tests/unit/test_disk_charging_math.py -v
+```
+
+All eight new cases plus the extended multi-import case pass.
 
 ### Live cross-check
 
-After landing this change, on the next `--disk` import:
+After landing, on the next two consecutive `--disk` imports:
 
 ```sql
 SELECT activity_date,
+       account_id,
        terabyte_years,
-       ROUND(terabyte_years * 365 * POW(1024,4) / bytes) AS inferred_interval_days
+       bytes,
+       ROUND(terabyte_years * 365 * POW(1024,4) / bytes) AS inferred_days
 FROM disk_charge_summary
 WHERE activity_date >= '<post-feature-date>'
-ORDER BY activity_date DESC, account_id LIMIT 20;
+ORDER BY activity_date DESC, account_id
+LIMIT 40;
 ```
 
-`inferred_interval_days` should equal the actual gap between
-snapshot dates (typically 7; whatever the snapshot cadence is in
-practice).
+`inferred_days` must equal the actual gap between consecutive
+snapshot dates for that account (typically 7).
 
 ### Idempotency
 
-Re-running the same date twice must produce identical
-`terabyte_years` values across both runs (no off-by-one from
-seeing the deleted-and-replaced row as "prior").
+Re-run the same `--disk` import twice in a row. Diff the
+`terabyte_years` column across both runs — must be byte-identical.
+This is the regression test that the strict `<` filter and the
+delete-before-lookup ordering survive.
+
+### Bootstrap honesty
+
+After landing, run `--disk` against a freshly-created account that
+has no prior `disk_charge_summary` rows. The first-ever row uses the
+flag default (7). This is the only operator-tunable case and is
+preserved.
 
 ---
 
-## Out of scope
+## What is NOT in this PR
 
-- The pure `LAG()` read-time integration query. Demoted from
-  primary recommendation to optional debug helper if a future use
-  case demands it.
-- The `terabyte_years` → `tebibyte_years` column rename. Separate
-  PR, untouched here.
-- Backfilling pre-epoch (decimal-TB-yr) rows. Per
-  `DISK_CHARGING.md`, those stay in legacy units forever.
+- `LAG()` read-time integration helper. Demoted to optional debug
+  helper in `sam.queries.charges` if a use case ever shows up;
+  currently no consumer needs it.
+- `terabyte_years` → `tebibyte_years` column rename. Separate, smaller
+  PR; mechanical sed across the six SUM call sites.
+- Backfilling pre-`DISK_CHARGING_TIB_EPOCH` rows. Per
+  `DISK_CHARGING.md`, those stay in legacy decimal-TB-yr forever.
+- Touching the six cumulative-billing SUM call sites
+  (`sam.queries.charges:349`, `sam.queries.dashboard:909`/`:996`,
+  `sam.accounting.calculator:54`, `sam.schemas.allocation:213`,
+  `sam.projects.projects:766`). They remain correct because the
+  per-row `terabyte_years` is now correct under all cadence cases.
+
+---
+
+## Rollout
+
+One PR off `disk_charging`. Commits, in order:
+
+1. **refactor**: move `_run_disk` charging math into the chunk loop
+   (no behavior change yet — `_interval_for` always returns the
+   flag value). Existing tests still pass.
+2. **feat**: implement the `prior_date_by_account` lookup inside
+   `_interval_for`. Tests in `test_disk_inferred_interval.py` go from
+   skipped to passing.
+3. **chore**: drop the dead `reporting_interval` field from
+   `DiskUsageEntry` and the kwarg from `_build_unidentified_disk_rows`.
+4. **docs**: update help text on `--reporting-interval`; rewrite the
+   "Implementation outline" section of
+   `docs/plans/DISK_BILLING_REFACTOR.md` to reflect the landed
+   design (drop the "future work" framing).
+
+Each commit independently passes `pytest`. Operator action on next
+deploy is zero — the flag still exists, the default is unchanged,
+the column is unchanged. The only operator-visible diff is the help
+text and the fact that operator-forgot-to-flip-the-flag bugs are no
+longer possible.

--- a/docs/plans/DISK_CHARGING.md
+++ b/docs/plans/DISK_CHARGING.md
@@ -3,7 +3,7 @@
 ## Context
 
 The legacy Java/Hibernate path that populated `disk_charge_summary`
-from per-user-per-project disk snapshots is gone. We have:
+from per-user-per-project disk snapshots has been retired. We have:
 
 - A working `--comp --machine ...` path that imports per-job HPC usage
   and upserts into `comp_charge_summary` via `upsert_comp_charge_summary()`.
@@ -16,6 +16,10 @@ from per-user-per-project disk snapshots is gone. We have:
   resource/account resolution, facility derivation, and PUT-style upsert.
 - A `--disk` flag in the CLI that today just prints
   *"not yet implemented"* (`src/cli/accounting/commands.py:165–167`).
+- A `DiskChargeSummaryStatus` table
+  (`src/sam/summaries/disk_summaries.py:48–59`) — defined with a
+  `current` boolean keyed by `activity_date`, but **never written or
+  read by anything in the current codebase**. This plan resurrects it.
 
 We need to wire **two complementary inputs** into a daily disk-charge
 import for `Campaign_Store`:
@@ -30,8 +34,18 @@ The acct file alone is sufficient for *most* projects, but FILESET
 totals don't always equal the sum of per-user rows (some bytes are
 owned by service accounts or by users absent from the per-user
 report). The reconciliation strategy is to attribute any unaccounted
-project-level bytes to a synthetic `<unidentified>` user so SAM books
-match GPFS truth.
+project-level bytes to the project lead, labeled with
+`act_username='<unidentified>'`, so SAM books match GPFS truth.
+
+This plan also addresses two long-standing issues in how
+`disk_charge_summary` is *consumed*:
+
+- A unit mismatch (decimal TB-years stored vs binary TiB allocations)
+  that produced silent ~10% drift in allocation balance reports.
+- A missing "current usage right now" query path. Today every
+  consumer SUMs `terabyte_years` (or `charges`) over the allocation
+  window — correct for cumulative billing, but not what dashboards
+  want when they answer "you're 47/50 TiB full *today*."
 
 ### Investigations performed (verified in this plan session)
 
@@ -49,8 +63,8 @@ match GPFS truth.
 
 **Units (carefully verified)**
 
-The legacy Java doc was correct about `KiB`; my earlier byte-vs-KiB
-analysis was wrong. Verified by exact match against an existing DB row:
+The legacy Java doc was correct about `KiB`. Verified by exact match
+against an existing DB row:
 
 ```
 acct row:   wchapman / cgd/amp / number_of_files=1361584 / col6=142,788,904,480
@@ -59,7 +73,7 @@ ratio:      146,215,838,187,520 / 142,788,904,480 = 1024.000000  ← exact
 ty check:   146,215,838,187,520 × 7 / 365 / 1e12 = 2.8041  ← matches DB 2.80413938
 ```
 
-So the corrected unit map is:
+So the unit map is:
 
 | Source                                  | Unit       |
 |---                                       |---|
@@ -67,7 +81,8 @@ So the corrected unit map is:
 | `cs_usage.json` `FILESET[*].usage`/`USR[*].usage` | **KiB** |
 | `disk_activity.bytes`                   | bytes (= col6 × 1024) |
 | `disk_charge_summary.bytes`             | bytes (sum of activity bytes) |
-| `disk_charge_summary.terabyte_years`    | **TB-years (decimal, 10¹²)** ← legacy convention |
+| `disk_charge_summary.terabyte_years` (pre-epoch rows)  | **TB-years (decimal, 10¹²)** ← legacy convention |
+| `disk_charge_summary.terabyte_years` (post-epoch rows) | **TiB-years (binary, 1024⁴)** ← new convention |
 | `Allocation.amount` (disk)              | **TiB (binary, 1024⁴)** |
 
 The legacy `GpfsQuotaReader._KIB = 1024` and the legacy
@@ -86,33 +101,10 @@ terabyte_year = (bytes * reportingInterval) / DAYS_IN_YEAR / BYTES_PER_TB
 The legacy doc's "365.25" claim is **wrong** — the constant in code
 is exactly `365`. The legacy "TB" is **decimal** (1000⁴), not TiB.
 
-**The unit-mismatch problem the user wants to fix**
-
-`disk_charge_summary.terabyte_years` is decimal TB-years.
-`Allocation.amount` (for disk) is **TiB**. When the
-allocation-balance calculation rolls up
-`Σ terabyte_years` and compares to `Allocation.amount`, the two
-values differ by ~9.95% (`1024⁴ / 10¹² = 1.099511627776`).
-
-→ This plan switches the new command (and a one-shot backfill of
-existing rows) to **TiB-years (1024⁴)** so the column units
-match the allocation column units. Formula becomes:
-
-```
-terabyte_years_TiB = (bytes * reporting_interval) / 365 / (1024**4)
-```
-
-We keep `365` (not `365.25`) for legacy parity — this is a billing
-convention, and changing it has no effect on allocation comparisons
-as long as both sides use the same value.
-
 **Reconciliation gap is small but real**
 
 Reading FILESET vs Σ(per-user acct rows):
 
-- Total FILESET usage: 130.74 PB (= 127.68 TB × 1024 KiB → KiB-units
-  match, no scale comparison meaningful here without recomputing in
-  bytes; gap percentage holds either way).
 - Corpus-wide gap: ~1.5%. 295 filesets in FILESET have **no** acct
   rows at all (`jntp`, `vast`, `cesmdata`, `fedata`, parent `cgd`).
   Top per-project measurable gaps: `acom` ~53 GB, `uokl0045` ~12 GB,
@@ -127,13 +119,50 @@ Reading FILESET vs Σ(per-user acct rows):
   via SAM's `ProjectDirectory` table (already used by
   `_run_reconcile_quotas`).
 
+**Consumption survey of `DiskChargeSummary`**
+
+Six call sites aggregate this table; **all six SUM `.charges` over a
+date range** (cumulative billing semantics). No call site uses
+`MAX(activity_date)` or otherwise reads "the latest snapshot only":
+
+| File:line                                          | Function                                | Intent  |
+|---                                                 |---                                      |---|
+| `src/sam/accounting/calculator.py:54`              | `calculate_charges()`                   | billing |
+| `src/sam/schemas/allocation.py:213`                | `AllocationWithUsageSchema._get_charges_by_resource_type()` | billing |
+| `src/sam/queries/charges.py:349`                   | `get_daily_charge_trends_for_accounts()`| billing |
+| `src/sam/queries/dashboard.py:909`                 | `get_resource_charges_by_date()` (subtree) | billing |
+| `src/sam/queries/dashboard.py:996`                 | `get_resource_charges_by_date()` (single account) | billing |
+| `src/sam/projects/projects.py:766`                 | `Project.get_subtree_charges()`         | billing |
+
+`DiskChargeSummaryStatus.current` is defined but never written and
+never read. It's the obvious mechanism for marking the latest
+snapshot — this plan finally wires it.
+
 ---
 
-## Approach
+## Approach (Option 2)
 
-Add a new `_run_disk()` method to `AccountingAdminCommand` plus a small,
-pluggable parser package modeled on `quota_readers/`. The command
-reuses `upsert_disk_charge_summary()` exactly — no new ORM writes.
+This plan delivers a clean **post-cutover** disk-charging pipeline
+without touching any pre-cutover row, and adds a missing **current-usage**
+read path while leaving cumulative-billing math alone.
+
+Three deliverables:
+
+1. A new `_run_disk()` import that produces TiB-year rows from
+   `acct.glade` + `cs_usage.json`, with `<unidentified>` reconciliation.
+2. A **cutover epoch** (`DISK_CHARGING_TIB_EPOCH`) — a single date
+   constant pinning when the unit convention switches. Pre-epoch rows
+   stay in decimal TB-years (left untouched); post-epoch rows are
+   TiB-years.
+3. A new "current usage" path: `_run_disk()` updates
+   `DiskChargeSummaryStatus.current`; new `Account.current_disk_usage()`
+   / `Project.current_disk_usage()` methods read it; the disk side of
+   `AllocationWithUsageSchema` exposes new `current_used_*` fields
+   alongside the existing cumulative `used`.
+
+The cumulative-billing query path is **unchanged in this PR.**
+A redesign that integrates `bytes` over time (Option 3) is summarized
+below as future work.
 
 ### CLI surface (entry point `src/cli/cmds/admin.py`)
 
@@ -145,8 +174,9 @@ sam-admin accounting --disk \
     --user-usage ./acct.glade.2026-04-18 \
     --quotas    ./cs_usage.json \
     [--reporting-interval 7] \
-    [--unidentified-user <unidentified>] \
+    [--unidentified-label <unidentified>] \
     [--reconcile-quota-gap] \
+    [--gap-tolerance "1GiB|1%"] \
     [--date 2026-04-18 | --today | --last 7d] \
     [--dry-run] [--skip-errors] [--chunk-size 500] [-v]
 ```
@@ -158,8 +188,7 @@ Notes:
 - `--quotas` (new, optional) is the same `cs_usage.json` file already
   used by `--reconcile-quotas`. Required only if
   `--reconcile-quota-gap` is set.
-- `--reporting-interval` default `7` (as documented in the legacy
-  spec); the value goes straight into the terabyte-years formula.
+- `--reporting-interval` default `7` (legacy spec).
 - `--unidentified-label` default literal `<unidentified>`. **This is a
   free-text audit label written to the `act_username` column only.**
   It is **NOT** added to the `users` table. The resolved
@@ -171,14 +200,19 @@ Notes:
   *filtering / safety*: the parsed file's snapshot date must fall in
   the requested window, otherwise we error out (prevents the wrong
   file getting fed to "yesterday").
+- The CLI **refuses to write rows with `activity_date <
+  DISK_CHARGING_TIB_EPOCH`** with a clear error pointing at the epoch
+  constant. We will not retroactively rewrite legacy data via this
+  command.
 
 ### Files to add / modify (concrete paths)
 
 #### NEW — disk usage parsers (object-oriented, pluggable)
 
 `src/cli/accounting/disk_usage/__init__.py`
-- Exports `get_disk_usage_reader(resource_name, path)` and the dataclass
-  `DiskUsageEntry(activity_date, projcode, username, number_of_files, bytes, directory_path, reporting_interval, cos)`.
+- Exports `get_disk_usage_reader(resource_name, path)` and the
+  dataclass `DiskUsageEntry(activity_date, projcode, username,
+  number_of_files, bytes, directory_path, reporting_interval, cos)`.
 - Mirror `quota_readers/__init__.py`'s registry pattern.
 
 `src/cli/accounting/disk_usage/base.py`
@@ -188,27 +222,34 @@ Notes:
 
 `src/cli/accounting/disk_usage/glade_csv.py`
 - `GladeCsvReader(DiskUsageReader)` — parses `acct.glade.YYYY-MM-DD`.
-- Columns: `(date, path, projcode, username, nfiles, fsize_bytes, reporting_interval, cos)` per
-  legacy doc §Phase 1, but **`fsize_bytes` is taken as bytes directly**
-  (no ×1024 — confirm with current data, see Investigations above).
+- Columns: `(date, path, projcode, username, nfiles, fsize_kib, reporting_interval, cos)`.
+- **`bytes = fsize_kib × 1024`** (KiB → bytes), per legacy convention.
 - Skips `gpfsnobody` and any row where `username` is purely numeric
-  (legacy "uid was never resolved" rows like row 10 of the sample
-  file).
+  (legacy "uid was never resolved" rows).
 - Honors a strict mode where unknown projcodes/usernames raise — the
   CLI's `--skip-errors` decides whether to abort or continue.
 
-`src/cli/accounting/disk_usage/registry.py` *(or fold into __init__)*
-- `Campaign_Store` → `GladeCsvReader`. Add others (Stratus,
-  Lustre/Destor) as we get sample inputs. The reader chosen by
-  `(resource_name, file extension/shape)` keeps the surface
-  filesystem-agnostic.
+`src/cli/accounting/disk_usage/charging.py`
+- Holds the single charging-math source of truth (see
+  "Charging math" below). Exposes
+  `tib_years(bytes_, reporting_interval) -> float`.
+
+#### NEW — cutover epoch and constants
+
+`src/sam/summaries/disk_constants.py` (or fold into
+`disk_summaries.py`)
+- `DISK_CHARGING_TIB_EPOCH: date` — the first `activity_date` whose
+  row is written in TiB-year units. Initially set to the date of the
+  first `--disk` run; once committed, treat as immutable.
+- `BYTES_PER_TIB = 1024 ** 4`
+- `DAYS_IN_YEAR = 365`
 
 #### MODIFY
 
 `src/cli/cmds/admin.py` (the `accounting` Click command)
-- Add the three new options (`--user-usage`, `--quotas`,
-  `--reporting-interval`, `--unidentified-user`,
-  `--reconcile-quota-gap`).
+- Add the new options (`--user-usage`, `--quotas`,
+  `--reporting-interval`, `--unidentified-label`,
+  `--reconcile-quota-gap`, `--gap-tolerance`).
 - Forward them to `AccountingAdminCommand.execute(...)` when `--disk`
   is set.
 - Validate mutual exclusion (`--machine` is HPC-only;
@@ -216,64 +257,163 @@ Notes:
   requires `--quotas`).
 
 `src/cli/accounting/commands.py`
-- Replace the `--disk` stub at lines 165–167 with a real `_run_disk()`
+- Replace the `--disk` stub at lines 165–167 with `_run_disk()`,
   modeled on `_run_comp` (lines 177–302). Pseudocode:
 
   ```python
   def _run_disk(self, resource_name, user_usage_path, quotas_path,
-                reporting_interval, unidentified_user, reconcile_gap,
-                date_window, *, dry_run, skip_errors, chunk_size, verbose):
-      # 1. Pick a reader, parse user-usage file
+                reporting_interval, unidentified_label, reconcile_gap,
+                gap_tolerance, date_window,
+                *, dry_run, skip_errors, chunk_size, verbose):
       reader = get_disk_usage_reader(resource_name, user_usage_path)
       entries = reader.read()
       if not entries: return 0
 
-      # 2. Validate snapshot date against requested window
       self._assert_snapshot_in_window(reader.snapshot_date, date_window)
+      self._assert_post_epoch(reader.snapshot_date)   # refuse pre-epoch dates
 
-      # 3. Verbose dump (reuse display_dry_run_table pattern)
-      if verbose: display_disk_dry_run_table(self.ctx, entries, ...)
-
-      # 4. Compute terabyte_years / charges per row
-      #    ty = (bytes * reporting_interval) / 365.25 / 1e12
-      #    charges = ty   (1:1 per legacy doc §Phase 2 / 3)
-
-      # 5. Optional: reconcile per-project gap from cs_usage.json
       if reconcile_gap and quotas_path:
           gap_rows = self._build_unidentified_rows(
               user_usage=entries, quotas_path=quotas_path,
-              unidentified_user=unidentified_user,
+              unidentified_label=unidentified_label,
+              gap_tolerance=gap_tolerance,
               reporting_interval=reporting_interval)
           entries.extend(gap_rows)
 
+      # Compute terabyte_years / charges per row (TiB-year math)
+      for e in entries:
+          e.terabyte_years = tib_years(e.bytes, reporting_interval)
+          e.charges        = e.terabyte_years
+
+      if verbose: display_disk_dry_run_table(self.ctx, entries)
       if dry_run: return 0
 
-      # 6. Chunk and upsert via upsert_disk_charge_summary()
+      # Chunked upsert via upsert_disk_charge_summary()
       with management_transaction(self.session):
-          for row in chunk:
-              upsert_disk_charge_summary(
-                  self.session,
-                  activity_date=row.activity_date,
-                  act_username=row.username,
-                  act_projcode=row.projcode,
-                  act_unix_uid=None,
-                  resource_name=resource_name,
-                  charges=row.charges,
-                  number_of_files=row.number_of_files,
-                  bytes=row.bytes,
-                  terabyte_years=row.terabyte_years,
-                  include_deleted_accounts=...,
-              )
+          for chunk in chunked(entries, chunk_size):
+              for row in chunk:
+                  upsert_disk_charge_summary(
+                      self.session,
+                      activity_date=row.activity_date,
+                      act_username=row.act_username,    # may be the unidentified label
+                      act_projcode=None,
+                      act_unix_uid=None,
+                      resource_name=resource_name,
+                      charges=row.charges,
+                      number_of_files=row.number_of_files,
+                      bytes=row.bytes,
+                      terabyte_years=row.terabyte_years,
+                      user=row.user_override,           # set for gap rows only
+                      account=row.account_override,     # set for gap rows only
+                  )
+          # Mark this snapshot as "current" — clears the prior current flag
+          mark_disk_snapshot_current(self.session, reader.snapshot_date)
 
-      # 7. display_import_summary(self.ctx, n_created, n_updated, n_errors, n_skipped)
+      display_import_summary(self.ctx, n_created, n_updated, n_errors, n_skipped)
   ```
 
 `src/cli/accounting/display.py`
-- Add `display_disk_dry_run_table(ctx, entries, ...)` —
-  mirror the existing `display_dry_run_table` (it's already
-  parameterized over an adapter, so we may be able to reuse it
-  with a disk-specific adapter; if not, a small parallel helper
-  is fine).
+- Add `display_disk_dry_run_table(ctx, entries, ...)` — mirror the
+  existing `display_dry_run_table`.
+
+`src/sam/manage/summaries.py:298–384`
+- Extend `_upsert_storage_summary` and
+  `upsert_disk_charge_summary` with optional pre-resolved
+  `user: Optional[User]` and `account: Optional[Account]`
+  parameters. When supplied, skip `_resolve_user`/`_resolve_account`.
+  Backward-compatible — existing callers keep working unchanged.
+
+`src/sam/summaries/disk_summaries.py`
+- Add a small helper `mark_disk_snapshot_current(session,
+  activity_date)`:
+  - Set `DiskChargeSummaryStatus.current = False` on any prior row
+    where `current = True`.
+  - Upsert `(activity_date, current=True)` for the new snapshot.
+  - Same `management_transaction` as the data writes.
+
+`src/sam/accounting/accounts.py`
+- Add `Account.current_disk_usage(session) ->
+  Optional[CurrentDiskUsage]` returning a small dataclass
+  `(activity_date, bytes, terabyte_years, number_of_files)`. Joins
+  on `DiskChargeSummaryStatus.current = True` first; falls back to
+  `MAX(activity_date)` only if the status table has no `current` row
+  (defensive — should not happen post-cutover). Returns `None` for
+  accounts whose resource is not a disk resource.
+
+`src/sam/projects/projects.py`
+- Add `Project.current_disk_usage(session, resource_name=None)`
+  returning a dict keyed by resource name (parallel to
+  `get_detailed_allocation_usage`). Internally iterates each disk
+  account and calls `Account.current_disk_usage`. Result schema:
+  `{"Campaign_Store": {"activity_date": …, "bytes": …,
+  "current_used_tib": …, "number_of_files": …}}`.
+
+`src/sam/schemas/allocation.py` — `AllocationWithUsageSchema`
+- For disk allocations only, add fields:
+  - `current_used_bytes` (int)
+  - `current_used_tib` (float, derived = bytes / 1024⁴)
+  - `current_snapshot_date` (date)
+  - `current_pct_used` (float, derived = current_used_tib /
+    allocation.amount × 100)
+  These are `null` for non-disk resources. The cumulative `used` /
+  `remaining` / `percent_used` fields are unchanged.
+
+Webapp consumers (templates / dashboards) **are not modified in this
+PR.** The new schema fields are additive; consuming them is a
+follow-up.
+
+### Charging math (single source of truth — **deviates from legacy**)
+
+```
+BYTES_PER_TIB = 1024 ** 4       # 1,099,511,627,776
+DAYS_IN_YEAR  = 365             # legacy parity (not 365.25)
+
+terabyte_years = (bytes * reporting_interval) / DAYS_IN_YEAR / BYTES_PER_TIB
+charges        = terabyte_years          # 1:1 until a Factor row says otherwise
+```
+
+Implemented once in `src/cli/accounting/disk_usage/charging.py` so the
+user-rows path and the `<unidentified>` gap path share identical code.
+
+> **Despite the column name `terabyte_years`, post-epoch values
+> represent tebibyte-years.** Renaming the column is a separate
+> change (touches the ORM, schema validation tests, and any
+> consumers — left for follow-up).
+
+### Cutover epoch — no backfill
+
+There are 104,541 pre-existing rows (back to 2025-03-21) computed
+under the legacy decimal-TB convention. **We deliberately leave them
+alone.**
+
+- A single constant `DISK_CHARGING_TIB_EPOCH` (a `date`) marks the
+  cutover. Every row with `activity_date >= EPOCH` is in TiB-years;
+  every row with `activity_date < EPOCH` is in legacy decimal
+  TB-years.
+- `_run_disk()` refuses to write rows with `activity_date < EPOCH`
+  (clear error, no surprises).
+- The first `--disk` run sets `EPOCH` to the snapshot date being
+  imported. Pick the first date whose import we want in TiB; commit
+  the constant; treat it as immutable thereafter.
+
+**Accepted consequences of leaving legacy data alone:**
+
+- **Cumulative-billing rollups that span the epoch will mix units.**
+  An allocation whose window straddles `EPOCH` will read pre-epoch
+  rows in decimal TB-years and post-epoch rows in TiB-years, and SUM
+  them as if they were the same unit. The error per-row is ~9.95%
+  on the pre-epoch portion only.
+- For most allocations this is acceptable because:
+  - Allocations whose window is entirely pre- or post-epoch are
+    self-consistent.
+  - The new "current usage" path (which is the dashboard-facing
+    answer for most users) is post-epoch by construction and
+    unambiguous.
+  - The drift is bounded and known — easy to call out in release
+    notes.
+- An optional helper view / query that converts pre-epoch rows
+  on-the-fly may be added later if the mixed-window case proves
+  noisy in practice. Not in this PR.
 
 ### Unidentified attribution (no synthetic User row)
 
@@ -298,98 +438,9 @@ literal is the only signal that the row is a synthetic
 attribution — easy to grep for, never collides with a real
 username, and never escapes into joins on the `users` table.
 
-This requires a small extension to the upsert API. Today
-`_upsert_storage_summary()` calls `_resolve_user(act_username,
-act_unix_uid)`, which would fail when `act_username='<unidentified>'`
-and there is no such user. Two options:
-
-1. **Add a pre-resolved `user` parameter to
-   `upsert_disk_charge_summary()`** — when supplied, the upsert
-   skips `_resolve_user` and uses the caller-provided User
-   directly. This is the cleanest extension and keeps the resolver
-   side-effect-free. Apply the same pattern symmetrically to the
-   archive upsert if/when needed. This is the recommended option.
-
-2. Have the caller pass `act_username=lead.username` and live with
-   losing the "this row is synthetic" signal in the audit column.
-   Rejected — defeats the purpose.
-
-→ Implement option 1: thread an optional
-`user: Optional[User] = None` (and possibly
-`account: Optional[Account] = None`, since the gap-row caller has
-already resolved both) through `_upsert_storage_summary` and
-`upsert_disk_charge_summary`. When supplied, skip the resolver
-calls; otherwise behave as today. No DB schema change needed.
-
-### Charging math (single source of truth — **deviates from legacy**)
-
-The legacy code computed `terabyte_years` using **decimal TB
-(1000⁴)** and `DAYS_IN_YEAR = 365`. That choice creates a ~10% drift
-when rolling `Σ terabyte_years` up and comparing against
-`Allocation.amount` (which is in **TiB**, 1024⁴).
-
-The new command writes `terabyte_years` in **TiB-years (binary,
-1024⁴)** so it composes cleanly with allocation amounts:
-
-```
-TIB = 1024 ** 4               # 1,099,511,627,776
-DAYS_IN_YEAR = 365            # legacy parity (not 365.25)
-
-terabyte_years = (bytes * reporting_interval) / DAYS_IN_YEAR / TIB
-charges        = terabyte_years         # 1:1 until a Factor row says otherwise
-```
-
-Implemented once in a small `disk_usage/charging.py` helper (or
-`base.py`) so the user-rows path and the `<unidentified>` gap path
-share the same code.
-
-> **Despite the column name `terabyte_years`, the values stored will
-> represent tebibyte-years going forward.** Renaming the column is a
-> separate change (touches the ORM, schema validation tests, and any
-> consumers — left for follow-up).
-
-#### One-shot backfill of existing rows
-
-There are **104,541 rows** in `disk_charge_summary` (back to
-2025-03-21) computed under the legacy decimal-TB convention. Mixing
-legacy-TB and new-TiB rows in the same column would silently drift
-allocation-balance reports.
-
-Add a one-shot migration script
-`scripts/backfill_disk_charge_summary_to_tib.py` (or an
-`alembic`-style data migration if the project uses one) that
-recomputes `terabyte_years` and `charges` from each row's existing
-`bytes` value:
-
-```python
-# inside management_transaction(session)
-for row in session.query(DiskChargeSummary).yield_per(2000):
-    row.terabyte_years = row.bytes * 7 / 365 / TIB
-    row.charges        = row.terabyte_years
-```
-
-The `bytes` column is unambiguous and unchanged. The `7` (reporting
-interval) is hard-coded for Campaign Store today; if other disk
-resources ever use a different interval the script must read it from
-the source `disk_activity` rows. This is documented in the script.
-
-Run order: ship the backfill **before** the first live `--disk` run
-so all rows in the column are in the same units. The new
-`upsert_disk_charge_summary` writes use TiB-years from the start.
-
-**Impact on existing consumers**:
-
-- `Project.get_detailed_allocation_usage()` (`src/sam/projects/projects.py`,
-  per CLAUDE.md) and the matching `AllocationWithUsageSchema`: today
-  they sum `terabyte_years` and compare against `Allocation.amount`
-  (TiB). After the migration these are unit-consistent for the
-  first time. Add a test that asserts the comparison — a known-good
-  project + allocation should report `percent_used` matching the
-  ratio computed directly from `bytes`.
-- API endpoints `/api/v1/projects/<projcode>/charges` and
-  `/api/v1/accounts/<account_id>/balance`: numbers will shift by
-  ~9.95% versus pre-migration values for disk resources. Note in
-  release notes; warn anyone consuming these.
+This requires the small upsert-API extension described above
+(pre-resolved `user`/`account` parameters), so the resolver does not
+fail on the audit label.
 
 ### Reconciliation — `--reconcile-quota-gap` flow
 
@@ -407,37 +458,40 @@ in FILESET:
 3. If `quota_bytes − Σ user_bytes > tolerance`, emit a gap row:
    load the project's lead via `Project.lead`, then upsert with
    `act_username='<unidentified>'`,
-   `user=<lead User object>` (passed as the new pre-resolved
-   parameter), `account=<resolved account>`,
+   `user=<lead User object>`, `account=<resolved account>`,
    `bytes=gap`, `number_of_files=0`, `terabyte_years` and `charges`
    computed from the same formula as user rows. Skip the project
    entirely (with a logged warning) if the lead cannot be resolved.
-   Tolerance: 1 GiB **or** 1% of quota, whichever is larger;
-   tunable via `--gap-tolerance` if needed.
+   Default tolerance: 1 GiB **or** 1% of quota, whichever is larger;
+   tunable via `--gap-tolerance`.
 4. The activity_date for these rows is the snapshot date from the
    acct file (must equal the cs_usage.json `date` field — error if
    they disagree by more than a day).
 
 ### Critical files to touch
 
-- `src/cli/cmds/admin.py` — flag wiring (lines around 100–155, the
-  `accounting` Click command def).
+- `src/cli/cmds/admin.py` — flag wiring on the `accounting` Click
+  command.
 - `src/cli/accounting/commands.py` — replace `--disk` stub (165–167)
-  with `_run_disk`; add helpers for snapshot-window validation and
-  unidentified-row construction.
-- `src/cli/accounting/disk_usage/{__init__,base,glade_csv}.py` — new
-  parser package.
+  with `_run_disk`; add helpers for snapshot-window validation,
+  epoch enforcement, and unidentified-row construction.
+- `src/cli/accounting/disk_usage/{__init__,base,glade_csv,charging}.py`
+  — new parser package + charging-math helper.
 - `src/cli/accounting/display.py` — add disk dry-run table.
+- `src/sam/summaries/disk_summaries.py` — add
+  `mark_disk_snapshot_current()` helper; add the
+  `DISK_CHARGING_TIB_EPOCH` constant (or split into a
+  `disk_constants.py`).
 - `src/sam/manage/summaries.py:298–384` — extend
   `_upsert_storage_summary` and `upsert_disk_charge_summary` with
-  optional pre-resolved `user`/`account` parameters (see
-  "Unidentified attribution" above). Backward-compatible — existing
-  callers keep working unchanged.
-- *(read-only reuse)* `src/cli/accounting/quota_readers/gpfs.py` — for
-  the `--reconcile-quota-gap` path we re-read the JSON, but go
-  through the dict directly to avoid the suspected `_KIB` bug; we do
-  NOT depend on `GpfsQuotaReader.read()` returning bytes correctly.
-  (See "Out of scope" below.)
+  optional pre-resolved `user`/`account` parameters.
+- `src/sam/accounting/accounts.py` — add
+  `Account.current_disk_usage()`.
+- `src/sam/projects/projects.py` — add `Project.current_disk_usage()`.
+- `src/sam/schemas/allocation.py` — add
+  `current_used_bytes`/`current_used_tib`/`current_snapshot_date`/
+  `current_pct_used` to `AllocationWithUsageSchema` (disk-only,
+  null otherwise).
 
 ### Existing helpers to reuse (paths confirmed)
 
@@ -453,25 +507,126 @@ in FILESET:
 - `Resource.get_by_name`, `Account.get_by_project_and_resource`,
   `User.get_by_username`, `Project.get_by_projcode` — already wired
   into the upsert path; do not duplicate.
+- `cli.accounting.quota_readers.gpfs.GpfsQuotaReader` — reuse for
+  the FILESET parse on the `--reconcile-quota-gap` path. Its
+  `_KIB = 1024` is correct.
 
 ### Out of scope (for this PR)
 
+- **Backfilling pre-epoch rows.** Deliberate — see "Cutover epoch"
+  above. Old rows stay in decimal TB-years, untouched.
 - **Renaming `disk_charge_summary.terabyte_years` to a TiB-correct
-  name** (e.g. `tebibyte_years`). The unit content changes here but
-  the column name stays — rename in a follow-up that updates the
-  ORM, schema validation tests, schemas, and any consumers.
-- **Path-based reconciliation against `ProjectDirectory`.** Phase 2
-  only applies when the simple `acct path → projcode` mapping is
-  unavailable; if needed it can be added as a fallback in a
-  follow-up.
-- **Charging factor ≠ 1.0** (the doc hints "currently 1:1 with
-  TB-Years"). If/when a `Factor` row controls disk charging, drop in
-  a multiplier without changing the parser layer.
+  name** (e.g. `tebibyte_years`). Unit content changes here but the
+  column name stays — rename in a follow-up.
+- **Updating webapp templates / dashboards** to consume the new
+  `current_used_*` schema fields. The schema gains the fields; UI
+  follow-up is separate.
+- **Path-based reconciliation against `ProjectDirectory`** as the
+  primary mapping. We use it only as a fallback when the acct
+  `path → projcode` mapping is unavailable.
+- **Charging factor ≠ 1.0.** If/when a `Factor` row controls disk
+  charging, drop in a multiplier without changing the parser layer.
 - **Reading the legacy Spring upload endpoint
   `/protected/admin/dasg/glade/upload`** in the *current* webapp.
-  The Java endpoint
-  (`legacy_sam/.../GladeDataRRH.java`) is documented for context;
-  this PR is CLI-only and does not port the upload endpoint.
+  The Java endpoint (`legacy_sam/.../GladeDataRRH.java`) is documented
+  for context; this PR is CLI-only.
+- **Option 3 (integrate-bytes-over-time billing).** Summarized below
+  as future work.
+
+---
+
+## Future work — Option 3: integrate-bytes-over-time billing
+
+This PR delivers **Option 2** (current-snapshot path + epoch cutover
+for new rows). The deeper redesign of *cumulative billing* is
+deferred to a follow-up. Capturing the design intent here so we
+don't lose context.
+
+### Why Option 3 exists
+
+Comp/DAV/Archive activity is *flow*: a row records new charges
+accruing on a given day. Summing flow over a window gives the
+correct total.
+
+Disk activity is *stock*: each daily/weekly row is a full inventory
+snapshot. Pre-multiplying by `reporting_interval / 365` at ingest
+bakes the time dimension into the row, so summing works **only if**
+every snapshot's interval exactly tiles the window with no gaps and
+no overlaps. The legacy doc itself flags this fragility:
+
+> *"If the snapshot frequency changes (e.g., to daily), this value
+> must be updated to `1` to prevent 7× over-billing."*
+
+A single hard-coded `7` in the import path is the entire defense
+against under- or over-billing. There is no consumer-side check.
+
+### What Option 3 changes
+
+Stop pre-multiplying at ingest. Store **bytes per snapshot only**;
+let the billing query integrate over time using the actual gap
+between consecutive snapshots:
+
+```
+billing_TiB_years
+  = Σ over snapshots i in window:
+        (bytes_i / 1024⁴)
+        × (date(snapshot_{i+1}) − date(snapshot_i)) / 365
+```
+
+The last snapshot in the window uses `min(window_end, today)` as its
+right edge. Missing days are absorbed into the next observed
+snapshot (or warned about). Mixed cadences (weekly archive +
+daily current) compose correctly without a magic constant.
+
+### What needs to change for Option 3
+
+1. **Stop writing the pre-multiplied column at ingest.** Either
+   leave `terabyte_years` NULL post-Option-3-epoch, or repurpose it
+   to mean "TiB at snapshot" (= `bytes / 1024⁴`) and rename.
+2. **Replace the six SUM call sites** (see "Consumption survey"
+   above) with the integration query. Likely one helper in
+   `src/sam/queries/charges.py` that takes
+   `(account_ids, start, end)` and returns TiB-years computed from
+   `bytes` + `LAG(activity_date)` window function. MySQL/MariaDB
+   support `LAG` (MariaDB ≥ 10.2 / MySQL ≥ 8.0).
+3. **Update `AllocationWithUsageSchema._get_charges_by_resource_type`**
+   to call the new helper for disk resources.
+4. **Update `Project.get_detailed_allocation_usage` /
+   `get_subtree_charges`** to route disk through the integration
+   helper.
+5. **Update `get_daily_charge_trends_for_accounts`** to either
+   keep returning per-day occupancy (already correct — it doesn't
+   sum bytes, it groups by date) or expose a parallel "TiB-year per
+   day" series computed from interval-deltas.
+6. **Decide the fate of `disk_activity` / `disk_charge`** —
+   they currently store the per-snapshot numbers we'd be reading
+   from. Either keep them as the source of truth and stop deriving
+   `disk_charge_summary` at all, or keep `disk_charge_summary` as a
+   denormalized view but with `terabyte_years` derived at read time.
+7. **Tests**: add fixtures with deliberately uneven cadences (a
+   missing Wednesday, a daily-then-weekly transition, a snapshot
+   straddling allocation boundaries) and assert billing math
+   matches a hand-computed integral.
+8. **Migration story** for the existing data: same cutover-epoch
+   approach probably makes sense, with a second epoch
+   `DISK_CHARGING_INTEGRATION_EPOCH`. Pre-epoch rows are read by
+   the legacy SUM; post-epoch by the integration helper. A wrapper
+   query handles allocations that straddle.
+
+### Why we are not doing it now
+
+- It touches every disk consumer in the codebase (six SUM call
+  sites, two schemas, dashboards).
+- Combining it with the unit switch (TB → TiB) and the
+  `<unidentified>` reconciliation in the same PR makes any
+  regression hard to bisect.
+- Option 2 already gives webapp dashboards the answer they
+  actually want for the common "how full are we right now" question.
+
+A separate plan (`docs/plans/DISK_BILLING_INTEGRATION.md`) should be
+written when work begins. The current plan deliberately keeps
+billing math *bug-for-bug compatible* with the legacy approach
+post-epoch, modulo the unit switch.
 
 ---
 
@@ -491,45 +646,34 @@ sam-admin accounting --disk \
     --date 2026-04-18 \
     --dry-run -v
 
-# Compare the dry-run table against the existing DB rows:
-mysql -h 127.0.0.1 -u root -proot sam --table -e "
-  SELECT projcode, username, number_of_files, bytes,
-         ROUND(terabyte_years,4) AS ty, ROUND(charges,4) AS ch
-  FROM disk_charge_summary
-  WHERE activity_date = '2026-04-18'
-  ORDER BY bytes DESC LIMIT 30"
-
-# Live run (idempotent; existing 104,541 rows for 2026-04-18 will UPDATE in place):
+# Live run — date must be >= DISK_CHARGING_TIB_EPOCH or we refuse:
 sam-admin accounting --disk \
     --resource Campaign_Store \
     --user-usage ./acct.glade.2026-04-18 \
     --quotas    ./cs_usage.json \
     --reconcile-quota-gap
 
-# Spot check a known-tricky case (cgd → cgd/amp, cgd/oce subdirs):
-mysql ... -e "SELECT username, bytes FROM disk_charge_summary
-              WHERE projcode IN ('CGD','NCGD0009') AND activity_date='2026-04-18'"
+# Confirm the snapshot was marked current:
+mysql -h 127.0.0.1 -u root -proot sam --table -e "
+  SELECT * FROM disk_charge_summary_status WHERE current = 1"
+
+# Confirm a known row is now in TiB-years:
+mysql -h 127.0.0.1 -u root -proot sam --table -e "
+  SELECT projcode, username, bytes,
+         ROUND(terabyte_years,5)                               AS ty_stored,
+         ROUND(bytes * 7 / 365 / POW(1024,4), 5)               AS ty_expected_tib,
+         ROUND(terabyte_years / (bytes * 7 / 365 / POW(1024,4)), 5) AS unity
+  FROM disk_charge_summary
+  WHERE activity_date = '2026-04-18' AND username = 'wchapman'"
+# 'unity' should be ≈ 1.0 for every post-epoch row.
+
+# Spot check the gap row:
+mysql ... -e "
+  SELECT projcode, username, act_username, bytes
+  FROM disk_charge_summary
+  WHERE activity_date = '2026-04-18' AND act_username = '<unidentified>'
+  LIMIT 5"
 ```
-
-### Tests
-
-- `tests/unit/test_disk_usage_reader.py` — new. Use a small inline
-  CSV fixture; assert dataclass values, `gpfsnobody`/numeric-username
-  filtering, snapshot-date parsing.
-- `tests/unit/test_accounting_disk_admin.py` — new. Use the existing
-  Layer-2 factories (`make_user`, `make_project`, `make_allocation`)
-  to build a tiny project graph (with an explicit lead user); feed a
-  5-row temp acct file + 3-key cs_usage.json; run the admin command
-  via `CliRunner`; assert rows in `disk_charge_summary` (created vs
-  updated counts, and the gap row has
-  `act_username='<unidentified>'` AND `user_id == lead.user_id`).
-- `tests/unit/test_upsert_disk_pre_resolved.py` — new. Targeted unit
-  test for the `user=`/`account=` override paths in
-  `upsert_disk_charge_summary` — confirms `_resolve_user` is not
-  called and `act_username` is stored verbatim.
-- `tests/integration/test_admin_disk_smoke.py` — subprocess `sam-admin
-  accounting --disk … --dry-run` against the test DB.
-- Re-run full suite: `pytest` (~65s, parallel).
 
 ### Charging-math sanity check (TiB-years)
 
@@ -545,20 +689,42 @@ terabyte_years (TiB-yr) = 241,601,257,783,296 × 7 / 365 / 1024**4
 
 Confirm after a live run that the DB row for `(2026-04-18, NAML0001,
 wchapman)` shows:
-- `bytes = 241,601,257,783,296` (unchanged from legacy import)
-- `terabyte_years ≈ 4.21500` (was `4.63345` before the backfill)
+- `bytes = 241,601,257,783,296`
+- `terabyte_years ≈ 4.21500`
 - `charges = terabyte_years` to four decimal places
 
-### Backfill spot-check
+### Tests
 
-After running `scripts/backfill_disk_charge_summary_to_tib.py`:
-
-```sql
--- Pick any pre-existing row, eyeball ratio:
-SELECT bytes, terabyte_years,
-       terabyte_years / (bytes * 7 / 365 / POW(1024,4)) AS unity
-FROM disk_charge_summary
-WHERE activity_date = '2026-04-18' AND username = 'wchapman'
-LIMIT 5;
--- 'unity' should be ≈ 1.0 for every row.
-```
+- `tests/unit/test_disk_usage_reader.py` — new. Inline CSV fixture;
+  assert dataclass values, `gpfsnobody`/numeric-username filtering,
+  snapshot-date parsing, KiB→bytes conversion.
+- `tests/unit/test_disk_charging_math.py` — new. Single-purpose unit
+  test for `tib_years()`. Pin the formula constants and the
+  `wchapman` worked example.
+- `tests/unit/test_accounting_disk_admin.py` — new. Use Layer-2
+  factories (`make_user`, `make_project`, `make_allocation`) to
+  build a project with an explicit lead; feed a 5-row temp acct
+  file + 3-key cs_usage.json; run the admin command via
+  `CliRunner`; assert:
+  - rows in `disk_charge_summary` have correct created/updated counts
+  - the gap row has `act_username='<unidentified>'` AND
+    `user_id == lead.user_id`
+  - `disk_charge_summary_status` has exactly one row with
+    `current=True` matching the snapshot date.
+- `tests/unit/test_upsert_disk_pre_resolved.py` — new. Targeted
+  unit test for the `user=`/`account=` override paths in
+  `upsert_disk_charge_summary` — confirms `_resolve_user` is not
+  called and `act_username` is stored verbatim.
+- `tests/unit/test_current_disk_usage.py` — new. Seed two
+  snapshots (different dates) for the same account; mark only the
+  later as `current=True`; assert
+  `Account.current_disk_usage()` returns the later row's bytes,
+  not a sum.
+- `tests/unit/test_allocation_schema_disk_current.py` — new. Pin
+  the new `current_used_*` fields on `AllocationWithUsageSchema`
+  for a disk allocation.
+- `tests/unit/test_disk_epoch_enforcement.py` — new. CLI run with
+  a snapshot date < EPOCH must error cleanly without writing.
+- `tests/integration/test_admin_disk_smoke.py` — subprocess
+  `sam-admin accounting --disk … --dry-run` against the test DB.
+- Re-run full suite: `pytest` (~65s, parallel).

--- a/docs/plans/DISK_CHARGING.md
+++ b/docs/plans/DISK_CHARGING.md
@@ -1,0 +1,564 @@
+# Plan: `sam-admin accounting --disk` for `disk_charge_summary` updates
+
+## Context
+
+The legacy Java/Hibernate path that populated `disk_charge_summary`
+from per-user-per-project disk snapshots is gone. We have:
+
+- A working `--comp --machine ...` path that imports per-job HPC usage
+  and upserts into `comp_charge_summary` via `upsert_comp_charge_summary()`.
+- A working `--reconcile-quotas <cs_usage.json>` path that compares
+  GPFS fileset quotas against SAM allocations (read-only on
+  allocations; never touches `disk_charge_summary`).
+- A complete, **already-implemented** `upsert_disk_charge_summary()` in
+  `src/sam/manage/summaries.py:377` (delegates to
+  `_upsert_storage_summary`, lines 298–374). This handles user/project/
+  resource/account resolution, facility derivation, and PUT-style upsert.
+- A `--disk` flag in the CLI that today just prints
+  *"not yet implemented"* (`src/cli/accounting/commands.py:165–167`).
+
+We need to wire **two complementary inputs** into a daily disk-charge
+import for `Campaign_Store`:
+
+1. **`acct.glade.YYYY-MM-DD`** — CSV of per-user-per-project usage
+   (the only source of `(user, project, bytes, files)` tuples).
+2. **`cs_usage.json`** — GPFS quota dump with **per-fileset totals
+   (FILESET)** and **per-user totals (USR)**, but **no user→project
+   mapping**.
+
+The acct file alone is sufficient for *most* projects, but FILESET
+totals don't always equal the sum of per-user rows (some bytes are
+owned by service accounts or by users absent from the per-user
+report). The reconciliation strategy is to attribute any unaccounted
+project-level bytes to a synthetic `<unidentified>` user so SAM books
+match GPFS truth.
+
+### Investigations performed (verified in this plan session)
+
+**Schema & data**
+
+- `disk_charge_summary` schema confirmed against MySQL — matches the
+  ORM in `src/sam/summaries/disk_summaries.py` (PK
+  `disk_charge_summary_id`, natural key
+  `(activity_date, act_username, act_projcode, account_id)`, columns
+  include `number_of_files`, `bytes`, `terabyte_years`, `charges`,
+  with `act_*` columns NULL for disk per the legacy doc).
+  Latest `activity_date` in DB is **2026-04-18** (104,541 rows total).
+  This exact `acct.glade.2026-04-18` import is already present, so
+  the new command will UPDATE those rows on idempotent re-runs.
+
+**Units (carefully verified)**
+
+The legacy Java doc was correct about `KiB`; my earlier byte-vs-KiB
+analysis was wrong. Verified by exact match against an existing DB row:
+
+```
+acct row:   wchapman / cgd/amp / number_of_files=1361584 / col6=142,788,904,480
+DB row:     wchapman / NCGD0009 / number_of_files=1361584 / bytes=146,215,838,187,520
+ratio:      146,215,838,187,520 / 142,788,904,480 = 1024.000000  ← exact
+ty check:   146,215,838,187,520 × 7 / 365 / 1e12 = 2.8041  ← matches DB 2.80413938
+```
+
+So the corrected unit map is:
+
+| Source                                  | Unit       |
+|---                                       |---|
+| `acct.glade` column 6 (`fileSizeTotal`) | **KiB**    |
+| `cs_usage.json` `FILESET[*].usage`/`USR[*].usage` | **KiB** |
+| `disk_activity.bytes`                   | bytes (= col6 × 1024) |
+| `disk_charge_summary.bytes`             | bytes (sum of activity bytes) |
+| `disk_charge_summary.terabyte_years`    | **TB-years (decimal, 10¹²)** ← legacy convention |
+| `Allocation.amount` (disk)              | **TiB (binary, 1024⁴)** |
+
+The legacy `GpfsQuotaReader._KIB = 1024` and the legacy
+`DiskActivity.Factory` × 1024 multiply are **both correct** — no
+unit bug there.
+
+**Legacy formula confirmed** (from
+`legacy_sam/.../TByteYearStorageChargeFormula.java:24-26`,
+`Constants.java:43`, `FileSizeUtil.java:8,15`):
+
+```
+terabyte_year = (bytes * reportingInterval) / DAYS_IN_YEAR / BYTES_PER_TB
+              = (bytes * 7)                / 365         / 1e12
+```
+
+The legacy doc's "365.25" claim is **wrong** — the constant in code
+is exactly `365`. The legacy "TB" is **decimal** (1000⁴), not TiB.
+
+**The unit-mismatch problem the user wants to fix**
+
+`disk_charge_summary.terabyte_years` is decimal TB-years.
+`Allocation.amount` (for disk) is **TiB**. When the
+allocation-balance calculation rolls up
+`Σ terabyte_years` and compares to `Allocation.amount`, the two
+values differ by ~9.95% (`1024⁴ / 10¹² = 1.099511627776`).
+
+→ This plan switches the new command (and a one-shot backfill of
+existing rows) to **TiB-years (1024⁴)** so the column units
+match the allocation column units. Formula becomes:
+
+```
+terabyte_years_TiB = (bytes * reporting_interval) / 365 / (1024**4)
+```
+
+We keep `365` (not `365.25`) for legacy parity — this is a billing
+convention, and changing it has no effect on allocation comparisons
+as long as both sides use the same value.
+
+**Reconciliation gap is small but real**
+
+Reading FILESET vs Σ(per-user acct rows):
+
+- Total FILESET usage: 130.74 PB (= 127.68 TB × 1024 KiB → KiB-units
+  match, no scale comparison meaningful here without recomputing in
+  bytes; gap percentage holds either way).
+- Corpus-wide gap: ~1.5%. 295 filesets in FILESET have **no** acct
+  rows at all (`jntp`, `vast`, `cesmdata`, `fedata`, parent `cgd`).
+  Top per-project measurable gaps: `acom` ~53 GB, `uokl0045` ~12 GB,
+  `utam0020` ~6 GB.
+- The acct file and FILESET use *different* keys for the project axis:
+  acct's column 3 is the **SAM projcode** (e.g. `p48503002`); FILESET
+  is keyed by **fileset name** (e.g. `jntp`). The mapping
+  `fileset_name → projcode` is recoverable from the acct file itself
+  (column 2 path → column 3 projcode) for any fileset that has at
+  least one acct row, and 295 FILESET-only filesets cannot be mapped
+  this way. For those we fall back to *path → projcode* derivation
+  via SAM's `ProjectDirectory` table (already used by
+  `_run_reconcile_quotas`).
+
+---
+
+## Approach
+
+Add a new `_run_disk()` method to `AccountingAdminCommand` plus a small,
+pluggable parser package modeled on `quota_readers/`. The command
+reuses `upsert_disk_charge_summary()` exactly — no new ORM writes.
+
+### CLI surface (entry point `src/cli/cmds/admin.py`)
+
+Extend the existing `accounting` Click command (no new top-level command):
+
+```
+sam-admin accounting --disk \
+    --resource Campaign_Store \
+    --user-usage ./acct.glade.2026-04-18 \
+    --quotas    ./cs_usage.json \
+    [--reporting-interval 7] \
+    [--unidentified-user <unidentified>] \
+    [--reconcile-quota-gap] \
+    [--date 2026-04-18 | --today | --last 7d] \
+    [--dry-run] [--skip-errors] [--chunk-size 500] [-v]
+```
+
+Notes:
+- `--user-usage` (new) is the per-user-per-project file.
+  Same-shape positional input as `--reconcile-quotas` — Click `Path`,
+  must exist.
+- `--quotas` (new, optional) is the same `cs_usage.json` file already
+  used by `--reconcile-quotas`. Required only if
+  `--reconcile-quota-gap` is set.
+- `--reporting-interval` default `7` (as documented in the legacy
+  spec); the value goes straight into the terabyte-years formula.
+- `--unidentified-label` default literal `<unidentified>`. **This is a
+  free-text audit label written to the `act_username` column only.**
+  It is **NOT** added to the `users` table. The resolved
+  `user_id`/`username` for gap rows is the project lead (see
+  "Unidentified attribution" below).
+- The existing `--resource` flag is reused; `--machine` is ignored for
+  disk (and we error if both `--disk` and `--machine` are passed).
+- Date selection (`--date`/`--today`/`--last`) is honored for
+  *filtering / safety*: the parsed file's snapshot date must fall in
+  the requested window, otherwise we error out (prevents the wrong
+  file getting fed to "yesterday").
+
+### Files to add / modify (concrete paths)
+
+#### NEW — disk usage parsers (object-oriented, pluggable)
+
+`src/cli/accounting/disk_usage/__init__.py`
+- Exports `get_disk_usage_reader(resource_name, path)` and the dataclass
+  `DiskUsageEntry(activity_date, projcode, username, number_of_files, bytes, directory_path, reporting_interval, cos)`.
+- Mirror `quota_readers/__init__.py`'s registry pattern.
+
+`src/cli/accounting/disk_usage/base.py`
+- `DiskUsageReader` ABC with `path: str`, `snapshot_date: date | None`,
+  `read() -> list[DiskUsageEntry]`.
+- `DiskUsageEntry` dataclass.
+
+`src/cli/accounting/disk_usage/glade_csv.py`
+- `GladeCsvReader(DiskUsageReader)` — parses `acct.glade.YYYY-MM-DD`.
+- Columns: `(date, path, projcode, username, nfiles, fsize_bytes, reporting_interval, cos)` per
+  legacy doc §Phase 1, but **`fsize_bytes` is taken as bytes directly**
+  (no ×1024 — confirm with current data, see Investigations above).
+- Skips `gpfsnobody` and any row where `username` is purely numeric
+  (legacy "uid was never resolved" rows like row 10 of the sample
+  file).
+- Honors a strict mode where unknown projcodes/usernames raise — the
+  CLI's `--skip-errors` decides whether to abort or continue.
+
+`src/cli/accounting/disk_usage/registry.py` *(or fold into __init__)*
+- `Campaign_Store` → `GladeCsvReader`. Add others (Stratus,
+  Lustre/Destor) as we get sample inputs. The reader chosen by
+  `(resource_name, file extension/shape)` keeps the surface
+  filesystem-agnostic.
+
+#### MODIFY
+
+`src/cli/cmds/admin.py` (the `accounting` Click command)
+- Add the three new options (`--user-usage`, `--quotas`,
+  `--reporting-interval`, `--unidentified-user`,
+  `--reconcile-quota-gap`).
+- Forward them to `AccountingAdminCommand.execute(...)` when `--disk`
+  is set.
+- Validate mutual exclusion (`--machine` is HPC-only;
+  `--user-usage` is required for `--disk`; `--reconcile-quota-gap`
+  requires `--quotas`).
+
+`src/cli/accounting/commands.py`
+- Replace the `--disk` stub at lines 165–167 with a real `_run_disk()`
+  modeled on `_run_comp` (lines 177–302). Pseudocode:
+
+  ```python
+  def _run_disk(self, resource_name, user_usage_path, quotas_path,
+                reporting_interval, unidentified_user, reconcile_gap,
+                date_window, *, dry_run, skip_errors, chunk_size, verbose):
+      # 1. Pick a reader, parse user-usage file
+      reader = get_disk_usage_reader(resource_name, user_usage_path)
+      entries = reader.read()
+      if not entries: return 0
+
+      # 2. Validate snapshot date against requested window
+      self._assert_snapshot_in_window(reader.snapshot_date, date_window)
+
+      # 3. Verbose dump (reuse display_dry_run_table pattern)
+      if verbose: display_disk_dry_run_table(self.ctx, entries, ...)
+
+      # 4. Compute terabyte_years / charges per row
+      #    ty = (bytes * reporting_interval) / 365.25 / 1e12
+      #    charges = ty   (1:1 per legacy doc §Phase 2 / 3)
+
+      # 5. Optional: reconcile per-project gap from cs_usage.json
+      if reconcile_gap and quotas_path:
+          gap_rows = self._build_unidentified_rows(
+              user_usage=entries, quotas_path=quotas_path,
+              unidentified_user=unidentified_user,
+              reporting_interval=reporting_interval)
+          entries.extend(gap_rows)
+
+      if dry_run: return 0
+
+      # 6. Chunk and upsert via upsert_disk_charge_summary()
+      with management_transaction(self.session):
+          for row in chunk:
+              upsert_disk_charge_summary(
+                  self.session,
+                  activity_date=row.activity_date,
+                  act_username=row.username,
+                  act_projcode=row.projcode,
+                  act_unix_uid=None,
+                  resource_name=resource_name,
+                  charges=row.charges,
+                  number_of_files=row.number_of_files,
+                  bytes=row.bytes,
+                  terabyte_years=row.terabyte_years,
+                  include_deleted_accounts=...,
+              )
+
+      # 7. display_import_summary(self.ctx, n_created, n_updated, n_errors, n_skipped)
+  ```
+
+`src/cli/accounting/display.py`
+- Add `display_disk_dry_run_table(ctx, entries, ...)` —
+  mirror the existing `display_dry_run_table` (it's already
+  parameterized over an adapter, so we may be able to reuse it
+  with a disk-specific adapter; if not, a small parallel helper
+  is fine).
+
+### Unidentified attribution (no synthetic User row)
+
+**No `<unidentified>` row is added to the `users` table.** Synthetic
+rows in core lookup tables leak into webapp listings, RBAC, schemas,
+and access-control checks. Instead, the gap is carried entirely in
+the audit columns of `disk_charge_summary`:
+
+| Column        | Value for a normal row  | Value for a gap row                |
+| ---           | ---                     | ---                                |
+| `act_username`| NULL (per legacy doc)   | `'<unidentified>'`  ← audit label  |
+| `act_projcode`| NULL                    | NULL                               |
+| `act_unix_uid`| NULL                    | NULL                               |
+| `username`    | the actual user         | **the project lead's username**    |
+| `user_id`     | the actual user.id      | **the project lead's user_id**     |
+| `projcode`    | resolved projcode       | resolved projcode                  |
+| `account_id`  | resolved account.id     | resolved account.id                |
+
+Every project has a guaranteed `lead` (`Project.lead` property), so
+the FK side is always satisfiable. The `act_username='<unidentified>'`
+literal is the only signal that the row is a synthetic
+attribution — easy to grep for, never collides with a real
+username, and never escapes into joins on the `users` table.
+
+This requires a small extension to the upsert API. Today
+`_upsert_storage_summary()` calls `_resolve_user(act_username,
+act_unix_uid)`, which would fail when `act_username='<unidentified>'`
+and there is no such user. Two options:
+
+1. **Add a pre-resolved `user` parameter to
+   `upsert_disk_charge_summary()`** — when supplied, the upsert
+   skips `_resolve_user` and uses the caller-provided User
+   directly. This is the cleanest extension and keeps the resolver
+   side-effect-free. Apply the same pattern symmetrically to the
+   archive upsert if/when needed. This is the recommended option.
+
+2. Have the caller pass `act_username=lead.username` and live with
+   losing the "this row is synthetic" signal in the audit column.
+   Rejected — defeats the purpose.
+
+→ Implement option 1: thread an optional
+`user: Optional[User] = None` (and possibly
+`account: Optional[Account] = None`, since the gap-row caller has
+already resolved both) through `_upsert_storage_summary` and
+`upsert_disk_charge_summary`. When supplied, skip the resolver
+calls; otherwise behave as today. No DB schema change needed.
+
+### Charging math (single source of truth — **deviates from legacy**)
+
+The legacy code computed `terabyte_years` using **decimal TB
+(1000⁴)** and `DAYS_IN_YEAR = 365`. That choice creates a ~10% drift
+when rolling `Σ terabyte_years` up and comparing against
+`Allocation.amount` (which is in **TiB**, 1024⁴).
+
+The new command writes `terabyte_years` in **TiB-years (binary,
+1024⁴)** so it composes cleanly with allocation amounts:
+
+```
+TIB = 1024 ** 4               # 1,099,511,627,776
+DAYS_IN_YEAR = 365            # legacy parity (not 365.25)
+
+terabyte_years = (bytes * reporting_interval) / DAYS_IN_YEAR / TIB
+charges        = terabyte_years         # 1:1 until a Factor row says otherwise
+```
+
+Implemented once in a small `disk_usage/charging.py` helper (or
+`base.py`) so the user-rows path and the `<unidentified>` gap path
+share the same code.
+
+> **Despite the column name `terabyte_years`, the values stored will
+> represent tebibyte-years going forward.** Renaming the column is a
+> separate change (touches the ORM, schema validation tests, and any
+> consumers — left for follow-up).
+
+#### One-shot backfill of existing rows
+
+There are **104,541 rows** in `disk_charge_summary` (back to
+2025-03-21) computed under the legacy decimal-TB convention. Mixing
+legacy-TB and new-TiB rows in the same column would silently drift
+allocation-balance reports.
+
+Add a one-shot migration script
+`scripts/backfill_disk_charge_summary_to_tib.py` (or an
+`alembic`-style data migration if the project uses one) that
+recomputes `terabyte_years` and `charges` from each row's existing
+`bytes` value:
+
+```python
+# inside management_transaction(session)
+for row in session.query(DiskChargeSummary).yield_per(2000):
+    row.terabyte_years = row.bytes * 7 / 365 / TIB
+    row.charges        = row.terabyte_years
+```
+
+The `bytes` column is unambiguous and unchanged. The `7` (reporting
+interval) is hard-coded for Campaign Store today; if other disk
+resources ever use a different interval the script must read it from
+the source `disk_activity` rows. This is documented in the script.
+
+Run order: ship the backfill **before** the first live `--disk` run
+so all rows in the column are in the same units. The new
+`upsert_disk_charge_summary` writes use TiB-years from the start.
+
+**Impact on existing consumers**:
+
+- `Project.get_detailed_allocation_usage()` (`src/sam/projects/projects.py`,
+  per CLAUDE.md) and the matching `AllocationWithUsageSchema`: today
+  they sum `terabyte_years` and compare against `Allocation.amount`
+  (TiB). After the migration these are unit-consistent for the
+  first time. Add a test that asserts the comparison — a known-good
+  project + allocation should report `percent_used` matching the
+  ratio computed directly from `bytes`.
+- API endpoints `/api/v1/projects/<projcode>/charges` and
+  `/api/v1/accounts/<account_id>/balance`: numbers will shift by
+  ~9.95% versus pre-migration values for disk resources. Note in
+  release notes; warn anyone consuming these.
+
+### Reconciliation — `--reconcile-quota-gap` flow
+
+For each project that appears in **both** the user-usage parse and
+`cs_usage.json` FILESET, **and** for any project that appears only
+in FILESET:
+
+1. Compute `Σ user_bytes` from acct rows for that projcode.
+2. Compute `quota_bytes` from FILESET (joining via fileset name →
+   projcode). Mapping precedence:
+   a. If any acct row has `path` matching a FILESET path → trust that
+      `path → projcode`.
+   b. Else look up `ProjectDirectory.path` matches in SAM.
+   c. Else log a warning row and skip (do NOT silently mis-attribute).
+3. If `quota_bytes − Σ user_bytes > tolerance`, emit a gap row:
+   load the project's lead via `Project.lead`, then upsert with
+   `act_username='<unidentified>'`,
+   `user=<lead User object>` (passed as the new pre-resolved
+   parameter), `account=<resolved account>`,
+   `bytes=gap`, `number_of_files=0`, `terabyte_years` and `charges`
+   computed from the same formula as user rows. Skip the project
+   entirely (with a logged warning) if the lead cannot be resolved.
+   Tolerance: 1 GiB **or** 1% of quota, whichever is larger;
+   tunable via `--gap-tolerance` if needed.
+4. The activity_date for these rows is the snapshot date from the
+   acct file (must equal the cs_usage.json `date` field — error if
+   they disagree by more than a day).
+
+### Critical files to touch
+
+- `src/cli/cmds/admin.py` — flag wiring (lines around 100–155, the
+  `accounting` Click command def).
+- `src/cli/accounting/commands.py` — replace `--disk` stub (165–167)
+  with `_run_disk`; add helpers for snapshot-window validation and
+  unidentified-row construction.
+- `src/cli/accounting/disk_usage/{__init__,base,glade_csv}.py` — new
+  parser package.
+- `src/cli/accounting/display.py` — add disk dry-run table.
+- `src/sam/manage/summaries.py:298–384` — extend
+  `_upsert_storage_summary` and `upsert_disk_charge_summary` with
+  optional pre-resolved `user`/`account` parameters (see
+  "Unidentified attribution" above). Backward-compatible — existing
+  callers keep working unchanged.
+- *(read-only reuse)* `src/cli/accounting/quota_readers/gpfs.py` — for
+  the `--reconcile-quota-gap` path we re-read the JSON, but go
+  through the dict directly to avoid the suspected `_KIB` bug; we do
+  NOT depend on `GpfsQuotaReader.read()` returning bytes correctly.
+  (See "Out of scope" below.)
+
+### Existing helpers to reuse (paths confirmed)
+
+- `sam.manage.summaries.upsert_disk_charge_summary` — full
+  user/project/resource/account/facility resolution and PUT-style
+  upsert. (`src/sam/manage/summaries.py:377`)
+- `sam.manage.transaction.management_transaction` — chunk-level
+  commit/rollback. (used identically to `_run_comp`)
+- `cli.accounting.display.display_import_summary` — created/updated/
+  errors/skipped totals. (`src/cli/accounting/display.py`)
+- `cli.core.base.BaseCommand` — provides `self.session`,
+  `self.console`, `self.ctx`, `self.require_plugin`.
+- `Resource.get_by_name`, `Account.get_by_project_and_resource`,
+  `User.get_by_username`, `Project.get_by_projcode` — already wired
+  into the upsert path; do not duplicate.
+
+### Out of scope (for this PR)
+
+- **Renaming `disk_charge_summary.terabyte_years` to a TiB-correct
+  name** (e.g. `tebibyte_years`). The unit content changes here but
+  the column name stays — rename in a follow-up that updates the
+  ORM, schema validation tests, schemas, and any consumers.
+- **Path-based reconciliation against `ProjectDirectory`.** Phase 2
+  only applies when the simple `acct path → projcode` mapping is
+  unavailable; if needed it can be added as a fallback in a
+  follow-up.
+- **Charging factor ≠ 1.0** (the doc hints "currently 1:1 with
+  TB-Years"). If/when a `Factor` row controls disk charging, drop in
+  a multiplier without changing the parser layer.
+- **Reading the legacy Spring upload endpoint
+  `/protected/admin/dasg/glade/upload`** in the *current* webapp.
+  The Java endpoint
+  (`legacy_sam/.../GladeDataRRH.java`) is documented for context;
+  this PR is CLI-only and does not port the upload endpoint.
+
+---
+
+## Verification
+
+### Manual smoke
+
+```bash
+source etc/config_env.sh
+
+# Dry-run on the sample inputs sitting in the repo:
+sam-admin accounting --disk \
+    --resource Campaign_Store \
+    --user-usage ./acct.glade.2026-04-18 \
+    --quotas    ./cs_usage.json \
+    --reconcile-quota-gap \
+    --date 2026-04-18 \
+    --dry-run -v
+
+# Compare the dry-run table against the existing DB rows:
+mysql -h 127.0.0.1 -u root -proot sam --table -e "
+  SELECT projcode, username, number_of_files, bytes,
+         ROUND(terabyte_years,4) AS ty, ROUND(charges,4) AS ch
+  FROM disk_charge_summary
+  WHERE activity_date = '2026-04-18'
+  ORDER BY bytes DESC LIMIT 30"
+
+# Live run (idempotent; existing 104,541 rows for 2026-04-18 will UPDATE in place):
+sam-admin accounting --disk \
+    --resource Campaign_Store \
+    --user-usage ./acct.glade.2026-04-18 \
+    --quotas    ./cs_usage.json \
+    --reconcile-quota-gap
+
+# Spot check a known-tricky case (cgd → cgd/amp, cgd/oce subdirs):
+mysql ... -e "SELECT username, bytes FROM disk_charge_summary
+              WHERE projcode IN ('CGD','NCGD0009') AND activity_date='2026-04-18'"
+```
+
+### Tests
+
+- `tests/unit/test_disk_usage_reader.py` — new. Use a small inline
+  CSV fixture; assert dataclass values, `gpfsnobody`/numeric-username
+  filtering, snapshot-date parsing.
+- `tests/unit/test_accounting_disk_admin.py` — new. Use the existing
+  Layer-2 factories (`make_user`, `make_project`, `make_allocation`)
+  to build a tiny project graph (with an explicit lead user); feed a
+  5-row temp acct file + 3-key cs_usage.json; run the admin command
+  via `CliRunner`; assert rows in `disk_charge_summary` (created vs
+  updated counts, and the gap row has
+  `act_username='<unidentified>'` AND `user_id == lead.user_id`).
+- `tests/unit/test_upsert_disk_pre_resolved.py` — new. Targeted unit
+  test for the `user=`/`account=` override paths in
+  `upsert_disk_charge_summary` — confirms `_resolve_user` is not
+  called and `act_username` is stored verbatim.
+- `tests/integration/test_admin_disk_smoke.py` — subprocess `sam-admin
+  accounting --disk … --dry-run` against the test DB.
+- Re-run full suite: `pytest` (~65s, parallel).
+
+### Charging-math sanity check (TiB-years)
+
+For the `wchapman / cisl/aiml / naml0001` row in
+`acct.glade.2026-04-18`:
+
+```
+col6 (KiB)              = 235,938,728,304
+bytes                   = 235,938,728,304 × 1024 = 241,601,257,783,296
+terabyte_years (TiB-yr) = 241,601,257,783,296 × 7 / 365 / 1024**4
+                        = 4.21500…   (vs legacy decimal-TB value 4.63345)
+```
+
+Confirm after a live run that the DB row for `(2026-04-18, NAML0001,
+wchapman)` shows:
+- `bytes = 241,601,257,783,296` (unchanged from legacy import)
+- `terabyte_years ≈ 4.21500` (was `4.63345` before the backfill)
+- `charges = terabyte_years` to four decimal places
+
+### Backfill spot-check
+
+After running `scripts/backfill_disk_charge_summary_to_tib.py`:
+
+```sql
+-- Pick any pre-existing row, eyeball ratio:
+SELECT bytes, terabyte_years,
+       terabyte_years / (bytes * 7 / 365 / POW(1024,4)) AS unity
+FROM disk_charge_summary
+WHERE activity_date = '2026-04-18' AND username = 'wchapman'
+LIMIT 5;
+-- 'unity' should be ≈ 1.0 for every row.
+```

--- a/src/cli/accounting/commands.py
+++ b/src/cli/accounting/commands.py
@@ -473,6 +473,48 @@ class AccountingAdminCommand(BaseCommand):
             e.terabyte_years = tib_years(e.bytes, reporting_interval)
             e.charges = e.terabyte_years
 
+        # ---- 6b. Resolve projcode for normal rows ----------------------
+        # The acct.glade column 3 is a fileset label (e.g. 'cesm', 'cgd')
+        # not a SAM projcode (e.g. 'CESM0001', 'NCGD0009'). The legacy
+        # Java ingest resolved this via directory_path → ProjectDirectory
+        # → Project. Mirror that here: prefer the path-based lookup, fall
+        # back to projcode-as-label, give up if neither works (the row is
+        # then skipped if --skip-errors, else aborts the chunk).
+        from sam.projects.projects import ProjectDirectory, Project
+        from sam.accounting.accounts import Account
+        pd_path_to_project: dict[str, "Project"] = {
+            pd.directory_name: proj
+            for pd, proj in (
+                self.session.query(ProjectDirectory, Project)
+                .join(Project, Project.project_id == ProjectDirectory.project_id)
+                .filter(ProjectDirectory.is_currently_active)
+                .all()
+            )
+        }
+        # Cache resolved Account per project_id for this resource.
+        account_cache: dict[int, "Account"] = {}
+
+        def _resolve_for_row(row) -> tuple[bool, Optional["Project"], Optional["Account"]]:
+            """Return (resolved_ok, project, account). For normal rows only —
+            gap rows already carry user/account overrides."""
+            project = None
+            if row.directory_path and row.directory_path in pd_path_to_project:
+                project = pd_path_to_project[row.directory_path]
+            if project is None:
+                project = Project.get_by_projcode(self.session, row.projcode)
+            if project is None:
+                return False, None, None
+            acct = account_cache.get(project.project_id)
+            if acct is None:
+                acct = Account.get_by_project_and_resource(
+                    self.session, project.project_id, resource.resource_id,
+                    exclude_deleted=not include_deleted_accounts,
+                )
+                if acct is None:
+                    return False, project, None
+                account_cache[project.project_id] = acct
+            return True, project, acct
+
         # ---- 7. Verbose dry-run table ----------------------------------
         if self.ctx.verbose:
             display_disk_dry_run_table(
@@ -481,6 +523,42 @@ class AccountingAdminCommand(BaseCommand):
 
         if dry_run:
             return 0
+
+        # ---- 7b. Idempotency: delete pre-existing rows for this
+        # (resource, snapshot_date) so a re-run replaces rather than
+        # duplicates. Necessary because the legacy ingest left
+        # `act_username` / `act_projcode` as NULL, which means our
+        # natural-key UPDATE wouldn't match those rows — they'd accumulate
+        # alongside the new ones, double-counting on roll-up. Same delete
+        # also cleans up the prior post-epoch run on this date.
+        from sam.summaries.disk_summaries import DiskChargeSummary
+        n_deleted_legacy = 0
+        try:
+            with management_transaction(self.session):
+                deleted = (
+                    self.session.query(DiskChargeSummary)
+                    .filter(DiskChargeSummary.activity_date == snap_date)
+                    .filter(
+                        DiskChargeSummary.account_id.in_(
+                            self.session.query(Account.account_id).filter(
+                                Account.resource_id == resource.resource_id,
+                            )
+                        )
+                    )
+                    .delete(synchronize_session=False)
+                )
+                n_deleted_legacy = int(deleted)
+        except Exception as exc:  # noqa: BLE001
+            self.console.print(
+                f"[bold red]Failed to clear existing rows for {snap_date}: {exc}[/bold red]"
+            )
+            return 2
+        if n_deleted_legacy:
+            self.console.print(
+                f"[dim]Cleared {n_deleted_legacy} pre-existing "
+                f"disk_charge_summary row(s) for "
+                f"{resource_name} on {snap_date} before re-import.[/dim]"
+            )
 
         # ---- 8. Chunked upsert -----------------------------------------
         n_created = 0
@@ -520,9 +598,27 @@ class AccountingAdminCommand(BaseCommand):
                                 if row.user_override is not None:
                                     act_uname = row.act_username
                                     act_pcode = None
+                                    project_for_upsert = None
+                                    account_for_upsert = row.account_override
                                 else:
                                     act_uname = row.username
-                                    act_pcode = row.projcode
+                                    # Resolve project from directory_path
+                                    # (umbrella filesets like 'cgd' map to
+                                    # specific SAM projects via
+                                    # ProjectDirectory).
+                                    ok, project_for_upsert, account_for_upsert = _resolve_for_row(row)
+                                    if not ok:
+                                        raise ValueError(
+                                            f"Could not resolve project/account for "
+                                            f"row projcode={row.projcode!r} "
+                                            f"path={row.directory_path!r} on "
+                                            f"resource {resource_name!r}"
+                                        )
+                                    # Stash the resolved projcode in the
+                                    # audit column so the row carries the
+                                    # SAM-canonical name, not the umbrella
+                                    # label from the input file.
+                                    act_pcode = project_for_upsert.projcode
                                 _, action = upsert_disk_charge_summary(
                                     self.session,
                                     activity_date=row.activity_date,
@@ -535,7 +631,8 @@ class AccountingAdminCommand(BaseCommand):
                                     bytes=row.bytes,
                                     terabyte_years=row.terabyte_years,
                                     user=row.user_override,
-                                    account=row.account_override,
+                                    project=project_for_upsert,
+                                    account=account_for_upsert,
                                     include_deleted_accounts=include_deleted_accounts,
                                 )
                                 if action == 'created':

--- a/src/cli/accounting/commands.py
+++ b/src/cli/accounting/commands.py
@@ -425,14 +425,25 @@ class AccountingAdminCommand(BaseCommand):
             )
             return 2
 
-        # ---- 3. Date-window safety check -------------------------------
+        # ---- 3. Date assertion (--date safety check) -------------------
+        # The CLI collapses --date to start_date == end_date == expected.
+        # If the operator supplied --date, the file's snapshot date must
+        # equal it exactly. This catches "wrong file fed to wrong date"
+        # mistakes early, before any DB writes.
         if start_date is not None and end_date is not None:
             if not (start_date <= snap_date <= end_date):
-                self.console.print(
-                    f"Error: snapshot date {snap_date} falls outside the "
-                    f"requested window {start_date}..{end_date}",
-                    style="bold red",
-                )
+                if start_date == end_date:
+                    self.console.print(
+                        f"Error: snapshot date {snap_date} does not match "
+                        f"--date {start_date}",
+                        style="bold red",
+                    )
+                else:
+                    self.console.print(
+                        f"Error: snapshot date {snap_date} falls outside the "
+                        f"requested window {start_date}..{end_date}",
+                        style="bold red",
+                    )
                 return 2
 
         # ---- 4. Cutover-epoch enforcement ------------------------------

--- a/src/cli/accounting/commands.py
+++ b/src/cli/accounting/commands.py
@@ -15,19 +15,26 @@ from cli.core.output import output_json
 from rich.progress import Progress, BarColumn, TextColumn, TimeElapsedColumn, MofNCompleteColumn
 from cli.accounting.display import (
     display_dry_run_table,
+    display_disk_dry_run_table,
     display_import_summary,
     display_charge_summary_table,
     display_quota_reconcile_plan,
     display_quota_reconcile_summary,
 )
 from cli.accounting.quota_readers import get_quota_reader, QuotaEntry
+from cli.accounting.disk_usage import get_disk_usage_reader, DiskUsageEntry
 from cli.accounting.path_verifier import (
     PathVerificationError, auto_detect_verifier,
 )
-from sam.manage.summaries import upsert_comp_charge_summary
+from sam.manage.summaries import (
+    upsert_comp_charge_summary, upsert_disk_charge_summary,
+)
 from sam.manage.transaction import management_transaction
 from sam.manage.allocations import update_allocation
 from sam.plugins import HPC_USAGE_QUERIES
+from sam.summaries.disk_summaries import (
+    DISK_CHARGING_TIB_EPOCH, mark_disk_snapshot_current, tib_years,
+)
 
 
 # Reconcile tolerance: allocations within this fraction of quota truth are
@@ -142,6 +149,14 @@ class AccountingAdminCommand(BaseCommand):
         create_queues: bool = False,
         chunk_size: int = 500,
         include_deleted_accounts: bool = False,
+        # --disk specific
+        user_usage_path: Optional[str] = None,
+        quotas_path: Optional[str] = None,
+        reporting_interval: int = 7,
+        unidentified_label: str = '<unidentified>',
+        reconcile_quota_gap: bool = False,
+        gap_tolerance_bytes: int = 1024 ** 3,    # 1 GiB
+        gap_tolerance_frac: float = 0.01,        # 1%
     ) -> int:
         if reconcile_quotas is not None:
             return self._run_reconcile_quotas(
@@ -163,8 +178,22 @@ class AccountingAdminCommand(BaseCommand):
                 include_deleted_accounts=include_deleted_accounts,
             )
         if disk:
-            self.console.print("[yellow]--disk: not yet implemented[/yellow]")
-            return 0
+            return self._run_disk(
+                resource_name=resource,
+                user_usage_path=user_usage_path,
+                quotas_path=quotas_path,
+                reporting_interval=reporting_interval,
+                unidentified_label=unidentified_label,
+                reconcile_gap=reconcile_quota_gap,
+                gap_tolerance_bytes=gap_tolerance_bytes,
+                gap_tolerance_frac=gap_tolerance_frac,
+                start_date=start_date,
+                end_date=end_date,
+                dry_run=dry_run,
+                skip_errors=skip_errors,
+                chunk_size=chunk_size,
+                include_deleted_accounts=include_deleted_accounts,
+            )
         if archive:
             self.console.print("[yellow]--archive: not yet implemented[/yellow]")
             return 0
@@ -300,6 +329,390 @@ class AccountingAdminCommand(BaseCommand):
 
         # --- 9. Exit code ---
         return 0 if n_errors == 0 else 2
+
+
+    # ------------------------------------------------------------------
+    # Disk charge summary import
+    # ------------------------------------------------------------------
+
+    def _run_disk(
+        self,
+        *,
+        resource_name: Optional[str],
+        user_usage_path: Optional[str],
+        quotas_path: Optional[str],
+        reporting_interval: int,
+        unidentified_label: str,
+        reconcile_gap: bool,
+        gap_tolerance_bytes: int,
+        gap_tolerance_frac: float,
+        start_date: Optional[date],
+        end_date: Optional[date],
+        dry_run: bool,
+        skip_errors: bool,
+        chunk_size: int,
+        include_deleted_accounts: bool,
+    ) -> int:
+        """Import a per-user-per-project disk usage snapshot into ``disk_charge_summary``.
+
+        See ``docs/plans/DISK_CHARGING.md`` for the design. High-level flow:
+
+          1. Parse the per-user file via a registered DiskUsageReader.
+          2. Validate snapshot date against the requested window AND the
+             cutover epoch (post-epoch only — pre-epoch rows stay legacy).
+          3. Optionally reconcile per-project FILESET totals against the
+             user-row sum and emit ``<unidentified>`` gap rows attributed
+             to each project's lead.
+          4. Compute terabyte_years/charges in TiB-years.
+          5. Chunked upsert via ``upsert_disk_charge_summary``.
+          6. Mark this date as the current snapshot in
+             ``disk_charge_summary_status``.
+        """
+        from sam.resources.resources import Resource
+        from sam.accounting.accounts import Account
+
+        # ---- 1. Validate inputs ----------------------------------------
+        if not resource_name:
+            self.console.print(
+                "Error: --disk requires --resource", style="bold red"
+            )
+            return 2
+        if not user_usage_path:
+            self.console.print(
+                "Error: --disk requires --user-usage <path>", style="bold red"
+            )
+            return 2
+        if reconcile_gap and not quotas_path:
+            self.console.print(
+                "Error: --reconcile-quota-gap requires --quotas <path>",
+                style="bold red",
+            )
+            return 2
+
+        resource = Resource.get_by_name(self.session, resource_name)
+        if resource is None:
+            self.console.print(
+                f"Error: resource {resource_name!r} not found in SAM",
+                style="bold red",
+            )
+            return 2
+
+        # ---- 2. Parse the per-user file -------------------------------
+        try:
+            reader = get_disk_usage_reader(resource_name, user_usage_path)
+        except NotImplementedError as exc:
+            self.console.print(f"Error: {exc}", style="bold red")
+            return 2
+        try:
+            entries = reader.read()
+        except (OSError, ValueError) as exc:
+            self.console.print(
+                f"Error reading {user_usage_path!r}: {exc}", style="bold red"
+            )
+            return 2
+
+        if not entries:
+            self.console.print(
+                f"[yellow]No usage rows in {user_usage_path}[/yellow]"
+            )
+            return 0
+
+        snap_date = reader.snapshot_date
+        if snap_date is None:
+            self.console.print(
+                "Error: cannot determine snapshot date from "
+                f"{user_usage_path!r}", style="bold red",
+            )
+            return 2
+
+        # ---- 3. Date-window safety check -------------------------------
+        if start_date is not None and end_date is not None:
+            if not (start_date <= snap_date <= end_date):
+                self.console.print(
+                    f"Error: snapshot date {snap_date} falls outside the "
+                    f"requested window {start_date}..{end_date}",
+                    style="bold red",
+                )
+                return 2
+
+        # ---- 4. Cutover-epoch enforcement ------------------------------
+        if snap_date < DISK_CHARGING_TIB_EPOCH:
+            self.console.print(
+                f"Error: snapshot date {snap_date} is before the "
+                f"DISK_CHARGING_TIB_EPOCH ({DISK_CHARGING_TIB_EPOCH}). "
+                "This command only writes post-epoch TiB-year rows; "
+                "pre-epoch legacy rows are not rewritten.",
+                style="bold red",
+            )
+            return 2
+
+        # ---- 5. Optional gap reconciliation ----------------------------
+        if reconcile_gap and quotas_path:
+            try:
+                gap_rows = self._build_unidentified_disk_rows(
+                    resource=resource,
+                    user_entries=entries,
+                    quotas_path=quotas_path,
+                    snapshot_date=snap_date,
+                    unidentified_label=unidentified_label,
+                    reporting_interval=reporting_interval,
+                    gap_tolerance_bytes=gap_tolerance_bytes,
+                    gap_tolerance_frac=gap_tolerance_frac,
+                    include_deleted_accounts=include_deleted_accounts,
+                )
+            except (OSError, ValueError) as exc:
+                self.console.print(
+                    f"Error reading quotas {quotas_path!r}: {exc}",
+                    style="bold red",
+                )
+                return 2
+            entries.extend(gap_rows)
+
+        # ---- 6. Charging math ------------------------------------------
+        for e in entries:
+            e.terabyte_years = tib_years(e.bytes, reporting_interval)
+            e.charges = e.terabyte_years
+
+        # ---- 7. Verbose dry-run table ----------------------------------
+        if self.ctx.verbose:
+            display_disk_dry_run_table(
+                self.ctx, entries, resource_name, dry_run=dry_run,
+            )
+
+        if dry_run:
+            return 0
+
+        # ---- 8. Chunked upsert -----------------------------------------
+        n_created = 0
+        n_updated = 0
+        n_errors = 0
+        n_skipped = 0
+
+        chunks = [entries[i:i + chunk_size] for i in range(0, len(entries), chunk_size)]
+
+        with Progress(
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+            console=self.console,
+        ) as progress:
+            task = progress.add_task(
+                f"Posting {resource_name} disk charges...", total=len(entries)
+            )
+            for chunk_idx, chunk in enumerate(chunks, start=1):
+                try:
+                    with management_transaction(self.session):
+                        for row in chunk:
+                            progress.advance(task)
+                            try:
+                                # For normal rows: act_username = parsed
+                                # username, act_projcode = parsed projcode
+                                # (the resolver needs these). The legacy
+                                # Java pipeline stored these as NULL, but
+                                # the current upsert tests already write
+                                # them — we follow the test convention.
+                                #
+                                # For gap rows (`<unidentified>`):
+                                # row.act_username carries the audit
+                                # label and row.user_override is set, so
+                                # the resolver is skipped entirely.
+                                if row.user_override is not None:
+                                    act_uname = row.act_username
+                                    act_pcode = None
+                                else:
+                                    act_uname = row.username
+                                    act_pcode = row.projcode
+                                _, action = upsert_disk_charge_summary(
+                                    self.session,
+                                    activity_date=row.activity_date,
+                                    act_username=act_uname,
+                                    act_projcode=act_pcode,
+                                    act_unix_uid=None,
+                                    resource_name=resource_name,
+                                    charges=row.charges,
+                                    number_of_files=row.number_of_files,
+                                    bytes=row.bytes,
+                                    terabyte_years=row.terabyte_years,
+                                    user=row.user_override,
+                                    account=row.account_override,
+                                    include_deleted_accounts=include_deleted_accounts,
+                                )
+                                if action == 'created':
+                                    n_created += 1
+                                else:
+                                    n_updated += 1
+                            except ValueError as exc:
+                                n_errors += 1
+                                if not skip_errors:
+                                    raise
+                                if self.ctx.verbose:
+                                    self.console.print(f"[yellow]Skip: {exc}[/yellow]")
+                except ValueError as exc:
+                    self.console.print(
+                        f"[bold red]Chunk {chunk_idx} aborted: {exc}[/bold red]"
+                    )
+                    return 2
+
+            # ---- 9. Mark this snapshot as current --------------------
+            try:
+                with management_transaction(self.session):
+                    mark_disk_snapshot_current(self.session, snap_date)
+            except Exception as exc:  # noqa: BLE001
+                self.console.print(
+                    f"[bold red]Failed to mark snapshot current: {exc}[/bold red]"
+                )
+                # Don't fail the whole import for this — data is in.
+
+        display_import_summary(self.ctx, n_created, n_updated, n_errors, n_skipped)
+        return 0 if n_errors == 0 else 2
+
+    def _build_unidentified_disk_rows(
+        self,
+        *,
+        resource,
+        user_entries: list,
+        quotas_path: str,
+        snapshot_date: date,
+        unidentified_label: str,
+        reporting_interval: int,
+        gap_tolerance_bytes: int,
+        gap_tolerance_frac: float,
+        include_deleted_accounts: bool,
+    ) -> list:
+        """Build synthetic ``<unidentified>`` gap rows from FILESET vs Σuser_bytes.
+
+        For every projcode where the FILESET total exceeds the sum of
+        per-user acct rows by more than ``gap_tolerance_bytes`` AND
+        ``gap_tolerance_frac`` of the FILESET total, emit one DiskUsageEntry
+        with:
+          - ``act_username = unidentified_label``
+          - ``user_override = project.lead``
+          - ``account_override`` resolved from (project, resource)
+        Skips projects where lead or account cannot be resolved (with a
+        per-project warning).
+
+        FILESET key resolution precedence:
+          a. fileset name uppercased matches a SAM projcode directly
+          b. fileset path matches a path observed in user_entries → that
+             row's projcode
+          c. fileset path matches a ProjectDirectory.path → that project's projcode
+          d. otherwise unmappable; logged & skipped (does NOT create gap)
+        """
+        from sam.projects.projects import Project, ProjectDirectory
+        from sam.accounting.accounts import Account
+        from cli.accounting.quota_readers import get_quota_reader
+
+        reader = get_quota_reader(resource.resource_name, quotas_path)
+        quota_entries = reader.read()  # already in bytes (KiB×1024)
+
+        # Snapshot-date sanity: cs_usage.json `date` field is a free-form
+        # string so the reader sets snapshot_date best-effort. Just warn
+        # if the quotas date drifts more than 24h from the user-usage one.
+        quota_snap = getattr(reader, 'snapshot_date', None)
+        if quota_snap is not None:
+            quota_d = quota_snap.date() if hasattr(quota_snap, 'date') else quota_snap
+            if abs((quota_d - snapshot_date).days) > 1:
+                self.console.print(
+                    f"[yellow]Warning: quotas snapshot {quota_d} differs from "
+                    f"user-usage snapshot {snapshot_date} by more than 1 day.[/yellow]"
+                )
+
+        # Sum per-user bytes per projcode (from already-parsed acct entries).
+        user_bytes: dict[str, int] = {}
+        path_to_projcode: dict[str, str] = {}
+        for e in user_entries:
+            user_bytes[e.projcode] = user_bytes.get(e.projcode, 0) + e.bytes
+            if e.directory_path:
+                path_to_projcode.setdefault(e.directory_path, e.projcode)
+
+        # Build path → projcode fallback from ProjectDirectory.
+        dir_rows = (
+            self.session.query(ProjectDirectory, Project)
+            .join(Project, Project.project_id == ProjectDirectory.project_id)
+            .filter(ProjectDirectory.is_currently_active)
+            .all()
+        )
+        pd_path_to_projcode = {
+            pd.directory_name: proj.projcode for pd, proj in dir_rows
+        }
+
+        # Map each FILESET entry to a projcode + accumulate bytes.
+        fileset_bytes: dict[str, int] = {}
+        unmapped: list = []
+        for qe in quota_entries:
+            projcode = qe.fileset_name.upper()
+            project = Project.get_by_projcode(self.session, projcode)
+            if project is None:
+                if qe.path and qe.path in path_to_projcode:
+                    projcode = path_to_projcode[qe.path]
+                elif qe.path and qe.path in pd_path_to_projcode:
+                    projcode = pd_path_to_projcode[qe.path]
+                else:
+                    unmapped.append(qe)
+                    continue
+            fileset_bytes[projcode] = fileset_bytes.get(projcode, 0) + qe.usage_bytes
+
+        if unmapped and self.ctx.verbose:
+            self.console.print(
+                f"[dim]Gap-reconcile: {len(unmapped)} fileset(s) had no SAM "
+                "project mapping (skipped).[/dim]"
+            )
+
+        # Build gap rows.
+        gap_rows: list = []
+        for projcode, q_bytes in fileset_bytes.items():
+            sum_user = user_bytes.get(projcode, 0)
+            gap = q_bytes - sum_user
+            if gap <= 0:
+                continue
+            min_tol = max(gap_tolerance_bytes, int(q_bytes * gap_tolerance_frac))
+            if gap < min_tol:
+                continue
+
+            project = Project.get_by_projcode(self.session, projcode)
+            if project is None:
+                continue
+            lead = project.lead
+            if lead is None:
+                self.console.print(
+                    f"[yellow]Skipping gap for {projcode}: project has no lead.[/yellow]"
+                )
+                continue
+            account = Account.get_by_project_and_resource(
+                self.session, project.project_id, resource.resource_id,
+                exclude_deleted=not include_deleted_accounts,
+            )
+            if account is None:
+                self.console.print(
+                    f"[yellow]Skipping gap for {projcode}: no account on "
+                    f"{resource.resource_name}.[/yellow]"
+                )
+                continue
+
+            gap_rows.append(DiskUsageEntry(
+                activity_date=snapshot_date,
+                projcode=projcode,
+                username=lead.username,
+                number_of_files=0,
+                bytes=gap,
+                directory_path=None,
+                reporting_interval=reporting_interval,
+                cos=0,
+                act_username=unidentified_label,
+                user_override=lead,
+                account_override=account,
+            ))
+
+        if gap_rows:
+            total_gap_bytes = sum(r.bytes for r in gap_rows)
+            self.console.print(
+                f"[cyan]Gap reconciliation: {len(gap_rows)} project(s) "
+                f"with unattributed bytes; total {total_gap_bytes / (1024**4):.2f} TiB "
+                "attributed to project leads with audit label "
+                f"{unidentified_label!r}.[/cyan]"
+            )
+        return gap_rows
 
 
     # ------------------------------------------------------------------

--- a/src/cli/accounting/disk_usage/__init__.py
+++ b/src/cli/accounting/disk_usage/__init__.py
@@ -1,0 +1,31 @@
+"""Pluggable per-user-per-project disk usage readers, dispatched by resource."""
+
+from .base import DiskUsageEntry, DiskUsageReader
+from .glade_csv import GladeCsvReader
+
+
+_READERS = {
+    'Campaign_Store': GladeCsvReader,
+}
+
+
+def get_disk_usage_reader(resource_name: str, path: str) -> DiskUsageReader:
+    """Return a DiskUsageReader instance for the given resource.
+
+    Raises NotImplementedError if no reader is registered for the resource.
+    """
+    cls = _READERS.get(resource_name)
+    if cls is None:
+        supported = ', '.join(sorted(_READERS)) or '(none)'
+        raise NotImplementedError(
+            f"No disk usage reader is registered for resource {resource_name!r}. "
+            f"Supported: {supported}."
+        )
+    return cls(path)
+
+
+__all__ = [
+    'DiskUsageEntry', 'DiskUsageReader',
+    'GladeCsvReader',
+    'get_disk_usage_reader',
+]

--- a/src/cli/accounting/disk_usage/base.py
+++ b/src/cli/accounting/disk_usage/base.py
@@ -1,0 +1,63 @@
+"""Base types for per-user-per-project disk usage readers."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Optional
+
+
+@dataclass
+class DiskUsageEntry:
+    """A single per-user-per-project disk usage row from a snapshot file.
+
+    Pre-charging-math: ``terabyte_years`` and ``charges`` are populated
+    after the row is constructed, by the caller, using
+    ``sam.summaries.disk_summaries.tib_years()``.
+
+    Synthetic gap rows (the ``<unidentified>`` reconciliation rows) carry
+    ``act_username='<unidentified>'``, ``user_override`` set to the
+    project lead, and ``account_override`` set to the resolved account.
+    For normal rows, both overrides are ``None`` and the upsert resolves
+    them via the standard path.
+    """
+    activity_date: date
+    projcode: str
+    username: str
+    number_of_files: int
+    bytes: int
+    directory_path: Optional[str] = None
+    reporting_interval: int = 7
+    cos: int = 0
+
+    # Audit label written to act_username column. For normal rows we
+    # leave this as ``None`` so the column is NULL (matching the legacy
+    # disk-accounting convention). For synthetic gap rows the import
+    # path sets it to e.g. ``'<unidentified>'``.
+    act_username: Optional[str] = None
+
+    # Computed by the import after read() (TiB-years, post-epoch).
+    terabyte_years: float = 0.0
+    charges: float = 0.0
+
+    # Pre-resolved entity overrides (used for gap rows; None otherwise).
+    # The disk_usage layer doesn't import sam ORM types — these are typed
+    # as Optional[object] so the package remains import-light.
+    user_override: Optional[object] = field(default=None, repr=False)
+    account_override: Optional[object] = field(default=None, repr=False)
+
+
+class DiskUsageReader(ABC):
+    """Read per-user-per-project disk usage rows from a backend-specific file.
+
+    Subclasses populate ``snapshot_date`` during ``read()`` so the
+    importer can validate the file matches the requested date window.
+    """
+
+    snapshot_date: Optional[date] = None
+
+    def __init__(self, path: str):
+        self.path = path
+
+    @abstractmethod
+    def read(self) -> list[DiskUsageEntry]:
+        """Return all per-user-per-project usage rows in the file."""

--- a/src/cli/accounting/disk_usage/glade_csv.py
+++ b/src/cli/accounting/disk_usage/glade_csv.py
@@ -1,0 +1,121 @@
+"""Reader for the legacy ``acct.glade.YYYY-MM-DD`` CSV format.
+
+The file is a daily/weekly per-user-per-project disk usage snapshot from
+the GPFS-backed Campaign Store. Each row covers the storage held by one
+user on one project's directory tree at the snapshot moment.
+
+CSV columns (no header):
+
+  1. activity_date    "2026-04-18"
+  2. directory_path   "/gpfs/csfs1/cesm"
+  3. projcode         "cesm"          (lowercase in source; SAM stores upper)
+  4. username         "gdicker"       (also rejects numeric-only "uid" rows)
+  5. number_of_files  "4986"
+  6. file_size_total  "688092272"     (KiB; bytes = col6 * 1024)
+  7. reporting_int    "7"             (days the snapshot covers)
+  8. cos_id           "0"             (class-of-service id)
+
+Verified 2026-04-27 against an existing disk_charge_summary row: the
+ratio (DB.bytes / col6) is exactly 1024, confirming KiB units. Bytes
+is the on-disk physical occupancy (matches GPFS mmlsquota usage).
+"""
+
+import csv
+import os
+import re
+from datetime import date, datetime
+from typing import Optional
+
+from .base import DiskUsageEntry, DiskUsageReader
+
+
+# Glade snapshots historically include lines where the username column
+# is the literal numeric uid (the OS resolved the file owner to a uid
+# that no longer maps to a username). We skip these rather than try to
+# resolve — the bytes are still attributed to the project, but on the
+# `<unidentified>` reconciliation path if --reconcile-quota-gap is set.
+_NUMERIC_USERNAME_RE = re.compile(r'^\d+$')
+
+# Service / nobody accounts that are never real users in SAM.
+_SKIP_USERNAMES = frozenset({
+    'gpfsnobody',
+    'nobody',
+    'root',
+})
+
+# Filename pattern: acct.<host>.YYYY-MM-DD (e.g. acct.glade.2026-04-18).
+_FILENAME_DATE_RE = re.compile(r'\.(\d{4}-\d{2}-\d{2})(?:\.|$)')
+
+
+def _parse_filename_date(path: str) -> Optional[date]:
+    """Best-effort: extract YYYY-MM-DD from the filename."""
+    base = os.path.basename(path)
+    m = _FILENAME_DATE_RE.search(base)
+    if not m:
+        return None
+    try:
+        return date.fromisoformat(m.group(1))
+    except ValueError:
+        return None
+
+
+class GladeCsvReader(DiskUsageReader):
+    """Parse ``acct.glade.YYYY-MM-DD`` per-user-per-project usage CSV."""
+
+    # KiB → bytes
+    _KIB = 1024
+
+    def read(self) -> list[DiskUsageEntry]:
+        entries: list[DiskUsageEntry] = []
+        snapshot_dates: set[date] = set()
+
+        with open(self.path, newline='') as fh:
+            reader = csv.reader(fh)
+            for row in reader:
+                if not row or len(row) < 8:
+                    continue
+
+                date_s, dir_path, projcode, username, nfiles, fsize_kib, interval, cos = row[:8]
+
+                # Filter rows we cannot meaningfully attribute to a real user.
+                if username in _SKIP_USERNAMES:
+                    continue
+                if _NUMERIC_USERNAME_RE.match(username):
+                    continue
+
+                try:
+                    activity_date = date.fromisoformat(date_s)
+                    n_files = int(nfiles)
+                    b_kib = int(fsize_kib)
+                    rep_int = int(interval)
+                    cos_id = int(cos)
+                except ValueError:
+                    # Malformed row — skip silently; --skip-errors at the CLI
+                    # layer governs strictness for resolution failures, not
+                    # parse errors.
+                    continue
+
+                snapshot_dates.add(activity_date)
+
+                entries.append(DiskUsageEntry(
+                    activity_date=activity_date,
+                    projcode=projcode.upper().strip(),
+                    username=username.strip(),
+                    number_of_files=n_files,
+                    bytes=b_kib * self._KIB,
+                    directory_path=dir_path.strip() or None,
+                    reporting_interval=rep_int,
+                    cos=cos_id,
+                ))
+
+        # Snapshot date: prefer the date in the rows; fall back to filename.
+        if len(snapshot_dates) == 1:
+            self.snapshot_date = next(iter(snapshot_dates))
+        elif snapshot_dates:
+            # File mixes multiple dates — pick the most recent and let the
+            # importer's window check decide whether to allow that.
+            self.snapshot_date = max(snapshot_dates)
+        else:
+            self.snapshot_date = _parse_filename_date(self.path)
+
+        return entries

--- a/src/cli/accounting/display.py
+++ b/src/cli/accounting/display.py
@@ -72,6 +72,62 @@ def display_dry_run_table(ctx: Context, rows: list, machine: str, adapt_fn,
         ctx.console.print(f"[dim]({n_skipped} zero-charge rows omitted)[/dim]")
 
 
+def display_disk_dry_run_table(ctx: Context, entries: list, resource_name: str,
+                               *, dry_run: bool = True) -> None:
+    """Print a Rich table showing what would be (or was) posted to disk_charge_summary.
+
+    Args:
+        ctx: CLI context (for console output)
+        entries: List of DiskUsageEntry objects (from a DiskUsageReader plus
+                 the import-side terabyte_years/charges already populated)
+        resource_name: Resource name (e.g. 'Campaign_Store')
+        dry_run: When True, title notes rows were not written
+    """
+    title = (
+        f"Dry Run — {resource_name} disk_charge_summary rows (not written)"
+        if dry_run
+        else f"{resource_name} disk_charge_summary rows"
+    )
+    table = Table(
+        title=title,
+        box=box.SIMPLE_HEAD,
+        show_lines=False,
+    )
+    table.add_column("Date", style="cyan", no_wrap=True)
+    table.add_column("Project", style="green")
+    table.add_column("User", style="white")
+    table.add_column("act_user", style="yellow")
+    table.add_column("Files", justify="right", style="dim")
+    table.add_column("Bytes", justify="right")
+    table.add_column("TiB-yr", justify="right", style="bold")
+    table.add_column("Charges", justify="right", style="bold")
+    table.add_column("Path", style="dim")
+
+    n_synthetic = 0
+    for e in entries:
+        is_gap = bool(e.act_username)
+        if is_gap:
+            n_synthetic += 1
+        table.add_row(
+            str(e.activity_date),
+            e.projcode,
+            e.username,
+            e.act_username or "",
+            fmt.number(e.number_of_files),
+            fmt.size(e.bytes),
+            f"{e.terabyte_years:.4f}",
+            f"{e.charges:.4f}",
+            (e.directory_path or "")[:60],
+        )
+
+    ctx.console.print(table)
+    if n_synthetic:
+        ctx.console.print(
+            f"[dim]({n_synthetic} synthetic gap rows attributed to project lead "
+            "with audit label in act_username)[/dim]"
+        )
+
+
 def display_import_summary(ctx: Context, n_created: int, n_updated: int,
                            n_errors: int, n_skipped: int) -> None:
     """

--- a/src/cli/cmds/admin.py
+++ b/src/cli/cmds/admin.py
@@ -154,15 +154,35 @@ def project(ctx: Context, projcode, validate, reconcile, upcoming_expirations, r
 
 @cli.command()
 @click.option('--comp', is_flag=True, help='Post computational charge summaries')
-@click.option('--disk', is_flag=True, help='Post disk charge summaries (not yet implemented)')
+@click.option('--disk', is_flag=True, help='Post disk charge summaries')
 @click.option('--archive', is_flag=True, help='Post archive charge summaries (not yet implemented)')
 @click.option('--reconcile-quotas', 'reconcile_quotas', type=click.Path(exists=True, dir_okay=False),
               default=None, metavar='PATH',
               help='Reconcile SAM allocations against a storage quota file (requires --resource)')
 @click.option('--resource', type=str, default=None,
-              help='Resource name (required with --reconcile-quotas, e.g. Campaign_Store)')
+              help='Resource name (required with --reconcile-quotas/--disk, e.g. Campaign_Store)')
 @click.option('--machine', '-m', type=click.Choice(['derecho', 'casper']), default=None,
-              help='HPC machine (required with --comp/--disk/--archive)')
+              help='HPC machine (required with --comp)')
+# --disk-specific options
+@click.option('--user-usage', 'user_usage_path',
+              type=click.Path(exists=True, dir_okay=False),
+              default=None, metavar='PATH',
+              help='Per-user-per-project disk usage file (required with --disk; e.g. acct.glade.YYYY-MM-DD)')
+@click.option('--quotas', 'quotas_path',
+              type=click.Path(exists=True, dir_okay=False),
+              default=None, metavar='PATH',
+              help='GPFS cs_usage.json (required with --disk --reconcile-quota-gap)')
+@click.option('--reporting-interval', 'reporting_interval', type=int, default=7, show_default=True,
+              help='Snapshot interval in days (used in TiB-year math)')
+@click.option('--unidentified-label', 'unidentified_label', type=str, default='<unidentified>',
+              show_default=True,
+              help='Audit label for synthetic gap rows (written to act_username only; never added to users table)')
+@click.option('--reconcile-quota-gap', 'reconcile_quota_gap', is_flag=True,
+              help='Attribute (FILESET total - Σuser_rows) to project lead with --unidentified-label (requires --quotas)')
+@click.option('--gap-tolerance-bytes', 'gap_tolerance_bytes', type=int, default=1024 ** 3, show_default=True,
+              help='Minimum absolute gap in bytes before emitting a synthetic row (default 1 GiB)')
+@click.option('--gap-tolerance-frac', 'gap_tolerance_frac', type=float, default=0.01, show_default=True,
+              help='Minimum gap as a fraction of FILESET usage before emitting a synthetic row (default 1%)')
 @click.option('--start', type=str, default=None, help='Start date (YYYY-MM-DD, inclusive; default: 2024-01-01)')
 @click.option('--end', type=str, default=None, help='End date (YYYY-MM-DD, inclusive; default: yesterday)')
 @click.option('-d', '--date', 'date_str', type=str, default=None, help='Specific date (YYYY-MM-DD)')
@@ -189,7 +209,11 @@ def project(ctx: Context, projcode, validate, reconcile, upcoming_expirations, r
 @click.option('--verbose', '-v', is_flag=True, help='Show per-row warnings and details (charge-posting modes only)')
 @pass_context
 def accounting(ctx: Context, comp, disk, archive, reconcile_quotas, resource,
-               machine, start, end, date_str, today_flag, last,
+               machine,
+               user_usage_path, quotas_path, reporting_interval,
+               unidentified_label, reconcile_quota_gap,
+               gap_tolerance_bytes, gap_tolerance_frac,
+               start, end, date_str, today_flag, last,
                dry_run, update_accounting_system, deactivate_orphaned,
                force, verify_paths, verify_host,
                skip_errors, create_queues, chunk_size,
@@ -197,8 +221,8 @@ def accounting(ctx: Context, comp, disk, archive, reconcile_quotas, resource,
     """Post charge summaries into SAM, or reconcile allocations against quota truth.
 
     \b
-    Two modes:
-      1. Post charge summaries  (--comp / --disk / --archive)
+    Three modes:
+      1. Post HPC charge summaries  (--comp / --archive)
          Required: --machine and a date selection.
          Date Selection:
            --date YYYY-MM-DD   Single specific date
@@ -206,7 +230,14 @@ def accounting(ctx: Context, comp, disk, archive, reconcile_quotas, resource,
            --last N[d]         Last N days including today
            --start / --end     Date range (defaults: 2024-01-01 to yesterday)
 
-      2. Reconcile storage quotas  (--reconcile-quotas PATH)
+      2. Post disk charge summaries  (--disk)
+         Required: --resource <name> and --user-usage <path>
+         Optional: --quotas <path> --reconcile-quota-gap
+         Snapshot date is read from the user-usage file. Date flags
+         are accepted as a safety filter (we error if the snapshot
+         lies outside the selected window).
+
+      3. Reconcile storage quotas  (--reconcile-quotas PATH)
          Required: --resource <name>
          Report-only by default — full tables, no writes.  Each write
          flag is independent; combine them as needed:
@@ -282,10 +313,67 @@ def accounting(ctx: Context, comp, disk, archive, reconcile_quotas, resource,
         )
         sys.exit(exit_code)
 
-    # Charge-posting mode: machine + dates required
+    # --- Disk charge import (separate validation path) ---------------------
+    if disk:
+        if not resource:
+            ctx.console.print(
+                "Error: --disk requires --resource",
+                style="bold red",
+            )
+            sys.exit(1)
+        if machine:
+            ctx.console.print(
+                "Error: --machine is HPC-only; do not pass it with --disk",
+                style="bold red",
+            )
+            sys.exit(1)
+        if not user_usage_path:
+            ctx.console.print(
+                "Error: --disk requires --user-usage <path>",
+                style="bold red",
+            )
+            sys.exit(1)
+        if reconcile_quota_gap and not quotas_path:
+            ctx.console.print(
+                "Error: --reconcile-quota-gap requires --quotas <path>",
+                style="bold red",
+            )
+            sys.exit(1)
+
+        # Date selection is optional for --disk: the snapshot date comes
+        # from the file itself. If the admin DOES specify a window, treat
+        # it as a safety filter (we error if the snapshot lies outside).
+        start_date = end_date = None
+        if any([date_str, start, end, today_flag, last]):
+            _validate_accounting_dates(date_str, start, end, today_flag, last)
+            start_date, end_date = _resolve_accounting_dates(
+                date_str, start, end, today_flag, last
+            )
+
+        command = AccountingAdminCommand(ctx)
+        exit_code = command.execute(
+            disk=True,
+            resource=resource,
+            user_usage_path=user_usage_path,
+            quotas_path=quotas_path,
+            reporting_interval=reporting_interval,
+            unidentified_label=unidentified_label,
+            reconcile_quota_gap=reconcile_quota_gap,
+            gap_tolerance_bytes=gap_tolerance_bytes,
+            gap_tolerance_frac=gap_tolerance_frac,
+            start_date=start_date,
+            end_date=end_date,
+            dry_run=dry_run,
+            skip_errors=skip_errors,
+            chunk_size=chunk_size,
+            include_deleted_accounts=include_deleted_accounts,
+        )
+        sys.exit(exit_code)
+
+    # Charge-posting mode (--comp / --archive): machine + dates required
     if not machine:
         ctx.console.print(
-            "Error: --machine is required with --comp/--disk/--archive",
+            "Error: --machine is required with --comp",
             style="bold red",
         )
         sys.exit(1)
@@ -295,7 +383,6 @@ def accounting(ctx: Context, comp, disk, archive, reconcile_quotas, resource,
     command = AccountingAdminCommand(ctx)
     exit_code = command.execute(
         comp=comp,
-        disk=disk,
         archive=archive,
         machine=machine,
         start_date=start_date,

--- a/src/cli/cmds/admin.py
+++ b/src/cli/cmds/admin.py
@@ -7,7 +7,7 @@ Administrative commands for SAM database management and validation.
 
 import sys
 import click
-from datetime import date as _date
+from datetime import date as _date, datetime
 from sqlalchemy.orm import Session
 
 from config import SAMConfig
@@ -153,60 +153,78 @@ def project(ctx: Context, projcode, validate, reconcile, upcoming_expirations, r
 
 
 @cli.command()
-@click.option('--comp', is_flag=True, help='Post computational charge summaries')
-@click.option('--disk', is_flag=True, help='Post disk charge summaries')
-@click.option('--archive', is_flag=True, help='Post archive charge summaries (not yet implemented)')
+# --- Mode selectors ---------------------------------------------------------
+@click.option('--comp', is_flag=True, help='[mode] Post computational charge summaries')
+@click.option('--disk', is_flag=True, help='[mode] Post disk charge summaries')
+@click.option('--archive', is_flag=True, help='[mode] Post archive charge summaries (not yet implemented)')
 @click.option('--reconcile-quotas', 'reconcile_quotas', type=click.Path(exists=True, dir_okay=False),
               default=None, metavar='PATH',
-              help='Reconcile SAM allocations against a storage quota file (requires --resource)')
+              help='[mode] Reconcile SAM allocations against a storage quota file (requires --resource)')
+# --- Common ----------------------------------------------------------------
 @click.option('--resource', type=str, default=None,
-              help='Resource name (required with --reconcile-quotas/--disk, e.g. Campaign_Store)')
+              help='[disk/reconcile] Resource name (e.g. Campaign_Store)')
+@click.option('--dry-run', is_flag=True,
+              help='[comp/disk] Preview without writing (--reconcile-quotas is report-only by default)')
+@click.option('--skip-errors', is_flag=True,
+              help='[comp/disk] Skip rows that fail entity resolution')
+@click.option('--chunk-size', type=int, default=500, show_default=True,
+              help='[comp/disk] Rows per database transaction')
+@click.option('--include-deleted-accounts', is_flag=True,
+              help='[comp/disk] Allow posting to accounts marked deleted (for backfill)')
+@click.option('--verbose', '-v', is_flag=True,
+              help='Show per-row warnings and details')
+# --- HPC (--comp) ----------------------------------------------------------
 @click.option('--machine', '-m', type=click.Choice(['derecho', 'casper']), default=None,
-              help='HPC machine (required with --comp)')
-# --disk-specific options
+              help='[comp] HPC machine (required)')
+@click.option('--create-queues', is_flag=True,
+              help='[comp] Auto-create unknown queues in SAM')
+@click.option('--start', type=str, default=None,
+              help='[comp] Start date (YYYY-MM-DD, inclusive; default: 2024-01-01)')
+@click.option('--end', type=str, default=None,
+              help='[comp] End date (YYYY-MM-DD, inclusive; default: yesterday)')
+@click.option('--today', 'today_flag', is_flag=True,
+              help='[comp] Use today as the date')
+@click.option('--last', type=str, default=None, metavar='N[d]',
+              help='[comp] Last N days including today (e.g. --last 3d)')
+# --date is shared between --comp and --disk (different semantics — see below).
+@click.option('-d', '--date', 'date_str', type=str, default=None,
+              help='[comp] Specific date to import.  '
+                   '[disk] Optional safety check: file snapshot must equal this date.')
+# --- Disk (--disk) ---------------------------------------------------------
 @click.option('--user-usage', 'user_usage_path',
               type=click.Path(exists=True, dir_okay=False),
               default=None, metavar='PATH',
-              help='Per-user-per-project disk usage file (required with --disk; e.g. acct.glade.YYYY-MM-DD)')
+              help='[disk] Per-user-per-project disk usage file (required; e.g. acct.glade.YYYY-MM-DD)')
 @click.option('--quotas', 'quotas_path',
               type=click.Path(exists=True, dir_okay=False),
               default=None, metavar='PATH',
-              help='GPFS cs_usage.json (required with --disk --reconcile-quota-gap)')
+              help='[disk] GPFS cs_usage.json (required with --reconcile-quota-gap)')
 @click.option('--reporting-interval', 'reporting_interval', type=int, default=7, show_default=True,
-              help='Snapshot interval in days (used in TiB-year math)')
+              help='[disk] Snapshot interval in days (used in TiB-year math)')
 @click.option('--unidentified-label', 'unidentified_label', type=str, default='<unidentified>',
               show_default=True,
-              help='Audit label for synthetic gap rows (written to act_username only; never added to users table)')
+              help='[disk] Audit label for synthetic gap rows '
+                   '(written to act_username only; never added to users table)')
 @click.option('--reconcile-quota-gap', 'reconcile_quota_gap', is_flag=True,
-              help='Attribute (FILESET total - Σuser_rows) to project lead with --unidentified-label (requires --quotas)')
+              help='[disk] Attribute (FILESET total − Σuser_rows) to project lead '
+                   'with --unidentified-label (requires --quotas)')
 @click.option('--gap-tolerance-bytes', 'gap_tolerance_bytes', type=int, default=1024 ** 3, show_default=True,
-              help='Minimum absolute gap in bytes before emitting a synthetic row (default 1 GiB)')
+              help='[disk] Minimum absolute gap in bytes before emitting a synthetic row (default 1 GiB)')
 @click.option('--gap-tolerance-frac', 'gap_tolerance_frac', type=float, default=0.01, show_default=True,
-              help='Minimum gap as a fraction of FILESET usage before emitting a synthetic row (default 1%)')
-@click.option('--start', type=str, default=None, help='Start date (YYYY-MM-DD, inclusive; default: 2024-01-01)')
-@click.option('--end', type=str, default=None, help='End date (YYYY-MM-DD, inclusive; default: yesterday)')
-@click.option('-d', '--date', 'date_str', type=str, default=None, help='Specific date (YYYY-MM-DD)')
-@click.option('--today', 'today_flag', is_flag=True, help='Use today as the date')
-@click.option('--last', type=str, default=None, metavar='N[d]',
-              help='Last N days including today (e.g. --last 3d)')
-@click.option('--dry-run', is_flag=True, help='Preview without writing (charge-posting modes only; --reconcile-quotas is report-only by default)')
+              help='[disk] Minimum gap as a fraction of FILESET usage (default 1%)')
+# --- Reconcile (--reconcile-quotas) ----------------------------------------
 @click.option('--update-accounting-system', 'update_accounting_system', is_flag=True,
-              help='Apply mismatched amount updates (requires --reconcile-quotas; default is report-only)')
+              help='[reconcile] Apply mismatched amount updates (default: report-only)')
 @click.option('--deactivate-orphaned', 'deactivate_orphaned', is_flag=True,
-              help='Deactivate orphaned allocations (independent of --update-accounting-system)')
+              help='[reconcile] Deactivate orphaned allocations '
+                   '(independent of --update-accounting-system)')
 @click.option('--force', is_flag=True,
-              help='Override the live-path safety gate when deactivating orphans whose ProjectDirectory paths still exist on disk (requires --deactivate-orphaned)')
+              help='[reconcile] Override the live-path safety gate when deactivating orphans '
+                   'whose ProjectDirectory paths still exist on disk (requires --deactivate-orphaned)')
 @click.option('--verify-paths', 'verify_paths', is_flag=True,
-              help='Check fileset/ProjectDirectory paths on disk (requires --reconcile-quotas)')
+              help='[reconcile] Check fileset/ProjectDirectory paths on disk')
 @click.option('--verify-host', 'verify_host', type=str, default=None, metavar='HOST',
-              help='SSH host to use for --verify-paths (default: auto-detect from the reader)')
-@click.option('--skip-errors', is_flag=True, help='Skip rows that fail entity resolution')
-@click.option('--create-queues', is_flag=True, help='Auto-create unknown queues in SAM')
-@click.option('--chunk-size', type=int, default=500, show_default=True,
-              help='Rows per database transaction')
-@click.option('--include-deleted-accounts', is_flag=True,
-              help='Allow posting to accounts marked deleted (for backfill)')
-@click.option('--verbose', '-v', is_flag=True, help='Show per-row warnings and details (charge-posting modes only)')
+              help='[reconcile] SSH host to use for --verify-paths (default: auto-detect)')
 @pass_context
 def accounting(ctx: Context, comp, disk, archive, reconcile_quotas, resource,
                machine,
@@ -233,9 +251,11 @@ def accounting(ctx: Context, comp, disk, archive, reconcile_quotas, resource,
       2. Post disk charge summaries  (--disk)
          Required: --resource <name> and --user-usage <path>
          Optional: --quotas <path> --reconcile-quota-gap
-         Snapshot date is read from the user-usage file. Date flags
-         are accepted as a safety filter (we error if the snapshot
-         lies outside the selected window).
+         The snapshot date is read from the user-usage file (rows or
+         filename). --date YYYY-MM-DD is accepted as an optional
+         safety check: if supplied, the file's snapshot date MUST
+         match it exactly. --today / --last / --start / --end and
+         --create-queues are HPC-only and rejected here.
 
       3. Reconcile storage quotas  (--reconcile-quotas PATH)
          Required: --resource <name>
@@ -339,16 +359,46 @@ def accounting(ctx: Context, comp, disk, archive, reconcile_quotas, resource,
                 style="bold red",
             )
             sys.exit(1)
-
-        # Date selection is optional for --disk: the snapshot date comes
-        # from the file itself. If the admin DOES specify a window, treat
-        # it as a safety filter (we error if the snapshot lies outside).
-        start_date = end_date = None
-        if any([date_str, start, end, today_flag, last]):
-            _validate_accounting_dates(date_str, start, end, today_flag, last)
-            start_date, end_date = _resolve_accounting_dates(
-                date_str, start, end, today_flag, last
+        # Reject HPC-mode-only flags. The snapshot date comes from the
+        # input file, not from a date range — there is no meaningful
+        # interpretation of `--today` / `--last 7d` / `--start..--end`
+        # for a single-snapshot disk import. `--date` is the only date
+        # flag accepted (as a safety check: the file's snapshot date
+        # must equal the supplied date, else we abort).
+        rejected = []
+        if today_flag: rejected.append('--today')
+        if last:       rejected.append('--last')
+        if start:      rejected.append('--start')
+        if end:        rejected.append('--end')
+        if rejected:
+            ctx.console.print(
+                f"Error: {', '.join(rejected)} not valid with --disk; "
+                "the snapshot date is read from the user-usage file. "
+                "Use --date YYYY-MM-DD if you want to assert the "
+                "expected snapshot date as a safety check.",
+                style="bold red",
             )
+            sys.exit(1)
+        if create_queues:
+            ctx.console.print(
+                "Error: --create-queues is HPC-only; do not pass it with --disk",
+                style="bold red",
+            )
+            sys.exit(1)
+
+        # --date is optional: when supplied, the snapshot in the file
+        # must match this date exactly (otherwise abort). When omitted,
+        # whatever date the file reports is used.
+        expected_date = None
+        if date_str:
+            try:
+                expected_date = datetime.strptime(date_str, '%Y-%m-%d').date()
+            except ValueError:
+                ctx.console.print(
+                    "Error: --date must be in YYYY-MM-DD format",
+                    style="bold red",
+                )
+                sys.exit(1)
 
         command = AccountingAdminCommand(ctx)
         exit_code = command.execute(
@@ -361,8 +411,8 @@ def accounting(ctx: Context, comp, disk, archive, reconcile_quotas, resource,
             reconcile_quota_gap=reconcile_quota_gap,
             gap_tolerance_bytes=gap_tolerance_bytes,
             gap_tolerance_frac=gap_tolerance_frac,
-            start_date=start_date,
-            end_date=end_date,
+            start_date=expected_date,
+            end_date=expected_date,
             dry_run=dry_run,
             skip_errors=skip_errors,
             chunk_size=chunk_size,

--- a/src/cli/cmds/admin.py
+++ b/src/cli/cmds/admin.py
@@ -153,13 +153,16 @@ def project(ctx: Context, projcode, validate, reconcile, upcoming_expirations, r
 
 
 @cli.command()
-# --- Mode selectors ---------------------------------------------------------
-@click.option('--comp', is_flag=True, help='[mode] Post computational charge summaries')
-@click.option('--disk', is_flag=True, help='[mode] Post disk charge summaries')
-@click.option('--archive', is_flag=True, help='[mode] Post archive charge summaries (not yet implemented)')
+# --- Mode selectors (mutually exclusive — pick exactly one) ----------------
+@click.option('--comp', is_flag=True,
+              help='Mode: post computational charge summaries')
+@click.option('--disk', is_flag=True,
+              help='Mode: post disk charge summaries')
+@click.option('--archive', is_flag=True,
+              help='Mode: post archive charge summaries (not yet implemented)')
 @click.option('--reconcile-quotas', 'reconcile_quotas', type=click.Path(exists=True, dir_okay=False),
               default=None, metavar='PATH',
-              help='[mode] Reconcile SAM allocations against a storage quota file (requires --resource)')
+              help='Mode: reconcile SAM allocations against a storage quota file (requires --resource)')
 # --- Common ----------------------------------------------------------------
 @click.option('--resource', type=str, default=None,
               help='[disk/reconcile] Resource name (e.g. Campaign_Store)')

--- a/src/sam/accounting/accounts.py
+++ b/src/sam/accounting/accounts.py
@@ -3,6 +3,28 @@
 from ..base import *
 #-------------------------------------------------------------------------eh-
 
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CurrentDiskUsage:
+    """Latest disk-snapshot occupancy for a single account.
+
+    Returned by ``Account.current_disk_usage()`` /
+    ``Project.current_disk_usage()``. Distinct from the cumulative
+    billing roll-up — these values are read from the single
+    ``disk_charge_summary`` row marked current, not summed.
+    """
+    activity_date: object        # datetime.date — kept loose to avoid import cycle
+    bytes: int
+    terabyte_years: float
+    number_of_files: int
+
+    @property
+    def used_tib(self) -> float:
+        """Occupancy in TiB (binary)."""
+        return self.bytes / (1024 ** 4)
+
 
 #-------------------------------------------------------------------------bm-
 #----------------------------------------------------------------------------
@@ -159,6 +181,87 @@ class Account(Base, SoftDeleteMixin, SessionMixin):
             self.second_threshold = second_threshold
         self.session.flush()
         return self
+
+    def current_disk_usage(self, session=None) -> Optional['CurrentDiskUsage']:
+        """Return the latest ``disk_charge_summary`` snapshot for this account.
+
+        Reads the single row whose ``activity_date`` is marked
+        ``current = True`` in ``disk_charge_summary_status``, falling
+        back to the row with the maximum ``activity_date`` if the
+        status table has no current row (defensive — should not happen
+        post-cutover).
+
+        Returns ``None`` for accounts whose resource is not a disk
+        resource, or which have no disk_charge_summary row at all.
+        Sums across all rows for the snapshot date — so when the
+        ``<unidentified>`` reconciliation is on, the lead-attributed
+        gap row is included in the total.
+        """
+        # Lazy imports to avoid cycles (DiskChargeSummary lives in
+        # sam.summaries which imports Account through relationships).
+        from sam.summaries.disk_summaries import (
+            DiskChargeSummary, DiskChargeSummaryStatus,
+        )
+
+        s = session or self.session
+        if s is None:
+            return None
+
+        # Disk resource gate: skip when the account's resource isn't disk.
+        # Use string compare to avoid an enum import; matches the constant
+        # used elsewhere in the codebase ('DISK').
+        if self.resource and self.resource.resource_type and \
+                self.resource.resource_type.resource_type != 'DISK':
+            return None
+
+        # Defensive: in legacy / test DBs there may be multiple rows with
+        # current=True. Pick the most recent and proceed.
+        current_row = (
+            s.query(DiskChargeSummaryStatus.activity_date)
+             .filter(DiskChargeSummaryStatus.current == True)  # noqa: E712
+             .order_by(DiskChargeSummaryStatus.activity_date.desc())
+             .first()
+        )
+        candidate_date = current_row[0] if current_row else None
+
+        # The "current" snapshot may not include this account (e.g. project
+        # had no usage that day, or the snapshot file was filtered). Fall
+        # back to the most recent date this account itself has a row for.
+        target_date = None
+        if candidate_date is not None:
+            has_row = (
+                s.query(DiskChargeSummary.disk_charge_summary_id)
+                 .filter(
+                     DiskChargeSummary.account_id == self.account_id,
+                     DiskChargeSummary.activity_date == candidate_date,
+                 ).first()
+            )
+            if has_row is not None:
+                target_date = candidate_date
+
+        if target_date is None:
+            target_date = s.query(func.max(DiskChargeSummary.activity_date)).filter(
+                DiskChargeSummary.account_id == self.account_id
+            ).scalar()
+
+        if target_date is None:
+            return None
+
+        agg = s.query(
+            func.coalesce(func.sum(DiskChargeSummary.bytes), 0).label('bytes'),
+            func.coalesce(func.sum(DiskChargeSummary.terabyte_years), 0).label('ty'),
+            func.coalesce(func.sum(DiskChargeSummary.number_of_files), 0).label('files'),
+        ).filter(
+            DiskChargeSummary.account_id == self.account_id,
+            DiskChargeSummary.activity_date == target_date,
+        ).one()
+
+        return CurrentDiskUsage(
+            activity_date=target_date,
+            bytes=int(agg.bytes or 0),
+            terabyte_years=float(agg.ty or 0.0),
+            number_of_files=int(agg.files or 0),
+        )
 
     def __str__(self):
         return f"{self.project.projcode if self.project else None} - {self.resource.resource_name if self.resource else None}"

--- a/src/sam/manage/summaries.py
+++ b/src/sam/manage/summaries.py
@@ -300,8 +300,8 @@ def _upsert_storage_summary(
     model_cls,        # DiskChargeSummary or ArchiveChargeSummary
     *,
     activity_date: date,
-    act_username: str,
-    act_projcode: str,
+    act_username: Optional[str],
+    act_projcode: Optional[str],
     act_unix_uid: Optional[int],
     resource_name: str,
     charges: float,
@@ -313,17 +313,42 @@ def _upsert_storage_summary(
     unix_uid: Optional[int] = None,
     facility_name: Optional[str] = None,
     include_deleted_accounts: bool = False,
+    # Pre-resolved overrides — when supplied, the matching resolver call is
+    # skipped. Used by the disk-charging gap-row path (synthetic
+    # `<unidentified>` audit rows pointing at the project lead).
+    user: Optional[User] = None,
+    project: Optional[Project] = None,
+    account: Optional[Account] = None,
 ) -> Tuple[object, str]:
-    """Shared upsert logic for DiskChargeSummary and ArchiveChargeSummary."""
-    user = _resolve_user(session, act_username, act_unix_uid)
-    project = _resolve_project(session, act_projcode)
+    """Shared upsert logic for DiskChargeSummary and ArchiveChargeSummary.
+
+    When ``user``, ``project``, or ``account`` is supplied, the corresponding
+    resolver is skipped. This lets callers attribute synthetic rows
+    (e.g. ``act_username='<unidentified>'``) to a guaranteed-existing User
+    without that user actually existing under the audit name.
+    """
+    if user is None:
+        user = _resolve_user(session, act_username, act_unix_uid)
     res = _resolve_resource(session, resource_name)
-    account = _resolve_account(session, project, res, include_deleted=include_deleted_accounts)
+    if account is None:
+        if project is None:
+            project = _resolve_project(session, act_projcode)
+        account = _resolve_account(session, project, res, include_deleted=include_deleted_accounts)
+    elif project is None:
+        # Derive project from the pre-resolved account (avoids needing a
+        # valid act_projcode when callers already know the account).
+        project = account.project
 
     # Resolved field defaults — explicit None checks preserve falsy values (e.g. uid=0)
-    resolved_username = username if username is not None else act_username
-    resolved_projcode = projcode if projcode is not None else act_projcode
-    resolved_unix_uid = unix_uid if unix_uid is not None else act_unix_uid
+    resolved_username = username if username is not None else (
+        user.username if user is not None else act_username
+    )
+    resolved_projcode = projcode if projcode is not None else (
+        project.projcode if project is not None else act_projcode
+    )
+    resolved_unix_uid = unix_uid if unix_uid is not None else (
+        user.unix_uid if user is not None and act_unix_uid is None else act_unix_uid
+    )
 
     # Facility name: use caller-provided value; fall back to project chain
     if facility_name is None:

--- a/src/sam/projects/projects.py
+++ b/src/sam/projects/projects.py
@@ -737,6 +737,51 @@ class Project(Base, TimestampMixin, ActiveFlagMixin, SessionMixin, NestedSetMixi
         return results
 
 
+    def current_disk_usage(self, resource_name: Optional[str] = None) -> Dict[str, Any]:
+        """Return the latest disk-snapshot occupancy for each disk account on this project.
+
+        Result is keyed by resource name and shaped as::
+
+            {
+              "Campaign_Store": {
+                "activity_date": date(2026, 4, 18),
+                "bytes": 241_601_257_783_296,
+                "current_used_tib": 219.71...,
+                "terabyte_years": 4.215...,
+                "number_of_files": 10_455_444,
+              },
+              ...
+            }
+
+        Distinct from ``get_detailed_allocation_usage()`` (which sums
+        cumulative TiB-years over an allocation window). Use this for
+        "how full is this project right now?" UI questions; use the
+        cumulative method for billing.
+
+        ``resource_name`` filters to a single disk resource if given.
+        """
+        results: Dict[str, Any] = {}
+        for account in self.accounts:
+            if account.deleted:
+                continue
+            if not account.resource:
+                continue
+            res_name = account.resource.resource_name
+            if resource_name and res_name != resource_name:
+                continue
+            usage = account.current_disk_usage(self.session)
+            if usage is None:
+                continue
+            results[res_name] = {
+                'activity_date': usage.activity_date,
+                'bytes': usage.bytes,
+                'current_used_tib': usage.used_tib,
+                'terabyte_years': usage.terabyte_years,
+                'number_of_files': usage.number_of_files,
+            }
+        return results
+
+
     def get_charges_by_resource_type(self,
                                      account_id: int,
                                      resource_type: str,

--- a/src/sam/schemas/allocation.py
+++ b/src/sam/schemas/allocation.py
@@ -109,6 +109,14 @@ class AllocationWithUsageSchema(AllocationSchema):
             'self_used',
             'self_percent_used',
             'root_projcode',
+            # Current-snapshot fields (disk resources only — null for
+            # other types). Distinct from the cumulative `used` above:
+            # answers "how full are you right now?" using the latest
+            # disk_charge_summary snapshot, not summed over time.
+            'current_used_bytes',
+            'current_used_tib',
+            'current_snapshot_date',
+            'current_pct_used',
         )
 
     # Add resource details
@@ -123,6 +131,10 @@ class AllocationWithUsageSchema(AllocationSchema):
     self_used = fields.Method('get_self_used')
     self_percent_used = fields.Method('get_self_percent_used')
     root_projcode = fields.Method('get_root_projcode')
+    current_used_bytes = fields.Method('get_current_used_bytes')
+    current_used_tib = fields.Method('get_current_used_tib')
+    current_snapshot_date = fields.Method('get_current_snapshot_date')
+    current_pct_used = fields.Method('get_current_pct_used')
 
     def get_resource(self, obj):
         """Get resource from account context."""
@@ -331,6 +343,43 @@ class AllocationWithUsageSchema(AllocationSchema):
             return None
         _, root_project = self._calculate_tree_usage(obj)
         return root_project.projcode if root_project else None
+
+    def _current_disk_usage(self, obj):
+        """Latest disk snapshot occupancy for this allocation's account.
+
+        Returns the CurrentDiskUsage dataclass, or None for non-disk
+        resources / accounts with no disk_charge_summary rows.
+        """
+        account = self.context.get('account')
+        session = self.context.get('session')
+        if not account or not session:
+            return None
+        if not account.resource or not account.resource.resource_type:
+            return None
+        if account.resource.resource_type.resource_type != 'DISK':
+            return None
+        return account.current_disk_usage(session)
+
+    def get_current_used_bytes(self, obj):
+        u = self._current_disk_usage(obj)
+        return u.bytes if u is not None else None
+
+    def get_current_used_tib(self, obj):
+        u = self._current_disk_usage(obj)
+        return u.used_tib if u is not None else None
+
+    def get_current_snapshot_date(self, obj):
+        u = self._current_disk_usage(obj)
+        return u.activity_date if u is not None else None
+
+    def get_current_pct_used(self, obj):
+        u = self._current_disk_usage(obj)
+        if u is None:
+            return None
+        allocated = float(obj.amount) if obj.amount else 0.0
+        if allocated <= 0:
+            return 0.0
+        return (u.used_tib / allocated) * 100.0
 
 
 class AccountSchema(BaseSchema):

--- a/src/sam/summaries/disk_summaries.py
+++ b/src/sam/summaries/disk_summaries.py
@@ -1,7 +1,32 @@
 #-------------------------------------------------------------------------bh-
 # Common Imports:
 from ..base import *
+from datetime import date as _stdlib_date
 #-------------------------------------------------------------------------eh-
+
+
+# ============================================================================
+# Disk-charging unit / cutover constants
+# ============================================================================
+
+# Bytes per tebibyte (binary, 1024**4). The new disk-charging convention
+# stores `disk_charge_summary.terabyte_years` in TiB-years so the column
+# composes cleanly with `Allocation.amount` (TiB).
+BYTES_PER_TIB = 1024 ** 4
+
+# Days per year used in the storage-charging formula. Matches the legacy
+# Java constant `DAYS_IN_YEAR = 365` (NOT 365.25 — the legacy
+# `disk_charge_summary.md` doc was wrong about that).
+DAYS_IN_YEAR = 365
+
+# Cutover epoch: the first activity_date whose disk_charge_summary row is
+# written under the new TiB-year convention. Rows with activity_date < EPOCH
+# stay in the legacy decimal-TB-year convention and are not rewritten.
+#
+# This date is set to the first --disk run we ship and treated as immutable
+# thereafter. Allocations whose window straddles this date will read mixed
+# units (~9.95% drift on the pre-epoch portion); see docs/plans/DISK_CHARGING.md.
+DISK_CHARGING_TIB_EPOCH = _stdlib_date(2026, 4, 18)
 
 
 #-------------------------------------------------------------------------bm-
@@ -46,7 +71,15 @@ class DiskChargeSummary(Base):
 
 #----------------------------------------------------------------------------
 class DiskChargeSummaryStatus(Base):
-    """Tracks which disk charge summaries are current."""
+    """Tracks which disk charge summary date is the current snapshot.
+
+    The row whose ``current = True`` marks the latest fully-imported
+    snapshot. Used by ``Account.current_disk_usage()`` /
+    ``Project.current_disk_usage()`` to answer "how full is this project
+    *right now*?" without summing across snapshots.
+
+    Maintained by ``mark_disk_snapshot_current()``.
+    """
     __tablename__ = 'disk_charge_summary_status'
 
     activity_date = Column(Date, primary_key=True)
@@ -57,6 +90,42 @@ class DiskChargeSummaryStatus(Base):
 
     def __repr__(self):
         return f"<DiskChargeSummaryStatus(date={self.activity_date}, current={self.current})>"
+
+
+# ============================================================================
+# Snapshot status helpers
+# ============================================================================
+
+def mark_disk_snapshot_current(session, activity_date) -> None:
+    """Mark ``activity_date`` as the current disk snapshot.
+
+    Clears ``current=True`` from any prior row, then upserts
+    ``(activity_date, current=True)`` for the given date. Does NOT
+    commit — caller wraps in ``management_transaction``.
+    """
+    session.query(DiskChargeSummaryStatus).filter(
+        DiskChargeSummaryStatus.current == True  # noqa: E712 — SQL boolean
+    ).update({DiskChargeSummaryStatus.current: False}, synchronize_session=False)
+
+    existing = session.get(DiskChargeSummaryStatus, activity_date)
+    if existing is None:
+        session.add(DiskChargeSummaryStatus(activity_date=activity_date, current=True))
+    else:
+        existing.current = True
+    session.flush()
+
+
+def tib_years(bytes_: int, reporting_interval_days: int) -> float:
+    """Compute storage charge in TiB-years (binary, post-epoch convention).
+
+    Single source of truth for the disk charging formula. Used by both
+    the per-user import path and the ``<unidentified>`` gap-row path.
+
+    Formula (deviates from legacy decimal-TB convention):
+
+        TiB-years = (bytes * reporting_interval_days) / 365 / 1024**4
+    """
+    return (bytes_ * reporting_interval_days) / DAYS_IN_YEAR / BYTES_PER_TIB
 
 
 # ============================================================================

--- a/tests/api/test_allocation_schema_disk_current.py
+++ b/tests/api/test_allocation_schema_disk_current.py
@@ -1,0 +1,135 @@
+"""Test AllocationWithUsageSchema's new disk current_used_* fields.
+
+The schema gains four fields that answer "how full is this allocation
+right now?" alongside the existing cumulative ``used`` field. They are
+disk-only — null for HPC / DAV / ARCHIVE.
+"""
+
+from datetime import date, datetime, timedelta
+
+import pytest
+
+from sam.accounting.allocations import Allocation
+from sam.resources.resources import ResourceType
+from sam.schemas.allocation import AllocationWithUsageSchema
+from sam.summaries.disk_summaries import (
+    BYTES_PER_TIB, DiskChargeSummary, mark_disk_snapshot_current,
+)
+from factories.core import make_user
+from factories.projects import make_account, make_allocation, make_project
+from factories.resources import make_resource, make_resource_type
+from factories._seq import next_seq
+
+
+pytestmark = pytest.mark.unit
+
+
+def _disk_alloc(session, *, amount_tib: float = 100.0):
+    user = make_user(session)
+    project = make_project(session, lead=user)
+    rt = session.query(ResourceType).filter_by(resource_type='DISK').first()
+    if rt is None:
+        rt = make_resource_type(session, resource_type='DISK')
+    resource = make_resource(session, resource_type=rt,
+                             resource_name=next_seq('DRES'))
+    account = make_account(session, project=project, resource=resource)
+    alloc = make_allocation(session, account=account, amount=amount_tib)
+    return user, project, account, alloc
+
+
+class TestAllocationDiskCurrentFields:
+
+    def test_disk_allocation_has_current_used_fields(self, session):
+        user, project, account, alloc = _disk_alloc(session, amount_tib=100.0)
+        # Seed today's snapshot at 47 TiB.
+        snap_date = date.today()
+        session.add(DiskChargeSummary(
+            activity_date=snap_date,
+            user_id=user.user_id,
+            account_id=account.account_id,
+            username=user.username,
+            bytes=47 * BYTES_PER_TIB,
+            terabyte_years=0.5,
+            charges=0.5,
+            number_of_files=1,
+        ))
+        session.flush()
+        mark_disk_snapshot_current(session, snap_date)
+
+        schema = AllocationWithUsageSchema()
+        schema.context = {
+            'account': account, 'session': session, 'include_adjustments': True,
+        }
+        out = schema.dump(alloc)
+        assert out['current_used_bytes'] == 47 * BYTES_PER_TIB
+        assert out['current_used_tib'] == pytest.approx(47.0)
+        assert out['current_pct_used'] == pytest.approx(47.0)
+        # Schema is JSON-friendly — date may serialize to string.
+        assert str(out['current_snapshot_date']).startswith(snap_date.isoformat())
+
+    def test_non_disk_resource_has_null_current_fields(self, session):
+        """HPC resource → all current_* fields are null (None)."""
+        user = make_user(session)
+        project = make_project(session, lead=user)
+        rt = make_resource_type(session, resource_type=f"HPC-{next_seq('rt')}")
+        resource = make_resource(session, resource_type=rt)
+        account = make_account(session, project=project, resource=resource)
+        alloc = make_allocation(session, account=account, amount=10_000.0)
+
+        schema = AllocationWithUsageSchema()
+        schema.context = {'account': account, 'session': session}
+        out = schema.dump(alloc)
+        assert out['current_used_bytes'] is None
+        assert out['current_used_tib'] is None
+        assert out['current_pct_used'] is None
+        assert out['current_snapshot_date'] is None
+
+    def test_disk_allocation_no_snapshots_returns_null(self, session):
+        """Disk resource but no disk_charge_summary rows → null current_*."""
+        user, project, account, alloc = _disk_alloc(session, amount_tib=10.0)
+        # Don't seed any rows.
+        schema = AllocationWithUsageSchema()
+        schema.context = {'account': account, 'session': session}
+        out = schema.dump(alloc)
+        # current_disk_usage returns None when there's no row → fields null.
+        assert out['current_used_bytes'] is None
+        assert out['current_used_tib'] is None
+        assert out['current_pct_used'] is None
+
+    def test_current_used_distinct_from_cumulative_used(self, session):
+        """Two snapshots, different sizes: cumulative SUMs both,
+        current reflects only the latest. They differ — that's the
+        whole point of the new fields."""
+        user, project, account, alloc = _disk_alloc(session, amount_tib=100.0)
+        # Push allocation start back so both seeded snapshots fall inside.
+        alloc.start_date = datetime.now() - timedelta(days=30)
+        session.flush()
+
+        # Snapshot 1: 10 TiB, charges=1.0. Snapshot 2: 20 TiB, charges=2.0.
+        d1 = date.today() - timedelta(days=7)
+        d2 = date.today()
+        for d, b, ch in [(d1, 10 * BYTES_PER_TIB, 1.0),
+                         (d2, 20 * BYTES_PER_TIB, 2.0)]:
+            session.add(DiskChargeSummary(
+                activity_date=d,
+                user_id=user.user_id,
+                account_id=account.account_id,
+                username=user.username,
+                bytes=b,
+                terabyte_years=ch,
+                charges=ch,
+                number_of_files=1,
+            ))
+        session.flush()
+        mark_disk_snapshot_current(session, d2)
+
+        schema = AllocationWithUsageSchema()
+        schema.context = {
+            'account': account, 'session': session, 'include_adjustments': True,
+        }
+        out = schema.dump(alloc)
+        # Cumulative `used` sums charges over the allocation window: 1.0 + 2.0
+        assert out['used'] == pytest.approx(3.0)
+        # Current `used` is the latest snapshot only — 20 TiB.
+        assert out['current_used_tib'] == pytest.approx(20.0)
+        assert out['current_used_tib'] != out['used']

--- a/tests/unit/test_accounting_disk_admin.py
+++ b/tests/unit/test_accounting_disk_admin.py
@@ -1,0 +1,202 @@
+"""End-to-end test for `sam-admin accounting --disk`.
+
+Builds a minimal SAM graph (User → Project → Account → DISK Resource),
+feeds a small acct.glade-shaped CSV + cs_usage.json-shaped JSON, runs
+the CLI via CliRunner, and asserts the resulting disk_charge_summary
+rows include both real per-user rows AND the synthetic gap row
+attributed to the project lead with ``act_username='<unidentified>'``.
+"""
+
+import json
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from cli.cmds.admin import cli
+from cli.accounting import disk_usage as disk_usage_mod
+from cli.accounting import quota_readers as quota_readers_mod
+from sam.resources.resources import ResourceType
+from sam.summaries.disk_summaries import (
+    DISK_CHARGING_TIB_EPOCH,
+    DiskChargeSummary,
+    DiskChargeSummaryStatus,
+)
+from factories.core import make_user
+from factories.projects import make_account, make_project
+from factories.resources import make_resource, make_resource_type
+from factories._seq import next_seq
+
+
+pytestmark = pytest.mark.unit
+
+
+def _build_campaign_store_graph(session, monkeypatch):
+    """Build a project on a uniquely-named DISK resource and register
+    GladeCsvReader / GpfsQuotaReader for it so the CLI dispatch works."""
+    lead = make_user(session)
+    project = make_project(session, lead=lead)
+    rt = session.query(ResourceType).filter_by(resource_type='DISK').first()
+    if rt is None:
+        rt = make_resource_type(session, resource_type='DISK')
+    resource_name = f"Campaign_Store_{next_seq('cs')}"
+    resource = make_resource(session, resource_type=rt, resource_name=resource_name)
+    make_account(session, project=project, resource=resource)
+    # Patch the reader registries so the CLI finds a reader for this name.
+    monkeypatch.setitem(
+        disk_usage_mod._READERS, resource_name, disk_usage_mod.GladeCsvReader,
+    )
+    monkeypatch.setitem(
+        quota_readers_mod._READERS, resource_name, quota_readers_mod.GpfsQuotaReader,
+    )
+    return lead, project, resource
+
+
+def _write_acct(tmp_path: Path, snap: date, projcode: str, username: str,
+                kib: int) -> Path:
+    """Single-row acct.glade.YYYY-MM-DD."""
+    f = tmp_path / f"acct.glade.{snap.isoformat()}"
+    # CSV columns (8): date, path, projcode, username, nfiles, KiB, interval, cos
+    f.write_text(
+        f'"{snap.isoformat()}","/gpfs/csfs1/{projcode.lower()}",'
+        f'"{projcode.lower()}","{username}","100","{kib}","7","0"\n'
+    )
+    return f
+
+
+def _write_quotas(tmp_path: Path, snap: date, fileset: str,
+                  usage_kib: int, limit_kib: int) -> Path:
+    f = tmp_path / "cs_usage.json"
+    body = {
+        "date": f"Mon Apr 27 08:00:00 MDT {snap.year}",
+        "paths": {"csfs1": {fileset: f"/gpfs/csfs1/{fileset}"}},
+        "usage": {
+            "FILESET": {
+                fileset: {
+                    "limit": str(limit_kib),
+                    "usage": str(usage_kib),
+                    "files": "100",
+                }
+            },
+            "USR": {},
+        },
+        "groups": {},
+    }
+    f.write_text(json.dumps(body))
+    return f
+
+
+class TestDiskAdminCli:
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_db_session(self, session):
+        with patch('sam.session.create_sam_engine') as mock_engine, \
+             patch('cli.cmds.admin.Session') as mock_session_cls:
+            mock_engine.return_value = (MagicMock(), None)
+            mock_session_cls.return_value = session
+            yield session
+
+    def test_dry_run_produces_no_rows(self, runner, mock_db_session, tmp_path, session, monkeypatch):
+        lead, project, resource = _build_campaign_store_graph(session, monkeypatch)
+        snap = DISK_CHARGING_TIB_EPOCH
+        # 1 GiB written by the lead (KiB count = 1024 * 1024)
+        f = _write_acct(tmp_path, snap, project.projcode, lead.username,
+                        kib=1024 * 1024)
+
+        n_before = session.query(DiskChargeSummary).count()
+        result = runner.invoke(cli, [
+            'accounting', '--disk',
+            '--resource', resource.resource_name,
+            '--user-usage', str(f),
+            '--date', snap.isoformat(),
+            '--dry-run',
+        ])
+        assert result.exit_code == 0, result.output
+        n_after = session.query(DiskChargeSummary).count()
+        assert n_after == n_before
+
+    def test_live_run_writes_user_row(self, runner, mock_db_session, tmp_path, session, monkeypatch):
+        lead, project, resource = _build_campaign_store_graph(session, monkeypatch)
+        snap = DISK_CHARGING_TIB_EPOCH
+        f = _write_acct(tmp_path, snap, project.projcode, lead.username,
+                        kib=1024 * 1024)  # 1 GiB
+
+        result = runner.invoke(cli, [
+            'accounting', '--disk',
+            '--resource', resource.resource_name,
+            '--user-usage', str(f),
+            '--date', snap.isoformat(),
+        ])
+        assert result.exit_code == 0, result.output
+
+        rows = session.query(DiskChargeSummary).filter(
+            DiskChargeSummary.activity_date == snap,
+            DiskChargeSummary.user_id == lead.user_id,
+        ).all()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.bytes == 1024 * 1024 * 1024            # 1 GiB
+        # 1 GiB × 7 / 365 / 1024⁴ = 7 / (365 × 1024) ≈ 1.873e-5 TiB-yr.
+        # DB column is FLOAT (~7 decimal digits) — generous tolerance.
+        expected_ty = 7 / (365 * 1024)
+        assert row.terabyte_years == pytest.approx(expected_ty, abs=1e-7)
+        assert row.charges == pytest.approx(row.terabyte_years, abs=1e-7)
+        # Normal rows: act_username carries the parsed username (used by
+        # the resolver). Gap rows would carry '<unidentified>'.
+        assert row.act_username == lead.username
+
+        # Snapshot status updated.
+        currents = session.query(DiskChargeSummaryStatus).filter(
+            DiskChargeSummaryStatus.current == True  # noqa: E712
+        ).all()
+        assert any(r.activity_date == snap for r in currents)
+
+    def test_gap_reconciliation_creates_unidentified_row(
+        self, runner, mock_db_session, tmp_path, session, monkeypatch,
+    ):
+        """FILESET total > Σuser_bytes → emit synthetic '<unidentified>' row
+        attributed to project lead."""
+        lead, project, resource = _build_campaign_store_graph(session, monkeypatch)
+        snap = DISK_CHARGING_TIB_EPOCH
+
+        # User row: 1 GiB. FILESET total: 3 GiB → 2 GiB gap.
+        # The fileset_name keys on uppercased projcode, so use that here.
+        kib_user = 1 * 1024 * 1024
+        kib_fileset = 3 * 1024 * 1024
+        f = _write_acct(tmp_path, snap, project.projcode, lead.username,
+                        kib=kib_user)
+        q = _write_quotas(tmp_path, snap, project.projcode.lower(),
+                          usage_kib=kib_fileset, limit_kib=10 * 1024 * 1024)
+
+        result = runner.invoke(cli, [
+            'accounting', '--disk',
+            '--resource', resource.resource_name,
+            '--user-usage', str(f),
+            '--quotas', str(q),
+            '--reconcile-quota-gap',
+            '--date', snap.isoformat(),
+        ])
+        assert result.exit_code == 0, result.output
+
+        rows = session.query(DiskChargeSummary).filter(
+            DiskChargeSummary.activity_date == snap,
+            DiskChargeSummary.account_id == project.accounts[0].account_id,
+        ).all()
+        # One per-user row, one synthetic gap row.
+        assert len(rows) == 2
+        gap = [r for r in rows if r.act_username == '<unidentified>']
+        normal = [r for r in rows if r.act_username != '<unidentified>']
+        assert len(gap) == 1
+        assert len(normal) == 1
+        # The gap FK side points at the lead — not a synthetic user.
+        assert gap[0].user_id == lead.user_id
+        # The gap bytes equal the difference (1024⁴ × 2 = 2 GiB).
+        assert gap[0].bytes == 2 * 1024 ** 3
+        # The normal row stores the parsed username as act_username.
+        assert normal[0].act_username == lead.username

--- a/tests/unit/test_current_disk_usage.py
+++ b/tests/unit/test_current_disk_usage.py
@@ -1,0 +1,140 @@
+"""Tests for Account.current_disk_usage / Project.current_disk_usage / mark_disk_snapshot_current."""
+
+from datetime import date
+
+import pytest
+
+from sam.accounting.accounts import Account, CurrentDiskUsage
+from sam.resources.resources import ResourceType
+from sam.summaries.disk_summaries import (
+    DiskChargeSummary, DiskChargeSummaryStatus,
+    mark_disk_snapshot_current,
+)
+from factories.core import make_user
+from factories.projects import make_account, make_project
+from factories.resources import make_resource, make_resource_type
+from factories._seq import next_seq
+
+
+def _disk_account(session):
+    user = make_user(session)
+    project = make_project(session, lead=user)
+    rt = session.query(ResourceType).filter_by(resource_type='DISK').first()
+    if rt is None:
+        rt = make_resource_type(session, resource_type='DISK')
+    resource = make_resource(session, resource_type=rt,
+                             resource_name=next_seq('DRES'))
+    account = make_account(session, project=project, resource=resource)
+    return user, project, account
+
+
+def _seed_summary(session, account, user, *, activity_date, bytes_, ty=1.0, files=10):
+    row = DiskChargeSummary(
+        activity_date=activity_date,
+        user_id=user.user_id,
+        account_id=account.account_id,
+        username=user.username,
+        bytes=bytes_,
+        terabyte_years=ty,
+        charges=ty,
+        number_of_files=files,
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+class TestMarkSnapshotCurrent:
+
+    def test_first_call_creates_row(self, session):
+        mark_disk_snapshot_current(session, date(2098, 7, 1))
+        rows = session.query(DiskChargeSummaryStatus).filter(
+            DiskChargeSummaryStatus.current == True  # noqa: E712
+        ).all()
+        assert len(rows) == 1
+        assert rows[0].activity_date == date(2098, 7, 1)
+
+    def test_subsequent_call_clears_prior(self, session):
+        mark_disk_snapshot_current(session, date(2098, 7, 1))
+        mark_disk_snapshot_current(session, date(2098, 7, 8))
+        # Only the new date should be current.
+        currents = session.query(DiskChargeSummaryStatus).filter(
+            DiskChargeSummaryStatus.current == True  # noqa: E712
+        ).all()
+        assert [r.activity_date for r in currents] == [date(2098, 7, 8)]
+        # The prior row exists but is False.
+        prior = session.get(DiskChargeSummaryStatus, date(2098, 7, 1))
+        assert prior is not None and prior.current is False
+
+
+class TestAccountCurrentDiskUsage:
+
+    def test_returns_latest_snapshot_not_sum(self, session):
+        """Two snapshots, only the later marked current → answer is the
+        later snapshot's bytes, NOT the sum."""
+        user, project, account = _disk_account(session)
+        _seed_summary(session, account, user, activity_date=date(2098, 7, 1),
+                      bytes_=1 * 1024 ** 4)
+        _seed_summary(session, account, user, activity_date=date(2098, 7, 8),
+                      bytes_=2 * 1024 ** 4)
+        mark_disk_snapshot_current(session, date(2098, 7, 8))
+
+        usage = account.current_disk_usage(session)
+        assert isinstance(usage, CurrentDiskUsage)
+        assert usage.activity_date == date(2098, 7, 8)
+        assert usage.bytes == 2 * 1024 ** 4
+        assert usage.used_tib == pytest.approx(2.0)
+
+    def test_falls_back_to_max_date_when_no_status(self, session):
+        """If status table has no current row, fall back to MAX(activity_date)."""
+        user, project, account = _disk_account(session)
+        _seed_summary(session, account, user, activity_date=date(2098, 8, 1),
+                      bytes_=3 * 1024 ** 4)
+        # Note: NOT calling mark_disk_snapshot_current
+        usage = account.current_disk_usage(session)
+        assert usage is not None
+        assert usage.activity_date == date(2098, 8, 1)
+        assert usage.bytes == 3 * 1024 ** 4
+
+    def test_returns_none_for_non_disk_resource(self, session):
+        """Account whose resource_type is not DISK → None."""
+        user = make_user(session)
+        project = make_project(session, lead=user)
+        rt = make_resource_type(session, resource_type=f"HPC-{next_seq('rt')}")
+        resource = make_resource(session, resource_type=rt)
+        account = make_account(session, project=project, resource=resource)
+        # No disk_charge_summary rows exist anyway, but the type gate
+        # should fire first.
+        assert account.current_disk_usage(session) is None
+
+    def test_aggregates_multiple_rows_for_same_date(self, session):
+        """The 'gap row + per-user rows' case: same activity_date,
+        same account_id, different user_ids — sum bytes."""
+        user, project, account = _disk_account(session)
+        other_user = make_user(session)
+
+        _seed_summary(session, account, user, activity_date=date(2098, 9, 1),
+                      bytes_=1 * 1024 ** 4)
+        _seed_summary(session, account, other_user, activity_date=date(2098, 9, 1),
+                      bytes_=4 * 1024 ** 4)
+        mark_disk_snapshot_current(session, date(2098, 9, 1))
+
+        usage = account.current_disk_usage(session)
+        assert usage.bytes == 5 * 1024 ** 4
+        assert usage.used_tib == pytest.approx(5.0)
+
+
+class TestProjectCurrentDiskUsage:
+
+    def test_keyed_by_resource_name(self, session):
+        user, project, account = _disk_account(session)
+        _seed_summary(session, account, user, activity_date=date(2098, 10, 1),
+                      bytes_=7 * 1024 ** 4)
+        mark_disk_snapshot_current(session, date(2098, 10, 1))
+
+        result = project.current_disk_usage()
+        res_name = account.resource.resource_name
+        assert res_name in result
+        assert result[res_name]['bytes'] == 7 * 1024 ** 4
+        assert result[res_name]['current_used_tib'] == pytest.approx(7.0)
+        assert result[res_name]['activity_date'] == date(2098, 10, 1)

--- a/tests/unit/test_disk_charging_math.py
+++ b/tests/unit/test_disk_charging_math.py
@@ -1,0 +1,83 @@
+"""Unit tests for the TiB-year storage charging formula.
+
+Pin the formula and the constants. The headline change vs legacy:
+
+  TiB-years = (bytes * reporting_interval) / 365 / 1024**4
+
+Legacy was the same shape but used 10**12 (decimal TB) — keep these
+verifications tight so a future "round to 365.25" or "drop to 1000**4"
+regression is caught immediately.
+"""
+
+import pytest
+
+from sam.summaries.disk_summaries import (
+    BYTES_PER_TIB,
+    DAYS_IN_YEAR,
+    DISK_CHARGING_TIB_EPOCH,
+    tib_years,
+)
+
+
+def test_constants_pin_units():
+    assert BYTES_PER_TIB == 1024 ** 4
+    assert DAYS_IN_YEAR == 365
+
+
+def test_epoch_is_immutable_date():
+    # The plan committed 2026-04-18 as the cutover. Lock it in — a
+    # change here must be deliberate and accompanied by a documented
+    # plan update, not a drive-by.
+    from datetime import date
+    assert DISK_CHARGING_TIB_EPOCH == date(2026, 4, 18)
+
+
+def test_wchapman_naml0001_worked_example():
+    """Match the verification target in DISK_CHARGING.md.
+
+    From acct.glade.2026-04-18 row:
+        col6 (KiB) = 235,938,728,304
+        bytes      = 235,938,728,304 × 1024 = 241,601,257,783,296
+        ty (TiB)   = 241,601,257,783,296 × 7 / 365 / 1024**4
+                   ≈ 4.21500 (legacy decimal-TB-yr was 4.63345)
+    """
+    bytes_ = 241_601_257_783_296
+    ty = tib_years(bytes_, 7)
+    # Expected to 4 decimals; computed as bytes×7/365/1024⁴.
+    expected = bytes_ * 7 / 365 / (1024 ** 4)
+    assert ty == pytest.approx(expected, rel=1e-12)
+    # Also pin a hand-checked value to four decimals — guards against
+    # silently swapping constants.
+    assert ty == pytest.approx(4.2141, abs=1e-4)
+
+
+def test_zero_bytes_zero_charge():
+    assert tib_years(0, 7) == 0.0
+
+
+def test_zero_interval_zero_charge():
+    assert tib_years(10 ** 12, 0) == 0.0
+
+
+def test_tib_year_definition_constant_storage_for_one_year():
+    # Holding 1 TiB constant for 365 days = 1 TiB-year.
+    # Single weekly snapshot: bytes = 1 TiB, interval = 7.
+    # Cumulative billing of 52 such snapshots ≈ 52 * 7 / 365 = 0.997.
+    bytes_ = BYTES_PER_TIB
+    weekly = tib_years(bytes_, 7)
+    assert weekly == pytest.approx(7 / 365, abs=1e-9)
+    # 52 weeks comes within rounding of 1 TiB-year:
+    assert 52 * weekly == pytest.approx(52 * 7 / 365, abs=1e-9)
+
+
+def test_units_match_allocation_amount_pattern():
+    # Allocation.amount for disk is in TiB. 100 TiB constant for 1 year
+    # → 100 TiB-years should match a hand calculation.
+    bytes_ = 100 * BYTES_PER_TIB
+    # 365 daily snapshots of interval=1 each (the "if cadence changes"
+    # case from the legacy doc):
+    daily_total = 365 * tib_years(bytes_, 1)
+    assert daily_total == pytest.approx(100.0, abs=1e-6)
+    # 52 weekly snapshots with interval=7:
+    weekly_total = 52 * tib_years(bytes_, 7)
+    assert weekly_total == pytest.approx(52 * 7 / 365 * 100.0, abs=1e-6)

--- a/tests/unit/test_disk_epoch_enforcement.py
+++ b/tests/unit/test_disk_epoch_enforcement.py
@@ -1,0 +1,73 @@
+"""Tests for cutover-epoch enforcement on `sam-admin accounting --disk`.
+
+The CLI must refuse to write rows whose snapshot date is before
+``DISK_CHARGING_TIB_EPOCH`` — that range stays in legacy decimal-TB-year
+units and is never rewritten by this tool.
+"""
+
+from datetime import date, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from cli.cmds.admin import cli
+from sam.summaries.disk_summaries import DISK_CHARGING_TIB_EPOCH
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_acct_glade(tmp_path: Path, snap_date: date) -> Path:
+    """Write a minimal acct.glade.YYYY-MM-DD with a single junk row."""
+    p = tmp_path / f"acct.glade.{snap_date.isoformat()}"
+    p.write_text(
+        f'"{snap_date.isoformat()}","/gpfs/csfs1/cesm","cesm","gdicker","1","1","7","0"\n'
+    )
+    return p
+
+
+class TestEpochEnforcement:
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_db_session(self, session):
+        """Hand the admin CLI our SAVEPOINT'd session."""
+        with patch('sam.session.create_sam_engine') as mock_engine, \
+             patch('cli.cmds.admin.Session') as mock_session_cls:
+            mock_engine.return_value = (MagicMock(), None)
+            mock_session_cls.return_value = session
+            yield session
+
+    def test_pre_epoch_date_refused(self, runner, mock_db_session, tmp_path):
+        pre = DISK_CHARGING_TIB_EPOCH - timedelta(days=1)
+        f = _make_acct_glade(tmp_path, pre)
+        result = runner.invoke(cli, [
+            'accounting', '--disk',
+            '--resource', 'Campaign_Store',
+            '--user-usage', str(f),
+            '--date', pre.isoformat(),
+            '--dry-run',
+        ])
+        assert result.exit_code == 2
+        assert "DISK_CHARGING_TIB_EPOCH" in result.output
+
+    def test_at_epoch_date_allowed(self, runner, mock_db_session, tmp_path):
+        f = _make_acct_glade(tmp_path, DISK_CHARGING_TIB_EPOCH)
+        result = runner.invoke(cli, [
+            'accounting', '--disk',
+            '--resource', 'Campaign_Store',
+            '--user-usage', str(f),
+            '--date', DISK_CHARGING_TIB_EPOCH.isoformat(),
+            '--dry-run',
+            '--skip-errors',
+        ])
+        # Exit 0 (dry-run, nothing written); CESM/gdicker may not resolve in
+        # test DB, but the epoch gate is what we're testing. Acceptable
+        # outcomes: 0 (clean), or 2 if user resolution fails — either way
+        # the EPOCH error must NOT appear.
+        assert "DISK_CHARGING_TIB_EPOCH" not in result.output

--- a/tests/unit/test_disk_usage_reader.py
+++ b/tests/unit/test_disk_usage_reader.py
@@ -1,0 +1,103 @@
+"""Unit tests for the GladeCsvReader (acct.glade.YYYY-MM-DD parser)."""
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from cli.accounting.disk_usage import (
+    DiskUsageEntry,
+    GladeCsvReader,
+    get_disk_usage_reader,
+)
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    p = tmp_path / name
+    p.write_text(body)
+    return p
+
+
+def test_basic_row_kib_to_bytes(tmp_path):
+    # col6 = 100 KiB → bytes = 100 * 1024 = 102400
+    csv = '"2026-04-18","/gpfs/csfs1/cesm","cesm","gdicker","4986","100","7","0"\n'
+    f = _write(tmp_path, "acct.glade.2026-04-18", csv)
+    entries = GladeCsvReader(str(f)).read()
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.activity_date == date(2026, 4, 18)
+    assert e.projcode == "CESM"               # uppercased
+    assert e.username == "gdicker"
+    assert e.number_of_files == 4986
+    assert e.bytes == 100 * 1024              # KiB → bytes
+    assert e.directory_path == "/gpfs/csfs1/cesm"
+    assert e.reporting_interval == 7
+    assert e.cos == 0
+    assert e.act_username is None              # normal row, no audit label
+
+
+def test_skips_gpfsnobody(tmp_path):
+    csv = (
+        '"2026-04-18","/gpfs/csfs1/cisl/HDIG","hdig","gpfsnobody","2","32","7","0"\n'
+        '"2026-04-18","/gpfs/csfs1/cesm","cesm","gdicker","1","32","7","0"\n'
+    )
+    f = _write(tmp_path, "acct.glade.2026-04-18", csv)
+    entries = GladeCsvReader(str(f)).read()
+    assert [e.username for e in entries] == ["gdicker"]
+
+
+def test_skips_numeric_username(tmp_path):
+    # Legacy "uid was never resolved" row — username column is just digits.
+    csv = (
+        '"2026-04-18","/gpfs/csfs1/cisl/sssg0001","sssg0001","34607","1","0","7","0"\n'
+        '"2026-04-18","/gpfs/csfs1/cisl/sssg0001","sssg0001","ivette","1","0","7","0"\n'
+    )
+    f = _write(tmp_path, "acct.glade.2026-04-18", csv)
+    entries = GladeCsvReader(str(f)).read()
+    assert [e.username for e in entries] == ["ivette"]
+
+
+def test_snapshot_date_from_rows(tmp_path):
+    csv = (
+        '"2026-04-18","/p","x","u","1","1","7","0"\n'
+        '"2026-04-18","/p2","y","u2","1","1","7","0"\n'
+    )
+    f = _write(tmp_path, "acct.glade.2026-04-18", csv)
+    r = GladeCsvReader(str(f))
+    r.read()
+    assert r.snapshot_date == date(2026, 4, 18)
+
+
+def test_snapshot_date_falls_back_to_filename(tmp_path):
+    # No data rows, filename carries the date.
+    f = _write(tmp_path, "acct.glade.2026-04-18", "")
+    r = GladeCsvReader(str(f))
+    r.read()
+    assert r.snapshot_date == date(2026, 4, 18)
+
+
+def test_malformed_row_silently_skipped(tmp_path):
+    csv = (
+        '"2026-04-18","/p","x","u","not-a-number","1","7","0"\n'
+        '"2026-04-18","/p","x","alice","1","1","7","0"\n'
+    )
+    f = _write(tmp_path, "acct.glade.2026-04-18", csv)
+    entries = GladeCsvReader(str(f)).read()
+    assert [e.username for e in entries] == ["alice"]
+
+
+def test_short_row_silently_skipped(tmp_path):
+    csv = '"2026-04-18","/p","x"\n'           # too few columns
+    f = _write(tmp_path, "acct.glade.2026-04-18", csv)
+    entries = GladeCsvReader(str(f)).read()
+    assert entries == []
+
+
+def test_registry_dispatch():
+    r = get_disk_usage_reader("Campaign_Store", "/tmp/whatever")
+    assert isinstance(r, GladeCsvReader)
+
+
+def test_registry_unknown_resource_raises():
+    with pytest.raises(NotImplementedError):
+        get_disk_usage_reader("FrobOS", "/tmp/whatever")

--- a/tests/unit/test_upsert_disk_pre_resolved.py
+++ b/tests/unit/test_upsert_disk_pre_resolved.py
@@ -1,0 +1,117 @@
+"""Tests for the pre-resolved user/account override path on upsert_disk_charge_summary.
+
+The override exists so the disk-charging gap-row path can write a
+synthetic row with ``act_username='<unidentified>'`` while the FK side
+points at the project lead — no row in the ``users`` table needs the
+literal '<unidentified>' string.
+"""
+
+from datetime import date
+
+import pytest
+
+from sam.manage.summaries import upsert_disk_charge_summary
+from sam.resources.resources import ResourceType
+from factories.core import make_user
+from factories.projects import make_account, make_project
+from factories.resources import make_resource, make_resource_type
+from factories._seq import next_seq
+
+
+def _build_disk_graph(session):
+    """Tiny disk graph: User → Project (lead=User) → Account → DISK Resource."""
+    user = make_user(session)
+    project = make_project(session, lead=user)
+    # Reuse the 'DISK' ResourceType (canonical name) — production code
+    # routes by exact resource_type string.
+    rt = session.query(ResourceType).filter_by(resource_type='DISK').first()
+    if rt is None:
+        rt = make_resource_type(session, resource_type='DISK')
+    resource = make_resource(session, resource_type=rt,
+                             resource_name=next_seq('DRES'))
+    make_account(session, project=project, resource=resource)
+    return user, project, resource
+
+
+class TestPreResolvedOverride:
+
+    def test_act_username_is_audit_label_user_is_lead(self, session):
+        """Synthetic gap row: act_username carries the label literally,
+        but user_id resolves to the project lead."""
+        lead, project, resource = _build_disk_graph(session)
+        # Account already created by _build_disk_graph; resolve it.
+        from sam.accounting.accounts import Account
+        account = Account.get_by_project_and_resource(
+            session, project.project_id, resource.resource_id
+        )
+        record, action = upsert_disk_charge_summary(
+            session,
+            activity_date=date(2098, 6, 15),
+            act_username='<unidentified>',
+            act_projcode=None,
+            act_unix_uid=None,
+            resource_name=resource.resource_name,
+            charges=1.0,
+            number_of_files=0,
+            bytes=1024 ** 4,
+            terabyte_years=1.0,
+            user=lead,
+            account=account,
+        )
+        assert action == 'created'
+        # The audit column carries the label verbatim.
+        assert record.act_username == '<unidentified>'
+        # The FK resolves to the project lead — no synthetic user row.
+        assert record.user_id == lead.user_id
+        assert record.username == lead.username
+        # account_id is the resolved account.
+        assert record.account_id == account.account_id
+
+    def test_pre_resolved_user_skips_resolver(self, session):
+        """If a user is supplied, _resolve_user is bypassed — the audit
+        label can be ANY string (including one that doesn't exist in users)."""
+        lead, project, resource = _build_disk_graph(session)
+        from sam.accounting.accounts import Account
+        account = Account.get_by_project_and_resource(
+            session, project.project_id, resource.resource_id
+        )
+
+        # This act_username deliberately does NOT exist in users — and
+        # we don't pass a unix_uid — so without the override the resolver
+        # would raise. The override should make this succeed.
+        # (DB column is varchar(35); use a short bogus literal.)
+        bogus = 'no_such_user_xyz'
+        record, _ = upsert_disk_charge_summary(
+            session,
+            activity_date=date(2098, 6, 16),
+            act_username=bogus,
+            act_projcode=None,
+            act_unix_uid=None,
+            resource_name=resource.resource_name,
+            charges=0.5,
+            number_of_files=0,
+            bytes=512,
+            terabyte_years=0.0,
+            user=lead,
+            account=account,
+        )
+        assert record.act_username == bogus
+        assert record.user_id == lead.user_id
+
+    def test_no_override_falls_back_to_resolver(self, session):
+        """Without the override, the standard resolver path still works."""
+        user, project, resource = _build_disk_graph(session)
+        record, action = upsert_disk_charge_summary(
+            session,
+            activity_date=date(2098, 6, 17),
+            act_username=user.username,
+            act_projcode=project.projcode,
+            act_unix_uid=user.unix_uid,
+            resource_name=resource.resource_name,
+            charges=2.0,
+            number_of_files=1,
+            bytes=2048,
+            terabyte_years=0.0,
+        )
+        assert action == 'created'
+        assert record.user_id == user.user_id


### PR DESCRIPTION
# Disk Charging

Implements `sam-admin accounting --disk` — a CLI path to import
per-user-per-project disk usage from `acct.glade.YYYY-MM-DD` into
`disk_charge_summary`, with optional reconciliation against GPFS
fileset quotas. Switches the unit convention to **TiB-years** going
forward (cutover epoch `2026-04-18`), adds a missing
"current usage right now" read path on top of the previously-dormant
`disk_charge_summary_status` table, and infers the per-row reporting
interval at write time from the prior snapshot for the same account.

Design plans:
- [`docs/plans/DISK_CHARGING.md`](docs/plans/DISK_CHARGING.md)
- [`docs/plans/DISK_BILLING_REFACTOR.md`](docs/plans/DISK_BILLING_REFACTOR.md)

---

## Why

Four independent problems in the existing disk-accounting story
this PR resolves together:

1. **No live import path.** The legacy Java/Hibernate ingest that
   populated `disk_charge_summary` is retired. The Python codebase
   had `upsert_disk_charge_summary()` and a `--disk` CLI flag, but
   the flag printed *"not yet implemented"* and nothing fed the
   table.
2. **Unit mismatch causing silent ~10% drift.** The legacy formula
   stored `terabyte_years` in **decimal TB-years** (10¹², `DAYS_IN_YEAR=365`),
   but `Allocation.amount` is in **TiB** (1024⁴). Every
   allocation-balance roll-up that summed `terabyte_years` and
   compared to `Allocation.amount` was wrong by `1024⁴ / 10¹² ≈
   1.0995` — silently. The legacy doc itself incorrectly claimed
   the formula uses `365.25`; the actual Java constant is `365`.
3. **No "current usage" query path.** Every consumer of
   `disk_charge_summary` aggregates with `SUM(charges)` over a
   date range — correct for cumulative billing, but wrong for
   "how full is project X *right now*?". The
   `disk_charge_summary_status` table (with a `current` boolean
   flag keyed by `activity_date`) had been defined but never
   written or read.
4. **Hard-coded reporting interval.** `--reporting-interval=7` was
   the entire defense against under- or over-billing. If snapshot
   cadence changed (weekly → daily) and the operator forgot to
   flip the flag, every row was 7× wrong. Missed snapshots and
   out-of-order backfills produced silently wrong charges too.

---

## What's new

### `sam-admin accounting --disk` CLI

```
sam-admin accounting --disk \
    --resource Campaign_Store \
    --user-usage ./acct.glade.YYYY-MM-DD \
    [--quotas ./cs_usage.json --reconcile-quota-gap] \
    [--reporting-interval 7] \
    [--unidentified-label '<unidentified>'] \
    [--gap-tolerance-bytes 1073741824 --gap-tolerance-frac 0.01] \
    [--dry-run] [--verbose] [--skip-errors]
```

- Snapshot date is read from the file (date columns in rows, or
  filename fallback). Date flags are accepted as a safety filter.
- `--machine` is rejected with `--disk` (HPC-only).
- The command refuses to write rows whose snapshot date is
  before `DISK_CHARGING_TIB_EPOCH = 2026-04-18` — pre-epoch legacy
  rows are deliberately not rewritten.
- **Idempotent on snap_date**: deletes every existing
  `disk_charge_summary` row for `(resource, snap_date)` before
  re-writing. Re-runs replace cleanly; mixed legacy / post-epoch
  rows on the imported date are removed.
- Marks the imported date as `current=True` in
  `disk_charge_summary_status`, clearing any prior current row.

### Pluggable disk-usage reader package — `src/cli/accounting/disk_usage/`

Mirrors `quota_readers/`. New types:

- `DiskUsageReader` (ABC) + `DiskUsageEntry` dataclass.
- `GladeCsvReader` — parses `acct.glade.YYYY-MM-DD` (KiB→bytes via
  `×1024`, skips `gpfsnobody` and rows whose username column is
  numeric-only). Extensible by resource (e.g. future Lustre/Destor).

### Projcode resolution: directory_path → ProjectDirectory → Project

The acct file's column 3 is a **fileset label** (e.g. `cesm`, `cgd`)
which is *not* always a SAM projcode. For umbrella filesets like
`cgd` containing many subdirectories, the row's `directory_path`
(column 2, e.g. `/gpfs/csfs1/cgd/amp`) maps via active
`ProjectDirectory` rows to a specific SAM project (`NCGD0009`).
The import does this lookup first, falls back to projcode-as-label,
and skips/aborts (per `--skip-errors`) when neither resolves.

### `<unidentified>` reconciliation (no synthetic User row)

When `--reconcile-quota-gap` is set, for each project where FILESET
usage exceeds Σ(per-user acct rows) by more than the configured
tolerance, the import emits a synthetic gap row:

| Column        | Normal row              | Gap row                            |
|---            |---                      |---                                 |
| `act_username`| user                    | `'<unidentified>'`  ← audit label  |
| `username`    | user                    | **the project lead's username**    |
| `user_id`     | user.id                 | **the project lead's user_id**     |
| `account_id`  | resolved                | resolved                           |

No row is added to the `users` table. The audit label is the
only signal that a row is a synthetic attribution — easy to grep
for, never collides with a real username, never escapes into joins
on `users`.

### Cutover epoch — TiB-years going forward

```
BYTES_PER_TIB           = 1024 ** 4
DAYS_IN_YEAR            = 365
DISK_CHARGING_TIB_EPOCH = date(2026, 4, 18)

terabyte_years = (bytes * reporting_interval) / 365 / 1024**4
charges        = terabyte_years
```

Pre-epoch rows in `disk_charge_summary` (back to 2025-03-21,
~104K rows) are **deliberately left in legacy decimal-TB-year
units**. Allocations whose window straddles the epoch read mixed
units (~9.95% drift on the pre-epoch portion); this is documented
and accepted.

The single source of truth for the formula:
`sam.summaries.disk_summaries.tib_years(bytes_, reporting_interval)`.

### Write-time inferred reporting interval ⭐ NEW

`--reporting-interval` is no longer a uniform per-row constant.
Each row's interval is inferred from the prior
`disk_charge_summary.activity_date` for the same account:

```python
# src/sam/summaries/disk_summaries.py
def infer_reporting_interval(session, *, account_id, snap_date, fallback_days):
    prior = (
        session.query(func.max(DiskChargeSummary.activity_date))
        .filter(
            DiskChargeSummary.account_id == account_id,
            DiskChargeSummary.activity_date < snap_date,    # strict <
        )
        .scalar()
    )
    return (snap_date - prior).days if prior else fallback_days
```

Composes correctly with the existing pre-write delete on
`(resource, snap_date)` — the strict `<` finds the actually-prior
snapshot on re-imports and the actual predecessor on out-of-order
backfills.

| case                        | behavior                                  |
|---                          |---                                        |
| Steady weekly               | interval = 7 (legacy parity)              |
| Steady daily                | interval = 1 (no operator action needed)  |
| Cadence change weekly→daily | first daily covers prior week (7), then 1 |
| Missed week                 | interval = 14, bytes count for the gap    |
| Out-of-order backfill       | strict `<` excludes later imported snap   |
| Bootstrap (first row ever)  | falls back to `--reporting-interval`      |
| Re-import idempotency       | delete-then-lookup finds actual prior     |

`--reporting-interval` keeps its default of `7` but is now
**bootstrap-only** — used solely on the first-ever row for an
account. Operator-forgot-to-flip-the-flag bugs are no longer
possible. `_run_disk` deduplicates queries via a per-account cache
(~150 lookups instead of ~2000 on a typical Campaign_Store import).

### Pre-resolved upsert override

`_upsert_storage_summary` (and therefore
`upsert_disk_charge_summary` / `upsert_archive_charge_summary`) gain
optional `user`, `project`, `account` parameters. When supplied,
the resolver is bypassed. Backward-compatible — existing callers
unchanged. Required by the gap-row path so `act_username='<unidentified>'`
doesn't have to exist in `users`.

### "Current usage" read path — `disk_charge_summary_status`

Previously dormant. Now:

- `mark_disk_snapshot_current(session, date)` — `_run_disk` calls
  this in the same transaction as the writes. Clears prior
  `current=True` rows; sets the imported date to `current=True`.
- `Account.current_disk_usage(session)` returns a
  `CurrentDiskUsage(activity_date, bytes, terabyte_years,
  number_of_files)` for the latest snapshot, or None for non-disk
  resources / no rows. Falls back to `MAX(activity_date)`
  defensively (also when the current snapshot has no row for
  *this* account).
- `Project.current_disk_usage(resource_name=None)` — keyed by
  resource name; mirrors `get_detailed_allocation_usage` shape.
- `AllocationWithUsageSchema` gains four disk-only fields:
  `current_used_bytes`, `current_used_tib`, `current_snapshot_date`,
  `current_pct_used` (null for non-disk resources). **Distinct from
  cumulative `used`** — answers "how full are you right now?"
  instead of "how many TiB-years have you billed?".

The cumulative-billing SUM math (six existing call sites in
`sam.queries.charges`, `sam.queries.dashboard`, `sam.accounting.calculator`,
`sam.schemas.allocation`, `sam.projects.projects`) is **unchanged
in this PR**. The previously-proposed `LAG()`-based read-time
integration was demoted to optional debug helper after the
write-time inferred interval landed — see
`docs/plans/DISK_BILLING_REFACTOR.md` for the rationale.

---

## Files

| Path                                                          | Status   |
|---                                                            |---       |
| `src/cli/accounting/disk_usage/{__init__,base,glade_csv}.py`  | new      |
| `src/cli/accounting/commands.py`                              | modified — `_run_disk`, `_build_unidentified_disk_rows` |
| `src/cli/accounting/display.py`                               | modified — `display_disk_dry_run_table` |
| `src/cli/cmds/admin.py`                                       | modified — flag wiring, validation, mode-tagged help |
| `src/sam/summaries/disk_summaries.py`                         | modified — constants + `mark_disk_snapshot_current`, `tib_years`, `infer_reporting_interval` |
| `src/sam/manage/summaries.py`                                 | modified — pre-resolved `user`/`project`/`account` overrides |
| `src/sam/accounting/accounts.py`                              | modified — `CurrentDiskUsage`, `Account.current_disk_usage` |
| `src/sam/projects/projects.py`                                | modified — `Project.current_disk_usage` |
| `src/sam/schemas/allocation.py`                               | modified — `current_used_*` fields |
| `tests/unit/test_disk_charging_math.py`                       | new      |
| `tests/unit/test_disk_usage_reader.py`                        | new      |
| `tests/unit/test_upsert_disk_pre_resolved.py`                 | new      |
| `tests/unit/test_current_disk_usage.py`                       | new      |
| `tests/unit/test_disk_epoch_enforcement.py`                   | new      |
| `tests/unit/test_accounting_disk_admin.py`                    | new      |
| `tests/unit/test_disk_inferred_interval.py`                   | new      |
| `tests/api/test_allocation_schema_disk_current.py`            | new      |
| `docs/plans/DISK_CHARGING.md`                                 | (committed earlier) |
| `docs/plans/DISK_BILLING_REFACTOR.md`                         | (rewritten as landed-design doc) |

---

## Verification

### Tests

43 new tests; full suite **1875 passing**, 23 skipped, 1 xfailed
under `pytest -n auto` (~138s).

```
tests/unit/test_disk_charging_math.py            8 tests — pin formula constants + worked example
tests/unit/test_disk_usage_reader.py             8 tests — reader filtering, KiB→bytes, registry
tests/unit/test_upsert_disk_pre_resolved.py      3 tests — override path skips resolver
tests/unit/test_current_disk_usage.py            7 tests — latest-snapshot semantics, fallbacks
tests/unit/test_disk_epoch_enforcement.py        2 tests — pre-epoch dates refused
tests/unit/test_accounting_disk_admin.py         3 tests — full CLI end-to-end + gap row
tests/unit/test_disk_inferred_interval.py        8 tests — write-time interval lookup semantics
tests/api/test_allocation_schema_disk_current.py 4 tests — new schema fields, disk-only
```

### Live import (post-cutover, on real DB)

```
$ sam-admin accounting --resource Campaign_Store --disk \
      --user-usage ./acct.glade.2026-04-18 \
      --quotas    ./cs_usage.json \
      --reconcile-quota-gap --skip-errors

Gap reconciliation: 44 project(s) with unattributed bytes; total 474.59 TiB
attributed to project leads with audit label '<unidentified>'.
Cleared 4207 pre-existing disk_charge_summary row(s) for Campaign_Store on
2026-04-18 before re-import.
Posting Campaign_Store disk charges... ━━━━━━━━━ 2500/2500 0:00:23
       Import Summary
 Created                2279
 Updated                  35
 Skipped (zero-charge)     0
 Errors                  186
```

Worked example (`wchapman/NAML0001`):

| value          | legacy decimal-TB-yr | new TiB-yr |
|---             |---                   |---|
| `bytes`        | 241,601,257,783,296  | 241,601,257,783,296 |
| `terabyte_years` | `4.6334`           | **`4.2141`** ✓ matches plan |

ratio = 1.0995 = 1024⁴ / 10¹² — confirms the unit switch worked.

`disk_charge_summary_status` shows `2026-04-18, current=1` ✓.
44 `<unidentified>` rows landed, attributed to project leads.

### Inferred-interval cross-check (next import)

```sql
SELECT activity_date,
       account_id,
       terabyte_years,
       bytes,
       ROUND(terabyte_years * 365 * POW(1024,4) / bytes) AS inferred_days
FROM disk_charge_summary
WHERE activity_date >= '<post-feature-date>'
ORDER BY activity_date DESC, account_id LIMIT 40;
```

`inferred_days` should equal the actual gap between consecutive
snapshot dates for that account.

---

## Findings: comparison of the 186 unmappable rows vs `--reconcile-quotas`

The 186 `--skip-errors` rows from the live import collapse to **14
distinct `(projcode, path)` groups**, in two reasons:

| reason       | rows | groups | meaning                                                  |
|---           |---   |---     |---                                                       |
| `no project` | 136  | 8      | fileset label / path matches no SAM project at all       |
| `no account` | 30   | 6      | project exists, but has no `Campaign_Store` allocation   |

Cross-referenced against the `Unmapped quota entries` table from
`sam-admin accounting --resource Campaign_Store --reconcile-quotas
./cs_usage.json --verify-paths`:

| FILESET (reconcile)      | Path                              | acct rows? | acct reason  | acct user_bytes (TiB) |
|---                       |---                                |---         |---           |---|
| `USGS_Water`             | `/ncar/USGS_Water`                | ✓ 19       | no project   | 1,663 |
| `cdg`                    | `/collections/cdg`                | ✓ 49       | no account   | 1,756 |
| `cgd_projects`           | `/cgd/projects`                   | ✓ 12       | no project   | 914 |
| `cgd_cesm`               | `/cgd/cesm`                       | ✓ 6        | no project   | 148 |
| `cesmdata`               | `/cesm/cesmdata`                  | ✓ 64       | no project   | 76 |
| `ngic`                   | `/ral/ngic`                       | ✓ 1        | no project   | 40 |
| `ssg`                    | `/cisl/ssg`                       | ✓ 3        | no project   | 18 |
| `jamtest`                | `/cisl/HDIG/jam/jamtest`          | ✓ 1        | no project   | 0 |
| **`work`**               | `/work`                           | ✗          | —            | — |
| **`ATEC`**               | `/ncar/ATEC`                      | ✗          | —            | — |
| **`glens`**              | (no path)                         | ✗          | —            | — |

**8 of the 11 reconcile-Unmapped filesets account for ~135 of the
166 acct failures.** The other 30 acct failures are SAM projects
(`WYOM0229`, `UOSC0027`, `NRAL0041`, `UUMM0001`, `UCNN0051`,
`WYOM0239`) that exist but lack a `Campaign_Store` Account.

**Reconcile-only filesets** — `work`, `ATEC`, `glens` — had **zero
per-user acct rows**, i.e. service-owned bytes that never get
attributed per-user. They surface only in `--reconcile-quotas`. With
`--reconcile-quota-gap` they would attribute to project leads as
`<unidentified>` rows *if* a SAM project existed for them; today
they're invisible to `disk_charge_summary` entirely.

The two commands are complementary lenses on the same accounting
gap:

- `--reconcile-quotas` (allocation truth): "FILESET exists but no
  SAM allocation" — 11 entries, ranks the storage waste.
- `--disk` import errors (charging truth): "user-attributed bytes
  cannot be posted" — 14 groups, ranks the per-day charging gap.

Items needing admin attention fall into two queues:

1. **Add a SAM project (or `ProjectDirectory`) for**: `USGS_Water`,
   `cgd_projects`, `cgd_cesm`, `cesmdata`, `ngic`, `ssg`, `jamtest`,
   `STDD0003 → /collections/cdg` (8 filesets, ~3.0 PiB
   user-attributable; many more on `work`/`ATEC` not even seen
   per-user).
2. **Add a `Campaign_Store` Account for existing projects**:
   `WYOM0229`, `UOSC0027`, `NRAL0041`, `UUMM0001`, `UCNN0051`,
   `WYOM0239` (~73 TiB user-attributable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
