### PR TITLE
Disk UX: capacity bars + dedicated Resource Usage Details view

### DIFF
--- a/src/sam/queries/allocations.py
+++ b/src/sam/queries/allocations.py
@@ -1144,24 +1144,40 @@ def get_allocation_summary_with_usage(
 
         # Disk capacity override: when every allocation in this row is on
         # a disk resource, replace the cumulative TiB-year total_used
-        # with the point-in-time TiB occupancy sum from
-        # Account.current_disk_usage(). The progress bar in the UI then
-        # reads "TiB used / TiB allocated", which is what users mean by
-        # "% used" for storage. Mixed-resource rows (rare) keep the
-        # cumulative number.
+        # with the point-in-time TiB occupancy of the project subtree
+        # (so parents like NMMM0003, whose children hold the bytes,
+        # don't read 0%). For single-project rows (the common case
+        # under projcode-grouping), `get_subtree_disk_capacity` walks
+        # `project.get_descendants()` on the row's resource and sums
+        # snapshot bytes. Multi-project rows fall back to summing
+        # per-account snapshots (legacy behaviour) — capacity-aware
+        # de-duplication across overlapping subtrees in TOTAL-style
+        # aggregates is a known limitation.
         all_disk = bool(item_allocations) and all(
             rt == 'DISK' for _, _, rt, _, _ in item_allocations
         )
         if all_disk:
-            capacity_used = 0.0
-            activity_date = None
-            for _, _, _, _, account in item_allocations:
-                snap = account.current_disk_usage()
-                if snap is None:
-                    continue
-                capacity_used += snap.used_tib
-                if activity_date is None or snap.activity_date > activity_date:
-                    activity_date = snap.activity_date
+            from sam.queries.disk_usage import get_subtree_disk_capacity
+            unique_projects = {p.project_id: p for _, _, _, p, _ in item_allocations}
+            unique_resources = {res for _, res, _, _, _ in item_allocations}
+            if len(unique_projects) == 1 and len(unique_resources) == 1:
+                only_project = next(iter(unique_projects.values()))
+                only_resource = next(iter(unique_resources))
+                cap = get_subtree_disk_capacity(
+                    session, only_project, only_resource,
+                )
+                capacity_used = cap['used_tib']
+                activity_date = cap['activity_date']
+            else:
+                capacity_used = 0.0
+                activity_date = None
+                for _, _, _, _, account in item_allocations:
+                    snap = account.current_disk_usage()
+                    if snap is None:
+                        continue
+                    capacity_used += snap.used_tib
+                    if activity_date is None or snap.activity_date > activity_date:
+                        activity_date = snap.activity_date
             item['total_used'] = capacity_used
             item['percent_used'] = (
                 (capacity_used / item['total_allocated'] * 100)

--- a/src/sam/queries/allocations.py
+++ b/src/sam/queries/allocations.py
@@ -1077,6 +1077,31 @@ def get_allocation_summary_with_usage(
     if account_infos:
         all_charges.update(Project.batch_get_account_charges(session, account_infos, include_adjustments))
 
+    # Bulk-resolve disk capacity for every all-disk row at once. The
+    # `get_subtree_disk_capacity` walk is expensive (per-account snapshot
+    # lookups) and the allocation summary may contain hundreds of disk
+    # rows — fanning out per-row drove route query counts above 4000.
+    # Collect the (project, resource_name) pairs we'll need and resolve
+    # them in a single fixed-size set of queries.
+    disk_capacity_pairs: List[Tuple['Project', str]] = []
+    for alloc_list in alloc_by_key.values():
+        if not alloc_list:
+            continue
+        if not all(rt == 'DISK' for _, _, rt, _, _ in alloc_list):
+            continue
+        unique_projects = {p.project_id: p for _, _, _, p, _ in alloc_list}
+        unique_resources = {res for _, res, _, _, _ in alloc_list}
+        if len(unique_projects) == 1 and len(unique_resources) == 1:
+            only_project = next(iter(unique_projects.values()))
+            only_resource = next(iter(unique_resources))
+            disk_capacity_pairs.append((only_project, only_resource))
+    from sam.queries.disk_usage import _EMPTY_CAP
+    if disk_capacity_pairs:
+        from sam.queries.disk_usage import bulk_get_subtree_disk_capacity
+        disk_caps = bulk_get_subtree_disk_capacity(session, disk_capacity_pairs)
+    else:
+        disk_caps = {}
+
     # Enrich each summary item with pre-computed usage data
     for item in summary:
         key = _summary_item_key(item, resource_name, facility_name, allocation_type, projcode)
@@ -1157,14 +1182,13 @@ def get_allocation_summary_with_usage(
             rt == 'DISK' for _, _, rt, _, _ in item_allocations
         )
         if all_disk:
-            from sam.queries.disk_usage import get_subtree_disk_capacity
             unique_projects = {p.project_id: p for _, _, _, p, _ in item_allocations}
             unique_resources = {res for _, res, _, _, _ in item_allocations}
             if len(unique_projects) == 1 and len(unique_resources) == 1:
                 only_project = next(iter(unique_projects.values()))
                 only_resource = next(iter(unique_resources))
-                cap = get_subtree_disk_capacity(
-                    session, only_project, only_resource,
+                cap = disk_caps.get(
+                    (only_project.project_id, only_resource), _EMPTY_CAP,
                 )
                 capacity_used = cap['used_tib']
                 activity_date = cap['activity_date']

--- a/src/sam/queries/allocations.py
+++ b/src/sam/queries/allocations.py
@@ -1142,4 +1142,34 @@ def get_allocation_summary_with_usage(
             item['percent_used'] = (self_used / item['total_allocated'] * 100) if item['total_allocated'] > 0 else 0
         item['charges_by_type'] = charges_by_type_total
 
+        # Disk capacity override: when every allocation in this row is on
+        # a disk resource, replace the cumulative TiB-year total_used
+        # with the point-in-time TiB occupancy sum from
+        # Account.current_disk_usage(). The progress bar in the UI then
+        # reads "TiB used / TiB allocated", which is what users mean by
+        # "% used" for storage. Mixed-resource rows (rare) keep the
+        # cumulative number.
+        all_disk = bool(item_allocations) and all(
+            rt == 'DISK' for _, _, rt, _, _ in item_allocations
+        )
+        if all_disk:
+            capacity_used = 0.0
+            activity_date = None
+            for _, _, _, _, account in item_allocations:
+                snap = account.current_disk_usage()
+                if snap is None:
+                    continue
+                capacity_used += snap.used_tib
+                if activity_date is None or snap.activity_date > activity_date:
+                    activity_date = snap.activity_date
+            item['total_used'] = capacity_used
+            item['percent_used'] = (
+                (capacity_used / item['total_allocated'] * 100)
+                if item['total_allocated'] > 0 else 0
+            )
+            if 'self_used' in item:
+                item['self_used'] = capacity_used
+                item['self_percent_used'] = item['percent_used']
+            item['activity_date'] = activity_date
+
     return summary

--- a/src/sam/queries/dashboard.py
+++ b/src/sam/queries/dashboard.py
@@ -54,7 +54,7 @@ charge-aggregation queries. Merging them would either pessimize the N=1
 case or complicate the N=many case — both are net losses for readers.
 """
 
-from datetime import datetime
+from datetime import datetime, date
 from typing import Any, List, Dict, Optional, TypedDict
 
 from sqlalchemy import func
@@ -136,6 +136,13 @@ class DashboardResource(TypedDict):
     days_until_expiration: Optional[int]
     date_group_key: str
 
+    # Disk-only: latest snapshot date for the capacity bar's "as of"
+    # label. None for non-disk resources and for disk accounts that
+    # have no snapshot yet (fresh allocations). When set, `used` and
+    # `percent_used` are point-in-time capacity (TiB used / TiB
+    # allocated), not cumulative TiB-year burn.
+    activity_date: Optional[date]
+
     # Timeline progress (mirrors allocations dashboard project_table.html)
     elapsed_pct: float
     bar_state: str  # one of: 'no-dates', 'open-ended', 'expired', 'active', 'no-duration'
@@ -178,6 +185,10 @@ def _build_project_resources_data(project: Project,
                                                         active_at=active_at)
 
     now = active_at or datetime.now()
+
+    # Map account_id → Account for disk capacity lookup. The dict is empty
+    # for projects with no disk accounts; cheap to build either way.
+    accounts_by_id = {a.account_id: a for a in project.accounts if not a.deleted}
 
     # Fetch rolling window usage (30d/90d) only when at least one account on
     # this project has a non-null threshold set. The dashboard template only
@@ -229,7 +240,8 @@ def _build_project_resources_data(project: Project,
                 bar_state   = 'no-duration'
 
         rwin = rolling_usage.get(resource_name, {}).get('windows', {})
-        resources.append({
+        resource_type = usage.get('resource_type', 'HPC')
+        resource_dict = {
             'resource_name': resource_name,
             'allocation_id': usage.get('allocation_id'),  # Required for edit functionality
             'parent_allocation_id': usage.get('parent_allocation_id'),
@@ -255,12 +267,61 @@ def _build_project_resources_data(project: Project,
             'date_group_key': date_group_key,
             'elapsed_pct': elapsed_pct,
             'bar_state': bar_state,
-            'resource_type': usage.get('resource_type', 'HPC'),
+            'resource_type': resource_type,
+            'activity_date': None,
             'rolling_30': rwin.get(30),
             'rolling_90': rwin.get(90),
-        })
+        }
+
+        if resource_type == 'DISK':
+            account = accounts_by_id.get(usage.get('account_id'))
+            if account is not None:
+                overrides = _disk_capacity_overrides(account, resource_dict['allocated'], resource_type)
+                if overrides is not None:
+                    resource_dict.update(overrides)
+
+        resources.append(resource_dict)
 
     return resources
+
+
+def _disk_capacity_overrides(
+    account: Account,
+    allocated: float,
+    resource_type: str,
+) -> Optional[Dict[str, Any]]:
+    """For disk allocations, return capacity-based overrides for the
+    dashboard dict.
+
+    Storage's user-facing "% used" is *capacity* (point-in-time TiB
+    used vs TiB allocated), not the cumulative TiB-year burn used for
+    billing. Returns a dict the caller merges into the resource dict,
+    or None for non-disk resources (caller leaves the dict unchanged).
+
+    The fields written are: ``used``, ``remaining``, ``percent_used``,
+    ``activity_date``. Cumulative TiB-yr (``charges_by_type``,
+    ``adjustments``) is intentionally untouched — it is no longer
+    surfaced in the disk UI but the underlying values remain available
+    for billing-side consumers.
+    """
+    if resource_type != 'DISK':
+        return None
+    snapshot = account.current_disk_usage()
+    if snapshot is None:
+        return {
+            'used': 0.0,
+            'remaining': allocated,
+            'percent_used': 0.0,
+            'activity_date': None,
+        }
+    used_tib = snapshot.used_tib
+    pct = (used_tib / allocated * 100) if allocated > 0 else 0.0
+    return {
+        'used': used_tib,
+        'remaining': allocated - used_tib,
+        'percent_used': pct,
+        'activity_date': snapshot.activity_date,
+    }
 
 
 def _select_query_alloc(account: Account, now: datetime):
@@ -600,7 +661,7 @@ def _build_user_projects_resources_batched(
 
         rwin = rolling_usage_by_projcode.get(project.projcode, {}).get(resource_name, {}).get('windows', {})
 
-        out[project.project_id].append({
+        resource_dict = {
             'resource_name':        resource_name,
             'allocation_id':        query_alloc.allocation_id,
             'parent_allocation_id': query_alloc.parent_allocation_id,
@@ -623,9 +684,16 @@ def _build_user_projects_resources_batched(
             'elapsed_pct':          elapsed_pct,
             'bar_state':            bar_state,
             'resource_type':        resource_type,
+            'activity_date':        None,
             'rolling_30':           rwin.get(30),
             'rolling_90':           rwin.get(90),
-        })
+        }
+
+        overrides = _disk_capacity_overrides(account, allocated, resource_type)
+        if overrides is not None:
+            resource_dict.update(overrides)
+
+        out[project.project_id].append(resource_dict)
 
     # Sort each project's resources by resource_name for stable ordering
     # (matches the implicit ordering of project.get_detailed_allocation_usage()

--- a/src/sam/queries/dashboard.py
+++ b/src/sam/queries/dashboard.py
@@ -186,10 +186,6 @@ def _build_project_resources_data(project: Project,
 
     now = active_at or datetime.now()
 
-    # Map account_id → Account for disk capacity lookup. The dict is empty
-    # for projects with no disk accounts; cheap to build either way.
-    accounts_by_id = {a.account_id: a for a in project.accounts if not a.deleted}
-
     # Fetch rolling window usage (30d/90d) only when at least one account on
     # this project has a non-null threshold set. The dashboard template only
     # displays the rolling-usage block when threshold_pct is not None
@@ -274,11 +270,12 @@ def _build_project_resources_data(project: Project,
         }
 
         if resource_type == 'DISK':
-            account = accounts_by_id.get(usage.get('account_id'))
-            if account is not None:
-                overrides = _disk_capacity_overrides(account, resource_dict['allocated'], resource_type)
-                if overrides is not None:
-                    resource_dict.update(overrides)
+            overrides = _disk_capacity_overrides(
+                project.session, project, resource_name,
+                resource_dict['allocated'], resource_type,
+            )
+            if overrides is not None:
+                resource_dict.update(overrides)
 
         resources.append(resource_dict)
 
@@ -286,7 +283,9 @@ def _build_project_resources_data(project: Project,
 
 
 def _disk_capacity_overrides(
-    account: Account,
+    session,
+    project: Project,
+    resource_name: str,
     allocated: float,
     resource_type: str,
 ) -> Optional[Dict[str, Any]]:
@@ -295,8 +294,13 @@ def _disk_capacity_overrides(
 
     Storage's user-facing "% used" is *capacity* (point-in-time TiB
     used vs TiB allocated), not the cumulative TiB-year burn used for
-    billing. Returns a dict the caller merges into the resource dict,
-    or None for non-disk resources (caller leaves the dict unchanged).
+    billing. The capacity is summed across the project's *subtree* on
+    this resource — parent projects (e.g. NMMM0003) hold no bytes
+    themselves; the occupancy lives on their child sub-projects. See
+    ``get_subtree_disk_capacity`` for the walk.
+
+    Returns a dict the caller merges into the resource dict, or None
+    for non-disk resources (caller leaves the dict unchanged).
 
     The fields written are: ``used``, ``remaining``, ``percent_used``,
     ``activity_date``. Cumulative TiB-yr (``charges_by_type``,
@@ -306,21 +310,15 @@ def _disk_capacity_overrides(
     """
     if resource_type != 'DISK':
         return None
-    snapshot = account.current_disk_usage()
-    if snapshot is None:
-        return {
-            'used': 0.0,
-            'remaining': allocated,
-            'percent_used': 0.0,
-            'activity_date': None,
-        }
-    used_tib = snapshot.used_tib
+    from sam.queries.disk_usage import get_subtree_disk_capacity
+    cap = get_subtree_disk_capacity(session, project, resource_name)
+    used_tib = cap['used_tib']
     pct = (used_tib / allocated * 100) if allocated > 0 else 0.0
     return {
         'used': used_tib,
         'remaining': allocated - used_tib,
         'percent_used': pct,
-        'activity_date': snapshot.activity_date,
+        'activity_date': cap['activity_date'],
     }
 
 
@@ -689,7 +687,9 @@ def _build_user_projects_resources_batched(
             'rolling_90':           rwin.get(90),
         }
 
-        overrides = _disk_capacity_overrides(account, allocated, resource_type)
+        overrides = _disk_capacity_overrides(
+            session, project, resource_name, allocated, resource_type,
+        )
         if overrides is not None:
             resource_dict.update(overrides)
 

--- a/src/sam/queries/dashboard.py
+++ b/src/sam/queries/dashboard.py
@@ -186,6 +186,20 @@ def _build_project_resources_data(project: Project,
 
     now = active_at or datetime.now()
 
+    # Bulk-resolve disk-capacity overrides for this project's disk
+    # resources (one fixed-size set of queries vs one per-resource fanout
+    # if we did this inline below).
+    disk_pairs = [
+        (project, name)
+        for name, usage in usage_data.items()
+        if usage.get('resource_type') == 'DISK'
+    ]
+    if disk_pairs:
+        from sam.queries.disk_usage import bulk_get_subtree_disk_capacity
+        disk_caps = bulk_get_subtree_disk_capacity(project.session, disk_pairs)
+    else:
+        disk_caps = {}
+
     # Fetch rolling window usage (30d/90d) only when at least one account on
     # this project has a non-null threshold set. The dashboard template only
     # displays the rolling-usage block when threshold_pct is not None
@@ -270,56 +284,31 @@ def _build_project_resources_data(project: Project,
         }
 
         if resource_type == 'DISK':
-            overrides = _disk_capacity_overrides(
-                project.session, project, resource_name,
-                resource_dict['allocated'], resource_type,
+            _apply_disk_capacity_overrides(
+                resource_dict,
+                disk_caps.get((project.project_id, resource_name)),
             )
-            if overrides is not None:
-                resource_dict.update(overrides)
 
         resources.append(resource_dict)
 
     return resources
 
 
-def _disk_capacity_overrides(
-    session,
-    project: Project,
-    resource_name: str,
-    allocated: float,
-    resource_type: str,
-) -> Optional[Dict[str, Any]]:
-    """For disk allocations, return capacity-based overrides for the
-    dashboard dict.
-
-    Storage's user-facing "% used" is *capacity* (point-in-time TiB
-    used vs TiB allocated), not the cumulative TiB-year burn used for
-    billing. The capacity is summed across the project's *subtree* on
-    this resource — parent projects (e.g. NMMM0003) hold no bytes
-    themselves; the occupancy lives on their child sub-projects. See
-    ``get_subtree_disk_capacity`` for the walk.
-
-    Returns a dict the caller merges into the resource dict, or None
-    for non-disk resources (caller leaves the dict unchanged).
-
-    The fields written are: ``used``, ``remaining``, ``percent_used``,
-    ``activity_date``. Cumulative TiB-yr (``charges_by_type``,
-    ``adjustments``) is intentionally untouched — it is no longer
-    surfaced in the disk UI but the underlying values remain available
-    for billing-side consumers.
-    """
-    if resource_type != 'DISK':
-        return None
-    from sam.queries.disk_usage import get_subtree_disk_capacity
-    cap = get_subtree_disk_capacity(session, project, resource_name)
+def _apply_disk_capacity_overrides(
+    resource_dict: Dict[str, Any],
+    cap: Optional[Dict[str, Any]],
+) -> None:
+    """Mutate resource_dict to swap cumulative TiB-yr for point-in-time
+    capacity from ``cap`` (output of bulk_get_subtree_disk_capacity)."""
+    if cap is None:
+        return
+    allocated = resource_dict.get('allocated', 0.0) or 0.0
     used_tib = cap['used_tib']
     pct = (used_tib / allocated * 100) if allocated > 0 else 0.0
-    return {
-        'used': used_tib,
-        'remaining': allocated - used_tib,
-        'percent_used': pct,
-        'activity_date': cap['activity_date'],
-    }
+    resource_dict['used'] = used_tib
+    resource_dict['remaining'] = allocated - used_tib
+    resource_dict['percent_used'] = pct
+    resource_dict['activity_date'] = cap['activity_date']
 
 
 def _select_query_alloc(account: Account, now: datetime):
@@ -599,6 +588,20 @@ def _build_user_projects_resources_batched(
     # ------------------------------------------------------------------
     out: Dict[int, List[DashboardResource]] = {p.project_id: [] for p in projects}
 
+    # Bulk-resolve disk-capacity overrides for every (project, resource)
+    # pair on a disk resource, so the per-row loop below becomes a pure
+    # dict lookup.
+    disk_pairs = [
+        (project, account.resource.resource_name)
+        for project, account, _qa, rtype, _ed in chosen.values()
+        if rtype == 'DISK'
+    ]
+    if disk_pairs:
+        from sam.queries.disk_usage import bulk_get_subtree_disk_capacity
+        disk_caps = bulk_get_subtree_disk_capacity(session, disk_pairs)
+    else:
+        disk_caps = {}
+
     for key, (project, account, query_alloc, resource_type, end_date) in chosen.items():
         resource_name = account.resource.resource_name
         start_date = query_alloc.start_date
@@ -687,11 +690,11 @@ def _build_user_projects_resources_batched(
             'rolling_90':           rwin.get(90),
         }
 
-        overrides = _disk_capacity_overrides(
-            session, project, resource_name, allocated, resource_type,
-        )
-        if overrides is not None:
-            resource_dict.update(overrides)
+        if resource_type == 'DISK':
+            _apply_disk_capacity_overrides(
+                resource_dict,
+                disk_caps.get((project.project_id, resource_name)),
+            )
 
         out[project.project_id].append(resource_dict)
 

--- a/src/sam/queries/disk_usage.py
+++ b/src/sam/queries/disk_usage.py
@@ -19,10 +19,10 @@ Two helpers:
 
 from __future__ import annotations
 
-from datetime import date as _stdlib_date, datetime
+from datetime import date as _stdlib_date
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import and_, func
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from sam.accounting.accounts import Account
@@ -259,14 +259,12 @@ def build_disk_subtree(
         a.project_id: a for a in accounts
     }
 
-    # Bulk-load active project directories for the subtree.
-    now = datetime.now()
+    # Bulk-load active project directories for the subtree. Use the
+    # universal `is_active` hybrid rather than hand-rolled date checks
+    # (CLAUDE.md "Universal is_active interface" rule).
     dirs = session.query(ProjectDirectory).filter(
         ProjectDirectory.project_id.in_(project_ids),
-        and_(
-            (ProjectDirectory.start_date == None) | (ProjectDirectory.start_date <= now),  # noqa: E711
-            (ProjectDirectory.end_date == None) | (ProjectDirectory.end_date > now),  # noqa: E711
-        ),
+        ProjectDirectory.is_active,
     ).all()
     dirs_by_project_id: Dict[int, List[str]] = {}
     for d in dirs:

--- a/src/sam/queries/disk_usage.py
+++ b/src/sam/queries/disk_usage.py
@@ -121,14 +121,22 @@ def get_disk_usage_timeseries_by_user(
     are dense-filled with 0 so every series has the same length as
     ``dates``.
 
+    Series order is **stack-friendly**: ``Others`` first (so it renders
+    at the bottom of the stacked area in a neutral colour), then named
+    users smallest-to-largest by latest-snapshot bytes (so the largest
+    user sits on top of the stack — easiest to scan against the
+    capacity bar). The chart layer reverses the legend so the visual
+    order from top to bottom matches the legend top to bottom.
+
     Returns::
 
         {
           'dates':  [date, ...],                   # sorted ascending
           'series': [
-            {'username': 'alice',  'values': [bytes, ...]},
-            ...,                                    # up to top_n users
             {'username': 'Others', 'values': [bytes, ...]},  # iff > top_n
+            {'username': 'alice',  'values': [bytes, ...]},  # smallest named
+            ...,                                              # ascending
+            {'username': 'zach',   'values': [bytes, ...]},  # largest named
           ],
         }
 
@@ -186,18 +194,22 @@ def get_disk_usage_timeseries_by_user(
     rest_users = ranked[top_n:]
 
     series: List[Dict[str, Any]] = []
-    for _uid, info in top_users:
-        series.append({
-            'username': info['username'],
-            'values':   [info['by_date'].get(d, 0) for d in dates],
-        })
-
+    # `Others` first → bottom of the stack, neutral colour at the chart
+    # layer.
     if rest_users:
         others_values = [0] * len(dates)
         for _uid, info in rest_users:
             for i, d in enumerate(dates):
                 others_values[i] += info['by_date'].get(d, 0)
         series.append({'username': 'Others', 'values': others_values})
+    # Named users smallest → largest. `top_users` is sorted descending
+    # by latest-snapshot bytes; reverse to put the largest on top of
+    # the stack.
+    for _uid, info in reversed(top_users):
+        series.append({
+            'username': info['username'],
+            'values':   [info['by_date'].get(d, 0) for d in dates],
+        })
 
     return {'dates': dates, 'series': series}
 
@@ -240,7 +252,12 @@ def build_disk_subtree(
             'account_ids': [],
         }
 
-    descendants = root_project.get_descendants(include_self=True)
+    # Filter inactive descendants — the tree gets noisy fast otherwise
+    # (decommissioned sub-projects, expired allocations leaving empty
+    # nodes). Use the universal `is_active` hybrid (ActiveFlagMixin on
+    # Project: ``active == True``).
+    descendants = [p for p in root_project.get_descendants(include_self=True)
+                   if p.is_active]
     project_ids = [p.project_id for p in descendants]
     if not project_ids:
         return {

--- a/src/sam/queries/disk_usage.py
+++ b/src/sam/queries/disk_usage.py
@@ -1,0 +1,265 @@
+"""Disk-specific query helpers for the Resource Usage Details view.
+
+These helpers exist because storage has different semantics than HPC/DAV:
+the user-facing question is *capacity* (how full is this project right
+now, and what does occupancy look like over time), not cumulative
+TiB-year burn.
+
+Two helpers:
+
+  * ``get_disk_usage_timeseries_by_user`` — per-user bytes vs time
+    pivot for the stacked-area chart, with top-N users carried as
+    individual series and the rest lumped into ``"Others"``.
+
+  * ``build_disk_subtree`` — filesystem tree (parent project + child
+    sub-projects) annotated with current bytes / file count / fileset
+    paths from ``ProjectDirectory``. Mirrors the shape produced by
+    ``sam-admin accounting --reconcile-quotas`` but is web-renderable.
+"""
+
+from __future__ import annotations
+
+from datetime import date as _stdlib_date, datetime
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import and_, func
+from sqlalchemy.orm import Session
+
+from sam.accounting.accounts import Account
+from sam.core.users import User
+from sam.projects.projects import Project, ProjectDirectory
+from sam.resources.resources import Resource
+from sam.summaries.disk_summaries import DiskChargeSummary
+
+
+def get_disk_usage_timeseries_by_user(
+    session: Session,
+    *,
+    account_ids: List[int],
+    start_date: Optional[_stdlib_date] = None,
+    end_date: Optional[_stdlib_date] = None,
+    top_n: int = 10,
+) -> Dict[str, Any]:
+    """Per-user disk-bytes time series for a stacked-area chart.
+
+    Sums ``DiskChargeSummary.bytes`` grouped by ``(activity_date,
+    user_id)`` for the given accounts and date range. Picks the top
+    ``top_n`` users by their *latest-snapshot* bytes; everyone else is
+    lumped into a single ``"Others"`` series. Missing (date, user) pairs
+    are dense-filled with 0 so every series has the same length as
+    ``dates``.
+
+    Returns::
+
+        {
+          'dates':  [date, ...],                   # sorted ascending
+          'series': [
+            {'username': 'alice',  'values': [bytes, ...]},
+            ...,                                    # up to top_n users
+            {'username': 'Others', 'values': [bytes, ...]},  # iff > top_n
+          ],
+        }
+
+    Empty input (no accounts, no rows) returns ``{'dates': [], 'series': []}``.
+    """
+    if not account_ids:
+        return {'dates': [], 'series': []}
+
+    q = session.query(
+        DiskChargeSummary.activity_date,
+        DiskChargeSummary.user_id,
+        DiskChargeSummary.username,
+        func.coalesce(func.sum(DiskChargeSummary.bytes), 0).label('bytes'),
+    ).filter(
+        DiskChargeSummary.account_id.in_(account_ids),
+    )
+    if start_date is not None:
+        q = q.filter(DiskChargeSummary.activity_date >= start_date)
+    if end_date is not None:
+        q = q.filter(DiskChargeSummary.activity_date <= end_date)
+    rows = q.group_by(
+        DiskChargeSummary.activity_date,
+        DiskChargeSummary.user_id,
+        DiskChargeSummary.username,
+    ).all()
+
+    if not rows:
+        return {'dates': [], 'series': []}
+
+    # Pivot: per_user[user_id] = {'username': str, 'by_date': {date: bytes}}
+    per_user: Dict[int, Dict[str, Any]] = {}
+    dates_set: set = set()
+    for activity_date, user_id, username, b in rows:
+        dates_set.add(activity_date)
+        u = per_user.setdefault(
+            user_id,
+            {'username': username or f'uid_{user_id}', 'by_date': {}},
+        )
+        # Same user might appear multiple times if username changed; take
+        # the most recent non-empty username.
+        if username and not u['username'].startswith('uid_'):
+            u['username'] = username
+        u['by_date'][activity_date] = int(b or 0)
+
+    dates = sorted(dates_set)
+    last_date = dates[-1]
+
+    # Rank users by latest-snapshot bytes (zero if absent on last date).
+    ranked = sorted(
+        per_user.items(),
+        key=lambda kv: kv[1]['by_date'].get(last_date, 0),
+        reverse=True,
+    )
+    top_users = ranked[:top_n]
+    rest_users = ranked[top_n:]
+
+    series: List[Dict[str, Any]] = []
+    for _uid, info in top_users:
+        series.append({
+            'username': info['username'],
+            'values':   [info['by_date'].get(d, 0) for d in dates],
+        })
+
+    if rest_users:
+        others_values = [0] * len(dates)
+        for _uid, info in rest_users:
+            for i, d in enumerate(dates):
+                others_values[i] += info['by_date'].get(d, 0)
+        series.append({'username': 'Others', 'values': others_values})
+
+    return {'dates': dates, 'series': series}
+
+
+def build_disk_subtree(
+    session: Session,
+    root_project: Project,
+    resource_name: str,
+) -> Dict[str, Any]:
+    """Filesystem-tree dict for the Resource Usage Details view.
+
+    Walks ``root_project`` and its descendants (NestedSetMixin), and for
+    each node attaches:
+
+      * ``account_id`` of the node's account on this disk resource
+        (None if the node has no account on this resource);
+      * ``current_bytes`` / ``current_used_tib`` / ``file_count`` /
+        ``activity_date`` from ``Account.current_disk_usage()``;
+      * ``fileset_paths`` — list of active ``ProjectDirectory.directory_name``
+        strings for the node;
+      * ``children`` — recursive list of node dicts.
+
+    Returns ``{'tree': <root_node_dict>, 'account_ids': [int, ...]}``,
+    where ``account_ids`` aggregates every node's disk account so the
+    caller can feed the stacked-area chart in a single query.
+
+    Nodes without a disk account on ``resource_name`` still appear in
+    the tree — they just have ``account_id=None`` and zero bytes. This
+    keeps the structural hierarchy visible even when an intermediate
+    project doesn't itself store data.
+    """
+    # Resolve the resource_id once so we can filter accounts cheaply.
+    resource = session.query(Resource).filter(
+        Resource.resource_name == resource_name,
+    ).first()
+    if resource is None:
+        return {
+            'tree': _node_dict(root_project, account=None, snapshot=None,
+                               fileset_paths=[]),
+            'account_ids': [],
+        }
+
+    descendants = root_project.get_descendants(include_self=True)
+    project_ids = [p.project_id for p in descendants]
+    if not project_ids:
+        return {
+            'tree': _node_dict(root_project, account=None, snapshot=None,
+                               fileset_paths=[]),
+            'account_ids': [],
+        }
+
+    # Bulk-load accounts on this resource for the subtree.
+    accounts = session.query(Account).filter(
+        Account.project_id.in_(project_ids),
+        Account.resource_id == resource.resource_id,
+        Account.deleted == False,  # noqa: E712 — SQLAlchemy expression
+    ).all()
+    account_by_project_id: Dict[int, Account] = {
+        a.project_id: a for a in accounts
+    }
+
+    # Bulk-load active project directories for the subtree.
+    now = datetime.now()
+    dirs = session.query(ProjectDirectory).filter(
+        ProjectDirectory.project_id.in_(project_ids),
+        and_(
+            (ProjectDirectory.start_date == None) | (ProjectDirectory.start_date <= now),  # noqa: E711
+            (ProjectDirectory.end_date == None) | (ProjectDirectory.end_date > now),  # noqa: E711
+        ),
+    ).all()
+    dirs_by_project_id: Dict[int, List[str]] = {}
+    for d in dirs:
+        dirs_by_project_id.setdefault(d.project_id, []).append(d.directory_name)
+
+    # Build a flat node map, then thread parents → children using the
+    # parent_id FK (works alongside the NestedSet coords).
+    node_by_pid: Dict[int, Dict[str, Any]] = {}
+    account_ids: List[int] = []
+    for proj in descendants:
+        account = account_by_project_id.get(proj.project_id)
+        snapshot = account.current_disk_usage() if account is not None else None
+        node = _node_dict(
+            proj,
+            account=account,
+            snapshot=snapshot,
+            fileset_paths=sorted(dirs_by_project_id.get(proj.project_id, [])),
+        )
+        node_by_pid[proj.project_id] = node
+        if account is not None:
+            account_ids.append(account.account_id)
+
+    for proj in descendants:
+        if proj.project_id == root_project.project_id:
+            continue
+        parent = node_by_pid.get(proj.parent_id)
+        if parent is not None:
+            parent['children'].append(node_by_pid[proj.project_id])
+
+    # Sort each node's children by projcode for deterministic display.
+    for n in node_by_pid.values():
+        n['children'].sort(key=lambda c: c['projcode'])
+
+    return {
+        'tree': node_by_pid[root_project.project_id],
+        'account_ids': account_ids,
+    }
+
+
+def _node_dict(
+    project: Project,
+    *,
+    account: Optional[Account],
+    snapshot,
+    fileset_paths: List[str],
+) -> Dict[str, Any]:
+    if snapshot is not None:
+        bytes_ = snapshot.bytes
+        used_tib = snapshot.used_tib
+        files = snapshot.number_of_files
+        activity_date = snapshot.activity_date
+    else:
+        bytes_ = 0
+        used_tib = 0.0
+        files = 0
+        activity_date = None
+    return {
+        'project_id':       project.project_id,
+        'projcode':         project.projcode,
+        'title':            project.title,
+        'account_id':       account.account_id if account is not None else None,
+        'current_bytes':    bytes_,
+        'current_used_tib': used_tib,
+        'file_count':       files,
+        'activity_date':    activity_date,
+        'fileset_paths':    fileset_paths,
+        'children':         [],
+    }

--- a/src/sam/queries/disk_usage.py
+++ b/src/sam/queries/disk_usage.py
@@ -20,16 +20,25 @@ Two helpers:
 from __future__ import annotations
 
 from datetime import date as _stdlib_date
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
-from sqlalchemy import func
+from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import Session
 
 from sam.accounting.accounts import Account
 from sam.core.users import User
 from sam.projects.projects import Project, ProjectDirectory
 from sam.resources.resources import Resource
-from sam.summaries.disk_summaries import DiskChargeSummary
+from sam.summaries.disk_summaries import DiskChargeSummary, DiskChargeSummaryStatus
+
+
+_EMPTY_CAP: Dict[str, Any] = {
+    'used_bytes':    0,
+    'used_tib':      0.0,
+    'file_count':    0,
+    'activity_date': None,
+    'account_ids':   [],
+}
 
 
 def get_subtree_disk_capacity(
@@ -39,69 +48,201 @@ def get_subtree_disk_capacity(
 ) -> Dict[str, Any]:
     """Point-in-time disk occupancy summed across a project's subtree.
 
-    For NMMM0003-shaped parents, the parent's own account holds 0 bytes
-    while the actual occupancy lives on the children — `Account
-    .current_disk_usage()` against just the parent reads 0%. This helper
-    walks ``project`` + descendants (NestedSet coords), finds each
-    descendant's account on ``resource_name``, sums the snapshot bytes
-    / file count, and reports the latest activity_date across them.
-
-    Returns ``{used_bytes, used_tib, file_count, activity_date,
-    account_ids}``. ``activity_date`` is None and totals are zero if no
-    descendant has a snapshot yet.
+    Thin wrapper over :func:`bulk_get_subtree_disk_capacity` for the
+    single-pair case (e.g. resource_details route). Both paths share one
+    bulk implementation so query-count behavior is uniform.
     """
-    resource = session.query(Resource).filter(
-        Resource.resource_name == resource_name,
-    ).first()
-    empty = {
-        'used_bytes':    0,
-        'used_tib':      0.0,
-        'file_count':    0,
-        'activity_date': None,
-        'account_ids':   [],
+    out = bulk_get_subtree_disk_capacity(session, [(project, resource_name)])
+    return out.get((project.project_id, resource_name), dict(_EMPTY_CAP))
+
+
+def bulk_get_subtree_disk_capacity(
+    session: Session,
+    pairs: List[Tuple[Project, str]],
+) -> Dict[Tuple[int, str], Dict[str, Any]]:
+    """Bulk variant of :func:`get_subtree_disk_capacity`.
+
+    Resolves all ``(project, resource_name)`` pairs in a fixed number of
+    queries (regardless of pair count):
+
+      1. ONE ``Resource`` lookup for the distinct resource names.
+      2. ONE OR-combined ``Account``/``Project`` subtree query covering
+         every pair's NestedSet range (or fallback project_id match).
+      3. ONE ``DiskChargeSummaryStatus`` lookup for the current snapshot date.
+      4. ONE bulk ``DiskChargeSummary`` aggregate keyed by account_id.
+      5. ONE per-account fallback aggregate for accounts not on the
+         current snapshot date (only fires if such accounts exist).
+
+    Returns ``{(project_id, resource_name): cap_dict}``. Pairs whose
+    resource doesn't exist or whose subtree has no disk accounts get an
+    empty cap dict.
+    """
+    if not pairs:
+        return {}
+
+    out: Dict[Tuple[int, str], Dict[str, Any]] = {
+        (p.project_id, rn): dict(_EMPTY_CAP) for p, rn in pairs
     }
-    if resource is None:
-        return empty
 
-    is_tree_valid = bool(project.tree_root and project.tree_left and project.tree_right)
-    if is_tree_valid:
-        accounts = session.query(Account).join(
-            Project, Account.project_id == Project.project_id,
-        ).filter(
-            Project.tree_root == project.tree_root,
-            Project.tree_left >= project.tree_left,
-            Project.tree_right <= project.tree_right,
-            Account.resource_id == resource.resource_id,
-            Account.deleted == False,  # noqa: E712
-        ).all()
-    else:
-        accounts = session.query(Account).filter(
-            Account.project_id == project.project_id,
-            Account.resource_id == resource.resource_id,
-            Account.deleted == False,  # noqa: E712
-        ).all()
+    # 1) Resolve resources in one query.
+    resource_names = sorted({rn for _, rn in pairs})
+    res_rows = session.query(Resource.resource_id, Resource.resource_name).filter(
+        Resource.resource_name.in_(resource_names),
+    ).all()
+    rid_by_name = {rn: rid for rid, rn in res_rows}
 
-    used_bytes = 0
-    files = 0
-    latest = None
-    account_ids = []
-    for acct in accounts:
-        snap = acct.current_disk_usage(session)
-        if snap is None:
+    # 2) Build OR-combined subtree filter; tag rows back to their pair via
+    #    in-Python matching against the project NestedSet coords.
+    conditions = []
+    valid_pairs: List[Tuple[Project, str, int]] = []
+    for project, rn in pairs:
+        rid = rid_by_name.get(rn)
+        if rid is None:
             continue
-        used_bytes += snap.bytes
-        files += snap.number_of_files
-        if latest is None or snap.activity_date > latest:
-            latest = snap.activity_date
-        account_ids.append(acct.account_id)
+        valid_pairs.append((project, rn, rid))
+        is_tree_valid = bool(project.tree_root and project.tree_left and project.tree_right)
+        if is_tree_valid:
+            conditions.append(and_(
+                Project.tree_root == project.tree_root,
+                Project.tree_left >= project.tree_left,
+                Project.tree_right <= project.tree_right,
+                Account.resource_id == rid,
+            ))
+        else:
+            conditions.append(and_(
+                Account.project_id == project.project_id,
+                Account.resource_id == rid,
+            ))
 
-    return {
-        'used_bytes':    used_bytes,
-        'used_tib':      used_bytes / (1024 ** 4),
-        'file_count':    files,
-        'activity_date': latest,
-        'account_ids':   account_ids,
+    if not conditions:
+        return out
+
+    candidate_rows = session.query(
+        Account.account_id,
+        Account.resource_id,
+        Project.tree_root,
+        Project.tree_left,
+        Project.tree_right,
+        Project.project_id,
+    ).join(Project, Account.project_id == Project.project_id).filter(
+        Account.deleted == False,  # noqa: E712
+        or_(*conditions),
+    ).all()
+
+    # Re-attribute candidate accounts to each (project, resource) pair.
+    accounts_per_pair: Dict[Tuple[int, str], List[int]] = {
+        (p.project_id, rn): [] for p, rn, _ in valid_pairs
     }
+    all_account_ids: set = set()
+    for project, rn, rid in valid_pairs:
+        key = (project.project_id, rn)
+        is_tree_valid = bool(project.tree_root and project.tree_left and project.tree_right)
+        if is_tree_valid:
+            for r in candidate_rows:
+                if r.resource_id != rid:
+                    continue
+                if r.tree_root != project.tree_root:
+                    continue
+                if r.tree_left is None or r.tree_right is None:
+                    continue
+                if r.tree_left >= project.tree_left and r.tree_right <= project.tree_right:
+                    accounts_per_pair[key].append(r.account_id)
+                    all_account_ids.add(r.account_id)
+        else:
+            for r in candidate_rows:
+                if r.resource_id == rid and r.project_id == project.project_id:
+                    accounts_per_pair[key].append(r.account_id)
+                    all_account_ids.add(r.account_id)
+
+    if not all_account_ids:
+        for key, aids in accounts_per_pair.items():
+            out[key] = {**_EMPTY_CAP, 'account_ids': aids}
+        return out
+
+    # 3) Current snapshot date.
+    current_row = (
+        session.query(DiskChargeSummaryStatus.activity_date)
+        .filter(DiskChargeSummaryStatus.current == True)  # noqa: E712
+        .order_by(DiskChargeSummaryStatus.activity_date.desc())
+        .first()
+    )
+    candidate_date = current_row[0] if current_row else None
+
+    # 4) Bulk aggregate at the candidate date.
+    snap_by_account: Dict[int, Dict[str, Any]] = {}
+    if candidate_date is not None:
+        rows = session.query(
+            DiskChargeSummary.account_id,
+            func.coalesce(func.sum(DiskChargeSummary.bytes), 0).label('bytes'),
+            func.coalesce(func.sum(DiskChargeSummary.number_of_files), 0).label('files'),
+        ).filter(
+            DiskChargeSummary.account_id.in_(all_account_ids),
+            DiskChargeSummary.activity_date == candidate_date,
+        ).group_by(DiskChargeSummary.account_id).all()
+        for r in rows:
+            snap_by_account[r.account_id] = {
+                'bytes':         int(r.bytes or 0),
+                'files':         int(r.files or 0),
+                'activity_date': candidate_date,
+            }
+
+    # 5) Fallback: any account without a row on the current snapshot date
+    #    falls back to its own most-recent row (matches single-account
+    #    semantics in Account.current_disk_usage). One query covers all
+    #    fallback accounts at once.
+    missing = [aid for aid in all_account_ids if aid not in snap_by_account]
+    if missing:
+        max_dates = dict(session.query(
+            DiskChargeSummary.account_id,
+            func.max(DiskChargeSummary.activity_date),
+        ).filter(
+            DiskChargeSummary.account_id.in_(missing),
+        ).group_by(DiskChargeSummary.account_id).all())
+        if max_dates:
+            # ONE aggregate query for all (account_id, max_date) pairs.
+            ors = [
+                and_(
+                    DiskChargeSummary.account_id == aid,
+                    DiskChargeSummary.activity_date == d,
+                )
+                for aid, d in max_dates.items()
+            ]
+            rows = session.query(
+                DiskChargeSummary.account_id,
+                DiskChargeSummary.activity_date,
+                func.coalesce(func.sum(DiskChargeSummary.bytes), 0).label('bytes'),
+                func.coalesce(func.sum(DiskChargeSummary.number_of_files), 0).label('files'),
+            ).filter(or_(*ors)).group_by(
+                DiskChargeSummary.account_id, DiskChargeSummary.activity_date,
+            ).all()
+            for r in rows:
+                snap_by_account[r.account_id] = {
+                    'bytes':         int(r.bytes or 0),
+                    'files':         int(r.files or 0),
+                    'activity_date': r.activity_date,
+                }
+
+    # 6) Roll up per-pair.
+    for (pid, rn), aids in accounts_per_pair.items():
+        used_bytes = 0
+        files = 0
+        latest = None
+        for aid in aids:
+            snap = snap_by_account.get(aid)
+            if snap is None:
+                continue
+            used_bytes += snap['bytes']
+            files += snap['files']
+            if latest is None or snap['activity_date'] > latest:
+                latest = snap['activity_date']
+        out[(pid, rn)] = {
+            'used_bytes':    used_bytes,
+            'used_tib':      used_bytes / (1024 ** 4),
+            'file_count':    files,
+            'activity_date': latest,
+            'account_ids':   aids,
+        }
+    return out
 
 
 def get_disk_usage_timeseries_by_user(

--- a/src/sam/queries/disk_usage.py
+++ b/src/sam/queries/disk_usage.py
@@ -32,6 +32,78 @@ from sam.resources.resources import Resource
 from sam.summaries.disk_summaries import DiskChargeSummary
 
 
+def get_subtree_disk_capacity(
+    session: Session,
+    project: Project,
+    resource_name: str,
+) -> Dict[str, Any]:
+    """Point-in-time disk occupancy summed across a project's subtree.
+
+    For NMMM0003-shaped parents, the parent's own account holds 0 bytes
+    while the actual occupancy lives on the children — `Account
+    .current_disk_usage()` against just the parent reads 0%. This helper
+    walks ``project`` + descendants (NestedSet coords), finds each
+    descendant's account on ``resource_name``, sums the snapshot bytes
+    / file count, and reports the latest activity_date across them.
+
+    Returns ``{used_bytes, used_tib, file_count, activity_date,
+    account_ids}``. ``activity_date`` is None and totals are zero if no
+    descendant has a snapshot yet.
+    """
+    resource = session.query(Resource).filter(
+        Resource.resource_name == resource_name,
+    ).first()
+    empty = {
+        'used_bytes':    0,
+        'used_tib':      0.0,
+        'file_count':    0,
+        'activity_date': None,
+        'account_ids':   [],
+    }
+    if resource is None:
+        return empty
+
+    is_tree_valid = bool(project.tree_root and project.tree_left and project.tree_right)
+    if is_tree_valid:
+        accounts = session.query(Account).join(
+            Project, Account.project_id == Project.project_id,
+        ).filter(
+            Project.tree_root == project.tree_root,
+            Project.tree_left >= project.tree_left,
+            Project.tree_right <= project.tree_right,
+            Account.resource_id == resource.resource_id,
+            Account.deleted == False,  # noqa: E712
+        ).all()
+    else:
+        accounts = session.query(Account).filter(
+            Account.project_id == project.project_id,
+            Account.resource_id == resource.resource_id,
+            Account.deleted == False,  # noqa: E712
+        ).all()
+
+    used_bytes = 0
+    files = 0
+    latest = None
+    account_ids = []
+    for acct in accounts:
+        snap = acct.current_disk_usage(session)
+        if snap is None:
+            continue
+        used_bytes += snap.bytes
+        files += snap.number_of_files
+        if latest is None or snap.activity_date > latest:
+            latest = snap.activity_date
+        account_ids.append(acct.account_id)
+
+    return {
+        'used_bytes':    used_bytes,
+        'used_tib':      used_bytes / (1024 ** 4),
+        'file_count':    files,
+        'activity_date': latest,
+        'account_ids':   account_ids,
+    }
+
+
 def get_disk_usage_timeseries_by_user(
     session: Session,
     *,

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -177,6 +177,71 @@ def generate_usage_timeseries_matplotlib(daily_charges) -> str:
 
 
 # ---------------------------------------------------------------------------
+# 1b. Disk usage stacked-area chart (Resource Usage Details — DISK)
+# ---------------------------------------------------------------------------
+
+_BYTES_PER_TIB = 1024 ** 4
+_BYTES_PER_PIB = 1024 ** 5
+
+
+@_chart_cache(maxsize=128)
+def generate_disk_usage_stacked_area(timeseries) -> str:
+    """Render a stacked-area chart of disk bytes vs time.
+
+    Args:
+        timeseries: dict shaped as ``sam.queries.disk_usage.get_disk_usage_timeseries_by_user``
+                    returns: ``{'dates': [...], 'series': [{'username','values'}, ...]}``.
+                    The last series is conventionally ``'Others'`` (rendered last
+                    so it sits on top of the named-user stack).
+
+    Y-axis is auto-scaled to TiB or PiB based on the peak stacked total
+    (>= 1 PiB → PiB, else TiB). X-axis is date-formatted. Legend on the
+    right.
+    """
+    if not timeseries or not timeseries.get('dates') or not timeseries.get('series'):
+        return '<div class="text-center text-muted">No disk-usage history for this period</div>'
+
+    dates = list(timeseries['dates'])
+    series = list(timeseries['series'])
+    if not dates or not series:
+        return '<div class="text-center text-muted">No disk-usage history for this period</div>'
+
+    stacked_totals = [
+        sum(s['values'][i] for s in series)
+        for i in range(len(dates))
+    ]
+    peak = max(stacked_totals) if stacked_totals else 0
+    if peak >= _BYTES_PER_PIB:
+        scale = _BYTES_PER_PIB
+        unit_label = 'PiB'
+    else:
+        scale = _BYTES_PER_TIB
+        unit_label = 'TiB'
+
+    fig, ax = plt.subplots(figsize=(12, 4.5))
+    scaled_series = [
+        [v / scale for v in s['values']]
+        for s in series
+    ]
+    labels = [s['username'] for s in series]
+    ax.stackplot(dates, *scaled_series, labels=labels, alpha=0.85)
+    ax.set_ylabel(f'Disk usage ({unit_label})')
+    ax.grid(True, alpha=0.3)
+    ax.legend(
+        loc='center left',
+        bbox_to_anchor=(1.01, 0.5),
+        frameon=False,
+        fontsize=9,
+    )
+    fig.autofmt_xdate()
+
+    svg_io = StringIO()
+    fig.savefig(svg_io, format='svg', bbox_inches='tight', transparent=True)
+    plt.close(fig)
+    return svg_io.getvalue()
+
+
+# ---------------------------------------------------------------------------
 # 2. Node type history (status dashboard)
 # ---------------------------------------------------------------------------
 

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -224,10 +224,26 @@ def generate_disk_usage_stacked_area(timeseries) -> str:
         for s in series
     ]
     labels = [s['username'] for s in series]
-    ax.stackplot(dates, *scaled_series, labels=labels, alpha=0.85)
+    # Others (always first per get_disk_usage_timeseries_by_user) gets a
+    # neutral grey so it doesn't compete with the named-user palette.
+    # Named users use matplotlib's default tab10 cycle.
+    cmap = matplotlib.colormaps.get_cmap('tab10')
+    colors = []
+    cycle_idx = 0
+    for s in series:
+        if s['username'] == 'Others':
+            colors.append('#9ca3af')   # tailwind-style neutral grey
+        else:
+            colors.append(cmap(cycle_idx % 10))
+            cycle_idx += 1
+    ax.stackplot(dates, *scaled_series, labels=labels, colors=colors, alpha=0.85)
     ax.set_ylabel(f'Disk usage ({unit_label})')
     ax.grid(True, alpha=0.3)
+    # Reverse the legend so it reads top-to-bottom in the same order as
+    # the visual stack (largest user on top).
+    handles, lbls = ax.get_legend_handles_labels()
     ax.legend(
+        handles[::-1], lbls[::-1],
         loc='center left',
         bbox_to_anchor=(1.01, 0.5),
         frameon=False,

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -16,16 +16,20 @@ from sam.schemas.forms.user import EditAllocationForm, SetShellForm, SetPrimaryG
 
 from webapp.extensions import db
 from sam.queries.dashboard import get_user_dashboard_data, get_resource_detail_data, get_project_dashboard_data
+from sam.queries.disk_usage import build_disk_subtree, get_disk_usage_timeseries_by_user
 from sam.queries.rolling_usage import get_project_rolling_usage
 from sam.queries.charges import get_user_queue_breakdown_for_project, get_daily_breakdown_for_project, get_charges_by_projcode
 from sam.queries.lookups import find_project_by_code, get_user_group_access, get_group_members
 from sam.queries.shells import get_allowable_shell_names, get_user_current_shell
 from sam.core.users import User
 from sam.projects.projects import Project
+from sam.resources.resources import Resource
+from sam.summaries.disk_summaries import DiskChargeSummary
+from sqlalchemy import func
 from webapp.utils.project_permissions import can_edit_consumption_threshold
 from webapp.utils.rbac import require_permission, Permission, has_permission
 from webapp.api.access_control import require_allocation_permission, require_project_access
-from ..charts import generate_usage_timeseries_matplotlib
+from ..charts import generate_usage_timeseries_matplotlib, generate_disk_usage_stacked_area
 
 
 bp = Blueprint('user_dashboard', __name__, url_prefix='/user')
@@ -387,6 +391,19 @@ def resource_details():
         flash(f'Project {projcode} not found', 'error')
         return redirect(url_for('user_dashboard.index'))
 
+    # Disk has different semantics than HPC/DAV (capacity, not burn-rate)
+    # so it gets its own template + data assembly. Branch here once the
+    # project is loaded; all the HPC-shaped scaffolding below is skipped.
+    resource = db.session.query(Resource).filter(
+        Resource.resource_name == resource_name,
+    ).first()
+    if resource is not None and resource.resource_type \
+            and resource.resource_type.resource_type == 'DISK':
+        return _render_disk_resource_details(
+            project=project, resource=resource,
+            start_date=start_date, end_date=end_date,
+        )
+
     can_edit_threshold = can_edit_consumption_threshold(current_user, project)
     has_children = bool(project.has_children)
 
@@ -494,6 +511,178 @@ def resource_details():
         tree_data=tree_data,
         alloc_start_date=alloc_start_date,
     )
+
+
+def _disk_subtree_total_bytes(node) -> int:
+    """Sum ``current_bytes`` over a tree node and all its descendants."""
+    total = node.get('current_bytes', 0) or 0
+    for c in node.get('children', []):
+        total += _disk_subtree_total_bytes(c)
+    return total
+
+
+def _disk_subtree_total_files(node) -> int:
+    total = node.get('file_count', 0) or 0
+    for c in node.get('children', []):
+        total += _disk_subtree_total_files(c)
+    return total
+
+
+def _disk_subtree_latest_activity_date(node):
+    """Most recent ``activity_date`` across the subtree (or None)."""
+    best = node.get('activity_date')
+    for c in node.get('children', []):
+        cand = _disk_subtree_latest_activity_date(c)
+        if cand is not None and (best is None or cand > best):
+            best = cand
+    return best
+
+
+def _find_disk_node(tree, projcode):
+    """Locate a node by projcode in a build_disk_subtree tree dict."""
+    if tree.get('projcode') == projcode:
+        return tree
+    for c in tree.get('children', []):
+        hit = _find_disk_node(c, projcode)
+        if hit is not None:
+            return hit
+    return None
+
+
+def _render_disk_resource_details(*, project, resource, start_date, end_date):
+    """Disk-flavored Resource Usage Details page.
+
+    Replaces the HPC/DAV daily-charges shape with capacity-oriented
+    components: a current-snapshot capacity header, a stacked-area chart
+    of bytes vs time (top-N users + Others), a filesystem-style project
+    tree, and a per-user table for the latest snapshot. Scope (subtree
+    selection) is set via the ``?scope=`` query param exactly like the
+    HPC view.
+    """
+    resource_name = resource.resource_name
+    scope = request.args.get('scope', project.projcode)
+
+    # Validate scope belongs to this project's tree; fall back to root.
+    if scope != project.projcode:
+        candidate = Project.get_by_projcode(db.session, scope)
+        if candidate is None or candidate.tree_root != project.tree_root:
+            scope = project.projcode
+
+    # Always build the full tree from the user's root project so the
+    # tree-navigation card shows everything; chart + table re-scope by
+    # locating the scope node within it.
+    full = build_disk_subtree(db.session, project, resource_name)
+    full_tree = full['tree']
+    scope_node = _find_disk_node(full_tree, scope) or full_tree
+    scope_account_ids = _collect_disk_account_ids(scope_node)
+
+    # Active disk allocation on the scope's first account drives the
+    # capacity bar's "allocated" denominator. For multi-account scopes
+    # (rare for disk) sum allocations across the scope.
+    allocated_tib = _sum_active_disk_allocations(
+        db.session, scope_account_ids,
+    )
+
+    used_bytes = _disk_subtree_total_bytes(scope_node)
+    used_tib = used_bytes / (1024 ** 4)
+    total_files = _disk_subtree_total_files(scope_node)
+    activity_date = _disk_subtree_latest_activity_date(scope_node)
+    percent_used = (used_tib / allocated_tib * 100) if allocated_tib > 0 else 0.0
+
+    # Time-series for the stacked-area chart.
+    timeseries = get_disk_usage_timeseries_by_user(
+        db.session,
+        account_ids=scope_account_ids,
+        start_date=start_date.date() if hasattr(start_date, 'date') else start_date,
+        end_date=end_date.date() if hasattr(end_date, 'date') else end_date,
+        top_n=10,
+    )
+    usage_chart = generate_disk_usage_stacked_area(timeseries)
+
+    # Per-user table at the latest snapshot date for the scope.
+    user_rows = _build_disk_user_table(
+        db.session, scope_account_ids, activity_date, used_bytes,
+    )
+
+    return render_template(
+        'dashboards/user/resource_details_disk.html',
+        user=current_user,
+        projcode=project.projcode,
+        project=project,
+        resource_name=resource_name,
+        resource=resource,
+        scope=scope,
+        scope_node=scope_node,
+        tree_data=full_tree,
+        has_children=bool(project.has_children),
+        start_date=start_date.strftime('%Y-%m-%d'),
+        end_date=end_date.strftime('%Y-%m-%d'),
+        usage_chart=usage_chart,
+        capacity={
+            'allocated_tib':  allocated_tib,
+            'used_tib':       used_tib,
+            'percent_used':   percent_used,
+            'used_bytes':     used_bytes,
+            'total_files':    total_files,
+            'activity_date':  activity_date,
+        },
+        user_rows=user_rows,
+    )
+
+
+def _collect_disk_account_ids(node) -> list:
+    out = []
+    if node.get('account_id') is not None:
+        out.append(node['account_id'])
+    for c in node.get('children', []):
+        out.extend(_collect_disk_account_ids(c))
+    return out
+
+
+def _sum_active_disk_allocations(session, account_ids) -> float:
+    """Sum the active disk allocation amounts (TiB) for a set of accounts."""
+    if not account_ids:
+        return 0.0
+    from sam.accounting.allocations import Allocation
+    now = datetime.now()
+    rows = session.query(Allocation).filter(
+        Allocation.account_id.in_(account_ids),
+        Allocation.deleted == False,  # noqa: E712
+        Allocation.start_date <= now,
+        ((Allocation.end_date.is_(None)) | (Allocation.end_date >= now)),
+    ).all()
+    return float(sum(a.amount for a in rows))
+
+
+def _build_disk_user_table(session, account_ids, activity_date, scope_bytes):
+    """Per-user current-snapshot rows for the scope, sorted by bytes desc."""
+    if not account_ids or activity_date is None:
+        return []
+    rows = session.query(
+        DiskChargeSummary.user_id,
+        DiskChargeSummary.username,
+        func.coalesce(func.sum(DiskChargeSummary.bytes), 0).label('bytes'),
+        func.coalesce(func.sum(DiskChargeSummary.number_of_files), 0).label('files'),
+    ).filter(
+        DiskChargeSummary.account_id.in_(account_ids),
+        DiskChargeSummary.activity_date == activity_date,
+    ).group_by(
+        DiskChargeSummary.user_id,
+        DiskChargeSummary.username,
+    ).all()
+
+    out = []
+    for user_id, username, b, f in rows:
+        bytes_ = int(b or 0)
+        out.append({
+            'user_id':       user_id,
+            'username':      username or f'uid_{user_id}',
+            'bytes':         bytes_,
+            'file_count':    int(f or 0),
+            'percent_of_project': (bytes_ / scope_bytes * 100) if scope_bytes > 0 else 0.0,
+        })
+    out.sort(key=lambda r: r['bytes'], reverse=True)
+    return out
 
 
 @bp.route('/tree/<projcode>')

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -21,6 +21,7 @@ from sam.queries.rolling_usage import get_project_rolling_usage
 from sam.queries.charges import get_user_queue_breakdown_for_project, get_daily_breakdown_for_project, get_charges_by_projcode
 from sam.queries.lookups import find_project_by_code, get_user_group_access, get_group_members
 from sam.queries.shells import get_allowable_shell_names, get_user_current_shell
+from sam.accounting.accounts import Account
 from sam.core.users import User
 from sam.projects.projects import Project
 from sam.resources.resources import Resource
@@ -576,11 +577,13 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
     scope_node = _find_disk_node(full_tree, scope) or full_tree
     scope_account_ids = _collect_disk_account_ids(scope_node)
 
-    # Active disk allocation on the scope's first account drives the
-    # capacity bar's "allocated" denominator. For multi-account scopes
-    # (rare for disk) sum allocations across the scope.
-    allocated_tib = _sum_active_disk_allocations(
-        db.session, scope_account_ids,
+    # Pool capacity (TiB) for the scope: the master allocation's
+    # amount, NOT the sum across child accounts. Inheriting children
+    # share the parent's cap; summing them double-counts. See
+    # `sam-admin accounting --reconcile-quotas` — NMMM0003 reads 16.4
+    # PiB total, not 6 × parent.
+    allocated_tib = _scope_disk_allocation_tib(
+        db.session, scope_node['projcode'], resource,
     )
 
     used_bytes = _disk_subtree_total_bytes(scope_node)
@@ -639,19 +642,42 @@ def _collect_disk_account_ids(node) -> list:
     return out
 
 
-def _sum_active_disk_allocations(session, account_ids) -> float:
-    """Sum the active disk allocation amounts (TiB) for a set of accounts."""
-    if not account_ids:
-        return 0.0
+def _scope_disk_allocation_tib(session, scope_projcode, resource) -> float:
+    """Pool capacity (TiB) for the scoped project on a disk resource.
+
+    The disk pool cap is the *master* allocation's amount — children
+    that inherit from it share the cap, they do not add to it. So
+    summing across all subtree allocations would double-count. We
+    instead locate the scope project's account on this resource (or
+    walk up the project tree if the scope itself doesn't hold an
+    account), pick the active allocation, and return
+    ``allocation.root.amount`` — which is the pool cap regardless of
+    whether the scope is the root or an inheriting child. Returns 0.0
+    if no active allocation can be located.
+    """
     from sam.accounting.allocations import Allocation
+    scope_project = Project.get_by_projcode(session, scope_projcode)
+    if scope_project is None:
+        return 0.0
+    candidates = [scope_project] + scope_project.get_ancestors(include_self=False)
     now = datetime.now()
-    rows = session.query(Allocation).filter(
-        Allocation.account_id.in_(account_ids),
-        Allocation.deleted == False,  # noqa: E712
-        Allocation.start_date <= now,
-        ((Allocation.end_date.is_(None)) | (Allocation.end_date >= now)),
-    ).all()
-    return float(sum(a.amount for a in rows))
+    for proj in candidates:
+        account = session.query(Account).filter(
+            Account.project_id == proj.project_id,
+            Account.resource_id == resource.resource_id,
+            Account.deleted == False,  # noqa: E712
+        ).first()
+        if account is None:
+            continue
+        for a in account.allocations:
+            if a.deleted:
+                continue
+            if a.start_date and a.start_date > now:
+                continue
+            if a.end_date and a.end_date < now:
+                continue
+            return float(a.root.amount)
+    return 0.0
 
 
 def _build_disk_user_table(session, account_ids, activity_date, scope_bytes):

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -379,9 +379,7 @@
     <div id="collapseUsage" class="collapse show">
         <div class="card-body">
             <div class="chart-container">
-              <center>
                 {{ usage_chart | safe }}
-              </center>
             </div>
         </div>
     </div>

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -124,7 +124,9 @@
         </h5>
     </div>
     <div class="card-body">
-        {{ usage_chart | safe }}
+        <div class="chart-container">
+            {{ usage_chart | safe }}
+        </div>
     </div>
 </div>
 

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -3,41 +3,55 @@
 
 {% block title %}Disk Usage Details - {{ resource_name }} - SAM{% endblock %}
 
-{# ── Filesystem-style project-tree macro ─────────────────────────────── #}
-{% macro render_disk_tree_node(node, depth=0) %}
-{% set is_scope = node.projcode == scope %}
+{# ── Filesystem-style project-tree macro (mirrors render_tree_node
+   in resource_details.html, but with disk size + fileset paths
+   instead of cumulative compute hours). ─────────────────────────── #}
+{% macro render_disk_tree_node(node) %}
+{% set is_selected = (node.projcode == scope) %}
 {% set is_clickable = node.account_id is not none or node.children %}
-<li class="{% if is_scope %}fw-bold{% endif %}">
+{% set node_url = url_for('user_dashboard.resource_details',
+                           projcode=projcode, resource=resource_name,
+                           scope=node.projcode,
+                           start_date=start_date, end_date=end_date) %}
+<li style="{{ 'background: #fff3cd; border-left-color: #ffc107; font-weight: bold;' if is_selected else '' }}">
     {% if is_clickable %}
-    <a href="{{ url_for('user_dashboard.resource_details',
-                         projcode=projcode,
-                         resource=resource_name,
-                         start_date=start_date,
-                         end_date=end_date,
-                         scope=node.projcode) }}"
-       class="text-decoration-none {% if is_scope %}text-warning{% endif %}">
+    <a href="{{ node_url }}" class="d-flex align-items-center gap-2 text-decoration-none text-body">
+    {% else %}
+    <span class="d-flex align-items-center gap-2 text-muted" style="cursor: default;" title="No {{ resource_name }} usage">
     {% endif %}
-        <code>{{ node.projcode }}</code>
-        {% if node.title %}<span class="text-muted small ms-1">{{ node.title }}</span>{% endif %}
+        {% if is_selected %}
+        <i class="fas fa-arrow-right text-warning me-1 flex-shrink-0"></i>
+        {% endif %}
+        <strong>{{ node.projcode }}</strong>
+        {% if node.title %}
+        <span class="{% if is_clickable %}text-muted{% endif %} fw-normal text-truncate" style="max-width: 35ch;">- {{ node.title }}</span>
+        {% endif %}
+        {% if node.fileset_paths %}
+        <span class="text-muted small font-monospace"
+              style="max-width: 70ch; white-space: normal; word-break: break-word;">
+            <i class="fas fa-folder-open me-1"></i>{{ node.fileset_paths | join(', ') }}
+        </span>
+        {% endif %}
         {% if node.current_bytes %}
-        <span class="badge bg-light text-dark ms-2" title="Current snapshot occupancy">
+        {% if is_selected %}
+        <span class="badge bg-warning text-dark ms-auto flex-shrink-0">
+            {{ node.current_bytes | fmt_size }}
+        </span>
+        {% else %}
+        <span class="text-muted small ms-auto flex-shrink-0 font-monospace">
             {{ node.current_bytes | fmt_size }}
         </span>
         {% endif %}
-    {% if is_clickable %}</a>{% endif %}
-
-    {% if node.fileset_paths %}
-    <div class="small text-muted ps-3">
-        {% for path in node.fileset_paths %}
-        <code class="text-muted">{{ path }}</code>{% if not loop.last %}<br>{% endif %}
-        {% endfor %}
-    </div>
+        {% endif %}
+    {% if is_clickable %}
+    </a>
+    {% else %}
+    </span>
     {% endif %}
-
     {% if node.children %}
     <ul class="tree-list">
         {% for child in node.children %}
-        {{ render_disk_tree_node(child, depth + 1) }}
+        {{ render_disk_tree_node(child) }}
         {% endfor %}
     </ul>
     {% endif %}
@@ -74,58 +88,59 @@
     </p>
 </div>
 
-{# ── Capacity card ──────────────────────────────────────────────────── #}
+{# ── Capacity summary card ─────────────────────────────────────────── #}
 <div class="card mb-4">
-    <div class="card-header">
+    <div class="card-header cursor-pointer"
+         data-bs-toggle="collapse" data-bs-target="#collapseDiskCapacity"
+         aria-expanded="true">
         <h5 class="mb-0">
-            <i class="fas fa-database"></i> Current capacity
+            <i class="fas fa-info-circle"></i> Capacity Summary
+            {% set _remaining = capacity.allocated_tib - capacity.used_tib %}
+            <i class="fas fa-chevron-down float-end transition-smooth"></i>
         </h5>
     </div>
-    <div class="card-body">
-        <div class="row align-items-center">
-            <div class="col-md-3">
-                <div class="text-muted small">Used</div>
-                <div class="h4 mb-0 text-warning">
-                    {{ capacity.used_bytes | fmt_size }}
-                </div>
-                <div class="small text-muted">
-                    {{ capacity.used_tib | fmt_number }} TiB
-                </div>
+    <div id="collapseDiskCapacity" class="collapse show">
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-sm table-bordered table-hover">
+                    <thead class="thead-light">
+                        <tr>
+                            <th>Resource</th>
+                            <th>Scope</th>
+                            <th>As of</th>
+                            <th>Allocated</th>
+                            <th>Used</th>
+                            <th>Remaining</th>
+                            <th class="text-end">Files</th>
+                            <th class="table-col-usage">Usage</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><strong>{{ resource_name }}</strong></td>
+                            <td><code>{{ scope }}</code></td>
+                            <td>{{ capacity.activity_date | fmt_date }}</td>
+                            <td class="text-primary">
+                                {{ capacity.allocated_tib | fmt_number }} TiB
+                            </td>
+                            <td class="text-warning">
+                                {{ capacity.used_bytes | fmt_size }}
+                                <span class="text-muted small">({{ capacity.used_tib | fmt_number }} TiB)</span>
+                            </td>
+                            <td class="text-success">
+                                {{ _remaining | fmt_number }} TiB
+                            </td>
+                            <td class="text-end">{{ capacity.total_files | fmt_number }}</td>
+                            <td>
+                                {{ render_usage_bar(capacity.percent_used,
+                                                    none,
+                                                    size_class='progress-large',
+                                                    show_label=True) }}
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
-            <div class="col-md-3">
-                <div class="text-muted small">Allocated</div>
-                <div class="h4 mb-0 text-primary">
-                    {{ capacity.allocated_tib | fmt_number }} TiB
-                </div>
-            </div>
-            <div class="col-md-3">
-                <div class="text-muted small">Files</div>
-                <div class="h4 mb-0">{{ capacity.total_files | fmt_number }}</div>
-            </div>
-            <div class="col-md-3">
-                <div class="text-muted small mb-1">Capacity used</div>
-                {{ render_usage_bar(capacity.percent_used,
-                                    none,
-                                    size_class='progress-large',
-                                    show_label=True) }}
-            </div>
-        </div>
-    </div>
-</div>
-
-{# ── Stacked-area chart ─────────────────────────────────────────────── #}
-<div class="card mb-4">
-    <div class="card-header">
-        <h5 class="mb-0">
-            <i class="fas fa-chart-area"></i> Usage over time
-            <small class="text-muted ms-2">
-                (top 10 users + Others, {{ start_date }} → {{ end_date }})
-            </small>
-        </h5>
-    </div>
-    <div class="card-body">
-        <div class="chart-container">
-            {{ usage_chart | safe }}
         </div>
     </div>
 </div>
@@ -134,15 +149,16 @@
 {% if has_children %}
 <div class="card mb-4">
     <div class="card-header cursor-pointer"
-         data-bs-toggle="collapse" data-bs-target="#disk-tree-card"
+         data-bs-toggle="collapse" data-bs-target="#collapseDiskTree"
          aria-expanded="true">
         <h5 class="mb-0">
-            <i class="fas fa-sitemap"></i> Project tree
-            <small class="text-muted ms-2">click a node to scope the chart and table</small>
+            <i class="fas fa-sitemap"></i> Project Hierarchy
+            <small class="text-muted fw-normal ms-2">Click a project to scope the chart and table below</small>
+            <i class="fas fa-chevron-down float-end transition-smooth"></i>
         </h5>
     </div>
-    <div class="collapse show" id="disk-tree-card">
-        <div class="card-body">
+    <div id="collapseDiskTree" class="collapse show">
+        <div class="card-body p-3 bg-light rounded" style="font-size: 0.875em; max-height: 400px; overflow-y: auto;">
             <ul class="tree-list">
                 {{ render_disk_tree_node(tree_data) }}
             </ul>
@@ -151,43 +167,76 @@
 </div>
 {% endif %}
 
-{# ── Per-user current-snapshot table ────────────────────────────────── #}
+{# ── Stacked-area chart ─────────────────────────────────────────────── #}
 <div class="card mb-4">
-    <div class="card-header">
+    <div class="card-header cursor-pointer"
+         data-bs-toggle="collapse" data-bs-target="#collapseDiskUsage"
+         aria-expanded="true">
         <h5 class="mb-0">
-            <i class="fas fa-users"></i> Per-user occupancy
-            {% if capacity.activity_date %}
-            <small class="text-muted ms-2">snapshot {{ capacity.activity_date | fmt_date }}</small>
+            <i class="fas fa-chart-area"></i> Usage Over Time
+            <small class="text-muted fw-normal ms-2">
+                top 10 users + Others, {{ start_date }} → {{ end_date }}
+            </small>
+            {% if has_children and scope != projcode %}
+            <small class="text-muted fw-normal ms-2">{{ scope }}</small>
             {% endif %}
+            <i class="fas fa-chevron-down float-end transition-smooth"></i>
         </h5>
     </div>
-    <div class="card-body">
-        {% if user_rows %}
-        <div class="table-responsive">
-            <table class="table table-sm table-hover">
-                <thead class="thead-light">
-                    <tr>
-                        <th>Username</th>
-                        <th class="text-end">Files</th>
-                        <th class="text-end">Size</th>
-                        <th class="text-end">% of {{ scope }}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for row in user_rows %}
-                    <tr>
-                        <td><code>{{ row.username }}</code></td>
-                        <td class="text-end">{{ row.file_count | fmt_number }}</td>
-                        <td class="text-end">{{ row.bytes | fmt_size }}</td>
-                        <td class="text-end">{{ row.percent_of_project | fmt_pct }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+    <div id="collapseDiskUsage" class="collapse show">
+        <div class="card-body">
+            <div class="chart-container">
+                {{ usage_chart | safe }}
+            </div>
         </div>
-        {% else %}
-        <p class="text-muted mb-0">No per-user usage recorded for this scope.</p>
-        {% endif %}
+    </div>
+</div>
+
+{# ── Per-user current-snapshot table ────────────────────────────────── #}
+<div class="card mb-4">
+    <div class="card-header cursor-pointer"
+         data-bs-toggle="collapse" data-bs-target="#collapseDiskUsers"
+         aria-expanded="true">
+        <h5 class="mb-0">
+            <i class="fas fa-users"></i> Per-User Occupancy
+            {% if capacity.activity_date %}
+            <small class="text-muted fw-normal ms-2">snapshot {{ capacity.activity_date | fmt_date }}</small>
+            {% endif %}
+            {% if has_children and scope != projcode %}
+            <small class="text-muted fw-normal ms-2">{{ scope }}</small>
+            {% endif %}
+            <i class="fas fa-chevron-down float-end transition-smooth"></i>
+        </h5>
+    </div>
+    <div id="collapseDiskUsers" class="collapse show">
+        <div class="card-body">
+            {% if user_rows %}
+            <div class="table-responsive">
+                <table class="table table-sm table-hover">
+                    <thead class="thead-light">
+                        <tr>
+                            <th>Username</th>
+                            <th class="text-end">Files</th>
+                            <th class="text-end">Size</th>
+                            <th class="text-end">% of {{ scope }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for row in user_rows %}
+                        <tr>
+                            <td><code>{{ row.username }}</code></td>
+                            <td class="text-end">{{ row.file_count | fmt_number }}</td>
+                            <td class="text-end">{{ row.bytes | fmt_size }}</td>
+                            <td class="text-end">{{ row.percent_of_project | fmt_pct }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+            <p class="text-muted mb-0">No per-user usage recorded for this scope.</p>
+            {% endif %}
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -1,0 +1,191 @@
+{% extends 'dashboards/base.html' %}
+{% from 'dashboards/shared/usage_bar.html' import render_usage_bar with context %}
+
+{% block title %}Disk Usage Details - {{ resource_name }} - SAM{% endblock %}
+
+{# ── Filesystem-style project-tree macro ─────────────────────────────── #}
+{% macro render_disk_tree_node(node, depth=0) %}
+{% set is_scope = node.projcode == scope %}
+{% set is_clickable = node.account_id is not none or node.children %}
+<li class="{% if is_scope %}fw-bold{% endif %}">
+    {% if is_clickable %}
+    <a href="{{ url_for('user_dashboard.resource_details',
+                         projcode=projcode,
+                         resource=resource_name,
+                         start_date=start_date,
+                         end_date=end_date,
+                         scope=node.projcode) }}"
+       class="text-decoration-none {% if is_scope %}text-warning{% endif %}">
+    {% endif %}
+        <code>{{ node.projcode }}</code>
+        {% if node.title %}<span class="text-muted small ms-1">{{ node.title }}</span>{% endif %}
+        {% if node.current_bytes %}
+        <span class="badge bg-light text-dark ms-2" title="Current snapshot occupancy">
+            {{ node.current_bytes | fmt_size }}
+        </span>
+        {% endif %}
+    {% if is_clickable %}</a>{% endif %}
+
+    {% if node.fileset_paths %}
+    <div class="small text-muted ps-3">
+        {% for path in node.fileset_paths %}
+        <code class="text-muted">{{ path }}</code>{% if not loop.last %}<br>{% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    {% if node.children %}
+    <ul class="tree-list">
+        {% for child in node.children %}
+        {{ render_disk_tree_node(child, depth + 1) }}
+        {% endfor %}
+    </ul>
+    {% endif %}
+</li>
+{% endmacro %}
+
+{% block content %}
+{% set _from_admin = request.args.get('from') == 'admin' %}
+<div class="back-link mb-3">
+    {% if _from_admin %}
+    <a href="{{ url_for('admin_dashboard.index', projcode=projcode) }}" class="btn btn-sm btn-outline-secondary">
+        <i class="fas fa-arrow-left"></i> <span class="back-link-text">Back to Admin</span>
+    </a>
+    {% else %}
+    <a href="{{ url_for('user_dashboard.index') }}" class="btn btn-sm btn-outline-secondary">
+        <i class="fas fa-arrow-left"></i> <span class="back-link-text">Back to Dashboard</span>
+    </a>
+    {% endif %}
+</div>
+
+<div class="page-header">
+    <h1>
+        <i class="fas fa-hdd"></i> Disk Usage Details
+    </h1>
+    <p class="text-muted">
+        Project: <strong>{{ projcode }}</strong>
+        | Resource: <strong>{{ resource_name }}</strong>
+        {% if scope != projcode %}
+        | Scope: <strong>{{ scope }}</strong>
+        {% endif %}
+        {% if capacity.activity_date %}
+        | <span title="Latest snapshot date">As of <strong>{{ capacity.activity_date | fmt_date }}</strong></span>
+        {% endif %}
+    </p>
+</div>
+
+{# ── Capacity card ──────────────────────────────────────────────────── #}
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="mb-0">
+            <i class="fas fa-database"></i> Current capacity
+        </h5>
+    </div>
+    <div class="card-body">
+        <div class="row align-items-center">
+            <div class="col-md-3">
+                <div class="text-muted small">Used</div>
+                <div class="h4 mb-0 text-warning">
+                    {{ capacity.used_bytes | fmt_size }}
+                </div>
+                <div class="small text-muted">
+                    {{ capacity.used_tib | fmt_number }} TiB
+                </div>
+            </div>
+            <div class="col-md-3">
+                <div class="text-muted small">Allocated</div>
+                <div class="h4 mb-0 text-primary">
+                    {{ capacity.allocated_tib | fmt_number }} TiB
+                </div>
+            </div>
+            <div class="col-md-3">
+                <div class="text-muted small">Files</div>
+                <div class="h4 mb-0">{{ capacity.total_files | fmt_number }}</div>
+            </div>
+            <div class="col-md-3">
+                <div class="text-muted small mb-1">Capacity used</div>
+                {{ render_usage_bar(capacity.percent_used,
+                                    none,
+                                    size_class='progress-large',
+                                    show_label=True) }}
+            </div>
+        </div>
+    </div>
+</div>
+
+{# ── Stacked-area chart ─────────────────────────────────────────────── #}
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="mb-0">
+            <i class="fas fa-chart-area"></i> Usage over time
+            <small class="text-muted ms-2">
+                (top 10 users + Others, {{ start_date }} → {{ end_date }})
+            </small>
+        </h5>
+    </div>
+    <div class="card-body">
+        {{ usage_chart | safe }}
+    </div>
+</div>
+
+{# ── Filesystem-style project tree ──────────────────────────────────── #}
+{% if has_children %}
+<div class="card mb-4">
+    <div class="card-header cursor-pointer"
+         data-bs-toggle="collapse" data-bs-target="#disk-tree-card"
+         aria-expanded="true">
+        <h5 class="mb-0">
+            <i class="fas fa-sitemap"></i> Project tree
+            <small class="text-muted ms-2">click a node to scope the chart and table</small>
+        </h5>
+    </div>
+    <div class="collapse show" id="disk-tree-card">
+        <div class="card-body">
+            <ul class="tree-list">
+                {{ render_disk_tree_node(tree_data) }}
+            </ul>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+{# ── Per-user current-snapshot table ────────────────────────────────── #}
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="mb-0">
+            <i class="fas fa-users"></i> Per-user occupancy
+            {% if capacity.activity_date %}
+            <small class="text-muted ms-2">snapshot {{ capacity.activity_date | fmt_date }}</small>
+            {% endif %}
+        </h5>
+    </div>
+    <div class="card-body">
+        {% if user_rows %}
+        <div class="table-responsive">
+            <table class="table table-sm table-hover">
+                <thead class="thead-light">
+                    <tr>
+                        <th>Username</th>
+                        <th class="text-end">Files</th>
+                        <th class="text-end">Size</th>
+                        <th class="text-end">% of {{ scope }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in user_rows %}
+                    <tr>
+                        <td><code>{{ row.username }}</code></td>
+                        <td class="text-end">{{ row.file_count | fmt_number }}</td>
+                        <td class="text-end">{{ row.bytes | fmt_size }}</td>
+                        <td class="text-end">{{ row.percent_of_project | fmt_pct }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="text-muted mb-0">No per-user usage recorded for this scope.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/tests/unit/test_disk_usage_queries.py
+++ b/tests/unit/test_disk_usage_queries.py
@@ -282,13 +282,20 @@ class TestBuildDiskSubtree:
         lead = make_user(session)
         project = make_project(session, lead=lead)
         make_account(session, project=project, resource=resource)
+        # Backdate start_date by a day so the row is unambiguously
+        # "active" under DateRangeMixin.is_active even if the test's
+        # Python clock and MySQL NOW() are in different timezones (CI
+        # containers can drift by hours).
+        backdate = datetime.now() - timedelta(days=1)
         ProjectDirectory.create(
             session, project_id=project.project_id,
             directory_name='/gpfs/csfs1/test/path_a',
+            start_date=backdate,
         )
         ProjectDirectory.create(
             session, project_id=project.project_id,
             directory_name='/gpfs/csfs1/test/path_b',
+            start_date=backdate,
         )
         session.flush()
         result = build_disk_subtree(session, project, resource.resource_name)

--- a/tests/unit/test_disk_usage_queries.py
+++ b/tests/unit/test_disk_usage_queries.py
@@ -1,0 +1,296 @@
+"""Unit tests for ``sam.queries.disk_usage`` — the disk-flavored
+Resource Usage Details data layer.
+
+Covers:
+  * ``get_disk_usage_timeseries_by_user``: top-N selection by latest
+    snapshot, "Others" lump-sum, dense-fill across snapshot dates,
+    empty-input edge case.
+  * ``build_disk_subtree``: parent + multi-child case, leaf-only case,
+    nodes with no disk account on the resource.
+"""
+
+from datetime import date as _date, datetime, timedelta
+
+import pytest
+
+from sam import ResourceType
+from sam.projects.projects import ProjectDirectory
+from sam.queries.disk_usage import (
+    build_disk_subtree,
+    get_disk_usage_timeseries_by_user,
+)
+from sam.summaries.disk_summaries import (
+    DiskChargeSummary,
+    mark_disk_snapshot_current,
+)
+
+from factories import (
+    make_account,
+    make_allocation,
+    make_project,
+    make_resource,
+    make_resource_type,
+    make_user,
+)
+from factories._seq import next_seq
+
+
+pytestmark = pytest.mark.unit
+
+
+BYTES_PER_TIB = 1024 ** 4
+
+
+def _disk_resource(session):
+    rt = session.query(ResourceType).filter_by(resource_type='DISK').first()
+    if rt is None:
+        rt = make_resource_type(session, resource_type='DISK')
+    return make_resource(
+        session, resource_type=rt,
+        resource_name=f"Campaign_Store_{next_seq('cs')}",
+    )
+
+
+def _seed_row(session, *, account, user, snap, bytes_, files=10):
+    session.add(DiskChargeSummary(
+        activity_date=snap,
+        account_id=account.account_id,
+        user_id=user.user_id,
+        username=user.username,
+        projcode=account.project.projcode,
+        number_of_files=files,
+        bytes=bytes_,
+        terabyte_years=0.0,
+        charges=0.0,
+    ))
+
+
+# ============================================================================
+# get_disk_usage_timeseries_by_user
+# ============================================================================
+
+
+class TestDiskUsageTimeseries:
+
+    def test_empty_account_ids_returns_empty(self, session):
+        out = get_disk_usage_timeseries_by_user(session, account_ids=[])
+        assert out == {'dates': [], 'series': []}
+
+    def test_single_user_single_date(self, session):
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        snap = _date(2026, 4, 11)
+        _seed_row(session, account=account, user=lead, snap=snap,
+                  bytes_=4 * BYTES_PER_TIB)
+        session.flush()
+
+        out = get_disk_usage_timeseries_by_user(
+            session, account_ids=[account.account_id],
+        )
+        assert out['dates'] == [snap]
+        assert len(out['series']) == 1
+        s0 = out['series'][0]
+        assert s0['username'] == lead.username
+        assert s0['values'] == [4 * BYTES_PER_TIB]
+
+    def test_top_n_with_others_lump(self, session):
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        snap = _date(2026, 4, 11)
+        # 12 distinct users with descending bytes (12, 11, ..., 1).
+        users = [make_user(session) for _ in range(12)]
+        for i, u in enumerate(users):
+            _seed_row(session, account=account, user=u, snap=snap,
+                      bytes_=(12 - i) * BYTES_PER_TIB)
+        session.flush()
+
+        out = get_disk_usage_timeseries_by_user(
+            session, account_ids=[account.account_id], top_n=10,
+        )
+        assert out['dates'] == [snap]
+        # 10 named users + Others
+        names = [s['username'] for s in out['series']]
+        assert names[-1] == 'Others'
+        assert len(names) == 11
+        # Top user (12 TiB) is the first series.
+        assert out['series'][0]['values'] == [12 * BYTES_PER_TIB]
+        # Others = users ranked 11 + 12 = 2 + 1 = 3 TiB
+        assert out['series'][-1]['values'] == [3 * BYTES_PER_TIB]
+
+    def test_dense_fill_zero_for_missing_user_dates(self, session):
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        other = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        d1 = _date(2026, 4, 4)
+        d2 = _date(2026, 4, 11)
+        # lead present on both dates; other only on d2
+        _seed_row(session, account=account, user=lead, snap=d1, bytes_=BYTES_PER_TIB)
+        _seed_row(session, account=account, user=lead, snap=d2, bytes_=2 * BYTES_PER_TIB)
+        _seed_row(session, account=account, user=other, snap=d2, bytes_=3 * BYTES_PER_TIB)
+        session.flush()
+
+        out = get_disk_usage_timeseries_by_user(
+            session, account_ids=[account.account_id],
+        )
+        assert out['dates'] == [d1, d2]
+        # Both series have length 2; missing date filled with 0.
+        for s in out['series']:
+            assert len(s['values']) == 2
+        by_user = {s['username']: s['values'] for s in out['series']}
+        assert by_user[lead.username] == [BYTES_PER_TIB, 2 * BYTES_PER_TIB]
+        assert by_user[other.username] == [0, 3 * BYTES_PER_TIB]
+
+    def test_no_others_series_when_under_top_n(self, session):
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        snap = _date(2026, 4, 11)
+        # 3 users, top_n=10 → no Others row
+        for _ in range(3):
+            u = make_user(session)
+            _seed_row(session, account=account, user=u, snap=snap, bytes_=BYTES_PER_TIB)
+        session.flush()
+
+        out = get_disk_usage_timeseries_by_user(
+            session, account_ids=[account.account_id], top_n=10,
+        )
+        names = [s['username'] for s in out['series']]
+        assert 'Others' not in names
+        assert len(names) == 3
+
+    def test_date_range_filter(self, session):
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        d1 = _date(2026, 1, 3)
+        d2 = _date(2026, 4, 11)
+        _seed_row(session, account=account, user=lead, snap=d1, bytes_=BYTES_PER_TIB)
+        _seed_row(session, account=account, user=lead, snap=d2, bytes_=2 * BYTES_PER_TIB)
+        session.flush()
+
+        out = get_disk_usage_timeseries_by_user(
+            session, account_ids=[account.account_id],
+            start_date=_date(2026, 4, 1),
+        )
+        assert out['dates'] == [d2]
+
+
+# ============================================================================
+# build_disk_subtree
+# ============================================================================
+
+
+class TestBuildDiskSubtree:
+
+    def test_leaf_project_no_children(self, session):
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        snap = _date(2026, 4, 11)
+        _seed_row(session, account=account, user=lead, snap=snap,
+                  bytes_=10 * BYTES_PER_TIB)
+        session.flush()
+        mark_disk_snapshot_current(session, snap)
+
+        result = build_disk_subtree(session, project, resource.resource_name)
+        tree = result['tree']
+        assert tree['projcode'] == project.projcode
+        assert tree['account_id'] == account.account_id
+        assert tree['current_bytes'] == 10 * BYTES_PER_TIB
+        assert tree['current_used_tib'] == pytest.approx(10.0, abs=1e-6)
+        assert tree['activity_date'] == snap
+        assert tree['children'] == []
+        assert result['account_ids'] == [account.account_id]
+
+    def test_parent_with_children(self, session):
+        resource = _disk_resource(session)
+        parent_lead = make_user(session)
+        parent = make_project(session, lead=parent_lead)
+        child_a = make_project(session, parent=parent, lead=make_user(session))
+        child_b = make_project(session, parent=parent, lead=make_user(session))
+
+        account_p = make_account(session, project=parent, resource=resource)
+        account_a = make_account(session, project=child_a, resource=resource)
+        account_b = make_account(session, project=child_b, resource=resource)
+
+        snap = _date(2026, 4, 11)
+        _seed_row(session, account=account_a, user=child_a.lead, snap=snap,
+                  bytes_=4 * BYTES_PER_TIB)
+        _seed_row(session, account=account_b, user=child_b.lead, snap=snap,
+                  bytes_=3 * BYTES_PER_TIB)
+        session.flush()
+        mark_disk_snapshot_current(session, snap)
+
+        result = build_disk_subtree(session, parent, resource.resource_name)
+        tree = result['tree']
+        assert tree['projcode'] == parent.projcode
+        assert len(tree['children']) == 2
+        kids = {c['projcode']: c for c in tree['children']}
+        assert kids[child_a.projcode]['current_bytes'] == 4 * BYTES_PER_TIB
+        assert kids[child_b.projcode]['current_bytes'] == 3 * BYTES_PER_TIB
+        # Children sorted by projcode for determinism.
+        assert [c['projcode'] for c in tree['children']] == sorted(kids)
+        # Account-id list aggregates the entire subtree.
+        assert sorted(result['account_ids']) == sorted(
+            [account_p.account_id, account_a.account_id, account_b.account_id]
+        )
+
+    def test_node_without_disk_account_still_shown(self, session):
+        resource = _disk_resource(session)
+        parent = make_project(session, lead=make_user(session))
+        child = make_project(session, parent=parent, lead=make_user(session))
+        # Only the child has a disk account on this resource.
+        account_child = make_account(session, project=child, resource=resource)
+        snap = _date(2026, 4, 11)
+        _seed_row(session, account=account_child, user=child.lead, snap=snap,
+                  bytes_=2 * BYTES_PER_TIB)
+        session.flush()
+        mark_disk_snapshot_current(session, snap)
+
+        result = build_disk_subtree(session, parent, resource.resource_name)
+        tree = result['tree']
+        # Parent has no account on this resource → present, but inert.
+        assert tree['account_id'] is None
+        assert tree['current_bytes'] == 0
+        assert tree['activity_date'] is None
+        # Child appears as expected.
+        assert len(tree['children']) == 1
+        assert tree['children'][0]['account_id'] == account_child.account_id
+        # Only the child contributes to account_ids.
+        assert result['account_ids'] == [account_child.account_id]
+
+    def test_unknown_resource_returns_empty_account_ids(self, session):
+        parent = make_project(session, lead=make_user(session))
+        result = build_disk_subtree(session, parent, 'NoSuchResource')
+        assert result['account_ids'] == []
+        assert result['tree']['projcode'] == parent.projcode
+
+    def test_fileset_paths_attached(self, session):
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        make_account(session, project=project, resource=resource)
+        ProjectDirectory.create(
+            session, project_id=project.project_id,
+            directory_name='/gpfs/csfs1/test/path_a',
+        )
+        ProjectDirectory.create(
+            session, project_id=project.project_id,
+            directory_name='/gpfs/csfs1/test/path_b',
+        )
+        session.flush()
+        result = build_disk_subtree(session, project, resource.resource_name)
+        paths = result['tree']['fileset_paths']
+        assert paths == [
+            '/gpfs/csfs1/test/path_a',
+            '/gpfs/csfs1/test/path_b',
+        ]

--- a/tests/unit/test_disk_usage_queries.py
+++ b/tests/unit/test_disk_usage_queries.py
@@ -112,14 +112,17 @@ class TestDiskUsageTimeseries:
             session, account_ids=[account.account_id], top_n=10,
         )
         assert out['dates'] == [snap]
-        # 10 named users + Others
+        # Stack-friendly order: Others first (bottom of stack, grey),
+        # then named users smallest → largest.
         names = [s['username'] for s in out['series']]
-        assert names[-1] == 'Others'
+        assert names[0] == 'Others'
         assert len(names) == 11
-        # Top user (12 TiB) is the first series.
-        assert out['series'][0]['values'] == [12 * BYTES_PER_TIB]
-        # Others = users ranked 11 + 12 = 2 + 1 = 3 TiB
-        assert out['series'][-1]['values'] == [3 * BYTES_PER_TIB]
+        # Others = users ranked 11 + 12 = 2 + 1 = 3 TiB (bottom of stack).
+        assert out['series'][0]['values'] == [3 * BYTES_PER_TIB]
+        # Largest named user (12 TiB) sits on top of the stack.
+        assert out['series'][-1]['values'] == [12 * BYTES_PER_TIB]
+        # Smallest named user (3 TiB total: rank 10 → 3) sits just above Others.
+        assert out['series'][1]['values'] == [3 * BYTES_PER_TIB]
 
     def test_dense_fill_zero_for_missing_user_dates(self, session):
         resource = _disk_resource(session)

--- a/tests/unit/test_query_functions.py
+++ b/tests/unit/test_query_functions.py
@@ -407,6 +407,67 @@ class TestDiskCapacityInDashboardData:
         assert disk['remaining'] == 100.0
         assert disk['activity_date'] is None
 
+    def test_parent_project_capacity_includes_child_subtree(self, session):
+        """For NMMM0003-shaped parents (own account holds 0 bytes, child
+        sub-projects hold the actual occupancy), the dashboard dict's
+        `used` must reflect the subtree total — not the parent account's
+        own snapshot."""
+        from datetime import date as _date
+        from sam import ResourceType
+        from sam.summaries.disk_summaries import (
+            DiskChargeSummary,
+            mark_disk_snapshot_current,
+        )
+        BYTES_PER_TIB = 1024 ** 4
+
+        rt = session.query(ResourceType).filter_by(resource_type='DISK').first()
+        if rt is None:
+            rt = make_resource_type(session, resource_type='DISK')
+        resource = make_resource(
+            session, resource_type=rt,
+            resource_name=f"Campaign_Store_{next_seq('cs')}",
+        )
+        parent_lead = make_user(session)
+        parent = make_project(session, lead=parent_lead)
+        child_a = make_project(session, parent=parent, lead=make_user(session))
+        child_b = make_project(session, parent=parent, lead=make_user(session))
+        # Allocation lives on the parent (capacity cap for the pool).
+        parent_account = make_account(session, project=parent, resource=resource)
+        make_allocation(
+            session, account=parent_account, amount=100.0,
+            start_date=datetime.now() - timedelta(days=30),
+            end_date=datetime.now() + timedelta(days=335),
+        )
+        # Children carry the actual snapshot bytes.
+        account_a = make_account(session, project=child_a, resource=resource)
+        account_b = make_account(session, project=child_b, resource=resource)
+        snap = _date(2026, 4, 18)
+        for acct, lead, tib in [
+            (account_a, child_a.lead, 30.0),
+            (account_b, child_b.lead, 20.0),
+        ]:
+            session.add(DiskChargeSummary(
+                activity_date=snap,
+                account_id=acct.account_id,
+                user_id=lead.user_id,
+                username=lead.username,
+                projcode=acct.project.projcode,
+                number_of_files=100,
+                bytes=int(tib * BYTES_PER_TIB),
+                terabyte_years=0.0,
+                charges=0.0,
+            ))
+        session.flush()
+        mark_disk_snapshot_current(session, snap)
+
+        rows = _build_project_resources_data(parent)
+        disk = next(r for r in rows if r['resource_type'] == 'DISK')
+        # Parent's bar must read 50 TiB used, not 0 — the parent's own
+        # account holds nothing; the children hold 30+20 = 50 TiB.
+        assert disk['used'] == pytest.approx(50.0, abs=1e-6)
+        assert disk['percent_used'] == pytest.approx(50.0, abs=1e-4)
+        assert disk['activity_date'] == snap
+
 
 class TestDiskCapacityInAllocationSummary:
     """`get_allocation_summary_with_usage` returns capacity-based

--- a/tests/unit/test_query_functions.py
+++ b/tests/unit/test_query_functions.py
@@ -67,9 +67,13 @@ from sam.core.groups import (
 )
 
 from factories import (
+    make_account,
     make_allocation,
     make_allocation_transaction,
     make_charge_adjustment,
+    make_project,
+    make_resource,
+    make_resource_type,
     make_user,
 )
 from factories._seq import next_int, next_seq
@@ -246,7 +250,7 @@ class TestDashboardQueries:
             'resource_name', 'allocation_id', 'parent_allocation_id',
             'is_inheriting', 'account_id', 'status', 'start_date', 'end_date',
             'days_until_expiration', 'date_group_key', 'bar_state',
-            'resource_type', 'root_projcode',
+            'resource_type', 'root_projcode', 'activity_date',
         )
         FLOAT_FIELDS = (
             'allocated', 'used', 'remaining', 'percent_used',
@@ -305,6 +309,160 @@ class TestDashboardQueries:
             assert 'values' in daily
             if daily['dates'] is not None:
                 assert len(daily['dates']) == len(daily['values'])
+
+
+class TestDiskCapacityInDashboardData:
+    """For DISK resources, both dashboard builders should emit *capacity*
+    (point-in-time TiB used / TiB allocated) in the `used`/`percent_used`
+    fields, not cumulative TiB-year burn. This pins the contract used by
+    the project card / project modal / allocations table progress bars.
+    """
+
+    def _build_disk_graph(self, session, *, allocated_tib: float):
+        """User → Project → DISK Account+Allocation. Returns (project, account, lead)."""
+        from sam import ResourceType
+        rt = session.query(ResourceType).filter_by(resource_type='DISK').first()
+        if rt is None:
+            rt = make_resource_type(session, resource_type='DISK')
+        resource = make_resource(
+            session, resource_type=rt,
+            resource_name=f"Campaign_Store_{next_seq('cs')}",
+        )
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        make_allocation(
+            session, account=account, amount=allocated_tib,
+            start_date=datetime.now() - timedelta(days=30),
+            end_date=datetime.now() + timedelta(days=335),
+        )
+        return project, account, lead
+
+    def _seed_snapshot(self, session, *, account, lead, snap_date,
+                       bytes_used: int, terabyte_years: float):
+        """Insert one DiskChargeSummary row + mark its date current."""
+        from sam.summaries.disk_summaries import (
+            DiskChargeSummary,
+            mark_disk_snapshot_current,
+        )
+        session.add(DiskChargeSummary(
+            activity_date=snap_date,
+            account_id=account.account_id,
+            user_id=lead.user_id,
+            username=lead.username,
+            projcode=account.project.projcode,
+            number_of_files=100,
+            bytes=bytes_used,
+            terabyte_years=terabyte_years,
+            charges=terabyte_years,
+        ))
+        session.flush()
+        mark_disk_snapshot_current(session, snap_date)
+
+    def test_per_project_builder_emits_capacity_not_burn(self, session):
+        from datetime import date as _date
+        BYTES_PER_TIB = 1024 ** 4
+        project, account, lead = self._build_disk_graph(session, allocated_tib=100.0)
+        snap = _date(2026, 4, 18)
+        # 50 TiB occupancy, but 4.21 TiB-yr cumulative billing burn —
+        # the bar must read 50%, not 4.21%.
+        self._seed_snapshot(
+            session, account=account, lead=lead, snap_date=snap,
+            bytes_used=50 * BYTES_PER_TIB, terabyte_years=4.2141,
+        )
+        rows = _build_project_resources_data(project)
+        disk = next(r for r in rows if r['resource_type'] == 'DISK')
+        assert disk['used'] == pytest.approx(50.0, abs=1e-6)
+        assert disk['percent_used'] == pytest.approx(50.0, abs=1e-4)
+        assert disk['remaining'] == pytest.approx(50.0, abs=1e-6)
+        assert disk['activity_date'] == snap
+        assert disk['allocated'] == pytest.approx(100.0, abs=1e-6)
+
+    def test_batched_builder_matches_per_project_for_disk(self, session):
+        from datetime import date as _date
+        BYTES_PER_TIB = 1024 ** 4
+        project, account, lead = self._build_disk_graph(session, allocated_tib=100.0)
+        snap = _date(2026, 4, 18)
+        self._seed_snapshot(
+            session, account=account, lead=lead, snap_date=snap,
+            bytes_used=50 * BYTES_PER_TIB, terabyte_years=4.2141,
+        )
+        per = _build_project_resources_data(project)
+        bat = _build_user_projects_resources_batched(session, [project])[project.project_id]
+        # Equivalence on the disk row's capacity fields.
+        assert len(per) == len(bat)
+        per_disk = next(r for r in per if r['resource_type'] == 'DISK')
+        bat_disk = next(r for r in bat if r['resource_type'] == 'DISK')
+        assert per_disk['used'] == pytest.approx(bat_disk['used'], abs=1e-6)
+        assert per_disk['percent_used'] == pytest.approx(bat_disk['percent_used'], abs=1e-6)
+        assert per_disk['activity_date'] == bat_disk['activity_date'] == snap
+
+    def test_no_snapshot_yields_zero_capacity_and_none_activity_date(self, session):
+        project, account, lead = self._build_disk_graph(session, allocated_tib=100.0)
+        # No DiskChargeSummary row seeded — fresh allocation.
+        rows = _build_project_resources_data(project)
+        disk = next(r for r in rows if r['resource_type'] == 'DISK')
+        assert disk['used'] == 0.0
+        assert disk['percent_used'] == 0.0
+        assert disk['remaining'] == 100.0
+        assert disk['activity_date'] is None
+
+
+class TestDiskCapacityInAllocationSummary:
+    """`get_allocation_summary_with_usage` returns capacity-based
+    total_used for disk-only rows (the /allocations dashboard table)."""
+
+    def test_disk_row_uses_capacity(self, session, active_project):
+        """Hang a fresh DISK account+allocation+snapshot off an existing
+        snapshot project so the AllocationType/Panel/Facility joins in
+        get_allocation_summary() resolve. The query inner-joins
+        Project → AllocationType → Panel → Facility, so a bare
+        make_project() (no allocation_type wiring) yields zero rows."""
+        from datetime import date as _date
+        from sam import ResourceType
+        from sam.summaries.disk_summaries import (
+            DiskChargeSummary,
+            mark_disk_snapshot_current,
+        )
+        BYTES_PER_TIB = 1024 ** 4
+        rt = session.query(ResourceType).filter_by(resource_type='DISK').first()
+        if rt is None:
+            rt = make_resource_type(session, resource_type='DISK')
+        resource = make_resource(
+            session, resource_type=rt,
+            resource_name=f"Campaign_Store_{next_seq('cs')}",
+        )
+        lead = active_project.lead or make_user(session)
+        account = make_account(session, project=active_project, resource=resource)
+        make_allocation(
+            session, account=account, amount=100.0,
+            start_date=datetime.now() - timedelta(days=30),
+            end_date=datetime.now() + timedelta(days=335),
+        )
+        snap = _date(2026, 4, 18)
+        session.add(DiskChargeSummary(
+            activity_date=snap,
+            account_id=account.account_id,
+            user_id=lead.user_id,
+            username=lead.username,
+            projcode=active_project.projcode,
+            number_of_files=100,
+            bytes=25 * BYTES_PER_TIB,
+            terabyte_years=2.5,
+            charges=2.5,
+        ))
+        session.flush()
+        mark_disk_snapshot_current(session, snap)
+        rows = get_allocation_summary_with_usage(
+            session,
+            resource_name=resource.resource_name,
+            projcode=active_project.projcode,
+        )
+        assert rows, "expected at least one summary row"
+        disk_row = rows[0]
+        assert disk_row['total_used'] == pytest.approx(25.0, abs=1e-6)
+        assert disk_row['percent_used'] == pytest.approx(25.0, abs=1e-4)
+        assert disk_row.get('activity_date') == snap
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Two corrections to the storage UX after PR #206 ("Disk Charging") landed
the write-time inferred reporting interval. The billing math is now
correct, but the UI was still treating disk like HPC/DAV — progress bars
and the Resource Usage Details page both spoke in cumulative TiB-years
instead of capacity. This PR fixes both.

- **Progress bars now read capacity** (point-in-time TiB used / TiB
  allocated) on the project card, project modal, and `/allocations`
  table — across the full project subtree.
- **A new disk-flavored Resource Usage Details page** replaces the
  HPC-shaped daily-charges shape with a stacked-area chart of bytes vs
  time, a filesystem-style project tree with fileset paths, and a
  current-snapshot per-user occupancy table.

No DB migrations, no schema change, no data backfill.

---

## Why

Storage and compute answer different "% used" questions. For HPC, "used"
means cumulative core-hours burned against a core-hour cap — a burn
rate. For storage, "used" means *how full is it right now* — capacity
against a TiB cap. Cumulative TiB-years is a billing concept that
doesn't surface in the user UI.

The codebase already had `Project.current_disk_usage()` /
`Account.current_disk_usage()` for exactly this — they read the row
marked `disk_charge_summary_status.current = True` — but the three
progress-bar locations and the Resource Usage Details page bypassed
them. This PR routes through that machinery and introduces a few new
helpers where the existing ones didn't fit.

---

## What changed

### 1. Capacity progress bars (commit `c7ada16`)

Single helper `_disk_capacity_overrides` is called by both dashboard
builders (`_build_project_resources_data` and
`_build_user_projects_resources_batched`) and by
`get_allocation_summary_with_usage`. For `resource_type == 'DISK'` the
helper overwrites `used` / `remaining` / `percent_used` with
point-in-time TiB and adds an `activity_date` field for the UI's "as of
YYYY-MM-DD" label. HPC / DAV / ARCHIVE rows are untouched.

The shared `render_usage_bar` macro is unchanged — capacity vs burn is
decided at the data layer, not the macro.

### 2. Subtree-aware capacity (commit `3f86d78`)

Parent projects (NMMM0003-shaped) hold no bytes on their own account;
the occupancy lives on the children. New
`get_subtree_disk_capacity(session, project, resource_name)` walks
`project + descendants` via NestedSet coords and sums per-account
snapshots. The card-level bar for NMMM0003 now reads ~12% (against the
~16 PiB pool cap), not 0%.

### 3. Pool-cap allocation, not subtree sum (commit `3f86d78`)

The Resource Usage Details "Allocated" header was previously summing
every active disk allocation in the subtree, double-counting:
inheriting children share the master's cap, they don't add to it. Fixed
by `_scope_disk_allocation_tib` which locates the scope's account
(walking up the project tree if needed) and returns
`allocation.root.amount` — the pool cap. Matches what `sam-admin
accounting --reconcile-quotas` shows.

### 4. New disk Resource Usage Details page (commit `5fcaf9b`)

Branched off the existing route — HPC / DAV / ARCHIVE keep the
burn-rate UI; disk gets the new page. Components:

- **Capacity Summary table** — Resource / Scope / As of / Allocated /
  Used / Remaining / Files / Usage. Same `render_usage_bar` macro the
  cards use. Replaces the HPC daily-charges header.
- **Project hierarchy** — filesystem-style tree mirroring `sam-admin
  --reconcile-quotas`. Inactive descendants filtered. Each node:
  `<strong>projcode</strong>` + muted title + fileset paths
  (`fa-folder-open` icon, monospace, wrapping) + size badge
  right-aligned. Click any node to set `?scope=<projcode>` and rescope
  the chart and per-user table to that subtree.
- **Stacked-area chart** — `bytes` vs time, top-10 users + Others,
  Y-axis auto-scaled to TiB or PiB based on peak. Others stacks at
  the bottom in neutral grey; named users go smallest → largest so
  the largest sits on top. Legend reversed to match the visual stack.
- **Per-user occupancy table** — Username / Files / Size / % of scope.
  Sorted by raw bytes descending; Size column rendered via `fmt_size`
  so PiB / TiB / GiB are auto-scaled (no separate Bytes column).

All four cards have collapsible headers (`cursor-pointer` +
`data-bs-toggle="collapse"` + chevron) matching the HPC details visual
language.

### 5. Other UX (commits `3f86d78`, `68f97c7`, `9f369d1`)

- Both Resource Usage Details pages (HPC and disk) wrap charts in
  `.chart-container` for consistent centering. Dropped the deprecated
  `<center>` tag from the HPC template.
- `ProjectDirectory.is_active` (the `DateRangeMixin` hybrid) replaces
  hand-rolled date arithmetic in `build_disk_subtree`.

---

## Tests

`tests/unit/test_query_functions.py`
- `TestDiskCapacityInDashboardData` — per-project builder emits TiB
  capacity not TiB-yr; batched builder matches per-project; no-snapshot
  yields zero used + None activity_date; **parent project capacity
  includes child subtree** (NMMM0003 case: parent 0 bytes, children
  30+20 TiB → bar reads 50/100 TiB = 50%).
- `TestDiskCapacityInAllocationSummary` — disk row in `/allocations`
  summary uses capacity from `current_disk_usage()`, not cumulative
  charges.
- Equivalence test's `SCALAR_FIELDS` extended with `activity_date`.

`tests/unit/test_disk_usage_queries.py` (new — 11 tests)
- `TestDiskUsageTimeseries` — empty input, single user/date, top-N
  with Others lump (12 users → 10 + Others, ordering pinned),
  dense-fill across missing (date, user) pairs, no-Others case when
  `N <= top_n`, start_date filter.
- `TestBuildDiskSubtree` — leaf project, parent + 2 children both with
  disk accounts, parent without a disk account (still appears in tree
  with `account_id=None`), unknown resource_name (empty account_ids),
  fileset paths attached and sorted.

---

## Out of scope

- `terabyte_years` → `tebibyte_years` column rename (separate PR).
- Backfilling pre-`DISK_CHARGING_TIB_EPOCH` rows.
- Capacity-aware deduplication across overlapping subtrees in
  `/allocations` TOTAL aggregates (multi-project rows fall back to
  per-account sums for now).
- Editing fileset quotas in the UI (read-only display only).

---

## Test plan

- [ ] `pytest tests/unit/test_query_functions.py::TestDiskCapacityInDashboardData tests/unit/test_query_functions.py::TestDiskCapacityInAllocationSummary tests/unit/test_disk_usage_queries.py -v`
- [ ] `pytest` full suite (xdist parallel, ~65s).
- [ ] Visit a parent project's card (e.g. NMMM0003) — disk bar reads
      ~12% with "as of" date, not 0%.
- [ ] Visit `/user/resource-details?projcode=NMMM0003&resource=Campaign_Store`
      — capacity table shows ~16 PiB allocated / ~11.6 PiB used,
      stacked-area chart with top-10 + grey Others at bottom, tree
      shows the 5 NMMM* children with fileset paths.
- [ ] Click a tree node — chart and per-user table re-scope.
- [ ] Visit Resource Usage Details for a Derecho project — the existing
      HPC view is unchanged (regression check).
- [ ] Visit `/allocations?resource=Campaign_Store` — disk rows show
      capacity numbers, not cumulative TiB-yr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)