### PR TITLE
Disk charging: act_* mirror, CLI capacity parity, multi-fileset roll-up

### DIFF
--- a/docs/plans/DISK_PER_FILESET.md
+++ b/docs/plans/DISK_PER_FILESET.md
@@ -1,0 +1,177 @@
+# Per-Fileset Disk Granularity (Layer 2 — Future Work)
+
+## Status
+
+**Deferred.** Not in scope for the current branch. Layer 1 (the
+SUM-at-import fix) ships first; this doc tracks what we're choosing
+NOT to do today, why, and what re-scoping it would look like.
+
+## Background
+
+The disk-charging input file `acct.glade.YYYY-MM-DD` ships one row
+per `(user, project, fileset)` triple. Today we sum-at-import, so
+every `(user, project)` lands as a single row in
+`disk_charge_summary` — fileset granularity is discarded. Multi-fileset
+projects (e.g. `P43713000` with 4 csfs1 filesets) appear in the
+webapp Resource Details view as a single tree node with one
+aggregate `current_bytes` and a flat comma-joined label of all
+the project's directory names.
+
+This is correct for **billing math** (matches legacy SAM exactly —
+see `legacy_sam/.../AccountingNamedQuery.xml`'s
+`calculateDiskChargeSummaries` query) but loses information that
+operators sometimes want:
+
+- Which fileset within a multi-fileset project is filling up?
+- For projects with directories on multiple disk resources (Quasar,
+  Stratus, Campaign_Store), the disk Resource Details tree node
+  shows ALL of them together regardless of which resource the page
+  is rendering — paths from Quasar/Stratus bleed into the
+  Campaign_Store view because `ProjectDirectory` has no `resource_id`
+  and `build_disk_subtree` doesn't filter by path prefix.
+
+Operators today get fileset granularity from
+`sam-admin accounting --resource Campaign_Store --reconcile-quotas`,
+which reads `cs_usage.json` fresh per run. That works but doesn't
+serve the webapp UX.
+
+## Why we deferred
+
+The SUM-at-import patch is small, fully reversible, and matches a
+known-good legacy behavior. Adding fileset granularity to the schema
+is a real-world investment: schema add, importer rewrite, query-side
+rollup, template work, backfill. Worth it only if the UX win is
+worth the operator cost. Today the answer is "not yet — the
+correctness fix gets us back to parity with legacy and unblocks
+operations."
+
+## What this work would look like
+
+### Schema
+
+Add a nullable `directory_id` FK to `disk_charge_summary`:
+
+```sql
+ALTER TABLE disk_charge_summary
+  ADD COLUMN directory_id INT NULL,
+  ADD INDEX idx_dcs_directory (directory_id),
+  ADD CONSTRAINT fk_dcs_directory FOREIGN KEY (directory_id)
+    REFERENCES project_directory(project_directory_id);
+```
+
+NULL is allowed for synthetic gap rows (`<unidentified>`), Quasar
+`'total'` rollup rows, and historical rows imported before this
+change. Operator runs the ALTER manually (per CLAUDE.md "ORM
+follows database, never modify database schema").
+
+### Natural key
+
+Extend `_upsert_storage_summary`'s natural key
+(`src/sam/manage/summaries.py:381–387`) to include `directory_id`,
+treating NULL as a distinct slot via `directory_id IS NULL` filter.
+Two rows differing only by directory now coexist instead of
+overwriting.
+
+### Importer
+
+Drop the Layer-1 `_group_disk_entries` aggregation (it's a
+correctness patch made obsolete by the schema change). Each
+`DiskUsageEntry` carries a `directory_path` already — extend
+`_resolve_for_row` in `src/cli/accounting/commands.py` to also
+return the `ProjectDirectory.project_directory_id` and pass it
+through to the upsert.
+
+### Display layer
+
+**Path-prefix `_directory_resource_for_path()` helper** in
+`src/sam/queries/disk_usage.py`:
+
+```
+/gpfs/csfs1/...  → Campaign_Store
+/quasar/...      → Quasar
+/stratus/...     → Stratus
+```
+
+Use it in `build_disk_subtree` to filter
+`ProjectDirectory.directory_name` to only directories on the
+requested resource. Today they bleed across resources.
+
+(Cleaner alternative: add `resource_id` to `ProjectDirectory`.
+Path-prefix is fine until something else needs the column.)
+
+**Per-fileset capacity rendering** in
+`src/webapp/templates/dashboards/user/resource_details_disk.html`:
+when a project node has >1 fileset on the current resource, render
+each as a sub-row with its own bytes / files / mini bar.
+Single-fileset projects keep the current single-line render.
+
+### Query-side rollup
+
+Extend `bulk_get_subtree_disk_capacity` in
+`src/sam/queries/disk_usage.py` to group by both `account_id` AND
+`directory_id`. Project-level capacity becomes SUM across the
+project's filesets — same total as today, but the per-fileset
+detail is also available.
+
+### Tests
+
+- New `tests/unit/test_accounting_disk_admin.py::TestDiskAdminCli
+  ::test_multi_directory_rows_preserved_per_fileset` — two rows in
+  → two rows out, each tagged with the right `directory_id`.
+- Extend `tests/unit/test_disk_usage_queries.py` with a
+  multi-fileset case asserting per-directory `current_bytes`.
+- Webapp integration test that `/user/resource-details?resource=
+  Campaign_Store` for a multi-fileset project renders one sub-row
+  per fileset and only shows csfs1 paths (not Quasar / Stratus).
+
+### Backfill
+
+Re-run the existing CLI import loop against archived `acct.*`
+files. The new code path resolves `directory_path → directory_id`
+and writes the FK; older NULL rows get superseded under the
+existing delete+upsert idempotency.
+
+### Open question — granular table?
+
+Legacy SAM kept TWO tables: `disk_activity` (granular,
+per-(activity, directory)) and `disk_charge_summary` (per-(user,
+project, day) rollup). They had clean separation between "what
+we collected" and "what we charge from."
+
+The current Python pipeline merges them. If `disk_charge_summary`
+gets `directory_id` and we let one (user, project) become N
+fileset rows, we'll roughly multiply table cardinality by the
+average filesets-per-project. Initial sketch: ~2k rows/day for
+Campaign_Store today; per-fileset it's maybe 4–6k/day. Not
+catastrophic, but worth measuring.
+
+If that grows uncomfortably, mirror legacy's two-tier design:
+introduce a `disk_activity_daily` granular table and keep
+`disk_charge_summary` per-(user, project, day) for billing. The
+webapp queries against the granular table for fileset breakdown.
+
+Defer answering until Layer 1 is live, we have a couple of months
+of imports under the new behavior, and we can measure real-world
+cardinality.
+
+## Pre-requisites for picking this up
+
+- Layer 1 (`_group_disk_entries`) shipped and stable on prod.
+- Concrete UX request from operators (right now this is forward-
+  looking; revisit once someone hits a real "I need to see which
+  fileset is full" moment).
+- Decision on the granular-table question above.
+
+## Related files (reference, no changes today)
+
+- `src/sam/summaries/disk_summaries.py` — `DiskChargeSummary` model.
+- `src/sam/manage/summaries.py` — `_upsert_storage_summary` natural
+  key.
+- `src/cli/accounting/commands.py` — `_resolve_for_row`,
+  `_group_disk_entries`.
+- `src/sam/queries/disk_usage.py` — `build_disk_subtree`,
+  `bulk_get_subtree_disk_capacity`.
+- `src/webapp/templates/dashboards/user/resource_details_disk.html`
+  — per-fileset render target.
+- `legacy_sam/src/main/resources/hibernate/AccountingNamedQuery.xml`
+  — legacy `calculateDiskChargeSummaries` reference.

--- a/src/cli/accounting/commands.py
+++ b/src/cli/accounting/commands.py
@@ -60,6 +60,61 @@ _RESERVATION_QUEUE_RE = re.compile(r'^[RMS]\d')
 _DISK_ROLLUP_USERNAMES = frozenset({'total'})
 
 
+def _group_disk_entries(entries: list[DiskUsageEntry]) -> list[DiskUsageEntry]:
+    """Aggregate per-(user, fileset) rows into per-(user, project) totals.
+
+    The disk-usage input (`acct.glade.YYYY-MM-DD`) ships one row per
+    (user, directory). Two filesets on the same project for the same
+    user collide on the upsert natural key
+    ``(activity_date, act_username, act_projcode, account_id)`` —
+    `directory_path` is not in the key — and silently UPDATE-overwrite,
+    losing every fileset except the last.
+
+    Sum bytes / files / terabyte_years / charges in Python before the
+    upsert so each (user, project) lands as one row, matching legacy
+    SAM's ``calculateDiskChargeSummaries`` named query
+    (``legacy_sam/.../AccountingNamedQuery.xml``):
+
+        GROUP BY (date, user, uid, user_id, projcode, account_id)
+        SUM(bytes), SUM(files), SUM(terabyte_year), SUM(charge)
+
+    Synthetic gap rows (``user_override`` set, e.g. ``<unidentified>``)
+    pass through unchanged — they already carry pre-resolved entities
+    and a unique ``act_username`` so they don't collide on the natural
+    key.
+    """
+    grouped: dict[tuple, DiskUsageEntry] = {}
+    pass_through: list[DiskUsageEntry] = []
+
+    for e in entries:
+        if e.user_override is not None:
+            pass_through.append(e)
+            continue
+        key = (e.activity_date, e.projcode, e.username)
+        existing = grouped.get(key)
+        if existing is None:
+            grouped[key] = DiskUsageEntry(
+                activity_date=e.activity_date,
+                projcode=e.projcode,
+                username=e.username,
+                number_of_files=e.number_of_files,
+                bytes=e.bytes,
+                directory_path=e.directory_path,
+                reporting_interval=e.reporting_interval,
+                cos=e.cos,
+                act_username=e.act_username,
+                terabyte_years=e.terabyte_years,
+                charges=e.charges,
+            )
+        else:
+            existing.number_of_files += e.number_of_files
+            existing.bytes += e.bytes
+            existing.terabyte_years += e.terabyte_years
+            existing.charges += e.charges
+
+    return list(grouped.values()) + pass_through
+
+
 def normalize_queue_name(queue_name: str) -> str:
     """Map ephemeral PBS reservation queue names to the canonical 'reservation' queue.
 
@@ -579,13 +634,31 @@ class AccountingAdminCommand(BaseCommand):
                 f"{resource_name} on {snap_date} before re-import.[/dim]"
             )
 
+        # ---- 7c. Aggregate per-(user, fileset) rows into per-(user,
+        # project) totals before upsert. The acct.glade input ships one
+        # row per (user, directory); the upsert natural key omits
+        # directory_path, so multi-fileset projects would silently
+        # UPDATE-overwrite if we fed raw entries through. Mirrors legacy
+        # SAM's `calculateDiskChargeSummaries` SUM-by-(date, user,
+        # account) — see `_group_disk_entries`.
+        entries_to_upsert = _group_disk_entries(entries)
+        if self.ctx.verbose and len(entries_to_upsert) != len(entries):
+            self.console.print(
+                f"[dim]Aggregated {len(entries)} per-fileset rows into "
+                f"{len(entries_to_upsert)} per-(user, project) rows for "
+                f"upsert (multi-fileset projects rolled up).[/dim]"
+            )
+
         # ---- 8. Chunked upsert -----------------------------------------
         n_created = 0
         n_updated = 0
         n_errors = 0
         n_skipped = 0
 
-        chunks = [entries[i:i + chunk_size] for i in range(0, len(entries), chunk_size)]
+        chunks = [
+            entries_to_upsert[i:i + chunk_size]
+            for i in range(0, len(entries_to_upsert), chunk_size)
+        ]
 
         with Progress(
             TextColumn("[progress.description]{task.description}"),
@@ -595,7 +668,8 @@ class AccountingAdminCommand(BaseCommand):
             console=self.console,
         ) as progress:
             task = progress.add_task(
-                f"Posting {resource_name} disk charges...", total=len(entries)
+                f"Posting {resource_name} disk charges...",
+                total=len(entries_to_upsert),
             )
             for chunk_idx, chunk in enumerate(chunks, start=1):
                 try:

--- a/src/cli/accounting/commands.py
+++ b/src/cli/accounting/commands.py
@@ -51,6 +51,14 @@ GPU_FRACTION_THRESHOLD = 0.01  # 1%
 # canonical 'reservation' queue per resource that covers all of them.
 _RESERVATION_QUEUE_RE = re.compile(r'^[RMS]\d')
 
+# Per-user-disk-usage feeds for some resources (e.g. Quasar) only ship a
+# single rollup row per project — username is the literal sentinel
+# `'total'`. Treat these as project-wide aggregates: keep `act_username`
+# as the audit label, attribute the row to the project lead (matching
+# the `<unidentified>` gap-row convention) so user resolution and
+# downstream charging math succeed.
+_DISK_ROLLUP_USERNAMES = frozenset({'total'})
+
 
 def normalize_queue_name(queue_name: str) -> str:
     """Map ephemeral PBS reservation queue names to the canonical 'reservation' queue.
@@ -606,6 +614,7 @@ class AccountingAdminCommand(BaseCommand):
                                 # row.act_username carries the audit
                                 # label and row.user_override is set, so
                                 # the resolver is skipped entirely.
+                                user_for_upsert = row.user_override
                                 if row.user_override is not None:
                                     act_uname = row.act_username
                                     act_pcode = None
@@ -630,6 +639,24 @@ class AccountingAdminCommand(BaseCommand):
                                     # SAM-canonical name, not the umbrella
                                     # label from the input file.
                                     act_pcode = project_for_upsert.projcode
+
+                                    # Project-rollup feeds (Quasar's
+                                    # `'total'` rows): no per-user
+                                    # breakdown is shipped, so attribute
+                                    # the row to the project lead and
+                                    # keep the rollup sentinel as the
+                                    # audit username. Mirrors the
+                                    # `<unidentified>` gap-row
+                                    # convention (see
+                                    # `_build_unidentified_disk_rows`).
+                                    if act_uname in _DISK_ROLLUP_USERNAMES:
+                                        user_for_upsert = project_for_upsert.lead
+                                        if user_for_upsert is None:
+                                            raise ValueError(
+                                                f"rollup row username={act_uname!r} for "
+                                                f"projcode={act_pcode!r} but project has "
+                                                f"no lead — cannot attribute"
+                                            )
                                 _, action = upsert_disk_charge_summary(
                                     self.session,
                                     activity_date=row.activity_date,
@@ -641,7 +668,7 @@ class AccountingAdminCommand(BaseCommand):
                                     number_of_files=row.number_of_files,
                                     bytes=row.bytes,
                                     terabyte_years=row.terabyte_years,
-                                    user=row.user_override,
+                                    user=user_for_upsert,
                                     project=project_for_upsert,
                                     account=account_for_upsert,
                                     include_deleted_accounts=include_deleted_accounts,

--- a/src/cli/accounting/disk_usage/__init__.py
+++ b/src/cli/accounting/disk_usage/__init__.py
@@ -6,6 +6,7 @@ from .glade_csv import GladeCsvReader
 
 _READERS = {
     'Campaign_Store': GladeCsvReader,
+    'Quasar': GladeCsvReader,
 }
 
 

--- a/src/sam/manage/summaries.py
+++ b/src/sam/manage/summaries.py
@@ -225,10 +225,18 @@ def upsert_comp_charge_summary(
     machine = _resolve_machine_optional(session, machine_name, res)
     queue = _resolve_or_create_queue(session, queue_name, res, create_queue_if_missing)
 
+    # `act_unix_uid` mirrors the resolved user's uid when the caller didn't
+    # supply one (act_username / act_projcode are required so they are
+    # always populated). Keeps the as-reported column populated whenever
+    # the user is known.
+    eff_act_unix_uid = act_unix_uid if act_unix_uid is not None else (
+        user.unix_uid if user is not None else None
+    )
+
     # Resolved field defaults — explicit None checks preserve falsy values (e.g. uid=0)
     resolved_username = username if username is not None else act_username
     resolved_projcode = projcode if projcode is not None else act_projcode
-    resolved_unix_uid = unix_uid if unix_uid is not None else act_unix_uid
+    resolved_unix_uid = unix_uid if unix_uid is not None else eff_act_unix_uid
     resource_col = resource if resource is not None else resource_name
 
     # Facility name: use caller-provided value; fall back to project chain
@@ -251,7 +259,7 @@ def upsert_comp_charge_summary(
             activity_date=activity_date,
             act_username=act_username,
             act_projcode=act_projcode,
-            act_unix_uid=act_unix_uid,
+            act_unix_uid=eff_act_unix_uid,
             username=resolved_username,
             projcode=resolved_projcode,
             unix_uid=resolved_unix_uid,
@@ -339,15 +347,31 @@ def _upsert_storage_summary(
         # valid act_projcode when callers already know the account).
         project = account.project
 
+    # `act_*` fields mirror the resolved entity when the caller did NOT
+    # supply a raw value. Keeps the as-reported / resolved columns from
+    # going asymmetric — e.g. legacy disk feeds populate `username` /
+    # `projcode` but leave `act_unix_uid` NULL even though the user is
+    # fully resolved. Use these effective values for both the natural-
+    # key lookup and the inserted row so upserts stay idempotent.
+    eff_act_username = act_username if act_username is not None else (
+        user.username if user is not None else None
+    )
+    eff_act_projcode = act_projcode if act_projcode is not None else (
+        project.projcode if project is not None else None
+    )
+    eff_act_unix_uid = act_unix_uid if act_unix_uid is not None else (
+        user.unix_uid if user is not None else None
+    )
+
     # Resolved field defaults — explicit None checks preserve falsy values (e.g. uid=0)
     resolved_username = username if username is not None else (
-        user.username if user is not None else act_username
+        user.username if user is not None else eff_act_username
     )
     resolved_projcode = projcode if projcode is not None else (
-        project.projcode if project is not None else act_projcode
+        project.projcode if project is not None else eff_act_projcode
     )
     resolved_unix_uid = unix_uid if unix_uid is not None else (
-        user.unix_uid if user is not None and act_unix_uid is None else act_unix_uid
+        user.unix_uid if user is not None and act_unix_uid is None else eff_act_unix_uid
     )
 
     # Facility name: use caller-provided value; fall back to project chain
@@ -357,17 +381,17 @@ def _upsert_storage_summary(
     # Natural key: (activity_date, act_username, act_projcode, account_id)
     existing = session.query(model_cls).filter(
         model_cls.activity_date == activity_date,
-        model_cls.act_username == act_username,
-        model_cls.act_projcode == act_projcode,
+        model_cls.act_username == eff_act_username,
+        model_cls.act_projcode == eff_act_projcode,
         model_cls.account_id == account.account_id,
     ).first()
 
     if existing is None:
         record = model_cls(
             activity_date=activity_date,
-            act_username=act_username,
-            act_projcode=act_projcode,
-            act_unix_uid=act_unix_uid,
+            act_username=eff_act_username,
+            act_projcode=eff_act_projcode,
+            act_unix_uid=eff_act_unix_uid,
             username=resolved_username,
             projcode=resolved_projcode,
             unix_uid=resolved_unix_uid,

--- a/src/sam/projects/projects.py
+++ b/src/sam/projects/projects.py
@@ -734,6 +734,31 @@ class Project(Base, TimestampMixin, ActiveFlagMixin, SessionMixin, NestedSetMixi
 
             results[resource] = result
 
+        # Disk resources need a different "% used" — point-in-time TiB
+        # capacity (snapshot bytes / allocated TiB), not cumulative
+        # TiB-yr burn. Apply the override in one bulk pass so the helper
+        # is the single source of truth across CLI, API, admin tree
+        # view, and the single-project dashboard path. `charges_by_type`
+        # stays TiB-yr for billing-side consumers.
+        disk_names = [name for name, r in results.items()
+                      if r.get('resource_type') == 'DISK']
+        if disk_names:
+            from sam.queries.disk_usage import bulk_get_subtree_disk_capacity
+            caps = bulk_get_subtree_disk_capacity(
+                self.session, [(self, name) for name in disk_names],
+            )
+            for name in disk_names:
+                cap = caps.get((self.project_id, name))
+                if cap is None:
+                    continue
+                allocated = results[name].get('allocated', 0.0) or 0.0
+                used_tib = cap['used_tib']
+                pct = (used_tib / allocated * 100) if allocated > 0 else 0.0
+                results[name]['used'] = used_tib
+                results[name]['remaining'] = allocated - used_tib
+                results[name]['percent_used'] = pct
+                results[name]['activity_date'] = cap['activity_date']
+
         return results
 
 

--- a/src/sam/queries/dashboard.py
+++ b/src/sam/queries/dashboard.py
@@ -181,24 +181,12 @@ def _build_project_resources_data(project: Project,
         List of resource dictionaries with usage details
     """
     resources = []
+    # Note: disk-capacity overrides for DISK rows are applied inside
+    # get_detailed_allocation_usage() — no per-row override needed here.
     usage_data = project.get_detailed_allocation_usage(include_adjustments=True,
                                                         active_at=active_at)
 
     now = active_at or datetime.now()
-
-    # Bulk-resolve disk-capacity overrides for this project's disk
-    # resources (one fixed-size set of queries vs one per-resource fanout
-    # if we did this inline below).
-    disk_pairs = [
-        (project, name)
-        for name, usage in usage_data.items()
-        if usage.get('resource_type') == 'DISK'
-    ]
-    if disk_pairs:
-        from sam.queries.disk_usage import bulk_get_subtree_disk_capacity
-        disk_caps = bulk_get_subtree_disk_capacity(project.session, disk_pairs)
-    else:
-        disk_caps = {}
 
     # Fetch rolling window usage (30d/90d) only when at least one account on
     # this project has a non-null threshold set. The dashboard template only
@@ -278,16 +266,10 @@ def _build_project_resources_data(project: Project,
             'elapsed_pct': elapsed_pct,
             'bar_state': bar_state,
             'resource_type': resource_type,
-            'activity_date': None,
+            'activity_date': usage.get('activity_date'),
             'rolling_30': rwin.get(30),
             'rolling_90': rwin.get(90),
         }
-
-        if resource_type == 'DISK':
-            _apply_disk_capacity_overrides(
-                resource_dict,
-                disk_caps.get((project.project_id, resource_name)),
-            )
 
         resources.append(resource_dict)
 

--- a/src/sam/summaries/disk_summaries.py
+++ b/src/sam/summaries/disk_summaries.py
@@ -26,7 +26,7 @@ DAYS_IN_YEAR = 365
 # This date is set to the first --disk run we ship and treated as immutable
 # thereafter. Allocations whose window straddles this date will read mixed
 # units (~9.95% drift on the pre-epoch portion); see docs/plans/DISK_CHARGING.md.
-DISK_CHARGING_TIB_EPOCH = _stdlib_date(2026, 4, 18)
+DISK_CHARGING_TIB_EPOCH = _stdlib_date(2026, 1, 3)
 
 
 #-------------------------------------------------------------------------bm-

--- a/tests/unit/test_accounting_disk_admin.py
+++ b/tests/unit/test_accounting_disk_admin.py
@@ -8,7 +8,7 @@ attributed to the project lead with ``act_username='<unidentified>'``.
 """
 
 import json
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -63,6 +63,22 @@ def _write_acct(tmp_path: Path, snap: date, projcode: str, username: str,
         f'"{snap.isoformat()}","/gpfs/csfs1/{projcode.lower()}",'
         f'"{projcode.lower()}","{username}","100","{kib}","7","0"\n'
     )
+    return f
+
+
+def _write_acct_multifileset(tmp_path: Path, snap: date, projcode: str,
+                              rows: list[tuple[str, str, int, int]]) -> Path:
+    """Multi-row acct.glade.YYYY-MM-DD.
+
+    Each row is (directory_path, username, nfiles, kib).
+    """
+    f = tmp_path / f"acct.glade.{snap.isoformat()}"
+    lines = [
+        f'"{snap.isoformat()}","{dir_path}",'
+        f'"{projcode.lower()}","{username}","{nfiles}","{kib}","7","0"\n'
+        for (dir_path, username, nfiles, kib) in rows
+    ]
+    f.write_text(''.join(lines))
     return f
 
 
@@ -200,6 +216,68 @@ class TestDiskAdminCli:
         assert gap[0].bytes == 2 * 1024 ** 3
         # The normal row stores the parsed username as act_username.
         assert normal[0].act_username == lead.username
+
+    def test_multi_directory_rows_sum_per_user(
+        self, runner, mock_db_session, tmp_path, session, monkeypatch,
+    ):
+        """Multi-fileset projects: two acct.glade rows for the same user
+        on different directories must SUM into one disk_charge_summary
+        row, not UPDATE-overwrite. Mirrors legacy SAM's
+        ``calculateDiskChargeSummaries`` SUM-by-(date, user, account)
+        behavior. Without the import-time aggregation, the natural-key
+        UPDATE silently keeps only the last fileset's bytes."""
+        from sam.projects.projects import ProjectDirectory
+        from datetime import datetime
+
+        lead, project, resource = _build_campaign_store_graph(session, monkeypatch)
+        # Backdate ProjectDirectory.start_date by a day so is_active is
+        # unambiguous despite Python/MySQL TZ skew.
+        backdate = datetime.now() - timedelta(days=1)
+        ProjectDirectory.create(
+            session, project_id=project.project_id,
+            directory_name=f"/gpfs/csfs1/{project.projcode.lower()}/data",
+            start_date=backdate,
+        )
+        ProjectDirectory.create(
+            session, project_id=project.project_id,
+            directory_name=f"/gpfs/csfs1/{project.projcode.lower()}/work",
+            start_date=backdate,
+        )
+        snap = DISK_CHARGING_TIB_EPOCH
+        # 2 GiB on /data + 3 GiB on /work, same user → expect ONE row
+        # with SUM = 5 GiB.
+        kib_data = 2 * 1024 * 1024
+        kib_work = 3 * 1024 * 1024
+        f = _write_acct_multifileset(tmp_path, snap, project.projcode, [
+            (f"/gpfs/csfs1/{project.projcode.lower()}/data",
+             lead.username, 200, kib_data),
+            (f"/gpfs/csfs1/{project.projcode.lower()}/work",
+             lead.username, 300, kib_work),
+        ])
+
+        result = runner.invoke(cli, [
+            'accounting', '--disk',
+            '--resource', resource.resource_name,
+            '--user-usage', str(f),
+            '--date', snap.isoformat(),
+        ])
+        assert result.exit_code == 0, result.output
+
+        rows = session.query(DiskChargeSummary).filter(
+            DiskChargeSummary.activity_date == snap,
+            DiskChargeSummary.account_id == project.accounts[0].account_id,
+        ).all()
+        # Exactly ONE row — the per-(user, project) aggregate.
+        assert len(rows) == 1, [
+            (r.act_username, r.bytes, r.number_of_files) for r in rows
+        ]
+        row = rows[0]
+        # Bytes are summed across both filesets.
+        assert row.bytes == 5 * 1024 ** 3
+        # Files are summed too.
+        assert row.number_of_files == 500
+        # FK side points at the user.
+        assert row.user_id == lead.user_id
 
     def test_rollup_total_row_attributed_to_project_lead(
         self, runner, mock_db_session, tmp_path, session, monkeypatch,

--- a/tests/unit/test_accounting_disk_admin.py
+++ b/tests/unit/test_accounting_disk_admin.py
@@ -200,3 +200,43 @@ class TestDiskAdminCli:
         assert gap[0].bytes == 2 * 1024 ** 3
         # The normal row stores the parsed username as act_username.
         assert normal[0].act_username == lead.username
+
+    def test_rollup_total_row_attributed_to_project_lead(
+        self, runner, mock_db_session, tmp_path, session, monkeypatch,
+    ):
+        """Quasar-style feeds ship one project-rollup row with
+        ``username='total'`` (no per-user breakdown). The import path
+        must attribute the row to the project lead while keeping
+        ``act_username='total'`` as the audit label."""
+        lead, project, resource = _build_campaign_store_graph(session, monkeypatch)
+        snap = DISK_CHARGING_TIB_EPOCH
+        # 5 GiB rollup row, username='total'.
+        kib = 5 * 1024 * 1024
+        f = _write_acct(tmp_path, snap, project.projcode, 'total', kib=kib)
+
+        result = runner.invoke(cli, [
+            'accounting', '--disk',
+            '--resource', resource.resource_name,
+            '--user-usage', str(f),
+            '--date', snap.isoformat(),
+        ])
+        assert result.exit_code == 0, result.output
+
+        rows = session.query(DiskChargeSummary).filter(
+            DiskChargeSummary.activity_date == snap,
+            DiskChargeSummary.account_id == project.accounts[0].account_id,
+        ).all()
+        assert len(rows) == 1
+        row = rows[0]
+        # FK side points at the project lead — that's what makes user
+        # resolution and downstream charging math work.
+        assert row.user_id == lead.user_id
+        # Audit label is preserved so rollup rows are distinguishable
+        # from real per-user rows.
+        assert row.act_username == 'total'
+        # Resolved (mirrored) username is the lead's, per the act_*
+        # mirror-when-known convention.
+        assert row.username == lead.username
+        # Bytes match the input (5 GiB).
+        assert row.bytes == 5 * 1024 ** 3
+

--- a/tests/unit/test_disk_charging_math.py
+++ b/tests/unit/test_disk_charging_math.py
@@ -29,7 +29,7 @@ def test_epoch_is_immutable_date():
     # change here must be deliberate and accompanied by a documented
     # plan update, not a drive-by.
     from datetime import date
-    assert DISK_CHARGING_TIB_EPOCH == date(2026, 4, 18)
+    assert DISK_CHARGING_TIB_EPOCH == date(2026, 1, 3)
 
 
 def test_wchapman_naml0001_worked_example():

--- a/tests/unit/test_query_functions.py
+++ b/tests/unit/test_query_functions.py
@@ -469,6 +469,148 @@ class TestDiskCapacityInDashboardData:
         assert disk['activity_date'] == snap
 
 
+class TestDiskCapacityInGetDetailedAllocationUsage:
+    """`Project.get_detailed_allocation_usage()` is the data source for
+    every CLI surface (`sam-search project`, `sam-admin project`) and
+    several webapp paths (admin tree view, single-project dashboard,
+    `GET /api/v1/users/<u>`). For DISK rows it must return point-in-time
+    capacity in `used`/`remaining`/`percent_used` — not cumulative
+    TiB-yr burn — so the CLI matches the webapp."""
+
+    def test_disk_used_reflects_capacity_not_burn(self, session):
+        from datetime import date as _date
+        from sam import ResourceType
+        from sam.summaries.disk_summaries import (
+            DiskChargeSummary,
+            mark_disk_snapshot_current,
+        )
+        BYTES_PER_TIB = 1024 ** 4
+
+        rt = session.query(ResourceType).filter_by(resource_type='DISK').first()
+        if rt is None:
+            rt = make_resource_type(session, resource_type='DISK')
+        resource = make_resource(
+            session, resource_type=rt,
+            resource_name=f"Campaign_Store_{next_seq('cs')}",
+        )
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        make_allocation(
+            session, account=account, amount=100.0,
+            start_date=datetime.now() - timedelta(days=30),
+            end_date=datetime.now() + timedelta(days=335),
+        )
+        snap = _date(2026, 4, 18)
+        # 50 TiB capacity vs. 4.21 TiB-yr cumulative burn — the helper
+        # must surface 50, not 4.21.
+        session.add(DiskChargeSummary(
+            activity_date=snap,
+            account_id=account.account_id,
+            user_id=lead.user_id,
+            username=lead.username,
+            projcode=project.projcode,
+            number_of_files=100,
+            bytes=50 * BYTES_PER_TIB,
+            terabyte_years=4.2141,
+            charges=4.2141,
+        ))
+        session.flush()
+        mark_disk_snapshot_current(session, snap)
+
+        usage = project.get_detailed_allocation_usage()
+        disk = usage[resource.resource_name]
+        assert disk['resource_type'] == 'DISK'
+        assert disk['used'] == pytest.approx(50.0, abs=1e-6)
+        assert disk['remaining'] == pytest.approx(50.0, abs=1e-6)
+        assert disk['percent_used'] == pytest.approx(50.0, abs=1e-4)
+        assert disk['activity_date'] == snap
+
+    def test_disk_capacity_includes_child_subtree(self, session):
+        """For NMMM0003-shaped parents (own account empty, children hold
+        the bytes), the helper's `used` must reflect the subtree total."""
+        from datetime import date as _date
+        from sam import ResourceType
+        from sam.summaries.disk_summaries import (
+            DiskChargeSummary,
+            mark_disk_snapshot_current,
+        )
+        BYTES_PER_TIB = 1024 ** 4
+
+        rt = session.query(ResourceType).filter_by(resource_type='DISK').first()
+        if rt is None:
+            rt = make_resource_type(session, resource_type='DISK')
+        resource = make_resource(
+            session, resource_type=rt,
+            resource_name=f"Campaign_Store_{next_seq('cs')}",
+        )
+        parent_lead = make_user(session)
+        parent = make_project(session, lead=parent_lead)
+        child_a = make_project(session, parent=parent, lead=make_user(session))
+        child_b = make_project(session, parent=parent, lead=make_user(session))
+        parent_account = make_account(session, project=parent, resource=resource)
+        make_allocation(
+            session, account=parent_account, amount=100.0,
+            start_date=datetime.now() - timedelta(days=30),
+            end_date=datetime.now() + timedelta(days=335),
+        )
+        account_a = make_account(session, project=child_a, resource=resource)
+        account_b = make_account(session, project=child_b, resource=resource)
+        snap = _date(2026, 4, 18)
+        for acct, lead, tib in [
+            (account_a, child_a.lead, 30.0),
+            (account_b, child_b.lead, 20.0),
+        ]:
+            session.add(DiskChargeSummary(
+                activity_date=snap,
+                account_id=acct.account_id,
+                user_id=lead.user_id,
+                username=lead.username,
+                projcode=acct.project.projcode,
+                number_of_files=100,
+                bytes=int(tib * BYTES_PER_TIB),
+                terabyte_years=0.0,
+                charges=0.0,
+            ))
+        session.flush()
+        mark_disk_snapshot_current(session, snap)
+
+        usage = parent.get_detailed_allocation_usage()
+        disk = usage[resource.resource_name]
+        assert disk['used'] == pytest.approx(50.0, abs=1e-6)
+        assert disk['percent_used'] == pytest.approx(50.0, abs=1e-4)
+        assert disk['activity_date'] == snap
+
+    def test_hpc_resource_unaffected_by_disk_pass(self, session):
+        """The disk pass must not touch HPC/DAV/ARCHIVE rows."""
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        # Build an HPC account using whatever default ResourceType the
+        # factory wires (HPC by default).
+        from sam import ResourceType
+        rt = session.query(ResourceType).filter_by(resource_type='HPC').first()
+        if rt is None:
+            rt = make_resource_type(session, resource_type='HPC')
+        resource = make_resource(
+            session, resource_type=rt,
+            resource_name=f"Derecho_{next_seq('hpc')}",
+        )
+        account = make_account(session, project=project, resource=resource)
+        make_allocation(
+            session, account=account, amount=1000.0,
+            start_date=datetime.now() - timedelta(days=30),
+            end_date=datetime.now() + timedelta(days=335),
+        )
+        usage = project.get_detailed_allocation_usage()
+        hpc = usage[resource.resource_name]
+        assert hpc['resource_type'] == 'HPC'
+        # Fresh allocation, no charges → used == 0, percent_used == 0,
+        # and the helper must NOT inject `activity_date` for HPC rows.
+        assert hpc['used'] == 0.0
+        assert hpc['percent_used'] == 0.0
+        assert 'activity_date' not in hpc
+
+
 class TestDiskCapacityInAllocationSummary:
     """`get_allocation_summary_with_usage` returns capacity-based
     total_used for disk-only rows (the /allocations dashboard table)."""

--- a/tests/unit/test_sam_search_cli.py
+++ b/tests/unit/test_sam_search_cli.py
@@ -151,6 +151,74 @@ class TestSamSearchCli:
         assert result.exit_code == 0
         assert "Abstract" in result.output
 
+    def test_project_disk_row_shows_capacity_not_burn(
+        self, runner, mock_db_session, active_project, session,
+    ):
+        """`sam-search project <p> --verbose` must render DISK capacity
+        (snapshot TiB / TiB allocated) — not cumulative TiB-yr burn — so
+        the CLI matches the webapp project card. Hangs a fresh DISK
+        account+allocation+snapshot off `active_project` (which already
+        has the AllocationType/Panel/Facility wiring needed for the
+        admin tree view path) and asserts the rendered '% Used' column
+        shows the capacity percent and not the much-smaller TiB-yr
+        percent."""
+        from datetime import date as _date
+        from datetime import datetime, timedelta
+        from sam import ResourceType
+        from sam.summaries.disk_summaries import (
+            DiskChargeSummary, mark_disk_snapshot_current,
+        )
+        from factories import (
+            make_account, make_allocation, make_resource, make_resource_type,
+        )
+        from factories._seq import next_seq
+
+        BYTES_PER_TIB = 1024 ** 4
+        rt = session.query(ResourceType).filter_by(resource_type='DISK').first()
+        if rt is None:
+            rt = make_resource_type(session, resource_type='DISK')
+        # Use a distinctive allocated amount (777 TiB) that won't collide
+        # with any snapshot row's value when scanning the rendered table.
+        resource_name = f"Campaign_Store_{next_seq('cs')}"
+        resource = make_resource(
+            session, resource_type=rt, resource_name=resource_name,
+        )
+        lead = active_project.lead
+        account = make_account(session, project=active_project, resource=resource)
+        make_allocation(
+            session, account=account, amount=777.0,
+            start_date=datetime.now() - timedelta(days=30),
+            end_date=datetime.now() + timedelta(days=335),
+        )
+        snap = _date(2026, 4, 18)
+        # 388.5 TiB capacity (= 50.0%), but only 4.21 TiB-yr cumulative
+        # burn (= 0.5%). The CLI's % Used column for *this* row must
+        # render as 50.0%, not 0.5%.
+        session.add(DiskChargeSummary(
+            activity_date=snap,
+            account_id=account.account_id,
+            user_id=lead.user_id,
+            username=lead.username,
+            projcode=active_project.projcode,
+            number_of_files=100,
+            bytes=int(388.5 * BYTES_PER_TIB),
+            terabyte_years=4.2141,
+            charges=4.2141,
+        ))
+        session.flush()
+        mark_disk_snapshot_current(session, snap)
+
+        result = runner.invoke(
+            cli, ['project', active_project.projcode, '--verbose'],
+        )
+        assert result.exit_code == 0
+        # Distinctive 777-TiB allocation row must render with capacity
+        # percent. Use substring across whitespace-collapsed text so the
+        # assertion is robust to Rich's column-width formatting.
+        flat = ' '.join(result.output.split())
+        assert "777 388 388 50.0%" in flat or "777 389 389 50.0%" in flat, \
+            f"capacity row not found in CLI output; got:\n{result.output}"
+
     # ------------------------------------------------------------------
     # Structural queries — don't care which data comes back
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Six commits hardening the disk-charging pipeline that landed in PR #207
(disk UX). Each commit is independently green; together they:

1. Make `act_*` audit columns mirror the resolved entity when the
   caller doesn't supply a raw value (closes a NULL-vs-populated
   asymmetry in the new collector).
2. Move the `DISK_CHARGING_TIB_EPOCH` cutover back to the first 2026
   snapshot so the early-2026 backfill is a single-pipeline import
   instead of a mixed legacy/new run.
3. Fix the CLI so `sam-search project --verbose` shows the same
   capacity values for DISK rows that the webapp project card
   already shows.
4. Handle Quasar's `'total'` project-rollup rows by attributing
   them to the project lead (matches the existing `<unidentified>`
   gap-row convention).
5. Restore legacy SAM's per-(user, project, day) roll-up shape by
   summing per-fileset input rows before the `disk_charge_summary`
   upsert — closes a silent-overwrite bug that was undercounting
   multi-fileset projects by orders of magnitude.
6. Track the deferred two-tier `disk_activity`/`disk_charge`
   restoration as Layer 2 future work.

## Why

PR #207 left two real gaps in the pipeline:

- **Audit asymmetry** — disk feeds populated `act_username` and
  `act_projcode` but left `act_unix_uid` NULL even when the user
  resolved cleanly. We were also writing `facility_name` from the
  collector while legacy left it NULL.
- **Silent data loss** — the `_upsert_storage_summary` natural
  key omits `directory_path`, so a project with multiple filesets
  on one resource (e.g. P43713000 with 4 csfs1 directories under
  `/gpfs/csfs1/collections/gdex/`) had every row UPDATE-overwrite
  instead of summing. Local 2026-04-25 P43713000 / Campaign_Store
  totals were ~1 PiB; production legacy 2025-08-30 had ~19 PiB on
  the same project shape.

A side gap was the CLI: `sam-search project NMMM0003 --verbose`
showed disk usage as cumulative TiB-yr burn while the dashboard
showed point-in-time TiB capacity. Same data, two different
numbers — confusing for operators.

## What changed (per commit)

### `bba96da` — `act_*` mirror when known

`src/sam/manage/summaries.py`. Both `_upsert_storage_summary` (Disk +
Archive) and `upsert_comp_charge_summary` now treat `act_*` fields as
"always mirror when known": `act_username` / `act_projcode` /
`act_unix_uid` fall back to the resolved entity's value
(`user.username`, `project.projcode`, `user.unix_uid`) when the
caller didn't supply a raw input. The storage-side natural-key
lookup uses the *effective* values too, preserving upsert
idempotency.

### `4ff0efa` — DISK_CHARGING_TIB_EPOCH → 2026-01-03

`src/sam/summaries/disk_summaries.py` plus the matching test in
`test_disk_charging_math.py`. Moves the epoch back so the entire
local 2026-* backfill imports through the new TiB-yr pipeline
instead of straddling legacy/new.

### `cfd30a5` — CLI disk capacity via `get_detailed_allocation_usage`

`src/sam/projects/projects.py` + `src/sam/queries/dashboard.py` plus
new tests in `test_query_functions.py` and `test_sam_search_cli.py`.
Folds the disk-aware capacity override into
`Project.get_detailed_allocation_usage()` so every consumer (CLI,
admin tree view, single-project dashboard, `GET /api/v1/users/<u>`)
sees capacity for DISK rows. Removes the now-redundant inline
override in `_build_project_resources_data`. The batched dashboard
and allocation-summary paths keep their inline overrides because
they bypass the helper.

### `a817dd4` — Quasar `'total'` rollup rows

`src/cli/accounting/commands.py` plus `disk_usage/__init__.py`
(registers `GladeCsvReader` for Quasar) and a new test in
`test_accounting_disk_admin.py`. Quasar's per-user file ships one
project-rollup row per project — username is the literal sentinel
`'total'`. The importer now detects the sentinel and attributes
the row to the project lead (mirrors the `<unidentified>`
gap-row convention at `commands.py:810`), keeping
`act_username='total'` as the audit label so rollup rows remain
distinguishable.

### `54d959d` — Multi-fileset roll-up (the main correctness fix)

`src/cli/accounting/commands.py` + `tests/unit/test_accounting_disk_admin.py`
+ `docs/plans/DISK_PER_FILESET.md`. Adds `_group_disk_entries()` that
pre-aggregates per-(user, fileset) rows into per-(user, project)
totals before the chunked upsert, mirroring legacy SAM's
`calculateDiskChargeSummaries` named query (legacy_sam SQL:
`GROUP BY (date, user, uid, user_id, projcode, account_id)`,
`SUM(bytes, files, terabyte_year, charge)`). Synthetic gap rows
and Quasar `'total'` rows pass through unchanged. The dry-run
table still shows per-fileset input rows; the upsert chunks
consume the aggregated list. Verbose output prints
`Aggregated N → M rows` when collapsing happens.

**Verified post-backfill**: P43713000 / Campaign_Store on 2026-04-25
now totals 19.31 PiB across 21 rows; gdexdata = 16.6 PiB summed
across 4 csfs1 filesets, matching the raw input file (~16.55 PiB).
Up from 1.02 PiB pre-fix.

### `c17a86c` — Layer 2 plan (`docs/plans/DISK_ACTIVITY.md`)

Pure documentation. Captures the next step: restore legacy SAM's
two-tier `disk_activity` / `disk_charge` design by populating those
existing (currently dormant) tables during import. No schema
changes required; per-fileset queries become possible by reading
`disk_activity` directly. To be picked up in a fresh session.

## Tests

All 1889 tests + 19 perf tests green. Five new disk-side tests:

- `TestDiskAdminCli.test_multi_directory_rows_sum_per_user` —
  load-bearing regression for the silent-overwrite bug.
- `TestDiskAdminCli.test_rollup_total_row_attributed_to_project_lead`
  — Quasar `'total'` flow.
- `TestDiskCapacityInGetDetailedAllocationUsage` (3 tests) —
  helper-side disk capacity override.
- `test_project_disk_row_shows_capacity_not_burn` — CLI render
  smoke test.

## Out of scope (deferred)

Tracked in `docs/plans/DISK_ACTIVITY.md` and `docs/plans/DISK_PER_FILESET.md`:

- Per-fileset rendering in the disk Resource Details tree
  (Layer 2 — populate `disk_activity` / `disk_charge`).
- Per-fileset stacked-area chart.
- `terabyte_years` → `tebibyte_years` rename.

## Test plan

- [ ] CI green on `staging` PR
- [ ] After deploy, re-import the latest 1–2 prod snapshots:
      `for rep in <prod-snapshots>; do sam-admin accounting --resource Campaign_Store --disk --user-usage \$rep --verbose --skip-errors; done`
- [ ] Spot-check a known multi-fileset project (e.g. P43713000) on the prod dashboard:
      capacity should jump to legacy-shape totals (PiB scale)
- [ ] Verify `sam-search project NMMM0003 --verbose` shows capacity
      percent matching the webapp project card
- [ ] Verify Quasar import:
      `sam-admin accounting --resource Quasar --disk --user-usage <quasar-snapshot> --verbose`
      runs to completion and writes per-project rollup rows
      attributed to project leads

🤖 Generated with [Claude Code](https://claude.com/claude-code)