### PR TITLE
disk charging: Layer 2 — populate disk_activity / disk_charge during import + per-fileset dashboard

### DIFF
--- a/docs/plans/DISK_ACTIVITY.md
+++ b/docs/plans/DISK_ACTIVITY.md
@@ -1,0 +1,493 @@
+# Layer 2 — Populate `disk_activity` / `disk_charge` During Import (Two-Tier Restoration)
+
+> **Status**: Plan-only, to be revisited and implemented in a fresh session.
+> **Branch**: open (probably a new branch `disk_activity_population`).
+> **Prerequisite**: Layer 1 (`_group_disk_entries` SUM-at-import,
+> commit `54d959d`) is shipped on `consistent-disk-rollup`.
+> **Companion doc**: this plan supersedes the
+> "schema-change" sketch in `docs/plans/DISK_PER_FILESET.md`. Update
+> that doc to point here once Layer 2 lands.
+
+## Context
+
+The current SAM disk pipeline writes only `disk_charge_summary`
+(per-(user, project, day) rollup). Per-fileset granularity is lost —
+the dashboard tree node shows a flat path label without per-directory
+bytes, and we can't answer "which fileset is filling up?" from SAM.
+
+**Legacy SAM** maintained a two-tier design:
+
+```
+disk_activity        (per-(directory, user, day) raw snapshot rows)
+    └── disk_charge  (per-activity FK → account, user, terabyte_year, charge)
+            └── disk_charge_summary  (per-(user, project, day) rollup,
+                                       built via SUM(...) GROUP BY ...)
+```
+
+Tier 1 carries the directory granularity. Tier 2 resolves directory →
+account/user. Tier 3 is the rollup for fast dashboard math. The
+`calculateDiskChargeSummaries` named query
+(`legacy_sam/.../AccountingNamedQuery.xml`) joins all three.
+
+We **already have all three ORM models** (`src/sam/activity/disk.py`,
+`src/sam/summaries/disk_summaries.py`) and tables — production carries
+5.3M `disk_activity` rows (2012 → 2026-04-25) and 934K `disk_charge`
+rows under the legacy collector. Tiers 1 and 2 are **dormant** in our
+new pipeline:
+
+- No code in `src/` instantiates `DiskActivity()` or
+  `DiskCharge()`.
+- `sam-admin accounting --disk` (`src/cli/accounting/commands.py:401–777`)
+  resolves directory → account → user, computes TiB-yr / charge, and
+  writes only to `disk_charge_summary` via `upsert_disk_charge_summary`.
+
+The Layer 1 SUM-at-import gives correct rollups but loses the per-
+fileset detail. **Layer 2 restores the two-tier design** by also
+populating `disk_activity` and `disk_charge` during the same import
+pass — no schema changes. Per-directory queries become possible by
+reading `disk_activity` directly.
+
+## Goals
+
+1. Populate `disk_activity` with one row per (directory, user, snapshot-date,
+   projcode) from the input file, idempotently (re-run replaces).
+2. Populate `disk_charge` with one row per `disk_activity` whose
+   directory resolves to a SAM project + account + user.
+3. Keep the existing `disk_charge_summary` writer unchanged — Layer 1
+   stays. The dashboard's hot-path queries continue to read the rollup.
+4. Add a per-directory query helper that reads `disk_activity` and
+   surfaces per-fileset bytes / files for the disk Resource Details
+   tree node.
+5. **Zero schema changes** anywhere. Use exactly what the existing
+   tables/columns already provide.
+
+## Existing infrastructure to reuse
+
+### Tier 1 — `DiskActivity` (`src/sam/activity/disk.py:9–55`)
+
+Columns:
+
+| Column | Type | Notes |
+|---|---|---|
+| `disk_activity_id` | INT PK | autoincrement |
+| `directory_name` | VARCHAR(255) NOT NULL | from input row |
+| `username` | VARCHAR(35) NOT NULL | from input row |
+| `projcode` | VARCHAR(30) | input file's projcode label (often the umbrella, e.g. `"cesm"`) |
+| `activity_date` | DATETIME NOT NULL | snapshot date |
+| `reporting_interval` | INT NOT NULL | days the snapshot covers (typically 7) |
+| `file_size_total` | BIGINT NOT NULL | legacy-mirror; populate `= bytes` |
+| `bytes` | BIGINT NOT NULL | snapshot bytes |
+| `number_of_files` | INT | snapshot file count |
+| `load_date` | DATETIME NOT NULL | `datetime.now()` at import time |
+| `disk_cos_id` | INT NOT NULL FK → `disk_cos` | use `0` (the seed "No class of service" row that already exists) |
+| `error_comment` | TEXT | NULL on success, error string on partial-resolve |
+| `processing_status` | BOOL | `True` on success, `False` on error |
+| `resource_name` | VARCHAR(40) | from `--resource` CLI arg (`'Campaign_Store'`, `'Quasar'`, …) |
+
+Plus `creation_time` / `modified_time` from `TimestampMixin`.
+
+**Natural key for upsert**: `(directory_name, username, activity_date, projcode)`
+— matches the legacy `disk_activity` unique constraint (verify on prod
+via `SHOW INDEX FROM disk_activity` before committing).
+
+### Tier 2 — `DiskCharge` (`src/sam/activity/disk.py:59–88`)
+
+Columns:
+
+| Column | Type | Notes |
+|---|---|---|
+| `disk_charge_id` | INT PK | autoincrement |
+| `disk_activity_id` | INT NOT NULL FK, **UNIQUE** | enforces 1:1 with `disk_activity` |
+| `account_id` | INT NOT NULL FK → `account` | from `_resolve_for_row` |
+| `user_id` | INT NOT NULL FK → `users` | from `_resolve_user` (or project lead for `'total'` rollup) |
+| `charge_date` | DATETIME NOT NULL | `datetime.now()` (when charge computed) |
+| `charge` | FLOAT | TiB-yr × rate (today rate=1) |
+| `terabyte_year` | FLOAT | from `tib_years()` |
+| `activity_date` | DATETIME | mirror of `disk_activity.activity_date` |
+
+The unique index on `disk_activity_id` enforces that a `disk_activity`
+row has at most one `disk_charge` row. Rows whose directory cannot be
+resolved to an account stay tier-1-only (disk_activity present,
+disk_charge absent).
+
+### Charging-interval semantics (identical to today)
+
+The "dynamic accounting interval" used by `disk_charge_summary` today
+is the per-row `reporting_interval` (column 7 of `acct.glade`,
+typically `7` days). The importer feeds it into
+`tib_years(bytes, reporting_interval)`
+(`src/sam/summaries/disk_summaries.py`) at WRITE time — the resulting
+`terabyte_years` / `charges` are persisted; the raw interval is not
+carried on the summary row.
+
+Layer 2 keeps that exactly:
+
+- `disk_charge.terabyte_year` and `disk_charge.charge` are computed
+  by the same `tib_years()` call, with the same per-row
+  `reporting_interval` from the input file.
+- `disk_charge_summary` continues to roll up via `_group_disk_entries`
+  and is unaffected (Layer 1 stays).
+- Bonus: the raw `reporting_interval` is **persisted on
+  `disk_activity.reporting_interval`** — a column the summary table
+  doesn't have. That makes per-row audits / recomputation feasible
+  without re-reading the input snapshot, and is exactly how
+  legacy SAM's `calculateDiskChargeSummaries` named query would
+  recompute summaries from scratch.
+- The `DISK_CHARGING_TIB_EPOCH` cutover guard (`src/sam/summaries/disk_summaries.py`)
+  stays at the importer level; both tier-2 and tier-3 writes are
+  gated by the same epoch check that's already in place
+  (`commands.py:450–458`).
+
+### Existing helpers to reuse
+
+- `_resolve_for_row` (`src/cli/accounting/commands.py:516–535`) —
+  already resolves directory_path → ProjectDirectory → Project →
+  Account.
+- `_resolve_user` (`src/sam/manage/summaries.py:36–50`) — username +
+  unix_uid → User.
+- `tib_years()` (`src/sam/summaries/disk_summaries.py`) — bytes ×
+  reporting_interval → TiB-years.
+- `_DISK_ROLLUP_USERNAMES` constant (`src/cli/accounting/commands.py:60`)
+  — sentinel set including `'total'`.
+- `mark_disk_snapshot_current()` (`src/sam/summaries/disk_summaries.py`)
+  — already advances the current-snapshot pointer.
+- `management_transaction` context manager.
+
+## Design
+
+### 1) New writer: `_write_disk_activity_and_charge(entries, ...)`
+
+Add to `src/cli/accounting/commands.py`. Runs once per import, after
+charging math, **before** the existing disk_charge_summary aggregation
++ upsert. Pseudocode:
+
+```
+for e in entries:
+    # Skip synthetic gap rows (`<unidentified>`) — they don't bind to
+    # a real directory.
+    if e.user_override is not None:
+        continue
+    # Skip rollup-sentinel rows (Quasar 'total') — they're not
+    # per-fileset by construction.
+    if e.username in _DISK_ROLLUP_USERNAMES:
+        continue
+
+    activity = upsert_disk_activity(
+        session,
+        directory_name=e.directory_path,
+        username=e.username,
+        projcode=e.projcode,        # the input file's label (e.g. 'cesm')
+        activity_date=e.activity_date,
+        reporting_interval=e.reporting_interval,
+        bytes=e.bytes,
+        file_size_total=e.bytes,
+        number_of_files=e.number_of_files,
+        disk_cos_id=0,
+        resource_name=resource_name,
+        load_date=now,
+        processing_status=True,    # flip to False / set error_comment if resolve fails
+    )
+
+    # Tier 2: only when resolve succeeds.
+    ok, project, account = _resolve_for_row(e)
+    if not ok:
+        continue
+    user = _resolve_user(session, e.username, None)
+    upsert_disk_charge(
+        session,
+        disk_activity_id=activity.disk_activity_id,
+        account_id=account.account_id,
+        user_id=user.user_id,
+        charge_date=now,
+        activity_date=e.activity_date,
+        terabyte_year=e.terabyte_years,
+        charge=e.charges,
+    )
+```
+
+**Idempotency**: before the loop, DELETE rows for
+`(activity_date == snap_date, resource_name == X)` from `disk_activity`
+(cascades to `disk_charge` via FK if configured; otherwise delete
+explicitly first). Same pattern the disk_charge_summary path already
+uses (`commands.py:546–580`). Re-running the same snapshot replaces
+all tier-1/tier-2 rows for that day on that resource.
+
+The unique constraint
+`(directory_name, username, activity_date, projcode)` on
+`disk_activity` is the upsert natural key. Place these helpers in
+`src/sam/manage/summaries.py` next to `upsert_disk_charge_summary`:
+
+- `upsert_disk_activity(session, *, directory_name, username, projcode, activity_date, ...) -> Tuple[DiskActivity, str]`
+- `upsert_disk_charge(session, *, disk_activity_id, account_id, user_id, ...) -> Tuple[DiskCharge, str]`
+
+Both follow the existing pattern: SELECT by natural key, INSERT-or-UPDATE,
+return `(record, 'created' | 'updated')`.
+
+### 2) Wire-up in `_run_disk()` (`src/cli/accounting/commands.py`)
+
+Insert one block between the charging-math pass (currently line 491–493)
+and the dry-run table check (currently line 537). Order:
+
+1. Parse entries (existing).
+2. Build gap rows (existing).
+3. Charging math (existing).
+4. **NEW: write tier-1 + tier-2** via `_write_disk_activity_and_charge()`.
+5. Dry-run table (existing — show per-fileset rows).
+6. Delete existing `disk_charge_summary` rows for snap (existing).
+7. `_group_disk_entries()` Layer-1 aggregation (existing).
+8. Chunked upsert to `disk_charge_summary` (existing).
+9. Mark snapshot current (existing).
+
+`--dry-run` skips both the new tier-1/tier-2 write AND the existing
+tier-3 write — same semantics.
+
+The new write needs its own `management_transaction` chunk (one chunk
+per ~1000 entries) for parity with the existing `disk_charge_summary`
+chunked upsert.
+
+### 3) Per-directory query — `get_directory_usage_at(...)`
+
+Add to `src/sam/queries/disk_usage.py`:
+
+```
+def get_directory_usage_at(
+    session, *,
+    project_id: int,
+    resource_name: str,
+    activity_date: date,
+) -> List[Dict]:
+    """Per-directory snapshot for one (project, resource, date)."""
+    rows = session.query(
+        DiskActivity.directory_name,
+        func.sum(DiskActivity.bytes).label('bytes'),
+        func.sum(DiskActivity.number_of_files).label('files'),
+        func.count(DiskActivity.disk_activity_id).label('row_count'),
+    ).join(DiskCharge, DiskCharge.disk_activity_id == DiskActivity.disk_activity_id) \
+     .join(Account, Account.account_id == DiskCharge.account_id) \
+     .filter(
+        Account.project_id == project_id,
+        DiskActivity.resource_name == resource_name,
+        DiskActivity.activity_date == activity_date,
+    ).group_by(DiskActivity.directory_name).all()
+    return [...]
+```
+
+Bulk variant for many `(project_id, resource_name)` pairs at once
+(mirrors `bulk_get_subtree_disk_capacity`'s pattern).
+
+### 4) Dashboard wiring — `build_disk_subtree` (per-fileset display)
+
+In `src/sam/queries/disk_usage.py`, when assembling each tree node's
+payload, attach a `directories: [{'name', 'bytes', 'files'}]` list
+when the project has >1 ProjectDirectory active on this resource.
+For projects with exactly one (the common case), keep the current
+single-line render path unchanged.
+
+Single-fileset tree nodes: identical to today (one bytes badge).
+Multi-fileset tree nodes: render the per-directory list under the
+node header. Template: `src/webapp/templates/dashboards/user/resource_details_disk.html`.
+
+### 5) Backfill
+
+Re-run the existing CLI loop after deploy:
+
+```
+for rep in data/project_user_usage/acct.glade.2026-*; do
+    sam-admin accounting --resource Campaign_Store --disk \
+        --user-usage $rep --verbose --skip-errors
+done
+for rep in data/project_user_usage/acct.quasar.2026-*; do
+    sam-admin accounting --resource Quasar --disk \
+        --user-usage $rep --verbose --skip-errors
+done
+```
+
+Idempotent under the per-resource per-date delete semantics.
+Each snapshot now writes 3 tables: `disk_activity`, `disk_charge`,
+`disk_charge_summary`. Old snapshots remain tier-3-only until they're
+re-imported.
+
+### 6) Production rollout
+
+1. Deploy code.
+2. Confirm prod's `disk_activity` unique index matches
+   `(directory_name, username, activity_date, projcode)` (legacy
+   schema; should be already present given prod has 5.3M rows under
+   it, but verify via `SHOW INDEX FROM disk_activity` before flipping
+   on the new writer).
+3. Re-import the latest 1–2 snapshots on prod via the existing CLI
+   loop. The new writer appends to `disk_activity` alongside legacy's
+   continuing writes — coexistence is fine because of the unique
+   key.
+4. Spot-check `disk_activity` row counts before/after for a known
+   multi-fileset project: e.g. P43713000 should gain ~4 csfs1 rows
+   per snapshot.
+5. Visit the disk Resource Details page for P43713000 and confirm
+   the tree node now shows per-fileset bytes.
+
+## Files
+
+### Modified
+
+- `src/sam/manage/summaries.py` — add `upsert_disk_activity()` and
+  `upsert_disk_charge()` helpers next to `upsert_disk_charge_summary()`.
+- `src/cli/accounting/commands.py` — add `_write_disk_activity_and_charge()`
+  helper; wire into `_run_disk()` between charging math and dry-run.
+- `src/sam/queries/disk_usage.py` — add `get_directory_usage_at()` and
+  its bulk variant; extend `build_disk_subtree` to attach per-directory
+  payloads when >1 fileset on the resource.
+- `src/webapp/templates/dashboards/user/resource_details_disk.html` —
+  per-fileset render under multi-fileset tree nodes.
+- `tests/unit/test_accounting_disk_admin.py` — new tests:
+  - `test_import_writes_disk_activity_per_directory`
+    (multi-directory project: 4 input rows → 4 disk_activity rows
+    + 4 disk_charge rows, each carrying its own bytes).
+  - `test_disk_activity_re_import_replaces_per_resource_date`
+    (idempotency: second run for same date deletes + re-inserts,
+    not append).
+  - `test_disk_activity_skipped_for_unidentified_and_total`
+    (synthetic rows produce no disk_activity row).
+- `tests/unit/test_disk_usage_queries.py` — new
+  `TestPerDirectoryQuery` class:
+  - `test_get_directory_usage_at_returns_per_directory_rows`
+  - `test_bulk_per_directory_query_pairs`.
+- `tests/unit/test_query_functions.py` — extend
+  `TestDiskCapacityInDashboardData` with a multi-fileset assertion
+  (the project's tree-node payload now carries `directories`).
+
+### Reused (no change)
+
+- `_group_disk_entries()` and the disk_charge_summary upsert path
+  — Layer 1 stays exactly as it is.
+- `Account.current_disk_usage()` — single-account read; unaffected.
+- `Project.is_active`, `ProjectDirectory.is_active` hybrids.
+- `bulk_get_subtree_disk_capacity()` — provides the project-level
+  capacity used for the headline bar.
+
+### Companion doc to update
+
+- `docs/plans/DISK_PER_FILESET.md` — replace its "schema add of
+  `directory_id`" sketch with a pointer to this plan and a note
+  that we chose the no-schema-change path. Mark Layer 2 as DONE
+  once it ships.
+
+## Verification
+
+### Unit / integration
+
+```
+source etc/config_env.sh
+pytest tests/unit/test_accounting_disk_admin.py tests/unit/test_disk_usage_queries.py tests/unit/test_query_functions.py -v
+pytest -m perf -n 0 -v
+```
+
+The new tests are the load-bearing ones. Existing perf budgets must
+still hold; the new writer adds a fixed ~2 queries per chunk (delete
++ batched insert), independent of project count.
+
+### Live sanity check
+
+After local re-import of 2026-04-25:
+
+```
+mysql -h 127.0.0.1 -u root -proot sam -e "
+  SELECT directory_name, SUM(bytes), SUM(number_of_files), COUNT(*)
+  FROM disk_activity
+  WHERE activity_date='2026-04-25'
+    AND resource_name='Campaign_Store'
+    AND projcode IN ('p43713000', 'P43713000', 'decs', 'cesm')
+  GROUP BY directory_name
+  ORDER BY 2 DESC;"
+```
+
+Expect 4 rows for P43713000's csfs1 filesets (data, decsdata,
+work, transfer), bytes summing to ~19 PiB.
+
+```
+mysql -h 127.0.0.1 -u root -proot sam -e "
+  SELECT COUNT(*) FROM disk_charge
+  WHERE activity_date='2026-04-25';"
+```
+
+Expect ~equal to the disk_activity row count for that date (1:1
+modulo unresolved rows).
+
+Webapp Resource Details for P43713000 on Campaign_Store:
+
+- Tree node lists 4 csfs1 filesets, each with its own bytes badge.
+- Per-fileset bytes sum to the project-level bar value.
+- Quasar / Stratus paths do **not** appear in the Campaign_Store
+  view (filtered by `resource_name` on the disk_activity side).
+
+### Production sanity check
+
+Compare prod `disk_activity` row counts before / after the
+post-deploy backfill of one snapshot:
+
+```
+SELECT COUNT(*) FROM disk_activity WHERE activity_date='YYYY-MM-DD';
+```
+
+Expect a step-up matching the per-(user, fileset) row count from
+that day's `acct.glade` file.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Coexistence with legacy writer on prod | The unique key
+`(directory_name, username, activity_date, projcode)` is shared. The
+new writer's UPSERT matches existing rows and updates them with the
+same data — no duplication. Verify via row-count delta before/after
+the first prod backfill. |
+| Row volume blow-up | ~2K rows/snapshot/resource × ~52 snapshots/year
+≈ 100K disk_activity rows/year/resource. Prod already runs at this
+scale (5.3M rows since 2012). Negligible. |
+| disk_cos_id=0 missing on a fresh DB | Add an idempotent
+`session.query(DiskCos).filter_by(disk_cos_id=0).first() or
+session.add(DiskCos(disk_cos_id=0, description='No class of service'))`
+guard at the top of `_write_disk_activity_and_charge()`. |
+| Quasar 'total' rollup rows have no real directory | Skip them at
+tier-1 (they remain tier-3-only via the existing rollup path). The
+disk Resource Details view falls back to project-level capacity for
+those projects, same as today. |
+| `<unidentified>` gap rows have no real directory | Same — skip at
+tier-1. |
+| Test-DB schema drift on disk_activity columns | Run
+`tests/integration/test_schema_validation.py` first; it will fail
+if the test snapshot's `disk_activity` differs from prod or our ORM. |
+| `_resolve_user` failures inside the new write loop | Tier-1 row
+still gets written with `processing_status=False` and
+`error_comment='User <X> not found'`; tier-2 row is skipped.
+Audit trail preserved without aborting the import. |
+
+## Out of scope
+
+- Adding `directory_id` or any new column to `disk_charge_summary`.
+- Adding `resource_id` to `ProjectDirectory`.
+- Cross-resource fileset views (e.g. show all of P43713000's
+  storage on Quasar+Stratus+Campaign_Store on one page).
+- Rewriting historical snapshots' `disk_charge_summary` rollups
+  on top of disk_activity (legacy-style `calculateDiskChargeSummaries`
+  recomputation). Layer 1 already gives us the rollup; we don't need
+  to recompute it.
+- Per-fileset stacked-area chart (today's chart is per-user; the
+  new infra makes per-fileset possible but no UX request for it
+  yet).
+- Renaming `terabyte_years` → `tebibyte_years`.
+
+## When to pick this up
+
+Trigger conditions, any of:
+
+1. An operator hits a "which fileset is filling up?" question that
+   today's project-level capacity bar can't answer.
+2. The `--reconcile-quotas` CLI surface starts showing meaningful
+   quota gaps that would benefit from per-fileset DB-side queries
+   instead of re-reading `cs_usage.json` each time.
+3. A multi-fileset project enters the dashboard's top-N attention
+   and the lack of per-fileset detail is a visible UX wart.
+
+Estimated effort: ~1 focused day (helpers + writer + dashboard
+wiring + tests + backfill verification). Smaller than the
+schema-add path because no DDL coordination with prod.

--- a/docs/plans/DISK_ACTIVITY.md
+++ b/docs/plans/DISK_ACTIVITY.md
@@ -1,493 +1,494 @@
-# Layer 2 — Populate `disk_activity` / `disk_charge` During Import (Two-Tier Restoration)
+# Layer 2 — Populate `disk_activity` / `disk_charge` During Import
 
-> **Status**: Plan-only, to be revisited and implemented in a fresh session.
-> **Branch**: open (probably a new branch `disk_activity_population`).
-> **Prerequisite**: Layer 1 (`_group_disk_entries` SUM-at-import,
-> commit `54d959d`) is shipped on `consistent-disk-rollup`.
-> **Companion doc**: this plan supersedes the
-> "schema-change" sketch in `docs/plans/DISK_PER_FILESET.md`. Update
-> that doc to point here once Layer 2 lands.
+> **Branch**: `disk_activity` (current).
+> **Source**: refines `docs/plans/DISK_ACTIVITY.md` based on
+> verification of current code state on 2026-04-28.
 
 ## Context
 
-The current SAM disk pipeline writes only `disk_charge_summary`
-(per-(user, project, day) rollup). Per-fileset granularity is lost —
-the dashboard tree node shows a flat path label without per-directory
-bytes, and we can't answer "which fileset is filling up?" from SAM.
+The disk import pipeline today writes only `disk_charge_summary`
+(per-(user, project, day) rollup, with `act_*` mirror columns from
+commit 711ef27 and SUM-at-import via `_group_disk_entries`). Per-fileset
+detail is lost — the dashboard tree node lists fileset paths as a
+comma-joined string with a single bytes badge, and we cannot answer
+"which fileset is filling up?" from SAM.
 
-**Legacy SAM** maintained a two-tier design:
+`disk_activity` and `disk_charge` ORM models exist (`src/sam/activity/disk.py`)
+with the legacy two-tier shape. Locally they're empty (0 rows); on
+prod they carry 5.3M / 934K rows from the legacy Java collector that
+ran through 2026-04-25.
 
-```
-disk_activity        (per-(directory, user, day) raw snapshot rows)
-    └── disk_charge  (per-activity FK → account, user, terabyte_year, charge)
-            └── disk_charge_summary  (per-(user, project, day) rollup,
-                                       built via SUM(...) GROUP BY ...)
-```
+This plan adds tier-1 (`disk_activity`) and tier-2 (`disk_charge`)
+writes alongside the existing tier-3 (`disk_charge_summary`) write.
+**No schema changes** — the existing tables and unique key
+`(directory_name, username, activity_date, projcode)` already provide
+everything needed. Per-fileset queries become possible by reading
+`disk_activity` directly. The hot-path dashboard rollup keeps reading
+`disk_charge_summary`; the tree node gains a per-fileset breakdown
+when the project has >1 active fileset on the resource.
 
-Tier 1 carries the directory granularity. Tier 2 resolves directory →
-account/user. Tier 3 is the rollup for fast dashboard math. The
-`calculateDiskChargeSummaries` named query
-(`legacy_sam/.../AccountingNamedQuery.xml`) joins all three.
+## Verified state (anchors for the implementation)
 
-We **already have all three ORM models** (`src/sam/activity/disk.py`,
-`src/sam/summaries/disk_summaries.py`) and tables — production carries
-5.3M `disk_activity` rows (2012 → 2026-04-25) and 934K `disk_charge`
-rows under the legacy collector. Tiers 1 and 2 are **dormant** in our
-new pipeline:
-
-- No code in `src/` instantiates `DiskActivity()` or
-  `DiskCharge()`.
-- `sam-admin accounting --disk` (`src/cli/accounting/commands.py:401–777`)
-  resolves directory → account → user, computes TiB-yr / charge, and
-  writes only to `disk_charge_summary` via `upsert_disk_charge_summary`.
-
-The Layer 1 SUM-at-import gives correct rollups but loses the per-
-fileset detail. **Layer 2 restores the two-tier design** by also
-populating `disk_activity` and `disk_charge` during the same import
-pass — no schema changes. Per-directory queries become possible by
-reading `disk_activity` directly.
-
-## Goals
-
-1. Populate `disk_activity` with one row per (directory, user, snapshot-date,
-   projcode) from the input file, idempotently (re-run replaces).
-2. Populate `disk_charge` with one row per `disk_activity` whose
-   directory resolves to a SAM project + account + user.
-3. Keep the existing `disk_charge_summary` writer unchanged — Layer 1
-   stays. The dashboard's hot-path queries continue to read the rollup.
-4. Add a per-directory query helper that reads `disk_activity` and
-   surfaces per-fileset bytes / files for the disk Resource Details
-   tree node.
-5. **Zero schema changes** anywhere. Use exactly what the existing
-   tables/columns already provide.
-
-## Existing infrastructure to reuse
-
-### Tier 1 — `DiskActivity` (`src/sam/activity/disk.py:9–55`)
-
-Columns:
-
-| Column | Type | Notes |
-|---|---|---|
-| `disk_activity_id` | INT PK | autoincrement |
-| `directory_name` | VARCHAR(255) NOT NULL | from input row |
-| `username` | VARCHAR(35) NOT NULL | from input row |
-| `projcode` | VARCHAR(30) | input file's projcode label (often the umbrella, e.g. `"cesm"`) |
-| `activity_date` | DATETIME NOT NULL | snapshot date |
-| `reporting_interval` | INT NOT NULL | days the snapshot covers (typically 7) |
-| `file_size_total` | BIGINT NOT NULL | legacy-mirror; populate `= bytes` |
-| `bytes` | BIGINT NOT NULL | snapshot bytes |
-| `number_of_files` | INT | snapshot file count |
-| `load_date` | DATETIME NOT NULL | `datetime.now()` at import time |
-| `disk_cos_id` | INT NOT NULL FK → `disk_cos` | use `0` (the seed "No class of service" row that already exists) |
-| `error_comment` | TEXT | NULL on success, error string on partial-resolve |
-| `processing_status` | BOOL | `True` on success, `False` on error |
-| `resource_name` | VARCHAR(40) | from `--resource` CLI arg (`'Campaign_Store'`, `'Quasar'`, …) |
-
-Plus `creation_time` / `modified_time` from `TimestampMixin`.
-
-**Natural key for upsert**: `(directory_name, username, activity_date, projcode)`
-— matches the legacy `disk_activity` unique constraint (verify on prod
-via `SHOW INDEX FROM disk_activity` before committing).
-
-### Tier 2 — `DiskCharge` (`src/sam/activity/disk.py:59–88`)
-
-Columns:
-
-| Column | Type | Notes |
-|---|---|---|
-| `disk_charge_id` | INT PK | autoincrement |
-| `disk_activity_id` | INT NOT NULL FK, **UNIQUE** | enforces 1:1 with `disk_activity` |
-| `account_id` | INT NOT NULL FK → `account` | from `_resolve_for_row` |
-| `user_id` | INT NOT NULL FK → `users` | from `_resolve_user` (or project lead for `'total'` rollup) |
-| `charge_date` | DATETIME NOT NULL | `datetime.now()` (when charge computed) |
-| `charge` | FLOAT | TiB-yr × rate (today rate=1) |
-| `terabyte_year` | FLOAT | from `tib_years()` |
-| `activity_date` | DATETIME | mirror of `disk_activity.activity_date` |
-
-The unique index on `disk_activity_id` enforces that a `disk_activity`
-row has at most one `disk_charge` row. Rows whose directory cannot be
-resolved to an account stay tier-1-only (disk_activity present,
-disk_charge absent).
-
-### Charging-interval semantics (identical to today)
-
-The "dynamic accounting interval" used by `disk_charge_summary` today
-is the per-row `reporting_interval` (column 7 of `acct.glade`,
-typically `7` days). The importer feeds it into
-`tib_years(bytes, reporting_interval)`
-(`src/sam/summaries/disk_summaries.py`) at WRITE time — the resulting
-`terabyte_years` / `charges` are persisted; the raw interval is not
-carried on the summary row.
-
-Layer 2 keeps that exactly:
-
-- `disk_charge.terabyte_year` and `disk_charge.charge` are computed
-  by the same `tib_years()` call, with the same per-row
-  `reporting_interval` from the input file.
-- `disk_charge_summary` continues to roll up via `_group_disk_entries`
-  and is unaffected (Layer 1 stays).
-- Bonus: the raw `reporting_interval` is **persisted on
-  `disk_activity.reporting_interval`** — a column the summary table
-  doesn't have. That makes per-row audits / recomputation feasible
-  without re-reading the input snapshot, and is exactly how
-  legacy SAM's `calculateDiskChargeSummaries` named query would
-  recompute summaries from scratch.
-- The `DISK_CHARGING_TIB_EPOCH` cutover guard (`src/sam/summaries/disk_summaries.py`)
-  stays at the importer level; both tier-2 and tier-3 writes are
-  gated by the same epoch check that's already in place
-  (`commands.py:450–458`).
-
-### Existing helpers to reuse
-
-- `_resolve_for_row` (`src/cli/accounting/commands.py:516–535`) —
-  already resolves directory_path → ProjectDirectory → Project →
-  Account.
-- `_resolve_user` (`src/sam/manage/summaries.py:36–50`) — username +
-  unix_uid → User.
-- `tib_years()` (`src/sam/summaries/disk_summaries.py`) — bytes ×
-  reporting_interval → TiB-years.
-- `_DISK_ROLLUP_USERNAMES` constant (`src/cli/accounting/commands.py:60`)
-  — sentinel set including `'total'`.
-- `mark_disk_snapshot_current()` (`src/sam/summaries/disk_summaries.py`)
-  — already advances the current-snapshot pointer.
-- `management_transaction` context manager.
+- `_run_disk()` lives in `src/cli/accounting/commands.py` (around lines
+  401–777) on a runner class. `_resolve_for_row` is a **closure**
+  defined at lines 571–590, sharing `pd_path_to_project`,
+  `account_cache`, `self.session`, and `resource` with the surrounding
+  scope. The new writer must be a method on the same class so it
+  inherits this state.
+- Insertion point for tier-1/tier-2 writes: **after** the `if dry_run:
+  return 0` gate at line 599, **before** the existing tier-3 delete at
+  line 601. This way `--dry-run` skips tier-1/tier-2 automatically.
+- `DiskActivity` ORM (`src/sam/activity/disk.py:9-55`) declares only
+  `ix_disk_activity_directory` and `ix_disk_activity_cos`, but the
+  live DB carries `disk_activity_unique_idx UNIQUE (directory_name,
+  username, activity_date, projcode)`. **ORM drift** — the model must
+  add `Index('disk_activity_unique_idx', ..., unique=True)` so
+  `tests/integration/test_schema_validation.py` stays green.
+- `DiskCharge.disk_activity_id` is UNIQUE (line 66) → enforces 1:1.
+  Prod FK `fk_disk_charge_disk_activity` is plain RESTRICT
+  (verified via `SHOW CREATE TABLE disk_charge` on
+  `sam-sql.ucar.edu`) — **no `ON DELETE CASCADE`**, so the ORM
+  matches prod and stays cascade-free. Idempotency delete is
+  two-step: delete `disk_charge` rows first, then `disk_activity`.
+- `disk_cos_id = 0` (description "No class of service") exists in the
+  seed — no runtime guard needed.
+- `DiskUsageEntry` (`src/cli/accounting/disk_usage/base.py:10-47`) has
+  all the attributes the writer needs: `directory_path`, `username`,
+  `projcode`, `activity_date`, `reporting_interval`, `bytes`,
+  `number_of_files`, `terabyte_years`, `charges`, `user_override`,
+  `account_override`, `act_username`.
+- Tree node from `build_disk_subtree` (`src/sam/queries/disk_usage.py:358-462`)
+  already attaches `fileset_paths: list[str]` (line 423-429) — Layer 2
+  enriches this into a per-fileset payload when >1 fileset.
 
 ## Design
 
-### 1) New writer: `_write_disk_activity_and_charge(entries, ...)`
+### 1. Fix ORM schema drift on `DiskActivity`
 
-Add to `src/cli/accounting/commands.py`. Runs once per import, after
-charging math, **before** the existing disk_charge_summary aggregation
-+ upsert. Pseudocode:
+`src/sam/activity/disk.py:13-16` — add the unique index that the live
+schema enforces:
 
+```python
+__table_args__ = (
+    Index('disk_activity_unique_idx',
+          'directory_name', 'username', 'activity_date', 'projcode',
+          unique=True),
+    Index('ix_disk_activity_directory', 'directory_name'),
+    Index('ix_disk_activity_cos', 'disk_cos_id'),
+)
 ```
-for e in entries:
-    # Skip synthetic gap rows (`<unidentified>`) — they don't bind to
-    # a real directory.
-    if e.user_override is not None:
-        continue
-    # Skip rollup-sentinel rows (Quasar 'total') — they're not
-    # per-fileset by construction.
-    if e.username in _DISK_ROLLUP_USERNAMES:
-        continue
 
-    activity = upsert_disk_activity(
-        session,
-        directory_name=e.directory_path,
-        username=e.username,
-        projcode=e.projcode,        # the input file's label (e.g. 'cesm')
-        activity_date=e.activity_date,
-        reporting_interval=e.reporting_interval,
-        bytes=e.bytes,
-        file_size_total=e.bytes,
-        number_of_files=e.number_of_files,
-        disk_cos_id=0,
-        resource_name=resource_name,
-        load_date=now,
-        processing_status=True,    # flip to False / set error_comment if resolve fails
+`tests/integration/test_schema_validation.py` will now compare the
+model and the DB index list 1:1.
+
+### 2. New upsert helpers in `src/sam/manage/summaries.py`
+
+Place next to `upsert_disk_charge_summary`. Both follow the existing
+return shape `(record, 'created' | 'updated')`.
+
+```python
+def upsert_disk_activity(
+    session, *,
+    directory_name: str,
+    username: str,
+    projcode: Optional[str],
+    activity_date: datetime,
+    reporting_interval: int,
+    bytes: int,
+    number_of_files: Optional[int],
+    resource_name: str,
+    load_date: datetime,
+    disk_cos_id: int = 0,
+    error_comment: Optional[str] = None,
+    processing_status: bool = True,
+) -> Tuple[DiskActivity, str]:
+    """SELECT by (directory_name, username, activity_date, projcode);
+    INSERT or UPDATE in place. file_size_total is mirrored from bytes
+    (legacy column kept for parity)."""
+
+def upsert_disk_charge(
+    session, *,
+    disk_activity_id: int,
+    account_id: int,
+    user_id: int,
+    charge_date: datetime,
+    activity_date: datetime,
+    terabyte_year: float,
+    charge: float,
+) -> Tuple[DiskCharge, str]:
+    """SELECT by disk_activity_id (UNIQUE); INSERT or UPDATE."""
+```
+
+No DB-resolve logic in these helpers — the caller supplies all FKs
+already resolved (consistent with how `upsert_disk_charge_summary`
+already accepts pre-resolved `user`, `project`, `account`).
+
+### 3. New writer method `_write_disk_activity_and_charge()`
+
+Add to the same runner class as `_run_disk` in
+`src/cli/accounting/commands.py`. Method, not closure, but called
+from `_run_disk` after the closure scope so it can take the closure
+as a callable parameter:
+
+```python
+def _write_disk_activity_and_charge(
+    self,
+    entries: list[DiskUsageEntry],
+    *,
+    snap_date: date,
+    resource,
+    resource_name: str,
+    resolve_for_row: Callable,  # the _resolve_for_row closure
+    chunk_size: int,
+    skip_errors: bool,
+) -> tuple[int, int, int]:  # (n_activity, n_charge, n_skipped)
+    now = datetime.now()
+
+    # --- Idempotency: delete pre-existing tier-1/tier-2 for this
+    # (resource_name, snap_date). FK has no CASCADE → two-step.
+    activity_ids_subq = (
+        self.session.query(DiskActivity.disk_activity_id)
+        .filter(DiskActivity.activity_date == snap_date)
+        .filter(DiskActivity.resource_name == resource_name)
+        .subquery()
     )
+    with management_transaction(self.session):
+        self.session.query(DiskCharge).filter(
+            DiskCharge.disk_activity_id.in_(select(activity_ids_subq))
+        ).delete(synchronize_session=False)
+        self.session.query(DiskActivity).filter(
+            DiskActivity.activity_date == snap_date,
+            DiskActivity.resource_name == resource_name,
+        ).delete(synchronize_session=False)
 
-    # Tier 2: only when resolve succeeds.
-    ok, project, account = _resolve_for_row(e)
-    if not ok:
-        continue
-    user = _resolve_user(session, e.username, None)
-    upsert_disk_charge(
-        session,
-        disk_activity_id=activity.disk_activity_id,
-        account_id=account.account_id,
-        user_id=user.user_id,
-        charge_date=now,
-        activity_date=e.activity_date,
-        terabyte_year=e.terabyte_years,
-        charge=e.charges,
+    # --- Chunked write
+    for chunk in _chunked(entries, chunk_size):
+        with management_transaction(self.session):
+            for e in chunk:
+                # Skip synthetic gap rows — no real directory.
+                if e.user_override is not None:
+                    continue
+                # Skip rollup-sentinel rows — not per-fileset.
+                if e.username in _DISK_ROLLUP_USERNAMES:
+                    continue
+
+                # Tier-2 resolution first; result drives processing_status.
+                ok, project, account = resolve_for_row(e)
+                user = None
+                err = None
+                if not ok:
+                    err = f"unresolved: projcode={e.projcode!r} path={e.directory_path!r}"
+                else:
+                    try:
+                        user = _resolve_user(self.session, e.username, None)
+                    except ValueError as exc:
+                        err = str(exc)
+
+                activity, _ = upsert_disk_activity(
+                    self.session,
+                    directory_name=e.directory_path,
+                    username=e.username,
+                    projcode=e.projcode,
+                    activity_date=e.activity_date,
+                    reporting_interval=e.reporting_interval,
+                    bytes=e.bytes,
+                    number_of_files=e.number_of_files,
+                    resource_name=resource_name,
+                    load_date=now,
+                    disk_cos_id=0,
+                    error_comment=err,
+                    processing_status=err is None,
+                )
+                n_activity += 1
+
+                if err is not None:
+                    n_skipped += 1
+                    continue
+
+                upsert_disk_charge(
+                    self.session,
+                    disk_activity_id=activity.disk_activity_id,
+                    account_id=account.account_id,
+                    user_id=user.user_id,
+                    charge_date=now,
+                    activity_date=e.activity_date,
+                    terabyte_year=e.terabyte_years,
+                    charge=e.charges,
+                )
+                n_charge += 1
+
+    return n_activity, n_charge, n_skipped
+```
+
+`_resolve_user` is already imported in `commands.py` (or trivially
+importable from `sam.manage.summaries`). `select` from sqlalchemy.
+
+### 4. Wire-up in `_run_disk()`
+
+Insert one block at `commands.py` between line 599 (`return 0` on
+dry-run) and line 601 (existing tier-3 delete):
+
+```python
+# ---- 7d. Tier-1 / Tier-2: populate disk_activity + disk_charge -----
+n_act, n_ch, n_skip_tier12 = self._write_disk_activity_and_charge(
+    entries,
+    snap_date=snap_date,
+    resource=resource,
+    resource_name=resource_name,
+    resolve_for_row=_resolve_for_row,
+    chunk_size=chunk_size,
+    skip_errors=skip_errors,
+)
+if self.ctx.verbose:
+    self.console.print(
+        f"[dim]Wrote {n_act} disk_activity / {n_ch} disk_charge "
+        f"row(s) for {resource_name} on {snap_date} "
+        f"({n_skip_tier12} unresolved → tier-1 only).[/dim]"
     )
 ```
 
-**Idempotency**: before the loop, DELETE rows for
-`(activity_date == snap_date, resource_name == X)` from `disk_activity`
-(cascades to `disk_charge` via FK if configured; otherwise delete
-explicitly first). Same pattern the disk_charge_summary path already
-uses (`commands.py:546–580`). Re-running the same snapshot replaces
-all tier-1/tier-2 rows for that day on that resource.
+Note: the writer iterates **raw `entries`** (per-fileset), not the
+post-`_group_disk_entries` rollup. That's the whole point — tier-1
+keeps directory granularity that tier-3 sums away.
 
-The unique constraint
-`(directory_name, username, activity_date, projcode)` on
-`disk_activity` is the upsert natural key. Place these helpers in
-`src/sam/manage/summaries.py` next to `upsert_disk_charge_summary`:
+### 5. Per-directory query in `src/sam/queries/disk_usage.py`
 
-- `upsert_disk_activity(session, *, directory_name, username, projcode, activity_date, ...) -> Tuple[DiskActivity, str]`
-- `upsert_disk_charge(session, *, disk_activity_id, account_id, user_id, ...) -> Tuple[DiskCharge, str]`
-
-Both follow the existing pattern: SELECT by natural key, INSERT-or-UPDATE,
-return `(record, 'created' | 'updated')`.
-
-### 2) Wire-up in `_run_disk()` (`src/cli/accounting/commands.py`)
-
-Insert one block between the charging-math pass (currently line 491–493)
-and the dry-run table check (currently line 537). Order:
-
-1. Parse entries (existing).
-2. Build gap rows (existing).
-3. Charging math (existing).
-4. **NEW: write tier-1 + tier-2** via `_write_disk_activity_and_charge()`.
-5. Dry-run table (existing — show per-fileset rows).
-6. Delete existing `disk_charge_summary` rows for snap (existing).
-7. `_group_disk_entries()` Layer-1 aggregation (existing).
-8. Chunked upsert to `disk_charge_summary` (existing).
-9. Mark snapshot current (existing).
-
-`--dry-run` skips both the new tier-1/tier-2 write AND the existing
-tier-3 write — same semantics.
-
-The new write needs its own `management_transaction` chunk (one chunk
-per ~1000 entries) for parity with the existing `disk_charge_summary`
-chunked upsert.
-
-### 3) Per-directory query — `get_directory_usage_at(...)`
-
-Add to `src/sam/queries/disk_usage.py`:
-
-```
+```python
 def get_directory_usage_at(
     session, *,
     project_id: int,
     resource_name: str,
     activity_date: date,
-) -> List[Dict]:
-    """Per-directory snapshot for one (project, resource, date)."""
-    rows = session.query(
-        DiskActivity.directory_name,
-        func.sum(DiskActivity.bytes).label('bytes'),
-        func.sum(DiskActivity.number_of_files).label('files'),
-        func.count(DiskActivity.disk_activity_id).label('row_count'),
-    ).join(DiskCharge, DiskCharge.disk_activity_id == DiskActivity.disk_activity_id) \
-     .join(Account, Account.account_id == DiskCharge.account_id) \
-     .filter(
-        Account.project_id == project_id,
-        DiskActivity.resource_name == resource_name,
-        DiskActivity.activity_date == activity_date,
-    ).group_by(DiskActivity.directory_name).all()
-    return [...]
+) -> list[dict]:
+    """Per-directory snapshot for one (project, resource, date).
+    Uses tier-1/tier-2 join so unresolved rows are excluded."""
+    rows = (
+        session.query(
+            DiskActivity.directory_name,
+            func.sum(DiskActivity.bytes).label('bytes'),
+            func.sum(DiskActivity.number_of_files).label('files'),
+        )
+        .join(DiskCharge,
+              DiskCharge.disk_activity_id == DiskActivity.disk_activity_id)
+        .join(Account, Account.account_id == DiskCharge.account_id)
+        .filter(
+            Account.project_id == project_id,
+            DiskActivity.resource_name == resource_name,
+            DiskActivity.activity_date == activity_date,
+        )
+        .group_by(DiskActivity.directory_name)
+        .all()
+    )
+    return [
+        {'name': r.directory_name, 'bytes': int(r.bytes or 0),
+         'files': int(r.files or 0)}
+        for r in rows
+    ]
+
+
+def bulk_get_directory_usage_at(
+    session, *,
+    project_resource_pairs: list[tuple[int, str]],
+    activity_date: date,
+) -> dict[tuple[int, str], list[dict]]:
+    """Bulk variant — single query for many (project_id, resource_name)
+    pairs. Mirrors `bulk_get_subtree_disk_capacity`'s pattern: build
+    one IN-list, GROUP BY (project_id, resource_name, directory_name),
+    bucket results into the result dict."""
 ```
 
-Bulk variant for many `(project_id, resource_name)` pairs at once
-(mirrors `bulk_get_subtree_disk_capacity`'s pattern).
+### 6. Dashboard wiring — `build_disk_subtree` enrichment
 
-### 4) Dashboard wiring — `build_disk_subtree` (per-fileset display)
+In `src/sam/queries/disk_usage.py:358-462`, after the existing
+fileset-paths fetch (line 423-429), add a per-fileset bytes lookup
+when the project has >1 active `ProjectDirectory` on this resource.
+Single-fileset projects keep the current path-list rendering
+(unchanged).
 
-In `src/sam/queries/disk_usage.py`, when assembling each tree node's
-payload, attach a `directories: [{'name', 'bytes', 'files'}]` list
-when the project has >1 ProjectDirectory active on this resource.
-For projects with exactly one (the common case), keep the current
-single-line render path unchanged.
+Replace `fileset_paths: list[str]` with a richer payload only when
+needed:
 
-Single-fileset tree nodes: identical to today (one bytes badge).
-Multi-fileset tree nodes: render the per-directory list under the
-node header. Template: `src/webapp/templates/dashboards/user/resource_details_disk.html`.
+```python
+# Current:
+node['fileset_paths'] = dirs_by_project_id.get(p.project_id, [])
 
-### 5) Backfill
-
-Re-run the existing CLI loop after deploy:
-
+# Layer 2:
+paths = dirs_by_project_id.get(p.project_id, [])
+node['fileset_paths'] = paths
+if len(paths) > 1 and node.get('activity_date'):
+    node['directories'] = bulk_lookup.get(
+        (p.project_id, resource_name), []
+    )
 ```
+
+`bulk_lookup` is computed once outside the per-node loop using
+`bulk_get_directory_usage_at` for all `(project_id, resource_name)`
+pairs that have multi-fileset projects. Single-fileset nodes pay
+nothing.
+
+### 7. Template rendering
+
+`src/webapp/templates/dashboards/user/resource_details_disk.html` —
+extend `render_disk_tree_node` macro (lines 9-59). When
+`node.directories` is present, render a small list under the node
+header with each directory's bytes badge:
+
+```jinja
+{% if node.directories %}
+  <ul class="disk-fileset-list">
+    {% for d in node.directories %}
+      <li><span class="path">{{ d.name }}</span>
+          <span class="bytes">{{ d.bytes | fmt_size }}</span>
+          <span class="files">{{ d.files | fmt_number }} files</span></li>
+    {% endfor %}
+  </ul>
+{% endif %}
+```
+
+Single-fileset projects (no `directories` key) render unchanged.
+
+### 8. Backfill
+
+After deploy, re-run the existing CLI loop over local snapshots:
+
+```bash
+source etc/config_env.sh
 for rep in data/project_user_usage/acct.glade.2026-*; do
     sam-admin accounting --resource Campaign_Store --disk \
-        --user-usage $rep --verbose --skip-errors
+        --user-usage "$rep" --verbose --skip-errors
 done
 for rep in data/project_user_usage/acct.quasar.2026-*; do
     sam-admin accounting --resource Quasar --disk \
-        --user-usage $rep --verbose --skip-errors
+        --user-usage "$rep" --verbose --skip-errors
 done
 ```
 
-Idempotent under the per-resource per-date delete semantics.
-Each snapshot now writes 3 tables: `disk_activity`, `disk_charge`,
-`disk_charge_summary`. Old snapshots remain tier-3-only until they're
-re-imported.
-
-### 6) Production rollout
-
-1. Deploy code.
-2. Confirm prod's `disk_activity` unique index matches
-   `(directory_name, username, activity_date, projcode)` (legacy
-   schema; should be already present given prod has 5.3M rows under
-   it, but verify via `SHOW INDEX FROM disk_activity` before flipping
-   on the new writer).
-3. Re-import the latest 1–2 snapshots on prod via the existing CLI
-   loop. The new writer appends to `disk_activity` alongside legacy's
-   continuing writes — coexistence is fine because of the unique
-   key.
-4. Spot-check `disk_activity` row counts before/after for a known
-   multi-fileset project: e.g. P43713000 should gain ~4 csfs1 rows
-   per snapshot.
-5. Visit the disk Resource Details page for P43713000 and confirm
-   the tree node now shows per-fileset bytes.
+Each snapshot now writes 3 tables. Idempotent under the
+per-(resource, date) two-step delete.
 
 ## Files
 
 ### Modified
 
+- `src/sam/activity/disk.py` — add `disk_activity_unique_idx` UNIQUE
+  index to `DiskActivity.__table_args__` (drift fix).
 - `src/sam/manage/summaries.py` — add `upsert_disk_activity()` and
-  `upsert_disk_charge()` helpers next to `upsert_disk_charge_summary()`.
+  `upsert_disk_charge()` next to `upsert_disk_charge_summary()`.
 - `src/cli/accounting/commands.py` — add `_write_disk_activity_and_charge()`
-  helper; wire into `_run_disk()` between charging math and dry-run.
-- `src/sam/queries/disk_usage.py` — add `get_directory_usage_at()` and
-  its bulk variant; extend `build_disk_subtree` to attach per-directory
-  payloads when >1 fileset on the resource.
+  method on the disk runner class; insert call between dry-run gate
+  (line 599) and existing tier-3 delete (line 601).
+- `src/sam/queries/disk_usage.py` — add `get_directory_usage_at()` +
+  `bulk_get_directory_usage_at()`; extend `build_disk_subtree` to
+  attach `directories` payload for multi-fileset nodes; mirror in
+  `bulk_get_subtree_disk_capacity` if it feeds the dashboard.
 - `src/webapp/templates/dashboards/user/resource_details_disk.html` —
   per-fileset render under multi-fileset tree nodes.
-- `tests/unit/test_accounting_disk_admin.py` — new tests:
-  - `test_import_writes_disk_activity_per_directory`
-    (multi-directory project: 4 input rows → 4 disk_activity rows
-    + 4 disk_charge rows, each carrying its own bytes).
-  - `test_disk_activity_re_import_replaces_per_resource_date`
-    (idempotency: second run for same date deletes + re-inserts,
-    not append).
-  - `test_disk_activity_skipped_for_unidentified_and_total`
-    (synthetic rows produce no disk_activity row).
-- `tests/unit/test_disk_usage_queries.py` — new
-  `TestPerDirectoryQuery` class:
-  - `test_get_directory_usage_at_returns_per_directory_rows`
+
+### New tests
+
+- `tests/unit/test_accounting_disk_admin.py`:
+  - `test_import_writes_disk_activity_per_directory` — multi-directory
+    project, 4 input rows → 4 disk_activity rows + 4 disk_charge rows.
+  - `test_disk_activity_re_import_replaces_per_resource_date` — second
+    run for same (resource, date) deletes + re-inserts, no duplicates.
+  - `test_disk_activity_skipped_for_unidentified_and_total` — gap rows
+    and rollup sentinel rows produce no tier-1 row.
+  - `test_disk_activity_unresolved_writes_tier1_only` — unresolved
+    directory writes disk_activity with `processing_status=False` and
+    no disk_charge row.
+- `tests/unit/test_disk_usage_queries.py`:
+  - `test_get_directory_usage_at_returns_per_directory_rows`.
   - `test_bulk_per_directory_query_pairs`.
 - `tests/unit/test_query_functions.py` — extend
-  `TestDiskCapacityInDashboardData` with a multi-fileset assertion
-  (the project's tree-node payload now carries `directories`).
+  `TestDiskCapacityInDashboardData` with a multi-fileset assertion:
+  the project's tree-node payload now carries `directories`.
 
 ### Reused (no change)
 
-- `_group_disk_entries()` and the disk_charge_summary upsert path
-  — Layer 1 stays exactly as it is.
-- `Account.current_disk_usage()` — single-account read; unaffected.
-- `Project.is_active`, `ProjectDirectory.is_active` hybrids.
+- `_group_disk_entries()` and the `disk_charge_summary` upsert path —
+  Layer 1 stays.
+- `Account.current_disk_usage()`, `Project.is_active`,
+  `ProjectDirectory.is_active` hybrids.
 - `bulk_get_subtree_disk_capacity()` — provides the project-level
-  capacity used for the headline bar.
-
-### Companion doc to update
-
-- `docs/plans/DISK_PER_FILESET.md` — replace its "schema add of
-  `directory_id`" sketch with a pointer to this plan and a note
-  that we chose the no-schema-change path. Mark Layer 2 as DONE
-  once it ships.
+  capacity for the headline bar (still tier-3-fed).
+- `_resolve_for_row` closure, `_resolve_user`, `tib_years`,
+  `mark_disk_snapshot_current`, `_DISK_ROLLUP_USERNAMES`,
+  `DISK_CHARGING_TIB_EPOCH`.
 
 ## Verification
 
 ### Unit / integration
 
-```
+```bash
 source etc/config_env.sh
-pytest tests/unit/test_accounting_disk_admin.py tests/unit/test_disk_usage_queries.py tests/unit/test_query_functions.py -v
-pytest -m perf -n 0 -v
+pytest tests/unit/test_accounting_disk_admin.py \
+       tests/unit/test_disk_usage_queries.py \
+       tests/unit/test_query_functions.py \
+       tests/integration/test_schema_validation.py -v
 ```
 
-The new tests are the load-bearing ones. Existing perf budgets must
-still hold; the new writer adds a fixed ~2 queries per chunk (delete
-+ batched insert), independent of project count.
+The schema-validation test catches any DiskActivity ORM/DB drift
+(post-drift-fix it should still pass). Per-perf budgets must hold —
+the new writer adds ~2 queries per chunk (delete + batched insert),
+independent of project count.
 
 ### Live sanity check
 
-After local re-import of 2026-04-25:
+After local re-import of one snapshot:
 
-```
-mysql -h 127.0.0.1 -u root -proot sam -e "
-  SELECT directory_name, SUM(bytes), SUM(number_of_files), COUNT(*)
-  FROM disk_activity
-  WHERE activity_date='2026-04-25'
-    AND resource_name='Campaign_Store'
-    AND projcode IN ('p43713000', 'P43713000', 'decs', 'cesm')
-  GROUP BY directory_name
-  ORDER BY 2 DESC;"
-```
+```sql
+-- Per-fileset rows present for a multi-fileset project
+SELECT directory_name, SUM(bytes), SUM(number_of_files), COUNT(*)
+FROM disk_activity
+WHERE activity_date = (SELECT MAX(activity_date) FROM disk_activity)
+  AND resource_name = 'Campaign_Store'
+GROUP BY directory_name
+ORDER BY 2 DESC LIMIT 20;
 
-Expect 4 rows for P43713000's csfs1 filesets (data, decsdata,
-work, transfer), bytes summing to ~19 PiB.
-
-```
-mysql -h 127.0.0.1 -u root -proot sam -e "
-  SELECT COUNT(*) FROM disk_charge
-  WHERE activity_date='2026-04-25';"
-```
-
-Expect ~equal to the disk_activity row count for that date (1:1
-modulo unresolved rows).
-
-Webapp Resource Details for P43713000 on Campaign_Store:
-
-- Tree node lists 4 csfs1 filesets, each with its own bytes badge.
-- Per-fileset bytes sum to the project-level bar value.
-- Quasar / Stratus paths do **not** appear in the Campaign_Store
-  view (filtered by `resource_name` on the disk_activity side).
-
-### Production sanity check
-
-Compare prod `disk_activity` row counts before / after the
-post-deploy backfill of one snapshot:
-
-```
-SELECT COUNT(*) FROM disk_activity WHERE activity_date='YYYY-MM-DD';
+-- 1:1 with disk_charge for resolved rows
+SELECT
+  (SELECT COUNT(*) FROM disk_activity
+   WHERE activity_date = :d AND resource_name = 'Campaign_Store'
+     AND processing_status = 1) AS n_resolved,
+  (SELECT COUNT(*) FROM disk_charge dc
+   JOIN disk_activity da ON da.disk_activity_id = dc.disk_activity_id
+   WHERE da.activity_date = :d AND da.resource_name = 'Campaign_Store')
+   AS n_charges;
 ```
 
-Expect a step-up matching the per-(user, fileset) row count from
-that day's `acct.glade` file.
+Webapp Resource Details for a multi-fileset project on Campaign_Store:
+
+- Tree node lists each fileset with its own bytes badge.
+- Per-fileset bytes sum to the project-level bar value (off by
+  rounding only).
+- Quasar / Stratus paths do not appear in the Campaign_Store view
+  (filtered by `resource_name`).
 
 ## Risks and mitigations
 
 | Risk | Mitigation |
 |---|---|
-| Coexistence with legacy writer on prod | The unique key
-`(directory_name, username, activity_date, projcode)` is shared. The
-new writer's UPSERT matches existing rows and updates them with the
-same data — no duplication. Verify via row-count delta before/after
-the first prod backfill. |
-| Row volume blow-up | ~2K rows/snapshot/resource × ~52 snapshots/year
-≈ 100K disk_activity rows/year/resource. Prod already runs at this
-scale (5.3M rows since 2012). Negligible. |
-| disk_cos_id=0 missing on a fresh DB | Add an idempotent
-`session.query(DiskCos).filter_by(disk_cos_id=0).first() or
-session.add(DiskCos(disk_cos_id=0, description='No class of service'))`
-guard at the top of `_write_disk_activity_and_charge()`. |
-| Quasar 'total' rollup rows have no real directory | Skip them at
-tier-1 (they remain tier-3-only via the existing rollup path). The
-disk Resource Details view falls back to project-level capacity for
-those projects, same as today. |
-| `<unidentified>` gap rows have no real directory | Same — skip at
-tier-1. |
-| Test-DB schema drift on disk_activity columns | Run
-`tests/integration/test_schema_validation.py` first; it will fail
-if the test snapshot's `disk_activity` differs from prod or our ORM. |
-| `_resolve_user` failures inside the new write loop | Tier-1 row
-still gets written with `processing_status=False` and
-`error_comment='User <X> not found'`; tier-2 row is skipped.
-Audit trail preserved without aborting the import. |
+| Coexistence with prod's legacy writer | UNIQUE key is shared; the new UPSERT matches existing rows and updates them. Verify row-count delta on the first prod backfill before/after. |
+| Row volume | ~2K rows/snapshot/resource × ~52 snapshots/year ≈ 100K disk_activity rows/year/resource. Prod already runs at 5.3M since 2012. Negligible. |
+| FK without CASCADE → orphan disk_charge rows on partial failure | Idempotency block runs both deletes inside one `management_transaction` — atomic. |
+| `_resolve_user` failure mid-write | Tier-1 row written with `processing_status=False`, error in `error_comment`; tier-2 skipped. Audit trail preserved without aborting. |
+| ORM drift on `DiskActivity` indexes | Drift fix in step 1 + `tests/integration/test_schema_validation.py` catches future drift. |
+| Performance of multi-fileset bulk query in dashboard | Single bulk query keyed by `(project_id, resource_name, directory_name)` with one JOIN. Cap at projects with >1 fileset; everyone else pays nothing. |
 
 ## Out of scope
 
-- Adding `directory_id` or any new column to `disk_charge_summary`.
-- Adding `resource_id` to `ProjectDirectory`.
-- Cross-resource fileset views (e.g. show all of P43713000's
-  storage on Quasar+Stratus+Campaign_Store on one page).
-- Rewriting historical snapshots' `disk_charge_summary` rollups
-  on top of disk_activity (legacy-style `calculateDiskChargeSummaries`
-  recomputation). Layer 1 already gives us the rollup; we don't need
-  to recompute it.
-- Per-fileset stacked-area chart (today's chart is per-user; the
-  new infra makes per-fileset possible but no UX request for it
-  yet).
+- Adding `directory_id` to `disk_charge_summary` (the alternative
+  schema-change path in `docs/plans/DISK_PER_FILESET.md`).
+- Cross-resource fileset views.
+- Recomputing historical `disk_charge_summary` from disk_activity
+  (legacy `calculateDiskChargeSummaries` path).
+- Per-fileset stacked-area chart.
 - Renaming `terabyte_years` → `tebibyte_years`.
 
-## When to pick this up
+## Companion doc updates
 
-Trigger conditions, any of:
-
-1. An operator hits a "which fileset is filling up?" question that
-   today's project-level capacity bar can't answer.
-2. The `--reconcile-quotas` CLI surface starts showing meaningful
-   quota gaps that would benefit from per-fileset DB-side queries
-   instead of re-reading `cs_usage.json` each time.
-3. A multi-fileset project enters the dashboard's top-N attention
-   and the lack of per-fileset detail is a visible UX wart.
-
-Estimated effort: ~1 focused day (helpers + writer + dashboard
-wiring + tests + backfill verification). Smaller than the
-schema-add path because no DDL coordination with prod.
+- `docs/plans/DISK_PER_FILESET.md` — replace the "schema-add" sketch
+  with a pointer to this plan and a note that we chose the
+  no-schema-change path.
+- `docs/plans/DISK_ACTIVITY.md` — mark "DONE" once Layer 2 ships and
+  this plan is verified end-to-end.

--- a/src/cli/accounting/commands.py
+++ b/src/cli/accounting/commands.py
@@ -856,104 +856,116 @@ class AccountingAdminCommand(BaseCommand):
             for i in range(0, len(writable), chunk_size)
         ]
 
-        for chunk_idx, chunk in enumerate(chunks, start=1):
-            try:
-                with management_transaction(self.session):
-                    if chunk_idx == 1:
-                        # Idempotency delete piggybacks the first chunk's
-                        # transaction. Two-step (FK has no CASCADE).
-                        existing_ids = [
-                            row[0] for row in (
-                                self.session.query(
-                                    DiskActivity.disk_activity_id
+        with Progress(
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+            console=self.console,
+        ) as progress:
+            task = progress.add_task(
+                f"Writing {resource_name} disk_activity/disk_charge...",
+                total=len(writable),
+            )
+            for chunk_idx, chunk in enumerate(chunks, start=1):
+                try:
+                    with management_transaction(self.session):
+                        if chunk_idx == 1:
+                            # Idempotency delete piggybacks the first chunk's
+                            # transaction. Two-step (FK has no CASCADE).
+                            existing_ids = [
+                                row[0] for row in (
+                                    self.session.query(
+                                        DiskActivity.disk_activity_id
+                                    )
+                                    .filter(
+                                        DiskActivity.activity_date == snap_date,
+                                        DiskActivity.resource_name == resource_name,
+                                    )
+                                    .all()
                                 )
-                                .filter(
-                                    DiskActivity.activity_date == snap_date,
-                                    DiskActivity.resource_name == resource_name,
+                            ]
+                            if existing_ids:
+                                self.session.query(DiskCharge).filter(
+                                    DiskCharge.disk_activity_id.in_(existing_ids)
+                                ).delete(synchronize_session=False)
+                                self.session.query(DiskActivity).filter(
+                                    DiskActivity.disk_activity_id.in_(existing_ids)
+                                ).delete(synchronize_session=False)
+                        for e in chunk:
+                            progress.advance(task)
+                            # Resolve project/account first; failure is
+                            # captured as audit metadata on the tier-1 row.
+                            ok, _project, account = resolve_for_row(e)
+                            user = None
+                            err = None
+                            if not ok:
+                                err = (
+                                    f"unresolved: projcode={e.projcode!r} "
+                                    f"path={e.directory_path!r}"
                                 )
-                                .all()
-                            )
-                        ]
-                        if existing_ids:
-                            self.session.query(DiskCharge).filter(
-                                DiskCharge.disk_activity_id.in_(existing_ids)
-                            ).delete(synchronize_session=False)
-                            self.session.query(DiskActivity).filter(
-                                DiskActivity.disk_activity_id.in_(existing_ids)
-                            ).delete(synchronize_session=False)
-                    for e in chunk:
-                        # Resolve project/account first; failure is
-                        # captured as audit metadata on the tier-1 row.
-                        ok, _project, account = resolve_for_row(e)
-                        user = None
-                        err = None
-                        if not ok:
-                            err = (
-                                f"unresolved: projcode={e.projcode!r} "
-                                f"path={e.directory_path!r}"
-                            )
-                        else:
+                            else:
+                                try:
+                                    user = _resolve_user(
+                                        self.session, e.username, None,
+                                    )
+                                except ValueError as uexc:
+                                    err = str(uexc)
+
                             try:
-                                user = _resolve_user(
-                                    self.session, e.username, None,
+                                activity, _ = upsert_disk_activity(
+                                    self.session,
+                                    directory_name=e.directory_path,
+                                    username=e.username,
+                                    projcode=e.projcode,
+                                    activity_date=e.activity_date,
+                                    reporting_interval=e.reporting_interval,
+                                    bytes=e.bytes,
+                                    number_of_files=e.number_of_files,
+                                    resource_name=resource_name,
+                                    load_date=now,
+                                    disk_cos_id=0,
+                                    error_comment=err,
+                                    processing_status=err is None,
                                 )
-                            except ValueError as uexc:
-                                err = str(uexc)
+                                n_activity += 1
+                            except Exception as exc:  # noqa: BLE001
+                                if not skip_errors:
+                                    raise
+                                if self.ctx.verbose:
+                                    self.console.print(
+                                        f"[yellow]Skip disk_activity: {exc}[/yellow]"
+                                    )
+                                continue
 
-                        try:
-                            activity, _ = upsert_disk_activity(
-                                self.session,
-                                directory_name=e.directory_path,
-                                username=e.username,
-                                projcode=e.projcode,
-                                activity_date=e.activity_date,
-                                reporting_interval=e.reporting_interval,
-                                bytes=e.bytes,
-                                number_of_files=e.number_of_files,
-                                resource_name=resource_name,
-                                load_date=now,
-                                disk_cos_id=0,
-                                error_comment=err,
-                                processing_status=err is None,
-                            )
-                            n_activity += 1
-                        except Exception as exc:  # noqa: BLE001
-                            if not skip_errors:
-                                raise
-                            if self.ctx.verbose:
-                                self.console.print(
-                                    f"[yellow]Skip disk_activity: {exc}[/yellow]"
+                            if err is not None:
+                                n_unresolved += 1
+                                continue
+
+                            try:
+                                upsert_disk_charge(
+                                    self.session,
+                                    disk_activity_id=activity.disk_activity_id,
+                                    account_id=account.account_id,
+                                    user_id=user.user_id,
+                                    charge_date=now,
+                                    activity_date=e.activity_date,
+                                    terabyte_year=e.terabyte_years,
+                                    charge=e.charges,
                                 )
-                            continue
-
-                        if err is not None:
-                            n_unresolved += 1
-                            continue
-
-                        try:
-                            upsert_disk_charge(
-                                self.session,
-                                disk_activity_id=activity.disk_activity_id,
-                                account_id=account.account_id,
-                                user_id=user.user_id,
-                                charge_date=now,
-                                activity_date=e.activity_date,
-                                terabyte_year=e.terabyte_years,
-                                charge=e.charges,
-                            )
-                            n_charge += 1
-                        except Exception as exc:  # noqa: BLE001
-                            if not skip_errors:
-                                raise
-                            if self.ctx.verbose:
-                                self.console.print(
-                                    f"[yellow]Skip disk_charge: {exc}[/yellow]"
-                                )
-            except Exception as exc:  # noqa: BLE001
-                self.console.print(
-                    f"[bold red]Tier-1/Tier-2 chunk {chunk_idx} aborted: {exc}[/bold red]"
-                )
-                raise
+                                n_charge += 1
+                            except Exception as exc:  # noqa: BLE001
+                                if not skip_errors:
+                                    raise
+                                if self.ctx.verbose:
+                                    self.console.print(
+                                        f"[yellow]Skip disk_charge: {exc}[/yellow]"
+                                    )
+                except Exception as exc:  # noqa: BLE001
+                    self.console.print(
+                        f"[bold red]Tier-1/Tier-2 chunk {chunk_idx} aborted: {exc}[/bold red]"
+                    )
+                    raise
 
         return n_activity, n_charge, n_unresolved
 

--- a/src/cli/accounting/commands.py
+++ b/src/cli/accounting/commands.py
@@ -27,7 +27,9 @@ from cli.accounting.path_verifier import (
     PathVerificationError, auto_detect_verifier,
 )
 from sam.manage.summaries import (
+    _resolve_user,
     upsert_comp_charge_summary, upsert_disk_charge_summary,
+    upsert_disk_activity, upsert_disk_charge,
 )
 from sam.manage.transaction import management_transaction
 from sam.manage.allocations import update_allocation
@@ -598,6 +600,31 @@ class AccountingAdminCommand(BaseCommand):
         if dry_run:
             return 0
 
+        # ---- 7a. Tier-1 / Tier-2: populate disk_activity + disk_charge.
+        # Per-fileset granularity that disk_charge_summary can't carry.
+        # Iterates raw entries (pre-_group_disk_entries) so multi-fileset
+        # projects produce one disk_activity row per (directory, user).
+        try:
+            n_act, n_ch, n_skip_tier12 = self._write_disk_activity_and_charge(
+                entries,
+                snap_date=snap_date,
+                resource_name=resource_name,
+                resolve_for_row=_resolve_for_row,
+                chunk_size=chunk_size,
+                skip_errors=skip_errors,
+            )
+        except ValueError as exc:
+            self.console.print(
+                f"[bold red]Tier-1/Tier-2 write aborted: {exc}[/bold red]"
+            )
+            return 2
+        if self.ctx.verbose:
+            self.console.print(
+                f"[dim]Wrote {n_act} disk_activity / {n_ch} disk_charge "
+                f"row(s) for {resource_name} on {snap_date} "
+                f"({n_skip_tier12} unresolved → tier-1 only).[/dim]"
+            )
+
         # ---- 7b. Idempotency: delete pre-existing rows for this
         # (resource, snapshot_date) so a re-run replaces rather than
         # duplicates. Necessary because the legacy ingest left
@@ -775,6 +802,160 @@ class AccountingAdminCommand(BaseCommand):
 
         display_import_summary(self.ctx, n_created, n_updated, n_errors, n_skipped)
         return 0 if n_errors == 0 else 2
+
+    def _write_disk_activity_and_charge(
+        self,
+        entries: list,
+        *,
+        snap_date: date,
+        resource_name: str,
+        resolve_for_row,
+        chunk_size: int,
+        skip_errors: bool,
+    ) -> tuple[int, int, int]:
+        """Tier-1/Tier-2 importer: populate ``disk_activity`` and
+        ``disk_charge`` from per-fileset entries.
+
+        Idempotent per ``(resource_name, snap_date)``: pre-existing rows
+        for this slice are deleted (two-step, since the prod FK has no
+        ``ON DELETE CASCADE``) before re-insert. Skips synthetic gap rows
+        (``user_override`` set) and rollup-sentinel rows
+        (``_DISK_ROLLUP_USERNAMES``) — both are tier-3-only by
+        construction.
+
+        Unresolved rows still get a ``disk_activity`` row with
+        ``processing_status=False`` and ``error_comment`` set; ``disk_charge``
+        is skipped for those (audit trail without tier-2 noise).
+
+        Returns ``(n_activity, n_charge, n_unresolved)``.
+        """
+        from sam.activity.disk import DiskActivity, DiskCharge
+
+        now = datetime.now()
+        n_activity = 0
+        n_charge = 0
+        n_unresolved = 0
+
+        # ---- Filter out tier-1-skip rows ------------------------------
+        # Compute writable BEFORE any DB access so the rollup-only /
+        # gap-only fast path is a true no-op (no probe SELECT).
+        writable = [
+            e for e in entries
+            if e.user_override is None
+            and e.username not in _DISK_ROLLUP_USERNAMES
+        ]
+        if not writable:
+            return 0, 0, 0
+
+        # ---- Idempotency: two-step delete (FK has no CASCADE).
+        # Combined with the chunked write into ONE management_transaction
+        # so nothing churns MySQL SAVEPOINTs in xdist test mode beyond
+        # what's strictly necessary.
+        chunks = [
+            writable[i:i + chunk_size]
+            for i in range(0, len(writable), chunk_size)
+        ]
+
+        for chunk_idx, chunk in enumerate(chunks, start=1):
+            try:
+                with management_transaction(self.session):
+                    if chunk_idx == 1:
+                        # Idempotency delete piggybacks the first chunk's
+                        # transaction. Two-step (FK has no CASCADE).
+                        existing_ids = [
+                            row[0] for row in (
+                                self.session.query(
+                                    DiskActivity.disk_activity_id
+                                )
+                                .filter(
+                                    DiskActivity.activity_date == snap_date,
+                                    DiskActivity.resource_name == resource_name,
+                                )
+                                .all()
+                            )
+                        ]
+                        if existing_ids:
+                            self.session.query(DiskCharge).filter(
+                                DiskCharge.disk_activity_id.in_(existing_ids)
+                            ).delete(synchronize_session=False)
+                            self.session.query(DiskActivity).filter(
+                                DiskActivity.disk_activity_id.in_(existing_ids)
+                            ).delete(synchronize_session=False)
+                    for e in chunk:
+                        # Resolve project/account first; failure is
+                        # captured as audit metadata on the tier-1 row.
+                        ok, _project, account = resolve_for_row(e)
+                        user = None
+                        err = None
+                        if not ok:
+                            err = (
+                                f"unresolved: projcode={e.projcode!r} "
+                                f"path={e.directory_path!r}"
+                            )
+                        else:
+                            try:
+                                user = _resolve_user(
+                                    self.session, e.username, None,
+                                )
+                            except ValueError as uexc:
+                                err = str(uexc)
+
+                        try:
+                            activity, _ = upsert_disk_activity(
+                                self.session,
+                                directory_name=e.directory_path,
+                                username=e.username,
+                                projcode=e.projcode,
+                                activity_date=e.activity_date,
+                                reporting_interval=e.reporting_interval,
+                                bytes=e.bytes,
+                                number_of_files=e.number_of_files,
+                                resource_name=resource_name,
+                                load_date=now,
+                                disk_cos_id=0,
+                                error_comment=err,
+                                processing_status=err is None,
+                            )
+                            n_activity += 1
+                        except Exception as exc:  # noqa: BLE001
+                            if not skip_errors:
+                                raise
+                            if self.ctx.verbose:
+                                self.console.print(
+                                    f"[yellow]Skip disk_activity: {exc}[/yellow]"
+                                )
+                            continue
+
+                        if err is not None:
+                            n_unresolved += 1
+                            continue
+
+                        try:
+                            upsert_disk_charge(
+                                self.session,
+                                disk_activity_id=activity.disk_activity_id,
+                                account_id=account.account_id,
+                                user_id=user.user_id,
+                                charge_date=now,
+                                activity_date=e.activity_date,
+                                terabyte_year=e.terabyte_years,
+                                charge=e.charges,
+                            )
+                            n_charge += 1
+                        except Exception as exc:  # noqa: BLE001
+                            if not skip_errors:
+                                raise
+                            if self.ctx.verbose:
+                                self.console.print(
+                                    f"[yellow]Skip disk_charge: {exc}[/yellow]"
+                                )
+            except Exception as exc:  # noqa: BLE001
+                self.console.print(
+                    f"[bold red]Tier-1/Tier-2 chunk {chunk_idx} aborted: {exc}[/bold red]"
+                )
+                raise
+
+        return n_activity, n_charge, n_unresolved
 
     def _build_unidentified_disk_rows(
         self,

--- a/src/sam/activity/disk.py
+++ b/src/sam/activity/disk.py
@@ -11,6 +11,9 @@ class DiskActivity(Base, TimestampMixin):
     __tablename__ = 'disk_activity'
 
     __table_args__ = (
+        Index('disk_activity_unique_idx',
+              'directory_name', 'username', 'activity_date', 'projcode',
+              unique=True),
         Index('ix_disk_activity_directory', 'directory_name'),
         Index('ix_disk_activity_cos', 'disk_cos_id'),
     )

--- a/src/sam/manage/summaries.py
+++ b/src/sam/manage/summaries.py
@@ -18,7 +18,7 @@ their natural key columns, so concurrent writes for the same natural key
 (date, user, project, ...) bucket may produce duplicate rows. Batch
 processes must serialize writes for the same natural key.
 """
-from datetime import date
+from datetime import date, datetime
 from typing import Optional, Tuple
 
 from sqlalchemy.orm import Session
@@ -28,6 +28,7 @@ from sam.projects.projects import Project
 from sam.resources.resources import Resource
 from sam.resources.machines import Machine, Queue
 from sam.accounting.accounts import Account
+from sam.activity.disk import DiskActivity, DiskCharge
 from sam.summaries.comp_summaries import CompChargeSummary
 from sam.summaries.disk_summaries import DiskChargeSummary
 from sam.summaries.archive_summaries import ArchiveChargeSummary
@@ -431,3 +432,110 @@ def upsert_disk_charge_summary(session: Session, **kwargs) -> Tuple[DiskChargeSu
 def upsert_archive_charge_summary(session: Session, **kwargs) -> Tuple[ArchiveChargeSummary, str]:
     """Insert or update an ArchiveChargeSummary row. Delegates to _upsert_storage_summary."""
     return _upsert_storage_summary(session, ArchiveChargeSummary, **kwargs)
+
+
+def upsert_disk_activity(
+    session: Session,
+    *,
+    directory_name: str,
+    username: str,
+    projcode: Optional[str],
+    activity_date: datetime,
+    reporting_interval: int,
+    bytes: int,
+    number_of_files: Optional[int],
+    resource_name: str,
+    load_date: datetime,
+    disk_cos_id: int = 0,
+    error_comment: Optional[str] = None,
+    processing_status: bool = True,
+) -> Tuple[DiskActivity, str]:
+    """Insert or update a DiskActivity row keyed on
+    (directory_name, username, activity_date, projcode) — the prod
+    UNIQUE constraint. ``file_size_total`` mirrors ``bytes`` (legacy
+    column, kept for parity with the Java collector).
+    """
+    existing = session.query(DiskActivity).filter(
+        DiskActivity.directory_name == directory_name,
+        DiskActivity.username == username,
+        DiskActivity.activity_date == activity_date,
+        DiskActivity.projcode == projcode,
+    ).first()
+
+    if existing is None:
+        record = DiskActivity(
+            directory_name=directory_name,
+            username=username,
+            projcode=projcode,
+            activity_date=activity_date,
+            reporting_interval=reporting_interval,
+            file_size_total=bytes,
+            bytes=bytes,
+            number_of_files=number_of_files,
+            load_date=load_date,
+            disk_cos_id=disk_cos_id,
+            error_comment=error_comment,
+            processing_status=processing_status,
+            resource_name=resource_name,
+        )
+        session.add(record)
+        action = 'created'
+    else:
+        existing.reporting_interval = reporting_interval
+        existing.file_size_total = bytes
+        existing.bytes = bytes
+        existing.number_of_files = number_of_files
+        existing.load_date = load_date
+        existing.disk_cos_id = disk_cos_id
+        existing.error_comment = error_comment
+        existing.processing_status = processing_status
+        existing.resource_name = resource_name
+        record = existing
+        action = 'updated'
+
+    session.flush()
+    return record, action
+
+
+def upsert_disk_charge(
+    session: Session,
+    *,
+    disk_activity_id: int,
+    account_id: int,
+    user_id: int,
+    charge_date: datetime,
+    activity_date: datetime,
+    terabyte_year: float,
+    charge: float,
+) -> Tuple[DiskCharge, str]:
+    """Insert or update a DiskCharge row keyed on disk_activity_id
+    (UNIQUE → 1:1 with DiskActivity).
+    """
+    existing = session.query(DiskCharge).filter(
+        DiskCharge.disk_activity_id == disk_activity_id,
+    ).first()
+
+    if existing is None:
+        record = DiskCharge(
+            disk_activity_id=disk_activity_id,
+            account_id=account_id,
+            user_id=user_id,
+            charge_date=charge_date,
+            activity_date=activity_date,
+            terabyte_year=terabyte_year,
+            charge=charge,
+        )
+        session.add(record)
+        action = 'created'
+    else:
+        existing.account_id = account_id
+        existing.user_id = user_id
+        existing.charge_date = charge_date
+        existing.activity_date = activity_date
+        existing.terabyte_year = terabyte_year
+        existing.charge = charge
+        record = existing
+        action = 'updated'
+
+    session.flush()
+    return record, action

--- a/src/sam/queries/disk_usage.py
+++ b/src/sam/queries/disk_usage.py
@@ -356,6 +356,196 @@ def get_disk_usage_timeseries_by_user(
     return {'dates': dates, 'series': series}
 
 
+def get_disk_usage_timeseries_for_directory(
+    session: Session,
+    *,
+    account_ids: List[int],
+    resource_name: str,
+    directory_name: str,
+    start_date: Optional[_stdlib_date] = None,
+    end_date: Optional[_stdlib_date] = None,
+    top_n: int = 10,
+) -> Dict[str, Any]:
+    """Per-user disk-bytes timeseries for a single fileset.
+
+    Same return shape and ranking semantics as
+    :func:`get_disk_usage_timeseries_by_user`, but reads from
+    ``disk_activity`` (joined through ``disk_charge`` for ``user_id``)
+    so it can filter by ``directory_name``. Used by the dashboard
+    when the user clicks a fileset row to scope the chart.
+
+    Accepts ``account_ids`` (not a single ``project_id``) so it works
+    for any subtree slice — a fileset can belong to a child project
+    deeper in the tree, but the scope's account set still bounds it
+    correctly.
+
+    History depth is bounded by what the importer has populated in
+    ``disk_activity`` — older snapshots that pre-date Layer 2 won't
+    appear. The summary path stays as the chart source for
+    project-level views.
+    """
+    if not account_ids:
+        return {'dates': [], 'series': []}
+    q = session.query(
+        DiskActivity.activity_date,
+        DiskCharge.user_id,
+        User.username,
+        func.coalesce(func.sum(DiskActivity.bytes), 0).label('bytes'),
+    ).join(
+        DiskCharge, DiskCharge.disk_activity_id == DiskActivity.disk_activity_id,
+    ).join(
+        User, User.user_id == DiskCharge.user_id,
+    ).filter(
+        DiskCharge.account_id.in_(account_ids),
+        DiskActivity.resource_name == resource_name,
+        DiskActivity.directory_name == directory_name,
+    )
+    if start_date is not None:
+        q = q.filter(DiskActivity.activity_date >= start_date)
+    if end_date is not None:
+        q = q.filter(DiskActivity.activity_date <= end_date)
+    rows = q.group_by(
+        DiskActivity.activity_date,
+        DiskCharge.user_id,
+        User.username,
+    ).all()
+
+    if not rows:
+        return {'dates': [], 'series': []}
+
+    per_user: Dict[int, Dict[str, Any]] = {}
+    dates_set: set = set()
+    for activity_date, user_id, username, b in rows:
+        dates_set.add(activity_date)
+        u = per_user.setdefault(
+            user_id,
+            {'username': username or f'uid_{user_id}', 'by_date': {}},
+        )
+        if username and not u['username'].startswith('uid_'):
+            u['username'] = username
+        u['by_date'][activity_date] = int(b or 0)
+
+    dates = sorted(dates_set)
+    last_date = dates[-1]
+
+    ranked = sorted(
+        per_user.items(),
+        key=lambda kv: kv[1]['by_date'].get(last_date, 0),
+        reverse=True,
+    )
+    top_users = ranked[:top_n]
+    rest_users = ranked[top_n:]
+
+    series: List[Dict[str, Any]] = []
+    if rest_users:
+        others_values = [0] * len(dates)
+        for _uid, info in rest_users:
+            for i, d in enumerate(dates):
+                others_values[i] += info['by_date'].get(d, 0)
+        series.append({'username': 'Others', 'values': others_values})
+    for _uid, info in reversed(top_users):
+        series.append({
+            'username': info['username'],
+            'values':   [info['by_date'].get(d, 0) for d in dates],
+        })
+    return {'dates': dates, 'series': series}
+
+
+def get_directory_user_breakdown_at(
+    session: Session,
+    *,
+    account_ids: List[int],
+    resource_name: str,
+    directory_name: str,
+    activity_date,
+) -> List[Dict[str, Any]]:
+    """Per-user bytes/files for a single fileset at one snapshot date.
+
+    Used by the dashboard's per-user table when scoped to a fileset.
+    Returns one row per resolved (tier-2-linked) user, sorted desc
+    by bytes. Accepts an ``account_ids`` set so it works for any
+    subtree slice (matching :func:`get_disk_usage_timeseries_for_directory`).
+    """
+    if activity_date is None or not account_ids:
+        return []
+    rows = (
+        session.query(
+            User.username.label('username'),
+            DiskCharge.user_id.label('user_id'),
+            func.sum(DiskActivity.bytes).label('bytes'),
+            func.sum(DiskActivity.number_of_files).label('files'),
+        )
+        .join(DiskCharge, DiskCharge.disk_activity_id == DiskActivity.disk_activity_id)
+        .join(User, User.user_id == DiskCharge.user_id)
+        .filter(
+            DiskCharge.account_id.in_(account_ids),
+            DiskActivity.resource_name == resource_name,
+            DiskActivity.directory_name == directory_name,
+            DiskActivity.activity_date == activity_date,
+        )
+        .group_by(User.username, DiskCharge.user_id)
+        .all()
+    )
+    return sorted(
+        [{'username': r.username,
+          'user_id': r.user_id,
+          'bytes': int(r.bytes or 0),
+          'files': int(r.files or 0)} for r in rows],
+        key=lambda d: d['bytes'],
+        reverse=True,
+    )
+
+
+def get_subtree_directory_usage_at(
+    session: Session,
+    *,
+    account_ids: List[int],
+    resource_name: str,
+    activity_date,
+) -> List[Dict[str, Any]]:
+    """Per-directory snapshot summed across an entire subtree.
+
+    Like :func:`get_directory_usage_at` but takes ``account_ids``
+    (typically every disk account in the scoped subtree) instead of
+    a single ``project_id``. Each result row also carries the owning
+    project's ``projcode`` so the dashboard can show which child
+    project a directory belongs to when the scope spans multiple
+    projects.
+
+    Returns ``[{name, bytes, files, projcode}, ...]`` sorted desc
+    by bytes. Empty list if ``account_ids`` is empty or
+    ``activity_date`` is None.
+    """
+    if activity_date is None or not account_ids:
+        return []
+    rows = (
+        session.query(
+            DiskActivity.directory_name.label('name'),
+            Project.projcode.label('projcode'),
+            func.sum(DiskActivity.bytes).label('bytes'),
+            func.sum(DiskActivity.number_of_files).label('files'),
+        )
+        .join(DiskCharge, DiskCharge.disk_activity_id == DiskActivity.disk_activity_id)
+        .join(Account, Account.account_id == DiskCharge.account_id)
+        .join(Project, Project.project_id == Account.project_id)
+        .filter(
+            DiskCharge.account_id.in_(account_ids),
+            DiskActivity.resource_name == resource_name,
+            DiskActivity.activity_date == activity_date,
+        )
+        .group_by(DiskActivity.directory_name, Project.projcode)
+        .all()
+    )
+    return sorted(
+        [{'name': r.name,
+          'projcode': r.projcode,
+          'bytes': int(r.bytes or 0),
+          'files': int(r.files or 0)} for r in rows],
+        key=lambda d: d['bytes'],
+        reverse=True,
+    )
+
+
 def get_directory_usage_at(
     session: Session,
     *,

--- a/src/sam/queries/disk_usage.py
+++ b/src/sam/queries/disk_usage.py
@@ -26,6 +26,7 @@ from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import Session
 
 from sam.accounting.accounts import Account
+from sam.activity.disk import DiskActivity, DiskCharge
 from sam.core.users import User
 from sam.projects.projects import Project, ProjectDirectory
 from sam.resources.resources import Resource
@@ -355,6 +356,109 @@ def get_disk_usage_timeseries_by_user(
     return {'dates': dates, 'series': series}
 
 
+def get_directory_usage_at(
+    session: Session,
+    *,
+    project_id: int,
+    resource_name: str,
+    activity_date,
+) -> List[Dict[str, Any]]:
+    """Per-directory snapshot for one ``(project, resource, date)``.
+
+    Joins ``disk_activity`` → ``disk_charge`` → ``account`` so unresolved
+    rows (no tier-2 row) are excluded. Returns a list of
+    ``{'name', 'bytes', 'files'}`` dicts, one per ``directory_name``,
+    sorted descending by bytes.
+    """
+    if activity_date is None:
+        return []
+    rows = (
+        session.query(
+            DiskActivity.directory_name.label('name'),
+            func.sum(DiskActivity.bytes).label('bytes'),
+            func.sum(DiskActivity.number_of_files).label('files'),
+        )
+        .join(DiskCharge,
+              DiskCharge.disk_activity_id == DiskActivity.disk_activity_id)
+        .join(Account, Account.account_id == DiskCharge.account_id)
+        .filter(
+            Account.project_id == project_id,
+            DiskActivity.resource_name == resource_name,
+            DiskActivity.activity_date == activity_date,
+        )
+        .group_by(DiskActivity.directory_name)
+        .all()
+    )
+    return sorted(
+        [{'name': r.name,
+          'bytes': int(r.bytes or 0),
+          'files': int(r.files or 0)} for r in rows],
+        key=lambda d: d['bytes'],
+        reverse=True,
+    )
+
+
+def bulk_get_directory_usage_at(
+    session: Session,
+    *,
+    project_resource_pairs: List[Tuple[int, str]],
+    activity_date,
+) -> Dict[Tuple[int, str], List[Dict[str, Any]]]:
+    """Bulk variant of :func:`get_directory_usage_at`.
+
+    One query covers many ``(project_id, resource_name)`` pairs. Result
+    is keyed by the input tuple; pairs with no rows map to an empty list.
+    """
+    out: Dict[Tuple[int, str], List[Dict[str, Any]]] = {
+        pair: [] for pair in project_resource_pairs
+    }
+    if not project_resource_pairs or activity_date is None:
+        return out
+
+    project_ids = sorted({pid for pid, _ in project_resource_pairs})
+    resource_names = sorted({rn for _, rn in project_resource_pairs})
+
+    rows = (
+        session.query(
+            Account.project_id.label('project_id'),
+            DiskActivity.resource_name.label('resource_name'),
+            DiskActivity.directory_name.label('name'),
+            func.sum(DiskActivity.bytes).label('bytes'),
+            func.sum(DiskActivity.number_of_files).label('files'),
+        )
+        .join(DiskCharge,
+              DiskCharge.disk_activity_id == DiskActivity.disk_activity_id)
+        .join(Account, Account.account_id == DiskCharge.account_id)
+        .filter(
+            Account.project_id.in_(project_ids),
+            DiskActivity.resource_name.in_(resource_names),
+            DiskActivity.activity_date == activity_date,
+        )
+        .group_by(
+            Account.project_id,
+            DiskActivity.resource_name,
+            DiskActivity.directory_name,
+        )
+        .all()
+    )
+
+    bucket: Dict[Tuple[int, str], List[Dict[str, Any]]] = {}
+    for r in rows:
+        key = (r.project_id, r.resource_name)
+        if key not in out:
+            # Pair wasn't requested but slipped through the broad IN
+            # filter. Skip — caller only asked for specific pairs.
+            continue
+        bucket.setdefault(key, []).append(
+            {'name': r.name,
+             'bytes': int(r.bytes or 0),
+             'files': int(r.files or 0)}
+        )
+    for key, dirs in bucket.items():
+        out[key] = sorted(dirs, key=lambda d: d['bytes'], reverse=True)
+    return out
+
+
 def build_disk_subtree(
     session: Session,
     root_project: Project,
@@ -432,6 +536,9 @@ def build_disk_subtree(
     # parent_id FK (works alongside the NestedSet coords).
     node_by_pid: Dict[int, Dict[str, Any]] = {}
     account_ids: List[int] = []
+    # For multi-fileset nodes, collect (project_id, activity_date) so we
+    # can bulk-query per-fileset bytes from disk_activity in one trip.
+    multifs_by_date: Dict[Any, List[int]] = {}
     for proj in descendants:
         account = account_by_project_id.get(proj.project_id)
         snapshot = account.current_disk_usage() if account is not None else None
@@ -444,6 +551,25 @@ def build_disk_subtree(
         node_by_pid[proj.project_id] = node
         if account is not None:
             account_ids.append(account.account_id)
+        if (len(node['fileset_paths']) > 1
+                and node.get('activity_date') is not None):
+            multifs_by_date.setdefault(node['activity_date'], []).append(
+                proj.project_id
+            )
+
+    # Per-fileset bytes lookup — only for projects that have >1 active
+    # fileset on this resource. Single-fileset projects keep the
+    # current per-project rendering and pay nothing.
+    for activity_dt, pids in multifs_by_date.items():
+        per_fs = bulk_get_directory_usage_at(
+            session,
+            project_resource_pairs=[(pid, resource_name) for pid in pids],
+            activity_date=activity_dt,
+        )
+        for pid in pids:
+            dirs = per_fs.get((pid, resource_name), [])
+            if dirs:
+                node_by_pid[pid]['directories'] = dirs
 
     for proj in descendants:
         if proj.project_id == root_project.project_id:

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -242,12 +242,18 @@ def generate_disk_usage_stacked_area(timeseries) -> str:
     # Reverse the legend so it reads top-to-bottom in the same order as
     # the visual stack (largest user on top).
     handles, lbls = ax.get_legend_handles_labels()
+    # Legend title — show the actual count of named user series
+    # (excluding the synthetic 'Others' bucket) so it self-describes
+    # the top-N selection regardless of caller's `top_n` argument.
+    n_named = sum(1 for s in series if s['username'] != 'Others')
     ax.legend(
         handles[::-1], lbls[::-1],
+        title=f'Top {n_named} Users',
         loc='center left',
         bbox_to_anchor=(1.01, 0.5),
         frameon=False,
         fontsize=9,
+        title_fontsize=10,
     )
     fig.autofmt_xdate()
 

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -628,7 +628,7 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
             account_ids=scope_account_ids,
             start_date=start_date.date() if hasattr(start_date, 'date') else start_date,
             end_date=end_date.date() if hasattr(end_date, 'date') else end_date,
-            top_n=10,
+            top_n=15,
         )
         user_rows = _build_disk_user_table(
             db.session, scope_account_ids, activity_date, used_bytes,
@@ -653,7 +653,7 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
             directory_name=fileset,
             start_date=start_date.date() if hasattr(start_date, 'date') else start_date,
             end_date=end_date.date() if hasattr(end_date, 'date') else end_date,
-            top_n=10,
+            top_n=15,
         )
         breakdown = get_directory_user_breakdown_at(
             db.session,

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -16,7 +16,13 @@ from sam.schemas.forms.user import EditAllocationForm, SetShellForm, SetPrimaryG
 
 from webapp.extensions import db
 from sam.queries.dashboard import get_user_dashboard_data, get_resource_detail_data, get_project_dashboard_data
-from sam.queries.disk_usage import build_disk_subtree, get_disk_usage_timeseries_by_user
+from sam.queries.disk_usage import (
+    build_disk_subtree,
+    get_directory_user_breakdown_at,
+    get_disk_usage_timeseries_by_user,
+    get_disk_usage_timeseries_for_directory,
+    get_subtree_directory_usage_at,
+)
 from sam.queries.rolling_usage import get_project_rolling_usage
 from sam.queries.charges import get_user_queue_breakdown_for_project, get_daily_breakdown_for_project, get_charges_by_projcode
 from sam.queries.lookups import find_project_by_code, get_user_group_access, get_group_members
@@ -562,6 +568,7 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
     """
     resource_name = resource.resource_name
     scope = request.args.get('scope', project.projcode)
+    fileset = request.args.get('fileset') or None
 
     # Validate scope belongs to this project's tree; fall back to root.
     if scope != project.projcode:
@@ -577,6 +584,30 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
     scope_node = _find_disk_node(full_tree, scope) or full_tree
     scope_account_ids = _collect_disk_account_ids(scope_node)
 
+    # Aggregate per-fileset rows across the entire scoped subtree at
+    # the latest snapshot date — single query covering every disk
+    # account in the scope. This populates the Filesets card on
+    # *both* leaf-project and tree pages (replacing the per-node
+    # `directories` payload that build_disk_subtree only attached
+    # for the multi-fileset case).
+    subtree_activity_date = _disk_subtree_latest_activity_date(scope_node)
+    fileset_dirs = get_subtree_directory_usage_at(
+        db.session,
+        account_ids=scope_account_ids,
+        resource_name=resource_name,
+        activity_date=subtree_activity_date,
+    )
+    # Make the Filesets card visible to the template by hanging
+    # the aggregated list off scope_node.
+    scope_node['directories'] = fileset_dirs
+
+    # Validate the fileset (if any) is one of the scope's directories.
+    # An invalid `?fileset=` is silently dropped — fall back to
+    # project-scope rendering.
+    if fileset is not None:
+        if not any(d['name'] == fileset for d in fileset_dirs):
+            fileset = None
+
     # Pool capacity (TiB) for the scope: the master allocation's
     # amount, NOT the sum across child accounts. Inheriting children
     # share the parent's cap; summing them double-counts. See
@@ -586,26 +617,62 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
         db.session, scope_node['projcode'], resource,
     )
 
-    used_bytes = _disk_subtree_total_bytes(scope_node)
-    used_tib = used_bytes / (1024 ** 4)
-    total_files = _disk_subtree_total_files(scope_node)
-    activity_date = _disk_subtree_latest_activity_date(scope_node)
+    if fileset is None:
+        # Project-scope rendering (default).
+        used_bytes = _disk_subtree_total_bytes(scope_node)
+        used_tib = used_bytes / (1024 ** 4)
+        total_files = _disk_subtree_total_files(scope_node)
+        activity_date = _disk_subtree_latest_activity_date(scope_node)
+        timeseries = get_disk_usage_timeseries_by_user(
+            db.session,
+            account_ids=scope_account_ids,
+            start_date=start_date.date() if hasattr(start_date, 'date') else start_date,
+            end_date=end_date.date() if hasattr(end_date, 'date') else end_date,
+            top_n=10,
+        )
+        user_rows = _build_disk_user_table(
+            db.session, scope_account_ids, activity_date, used_bytes,
+        )
+    else:
+        # Fileset-scoped rendering: chart + per-user table read from
+        # `disk_activity` (joined through `disk_charge` for `user_id`)
+        # filtered by `directory_name`. Capacity card numbers come
+        # from the aggregated per-fileset row. The fileset may belong
+        # to a child project deeper in the subtree — `scope_account_ids`
+        # bounds the query correctly without needing the owner's
+        # project_id explicitly.
+        fileset_row = next(d for d in fileset_dirs if d['name'] == fileset)
+        used_bytes = fileset_row['bytes']
+        used_tib = used_bytes / (1024 ** 4)
+        total_files = fileset_row['files']
+        activity_date = subtree_activity_date
+        timeseries = get_disk_usage_timeseries_for_directory(
+            db.session,
+            account_ids=scope_account_ids,
+            resource_name=resource_name,
+            directory_name=fileset,
+            start_date=start_date.date() if hasattr(start_date, 'date') else start_date,
+            end_date=end_date.date() if hasattr(end_date, 'date') else end_date,
+            top_n=10,
+        )
+        breakdown = get_directory_user_breakdown_at(
+            db.session,
+            account_ids=scope_account_ids,
+            resource_name=resource_name,
+            directory_name=fileset,
+            activity_date=activity_date,
+        )
+        user_rows = [{
+            'user_id':       r['user_id'],
+            'username':      r['username'],
+            'bytes':         r['bytes'],
+            'file_count':    r['files'],
+            'percent_of_project':
+                (r['bytes'] / used_bytes * 100) if used_bytes > 0 else 0.0,
+        } for r in breakdown]
+
     percent_used = (used_tib / allocated_tib * 100) if allocated_tib > 0 else 0.0
-
-    # Time-series for the stacked-area chart.
-    timeseries = get_disk_usage_timeseries_by_user(
-        db.session,
-        account_ids=scope_account_ids,
-        start_date=start_date.date() if hasattr(start_date, 'date') else start_date,
-        end_date=end_date.date() if hasattr(end_date, 'date') else end_date,
-        top_n=10,
-    )
     usage_chart = generate_disk_usage_stacked_area(timeseries)
-
-    # Per-user table at the latest snapshot date for the scope.
-    user_rows = _build_disk_user_table(
-        db.session, scope_account_ids, activity_date, used_bytes,
-    )
 
     return render_template(
         'dashboards/user/resource_details_disk.html',
@@ -616,6 +683,7 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
         resource=resource,
         scope=scope,
         scope_node=scope_node,
+        fileset=fileset,
         tree_data=full_tree,
         has_children=bool(project.has_children),
         start_date=start_date.strftime('%Y-%m-%d'),

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -26,7 +26,7 @@
         {% if node.title %}
         <span class="{% if is_clickable %}text-muted{% endif %} fw-normal text-truncate" style="max-width: 35ch;">- {{ node.title }}</span>
         {% endif %}
-        {% if node.fileset_paths and not node.directories %}
+        {% if node.fileset_paths %}
         <span class="text-muted small font-monospace"
               style="max-width: 70ch; white-space: normal; word-break: break-word;">
             <i class="fas fa-folder-open me-1"></i>{{ node.fileset_paths | join(', ') }}
@@ -47,27 +47,6 @@
     </a>
     {% else %}
     </span>
-    {% endif %}
-    {% if node.directories %}
-    <ul class="tree-list disk-fileset-list">
-        {% for d in node.directories %}
-        <li>
-            <span class="d-flex align-items-center gap-2 text-muted">
-                <i class="fas fa-folder-open me-1 flex-shrink-0"></i>
-                <span class="small font-monospace text-truncate"
-                      style="max-width: 70ch;">{{ d.name }}</span>
-                {% if d.files %}
-                <span class="text-muted small flex-shrink-0">
-                    {{ d.files | fmt_number }} files
-                </span>
-                {% endif %}
-                <span class="text-muted small ms-auto flex-shrink-0 font-monospace">
-                    {{ d.bytes | fmt_size }}
-                </span>
-            </span>
-        </li>
-        {% endfor %}
-    </ul>
     {% endif %}
     {% if node.children %}
     <ul class="tree-list">
@@ -102,6 +81,14 @@
         | Resource: <strong>{{ resource_name }}</strong>
         {% if scope != projcode %}
         | Scope: <strong>{{ scope }}</strong>
+        {% endif %}
+        {% if fileset %}
+        | Fileset: <strong><code>{{ fileset }}</code></strong>
+        <a href="{{ url_for('user_dashboard.resource_details',
+                            projcode=projcode, resource=resource_name,
+                            scope=scope,
+                            start_date=start_date, end_date=end_date) }}"
+           class="ms-1 small">[clear]</a>
         {% endif %}
         {% if capacity.activity_date %}
         | <span title="Latest snapshot date">As of <strong>{{ capacity.activity_date | fmt_date }}</strong></span>
@@ -165,6 +152,82 @@
         </div>
     </div>
 </div>
+
+{# ── Per-fileset breakdown ──────────────────────────────────────────── #}
+{# Aggregated across the entire scoped subtree — shows whenever
+   any fileset in the scope has tier-1 data. Rows are clickable to
+   scope chart + per-user table by `directory_name` via `?fileset=`.
+   The selected row mirrors the warning highlight used by the
+   tree's `?scope=` selection. #}
+{% set _multi_proj = scope_node.directories
+                     and (scope_node.directories | map(attribute='projcode') | unique | list | length > 1) %}
+{% if scope_node and scope_node.directories %}
+<div class="card mb-4">
+    <div class="card-header cursor-pointer"
+         data-bs-toggle="collapse" data-bs-target="#collapseDiskFilesets"
+         aria-expanded="true">
+        <h5 class="mb-0">
+            <i class="fas fa-folder-open"></i> Filesets
+            <small class="text-muted fw-normal ms-2">
+                {{ scope_node.directories | length }} active fileset{{ '' if scope_node.directories|length == 1 else 's' }}
+                on {{ resource_name }}
+                {% if scope != projcode %}
+                under <code>{{ scope }}</code>
+                {% endif %}
+                {% if fileset %}
+                — scoped to <code>{{ fileset }}</code>
+                {% else %}
+                <span class="text-muted">— click a row to scope chart + table</span>
+                {% endif %}
+            </small>
+            <i class="fas fa-chevron-down float-end transition-smooth"></i>
+        </h5>
+    </div>
+    <div id="collapseDiskFilesets" class="collapse show">
+        <div class="card-body p-3">
+            <div class="table-responsive">
+                <table class="table table-sm table-hover mb-0">
+                    <thead class="thead-light">
+                        <tr>
+                            {% if _multi_proj %}<th>Project</th>{% endif %}
+                            <th>Path</th>
+                            <th class="text-end">Files</th>
+                            <th class="text-end">Size</th>
+                            <th class="table-col-usage">Share</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% set _scope_bytes = scope_node.directories | sum(attribute='bytes') %}
+                        {% for d in scope_node.directories %}
+                        {% set _share = (d.bytes / _scope_bytes * 100) if _scope_bytes else 0 %}
+                        {% set is_active = (fileset == d.name) %}
+                        {% set row_url = url_for('user_dashboard.resource_details',
+                                                  projcode=projcode, resource=resource_name,
+                                                  scope=scope, fileset=d.name,
+                                                  start_date=start_date, end_date=end_date) %}
+                        <tr style="cursor: pointer;{% if is_active %} background: #fff3cd;{% endif %}"
+                            onclick="window.location='{{ row_url }}'">
+                            {% if _multi_proj %}
+                            <td><strong>{{ d.projcode }}</strong></td>
+                            {% endif %}
+                            <td>
+                                {% if is_active %}
+                                <i class="fas fa-arrow-right text-warning me-1"></i>
+                                {% endif %}
+                                <code>{{ d.name }}</code>
+                            </td>
+                            <td class="text-end">{{ d.files | fmt_number }}</td>
+                            <td class="text-end font-monospace">{{ d.bytes | fmt_size }}</td>
+                            <td>{{ render_usage_bar(_share, none, size_class='progress-small', show_label=True) }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
 
 {# ── Filesystem-style project tree ──────────────────────────────────── #}
 {% if has_children %}

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -26,7 +26,7 @@
         {% if node.title %}
         <span class="{% if is_clickable %}text-muted{% endif %} fw-normal text-truncate" style="max-width: 35ch;">- {{ node.title }}</span>
         {% endif %}
-        {% if node.fileset_paths %}
+        {% if node.fileset_paths and not node.directories %}
         <span class="text-muted small font-monospace"
               style="max-width: 70ch; white-space: normal; word-break: break-word;">
             <i class="fas fa-folder-open me-1"></i>{{ node.fileset_paths | join(', ') }}
@@ -47,6 +47,27 @@
     </a>
     {% else %}
     </span>
+    {% endif %}
+    {% if node.directories %}
+    <ul class="tree-list disk-fileset-list">
+        {% for d in node.directories %}
+        <li>
+            <span class="d-flex align-items-center gap-2 text-muted">
+                <i class="fas fa-folder-open me-1 flex-shrink-0"></i>
+                <span class="small font-monospace text-truncate"
+                      style="max-width: 70ch;">{{ d.name }}</span>
+                {% if d.files %}
+                <span class="text-muted small flex-shrink-0">
+                    {{ d.files | fmt_number }} files
+                </span>
+                {% endif %}
+                <span class="text-muted small ms-auto flex-shrink-0 font-monospace">
+                    {{ d.bytes | fmt_size }}
+                </span>
+            </span>
+        </li>
+        {% endfor %}
+    </ul>
     {% endif %}
     {% if node.children %}
     <ul class="tree-list">

--- a/tests/unit/test_accounting_disk_admin.py
+++ b/tests/unit/test_accounting_disk_admin.py
@@ -19,6 +19,7 @@ from cli.cmds.admin import cli
 from cli.accounting import disk_usage as disk_usage_mod
 from cli.accounting import quota_readers as quota_readers_mod
 from sam.resources.resources import ResourceType
+from sam.activity.disk import DiskActivity, DiskCharge
 from sam.summaries.disk_summaries import (
     DISK_CHARGING_TIB_EPOCH,
     DiskChargeSummary,
@@ -317,4 +318,205 @@ class TestDiskAdminCli:
         assert row.username == lead.username
         # Bytes match the input (5 GiB).
         assert row.bytes == 5 * 1024 ** 3
+
+    # ------------------------------------------------------------------
+    # Layer 2: tier-1 (disk_activity) + tier-2 (disk_charge) writes
+    # ------------------------------------------------------------------
+
+    def test_import_writes_disk_activity_per_directory(
+        self, runner, mock_db_session, tmp_path, session, monkeypatch,
+    ):
+        """Multi-fileset project: per-directory rows land in disk_activity
+        (one per fileset) and disk_charge (1:1)."""
+        from sam.projects.projects import ProjectDirectory
+        from datetime import datetime
+
+        lead, project, resource = _build_campaign_store_graph(session, monkeypatch)
+        backdate = datetime.now() - timedelta(days=1)
+        for sub in ('data', 'work'):
+            ProjectDirectory.create(
+                session, project_id=project.project_id,
+                directory_name=f"/gpfs/csfs1/{project.projcode.lower()}/{sub}",
+                start_date=backdate,
+            )
+        snap = DISK_CHARGING_TIB_EPOCH
+        kib_data = 2 * 1024 * 1024  # 2 GiB
+        kib_work = 3 * 1024 * 1024  # 3 GiB
+        f = _write_acct_multifileset(tmp_path, snap, project.projcode, [
+            (f"/gpfs/csfs1/{project.projcode.lower()}/data",
+             lead.username, 200, kib_data),
+            (f"/gpfs/csfs1/{project.projcode.lower()}/work",
+             lead.username, 300, kib_work),
+        ])
+
+        result = runner.invoke(cli, [
+            'accounting', '--disk',
+            '--resource', resource.resource_name,
+            '--user-usage', str(f),
+            '--date', snap.isoformat(),
+        ])
+        assert result.exit_code == 0, result.output
+
+        activities = session.query(DiskActivity).filter(
+            DiskActivity.activity_date == snap,
+            DiskActivity.resource_name == resource.resource_name,
+        ).all()
+        # One row per directory (per-fileset granularity preserved).
+        assert len(activities) == 2, [
+            (a.directory_name, a.bytes) for a in activities
+        ]
+        by_dir = {a.directory_name: a for a in activities}
+        data_path = f"/gpfs/csfs1/{project.projcode.lower()}/data"
+        work_path = f"/gpfs/csfs1/{project.projcode.lower()}/work"
+        assert by_dir[data_path].bytes == 2 * 1024 ** 3
+        assert by_dir[work_path].bytes == 3 * 1024 ** 3
+        assert by_dir[data_path].number_of_files == 200
+        assert by_dir[work_path].number_of_files == 300
+        # file_size_total mirrors bytes (legacy column parity).
+        assert by_dir[data_path].file_size_total == by_dir[data_path].bytes
+        # Resolved cleanly.
+        assert all(a.processing_status is True for a in activities)
+        assert all(a.error_comment is None for a in activities)
+
+        charges = session.query(DiskCharge).filter(
+            DiskCharge.disk_activity_id.in_(
+                [a.disk_activity_id for a in activities]
+            )
+        ).all()
+        # 1:1 with disk_activity.
+        assert len(charges) == 2
+        assert all(c.user_id == lead.user_id for c in charges)
+        assert all(c.account_id == project.accounts[0].account_id
+                   for c in charges)
+        # tib_years computed per-row at the input's bytes (no rollup).
+        # 2 GiB × 7 / 365 / 1024⁴ ≈ 3.745e-5 ; 3 GiB → 5.617e-5.
+        ty_data = (2 * 1024 ** 3) * 7 / 365 / (1024 ** 4)
+        ty_work = (3 * 1024 ** 3) * 7 / 365 / (1024 ** 4)
+        ch_by_dir = {
+            c.activity.directory_name: c for c in charges
+        }
+        assert ch_by_dir[data_path].terabyte_year == pytest.approx(
+            ty_data, abs=1e-7
+        )
+        assert ch_by_dir[work_path].terabyte_year == pytest.approx(
+            ty_work, abs=1e-7
+        )
+
+    def test_disk_activity_re_import_replaces_per_resource_date(
+        self, runner, mock_db_session, tmp_path, session, monkeypatch,
+    ):
+        """Re-running the same (resource, snap_date) deletes pre-existing
+        tier-1/tier-2 rows and re-inserts — no append, no duplicates."""
+        lead, project, resource = _build_campaign_store_graph(session, monkeypatch)
+        snap = DISK_CHARGING_TIB_EPOCH
+        # First run: 1 GiB.
+        f1 = _write_acct(tmp_path, snap, project.projcode, lead.username,
+                         kib=1 * 1024 * 1024)
+        r1 = runner.invoke(cli, [
+            'accounting', '--disk',
+            '--resource', resource.resource_name,
+            '--user-usage', str(f1),
+            '--date', snap.isoformat(),
+        ])
+        assert r1.exit_code == 0, r1.output
+        n_after_first = session.query(DiskActivity).filter(
+            DiskActivity.activity_date == snap,
+            DiskActivity.resource_name == resource.resource_name,
+        ).count()
+        assert n_after_first == 1
+
+        # Second run with different bytes: should REPLACE, not append.
+        f2 = _write_acct(tmp_path, snap, project.projcode, lead.username,
+                         kib=4 * 1024 * 1024)
+        r2 = runner.invoke(cli, [
+            'accounting', '--disk',
+            '--resource', resource.resource_name,
+            '--user-usage', str(f2),
+            '--date', snap.isoformat(),
+        ])
+        assert r2.exit_code == 0, r2.output
+
+        activities = session.query(DiskActivity).filter(
+            DiskActivity.activity_date == snap,
+            DiskActivity.resource_name == resource.resource_name,
+        ).all()
+        # Still exactly one row — the prior one was deleted.
+        assert len(activities) == 1
+        assert activities[0].bytes == 4 * 1024 ** 3
+
+        # disk_charge mirrors the new tier-1.
+        charges = session.query(DiskCharge).filter(
+            DiskCharge.disk_activity_id == activities[0].disk_activity_id
+        ).all()
+        assert len(charges) == 1
+
+    def test_disk_activity_skipped_for_total_rollup(
+        self, runner, mock_db_session, tmp_path, session, monkeypatch,
+    ):
+        """Quasar-style ``username='total'`` rollup rows produce no
+        tier-1 row (no real directory binding), even though tier-3 still
+        attributes them to the project lead."""
+        lead, project, resource = _build_campaign_store_graph(session, monkeypatch)
+        snap = DISK_CHARGING_TIB_EPOCH
+        f = _write_acct(tmp_path, snap, project.projcode, 'total',
+                        kib=5 * 1024 * 1024)
+
+        result = runner.invoke(cli, [
+            'accounting', '--disk',
+            '--resource', resource.resource_name,
+            '--user-usage', str(f),
+            '--date', snap.isoformat(),
+        ])
+        assert result.exit_code == 0, result.output
+
+        # No tier-1 row for the rollup sentinel.
+        n_act = session.query(DiskActivity).filter(
+            DiskActivity.activity_date == snap,
+            DiskActivity.resource_name == resource.resource_name,
+        ).count()
+        assert n_act == 0
+        # But tier-3 still has the row (Layer 1 path unchanged).
+        n_summary = session.query(DiskChargeSummary).filter(
+            DiskChargeSummary.activity_date == snap,
+            DiskChargeSummary.account_id == project.accounts[0].account_id,
+        ).count()
+        assert n_summary == 1
+
+    def test_disk_activity_skipped_for_unidentified_gap_rows(
+        self, runner, mock_db_session, tmp_path, session, monkeypatch,
+    ):
+        """Synthetic ``<unidentified>`` gap rows — no real directory —
+        produce no tier-1 row."""
+        lead, project, resource = _build_campaign_store_graph(session, monkeypatch)
+        snap = DISK_CHARGING_TIB_EPOCH
+        kib_user = 1 * 1024 * 1024
+        kib_fileset = 3 * 1024 * 1024
+        f = _write_acct(tmp_path, snap, project.projcode, lead.username,
+                        kib=kib_user)
+        q = _write_quotas(tmp_path, snap, project.projcode.lower(),
+                          usage_kib=kib_fileset, limit_kib=10 * 1024 * 1024)
+
+        result = runner.invoke(cli, [
+            'accounting', '--disk',
+            '--resource', resource.resource_name,
+            '--user-usage', str(f),
+            '--quotas', str(q),
+            '--reconcile-quota-gap',
+            '--date', snap.isoformat(),
+        ])
+        assert result.exit_code == 0, result.output
+
+        # tier-1: only the real (lead) row, NOT the <unidentified> gap row.
+        activities = session.query(DiskActivity).filter(
+            DiskActivity.activity_date == snap,
+            DiskActivity.resource_name == resource.resource_name,
+        ).all()
+        assert len(activities) == 1
+        assert activities[0].username == lead.username
+        # tier-3 still has both rows (gap row tier-3-only).
+        n_summary = session.query(DiskChargeSummary).filter(
+            DiskChargeSummary.activity_date == snap,
+            DiskChargeSummary.account_id == project.accounts[0].account_id,
+        ).count()
+        assert n_summary == 2
 

--- a/tests/unit/test_disk_usage_queries.py
+++ b/tests/unit/test_disk_usage_queries.py
@@ -15,8 +15,11 @@ import pytest
 
 from sam import ResourceType
 from sam.projects.projects import ProjectDirectory
+from sam.activity.disk import DiskActivity, DiskCharge
 from sam.queries.disk_usage import (
     build_disk_subtree,
+    bulk_get_directory_usage_at,
+    get_directory_usage_at,
     get_disk_usage_timeseries_by_user,
 )
 from sam.summaries.disk_summaries import (
@@ -304,3 +307,285 @@ class TestBuildDiskSubtree:
             '/gpfs/csfs1/test/path_a',
             '/gpfs/csfs1/test/path_b',
         ]
+
+
+# ============================================================================
+# get_directory_usage_at / bulk_get_directory_usage_at  (Layer 2 tier-1/-2)
+# ============================================================================
+
+
+def _seed_disk_activity(
+    session, *, account, user, directory, snap, bytes_, files=10,
+    resource_name=None,
+):
+    """Insert one disk_activity + matching disk_charge row."""
+    activity = DiskActivity(
+        directory_name=directory,
+        username=user.username,
+        projcode=account.project.projcode,
+        activity_date=snap,
+        reporting_interval=7,
+        file_size_total=bytes_,
+        bytes=bytes_,
+        number_of_files=files,
+        load_date=datetime.now(),
+        disk_cos_id=0,
+        processing_status=True,
+        resource_name=resource_name,
+    )
+    session.add(activity)
+    session.flush()
+    session.add(DiskCharge(
+        disk_activity_id=activity.disk_activity_id,
+        account_id=account.account_id,
+        user_id=user.user_id,
+        charge_date=datetime.now(),
+        activity_date=snap,
+        terabyte_year=0.0,
+        charge=0.0,
+    ))
+    session.flush()
+    return activity
+
+
+class TestPerDirectoryQuery:
+
+    def test_get_directory_usage_at_returns_per_directory_rows(self, session):
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        snap = _date(2026, 4, 11)
+        _seed_disk_activity(
+            session, account=account, user=lead,
+            directory='/gpfs/csfs1/test/data',
+            snap=snap, bytes_=2 * BYTES_PER_TIB, files=200,
+            resource_name=resource.resource_name,
+        )
+        _seed_disk_activity(
+            session, account=account, user=lead,
+            directory='/gpfs/csfs1/test/work',
+            snap=snap, bytes_=3 * BYTES_PER_TIB, files=300,
+            resource_name=resource.resource_name,
+        )
+
+        rows = get_directory_usage_at(
+            session,
+            project_id=project.project_id,
+            resource_name=resource.resource_name,
+            activity_date=snap,
+        )
+        # Sorted desc by bytes.
+        assert [r['name'] for r in rows] == [
+            '/gpfs/csfs1/test/work',
+            '/gpfs/csfs1/test/data',
+        ]
+        assert rows[0]['bytes'] == 3 * BYTES_PER_TIB
+        assert rows[0]['files'] == 300
+        assert rows[1]['bytes'] == 2 * BYTES_PER_TIB
+        assert rows[1]['files'] == 200
+
+    def test_get_directory_usage_at_filters_by_resource(self, session):
+        """Rows on a different resource on the same date must not leak in."""
+        resource_a = _disk_resource(session)
+        resource_b = _disk_resource(session)
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        acct_a = make_account(session, project=project, resource=resource_a)
+        acct_b = make_account(session, project=project, resource=resource_b)
+        snap = _date(2026, 4, 11)
+        _seed_disk_activity(
+            session, account=acct_a, user=lead,
+            directory='/cs/data', snap=snap, bytes_=BYTES_PER_TIB,
+            resource_name=resource_a.resource_name,
+        )
+        _seed_disk_activity(
+            session, account=acct_b, user=lead,
+            directory='/quasar/data', snap=snap, bytes_=BYTES_PER_TIB,
+            resource_name=resource_b.resource_name,
+        )
+
+        rows_a = get_directory_usage_at(
+            session,
+            project_id=project.project_id,
+            resource_name=resource_a.resource_name,
+            activity_date=snap,
+        )
+        assert [r['name'] for r in rows_a] == ['/cs/data']
+
+    def test_get_directory_usage_at_unresolved_excluded(self, session):
+        """A disk_activity row with no disk_charge (unresolved) is excluded
+        — the join filter requires both tiers."""
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        snap = _date(2026, 4, 11)
+        # Resolved row (writes both tiers).
+        _seed_disk_activity(
+            session, account=account, user=lead,
+            directory='/cs/data', snap=snap, bytes_=BYTES_PER_TIB,
+            resource_name=resource.resource_name,
+        )
+        # Tier-1-only row (no tier-2 — simulates unresolved import).
+        session.add(DiskActivity(
+            directory_name='/cs/orphan',
+            username='ghost',
+            projcode='ZZZZ9999',
+            activity_date=snap,
+            reporting_interval=7,
+            file_size_total=BYTES_PER_TIB,
+            bytes=BYTES_PER_TIB,
+            number_of_files=1,
+            load_date=datetime.now(),
+            disk_cos_id=0,
+            processing_status=False,
+            error_comment='unresolved',
+            resource_name=resource.resource_name,
+        ))
+        session.flush()
+
+        rows = get_directory_usage_at(
+            session,
+            project_id=project.project_id,
+            resource_name=resource.resource_name,
+            activity_date=snap,
+        )
+        # Only the resolved row.
+        assert [r['name'] for r in rows] == ['/cs/data']
+
+    def test_bulk_per_directory_query_pairs(self, session):
+        """Bulk variant returns a dict keyed by (project_id, resource_name);
+        unrequested pairs are absent or empty."""
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        proj_a = make_project(session, lead=lead)
+        proj_b = make_project(session, lead=lead)
+        acct_a = make_account(session, project=proj_a, resource=resource)
+        acct_b = make_account(session, project=proj_b, resource=resource)
+        snap = _date(2026, 4, 11)
+        _seed_disk_activity(
+            session, account=acct_a, user=lead,
+            directory='/cs/a/data', snap=snap, bytes_=BYTES_PER_TIB,
+            resource_name=resource.resource_name,
+        )
+        _seed_disk_activity(
+            session, account=acct_a, user=lead,
+            directory='/cs/a/work', snap=snap, bytes_=2 * BYTES_PER_TIB,
+            resource_name=resource.resource_name,
+        )
+        _seed_disk_activity(
+            session, account=acct_b, user=lead,
+            directory='/cs/b/data', snap=snap, bytes_=3 * BYTES_PER_TIB,
+            resource_name=resource.resource_name,
+        )
+
+        out = bulk_get_directory_usage_at(
+            session,
+            project_resource_pairs=[
+                (proj_a.project_id, resource.resource_name),
+                (proj_b.project_id, resource.resource_name),
+            ],
+            activity_date=snap,
+        )
+        assert set(out.keys()) == {
+            (proj_a.project_id, resource.resource_name),
+            (proj_b.project_id, resource.resource_name),
+        }
+        names_a = [d['name'] for d in out[(proj_a.project_id,
+                                           resource.resource_name)]]
+        assert names_a == ['/cs/a/work', '/cs/a/data']
+        names_b = [d['name'] for d in out[(proj_b.project_id,
+                                           resource.resource_name)]]
+        assert names_b == ['/cs/b/data']
+
+    def test_bulk_per_directory_query_empty_input(self, session):
+        out = bulk_get_directory_usage_at(
+            session,
+            project_resource_pairs=[],
+            activity_date=_date(2026, 4, 11),
+        )
+        assert out == {}
+
+
+class TestBuildDiskSubtreeMultifileset:
+    """build_disk_subtree attaches per-fileset bytes when >1 active
+    ProjectDirectory exists."""
+
+    def test_multifileset_node_carries_directories(self, session):
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        backdate = datetime.now() - timedelta(days=1)
+        ProjectDirectory.create(
+            session, project_id=project.project_id,
+            directory_name='/gpfs/csfs1/test/data',
+            start_date=backdate,
+        )
+        ProjectDirectory.create(
+            session, project_id=project.project_id,
+            directory_name='/gpfs/csfs1/test/work',
+            start_date=backdate,
+        )
+        snap = _date(2026, 4, 11)
+        # Tier-3 row drives node.activity_date.
+        _seed_row(session, account=account, user=lead, snap=snap,
+                  bytes_=5 * BYTES_PER_TIB)
+        # Tier-1/2 rows drive the per-fileset breakdown.
+        _seed_disk_activity(
+            session, account=account, user=lead,
+            directory='/gpfs/csfs1/test/data',
+            snap=snap, bytes_=2 * BYTES_PER_TIB, files=200,
+            resource_name=resource.resource_name,
+        )
+        _seed_disk_activity(
+            session, account=account, user=lead,
+            directory='/gpfs/csfs1/test/work',
+            snap=snap, bytes_=3 * BYTES_PER_TIB, files=300,
+            resource_name=resource.resource_name,
+        )
+        mark_disk_snapshot_current(session, snap)
+        session.flush()
+
+        result = build_disk_subtree(session, project, resource.resource_name)
+        node = result['tree']
+        # Multi-fileset → directories attached, sorted desc by bytes.
+        assert 'directories' in node
+        assert [d['name'] for d in node['directories']] == [
+            '/gpfs/csfs1/test/work',
+            '/gpfs/csfs1/test/data',
+        ]
+        # Sum of per-fileset bytes equals the project-level current_bytes.
+        assert (sum(d['bytes'] for d in node['directories'])
+                == node['current_bytes'])
+
+    def test_single_fileset_node_omits_directories(self, session):
+        """Single-fileset projects keep the existing render path — no
+        ``directories`` payload."""
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        backdate = datetime.now() - timedelta(days=1)
+        ProjectDirectory.create(
+            session, project_id=project.project_id,
+            directory_name='/gpfs/csfs1/test/only',
+            start_date=backdate,
+        )
+        snap = _date(2026, 4, 11)
+        _seed_row(session, account=account, user=lead, snap=snap,
+                  bytes_=BYTES_PER_TIB)
+        _seed_disk_activity(
+            session, account=account, user=lead,
+            directory='/gpfs/csfs1/test/only',
+            snap=snap, bytes_=BYTES_PER_TIB,
+            resource_name=resource.resource_name,
+        )
+        mark_disk_snapshot_current(session, snap)
+        session.flush()
+
+        result = build_disk_subtree(session, project, resource.resource_name)
+        node = result['tree']
+        assert 'directories' not in node
+        assert node['fileset_paths'] == ['/gpfs/csfs1/test/only']


### PR DESCRIPTION
## Summary

Restores the legacy two-tier disk-charging design (`disk_activity` +
`disk_charge`) alongside today's tier-3 rollup (`disk_charge_summary`)
and surfaces the new per-fileset granularity in the disk Resource
Details dashboard. **No schema changes** — the existing tables and
prod's `(directory_name, username, activity_date, projcode)` UNIQUE
key provide everything needed.

Plan: [`docs/plans/DISK_ACTIVITY.md`](https://github.com/benkirk/sam-queries/blob/disk_activity/docs/plans/DISK_ACTIVITY.md).

## Why

Today's pipeline only persists `disk_charge_summary` (per-(user,
project, day) rollup, with `act_*` mirror columns from #208). The
dashboard tree node shows fileset paths as a comma-joined string with
a single bytes badge; per-fileset detail is lost on import. We can't
answer "which fileset is filling up?" from SAM. The legacy SAM Java
collector did populate `disk_activity` / `disk_charge` (5.3M / 934K
prod rows through 2026-04-25), but our new pipeline left those tables
dormant.

## What changed

### Importer — tier-1/tier-2 writes

`AccountingAdminCommand._write_disk_activity_and_charge()` runs in
`_run_disk` between the `--dry-run` gate and the existing tier-3
delete. Iterates raw entries (pre-`_group_disk_entries`) so each
fileset on a multi-fileset project produces its own tier-1 row.

- Skips synthetic `<unidentified>` gap rows (`user_override` set) and
  `'total'` rollup-sentinel rows — both are tier-3-only by
  construction (Quasar feeds for example).
- Unresolved directories still get a tier-1 row with
  `processing_status=False` and the failure reason in
  `error_comment`; tier-2 is skipped (audit trail without noise).
- Idempotent per `(resource_name, snap_date)`: pre-existing rows are
  removed via two-step delete (prod FK is RESTRICT, not CASCADE —
  verified against `sam-sql.ucar.edu`) and the delete piggybacks on
  the first chunk's `management_transaction` to keep MySQL SAVEPOINT
  churn low under xdist test mode.
- Progress bar in the same rich.progress style as the tier-3
  "Posting … disk charges…" bar (label + bar + M-of-N + elapsed).

### Helpers

`sam.manage.summaries`:
- `upsert_disk_activity()` keyed on `(directory_name, username,
  activity_date, projcode)`. `file_size_total` mirrors `bytes`
  (legacy column kept for parity).
- `upsert_disk_charge()` keyed on `disk_activity_id` (1:1).

Both follow the `(record, 'created'|'updated')` shape used by
`upsert_disk_charge_summary`. Callers supply pre-resolved FKs; no DB
resolve in the helpers.

### Per-fileset queries

`sam.queries.disk_usage`:
- `get_directory_usage_at(project_id, resource_name, activity_date)`
  joins `DiskActivity → DiskCharge → Account` so unresolved rows are
  excluded.
- `bulk_get_directory_usage_at(pairs, activity_date)` — single query
  for many `(project_id, resource_name)` pairs.
- `get_subtree_directory_usage_at(account_ids, resource_name,
  activity_date)` — aggregates an entire scoped subtree's directories
  in one grouped query, with the owning project's projcode attached
  to each row.
- `get_disk_usage_timeseries_for_directory(account_ids, ...)` —
  per-user bytes timeseries restricted to one fileset, same shape
  as `get_disk_usage_timeseries_by_user`.
- `get_directory_user_breakdown_at(account_ids, ...)` — per-user
  bytes/files at one snapshot date for one fileset.

All take `account_ids` (not a single `project_id`) so a fileset that
lives under a child project deeper in the tree resolves correctly
without the caller needing to know its owner.

### Dashboard — disk Resource Details

`_render_disk_resource_details` aggregates the scope's directory list
via `get_subtree_directory_usage_at` and hangs it off `scope_node`
for the template. Then branches on `fileset is None`: project-scope
path unchanged; fileset-scope path uses the refactored helpers with
`scope_account_ids`.

`render_disk_tree_node` macro: dropped its inline per-fileset block
(redundant once the standalone Filesets card is the canonical view).
The tree card itself is otherwise unchanged on multi-project pages.

New **Filesets card** (`resource_details_disk.html`):
- Lists every directory in the scoped subtree at the latest
  snapshot, summed across all disk accounts under the scope. Auto-
  shows a Project column when the scope spans more than one
  projcode (e.g. `?scope=NRAL0002` shows 9 filesets across 8 RAL
  child projects). Single-project scopes hide the column.
- Rows are clickable: `?fileset=<directory>` re-renders chart + per-
  user table scoped to that directory. Selected row highlights
  warning-yellow with a → icon, mirroring the tree's `?scope=`
  selection convention.
- Page-header breadcrumb gains `| Fileset: <code> [clear]` when
  scoped — `[clear]` sits outside any collapse trigger so it just
  navigates back to the unscoped scope.

### ORM drift fix

`DiskActivity.__table_args__` now declares the
`disk_activity_unique_idx UNIQUE` index that prod has but the model
was missing. Keeps `tests/integration/test_schema_validation.py`
honest going forward.

## Local validation (post-import, 17 weekly snapshots
`2026-01-03` → `2026-04-25`)

**Campaign_Store** (per-user/per-fileset feed) — all three tiers:
```
tier-1:  42,584 disk_activity rows
tier-2:  39,325 disk_charge rows (1:1 with resolved tier-1) ✓
tier-3:  38,625 disk_charge_summary rows
```

**Quasar** (project-rollup feed, `username='total'`) — tier-3 only,
by design:
```
tier-1:       0 rows  ← rollup sentinel skipped
tier-2:       0 rows
tier-3:     161 rows  (~9-10 projects × 17 snaps,
                       attributed to project lead via the existing
                       rollup-attribution path)
```

Resolution rate ~92% on Campaign_Store (~190 unresolved per snapshot,
written tier-1-only with `processing_status=False` — orphan filesets
without a `ProjectDirectory` entry).

Multi-fileset granularity surfaces correctly: e.g. `CESM` 140 dirs /
14.7 PiB, `ACOM` 80 dirs / 8.5 PiB, `DECS` 13 dirs / 17.4 PiB.

End-to-end Filesets-card check on `?projcode=NRAL0002&scope=NRAL0002`:
card shows 9 filesets across 8 RAL child projects with correct PiB
totals. Clicking `/gpfs/csfs1/ral/hap` (owned by P48500028) re-scopes
the chart and per-user table to the fileset's 4.16 PiB / 333M files —
correct attribution despite the directory belonging to a deeper
project. `[clear]` navigates back cleanly.

## Tests

13 new tests passing (full suite green under xdist parallel —
1900 passed / 23 skipped / 1 xfailed in 3:49):

- `tests/unit/test_accounting_disk_admin.py` — 4 new tests covering
  per-directory write, re-import idempotency, `'total'` sentinel
  skip, `<unidentified>` gap-row skip.
- `tests/unit/test_disk_usage_queries.py` — `TestPerDirectoryQuery`
  (5 tests: per-directory rows, resource-filter, unresolved
  excluded, bulk pairs, empty input) + `TestBuildDiskSubtreeMultifileset`
  (2 tests: directories attached only for multi-fileset projects;
  bytes sum to project-level total).

## Notes / out of scope for this PR

- **Per-fileset quota limits** are not yet shown on the dashboard.
  The data lives in `cs_usage.json` but isn't persisted in SAM —
  follow-up patch to fold limits into the import via a small
  `fileset_quota` table (no DDL on the 5.3M-row `disk_activity`).
- **Pre-existing data hygiene**: 934,212 orphan `disk_charge` rows
  on local DB reference `disk_activity_id`s that no longer exist —
  legacy artifacts from before this branch (prod FK is RESTRICT,
  prior wipes left charges behind). My idempotency delete only
  touches `(resource_name=X, activity_date=Y)` slices and didn't
  introduce any new orphans. Separate cleanup pass.
- Template companion doc in `docs/plans/DISK_PER_FILESET.md` —
  superseded by `DISK_ACTIVITY.md` (no-schema-change path chosen);
  follow-up doc cleanup deferred.

## Test plan

- [ ] CI green on staging (test/lint/integration workflows)
- [ ] Re-import a fresh `acct.glade.YYYY-MM-DD` against a clean DB;
      verify `disk_activity` / `disk_charge` row counts match the
      input's per-(user, fileset) rows (resolved) + tier-1-only for
      unresolved
- [ ] Re-run the same snapshot; verify counts unchanged (idempotency)
- [ ] Quasar import: confirm tier-1/tier-2 stay empty, tier-3 rows
      attributed to project lead
- [ ] Visit disk Resource Details for a multi-fileset project
      (e.g. `P43713000` on Campaign_Store): Filesets card lists
      4 csfs1 directories with bytes / files / share bars
- [ ] Visit a tree page (e.g. `NRAL0002`): Filesets card aggregates
      directories from child projects, Project column visible,
      click-scoping works
- [ ] `[clear]` link in page-header breadcrumb returns to unscoped view

🤖 Generated with [Claude Code](https://claude.com/claude-code)