### PR TITLE
ORM ↔ prod DB drift audit, full alignment, and FK-faithful local clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CONDA_ROOT := $(shell conda info --base)
 # Common way to initialize environment across various types of systems
 config_env := module load conda >/dev/null 2>&1 || true && . $(CONDA_ROOT)/etc/profile.d/conda.sh
 
-.PHONY: help clean clobber distclean fixperms check perf docker-build docker-up docker-down docker-restart
+.PHONY: help clean clobber distclean fixperms check perf check-db-vs-orms docker-build docker-up docker-down docker-restart
 
 # -------------------------------------------------------------------
 # Default target: help
@@ -76,6 +76,10 @@ check: ## Run tests
 perf: ## Run perf regression + benchmark suite (serial)
 	$(config_env) && source etc/config_env.sh && \
 	    python3 -m pytest -m perf -n 0 -v
+
+check-db-vs-orms: ## Audit prod DB schema vs ORM models — runs check_db_drift + orm_inventory (skips if PROD_* env unset / VPN unreachable)
+	$(config_env) && source etc/config_env.sh && \
+	    python3 scripts/check_db_drift.py
 
 docker-build: ## Build docker containers
 	@docker compose build

--- a/containers/sam-sql-dev/Makefile
+++ b/containers/sam-sql-dev/Makefile
@@ -9,7 +9,7 @@ all: clone
 
 clone:
 	@python bootstrap_clone.py
-	@docker compose -f $(COMPOSE_FILE) exec -T mysql  sh -c 'mysql -uroot -proot -e "USE sam; TRUNCATE TABLE api_credentials;"'
+	@docker compose -f $(COMPOSE_FILE) exec -T mysql sh -c 'mysql -uroot -proot -e "USE sam; SET FOREIGN_KEY_CHECKS=0; TRUNCATE TABLE api_credentials; SET FOREIGN_KEY_CHECKS=1;"'
 
 clean:
 	rm -rf dump/ *.sql.xz *~

--- a/containers/sam-sql-dev/backups/sam-obfuscated.sql.xz
+++ b/containers/sam-sql-dev/backups/sam-obfuscated.sql.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:80aa0cd0ddf4e6162ef1b1813693690315132423a385f11f9d774a60aa21028f
-size 18880124
+oid sha256:96560d02d4dfaf771f36bad1375954d720dfeccffdc6deb5582986b5ae584bea
+size 18934540

--- a/containers/sam-sql-dev/bootstrap_clone.py
+++ b/containers/sam-sql-dev/bootstrap_clone.py
@@ -150,6 +150,65 @@ def get_foreign_keys(conn, db):
         cur.execute(q, (db,))
         return cur.fetchall()
 
+
+def get_foreign_key_constraints(conn, db):
+    """Return remote FK constraints as a list of dicts ready for ALTER TABLE.
+
+    Groups multi-column composite FKs into a single record with ordered
+    `child_cols` / `parent_cols` lists. Captures ON DELETE / ON UPDATE
+    rules from REFERENTIAL_CONSTRAINTS so the rebuilt FK matches prod
+    exactly.
+
+    Output shape per FK:
+        {
+            'child_table':   str,
+            'constraint':    str,
+            'child_cols':    [str, ...],
+            'parent_table':  str,
+            'parent_cols':   [str, ...],
+            'on_delete':     str,   # 'CASCADE' | 'SET NULL' | 'RESTRICT' | 'NO ACTION'
+            'on_update':     str,
+        }
+    """
+    q = """
+    SELECT kcu.TABLE_NAME            AS child_table,
+           kcu.CONSTRAINT_NAME       AS constraint_name,
+           kcu.COLUMN_NAME           AS child_col,
+           kcu.REFERENCED_TABLE_NAME AS parent_table,
+           kcu.REFERENCED_COLUMN_NAME AS parent_col,
+           kcu.ORDINAL_POSITION      AS ordinal,
+           rc.DELETE_RULE            AS on_delete,
+           rc.UPDATE_RULE            AS on_update
+    FROM information_schema.key_column_usage kcu
+    JOIN information_schema.referential_constraints rc
+      ON kcu.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA
+     AND kcu.CONSTRAINT_NAME   = rc.CONSTRAINT_NAME
+    WHERE kcu.TABLE_SCHEMA = %s
+      AND kcu.REFERENCED_TABLE_NAME IS NOT NULL
+    ORDER BY kcu.TABLE_NAME, kcu.CONSTRAINT_NAME, kcu.ORDINAL_POSITION
+    """
+    with conn.cursor() as cur:
+        cur.execute(q, (db,))
+        rows = cur.fetchall()
+
+    grouped = {}
+    for r in rows:
+        key = (r["child_table"], r["constraint_name"])
+        if key not in grouped:
+            grouped[key] = {
+                "child_table":  r["child_table"],
+                "constraint":   r["constraint_name"],
+                "child_cols":   [],
+                "parent_table": r["parent_table"],
+                "parent_cols":  [],
+                "on_delete":    r["on_delete"],
+                "on_update":    r["on_update"],
+            }
+        grouped[key]["child_cols"].append(r["child_col"])
+        grouped[key]["parent_cols"].append(r["parent_col"])
+
+    return list(grouped.values())
+
 def get_primary_key_columns(conn, db, table):
     q = """
     SELECT COLUMN_NAME as column_name
@@ -378,6 +437,55 @@ def dump_table_where(cfg, table, where_clause):
     )
     run(cmd)
     return out
+
+def reapply_foreign_keys(cfg, fk_constraints):
+    """Phase C: re-apply prod's FK constraints to the local clone.
+
+    The schema load strips FK constraints (see load_local with
+    disable_fk_checks=True) because mysqldump's pre-table FOREIGN KEY
+    declarations cause issues on MySQL 9 when tables are loaded in any
+    order other than strict topological. After data has been loaded
+    in topological order with FK-aware sampling, parent rows for every
+    sampled child row are guaranteed to exist, so we can re-apply the
+    constraints as a single batched ALTER TABLE script.
+
+    This restores full prod parity for FK metadata in the local clone,
+    which is what the schema-validation tests need to assert against.
+
+    Acts as a final integrity check: if cleanup_orphans missed anything,
+    the constraint creation will fail loudly here.
+    """
+    if not fk_constraints:
+        print("ℹ️  No FK constraints to re-apply.")
+        return
+
+    out = os.path.join(DUMP_DIR, "foreign_keys.sql")
+    with open(out, "w") as f:
+        # Wrap the script so MySQL doesn't try to validate constraints
+        # mid-load when adding FKs across already-populated tables.
+        f.write("SET FOREIGN_KEY_CHECKS=0;\n")
+        for fk in fk_constraints:
+            child_cols  = ", ".join(f"`{c}`" for c in fk["child_cols"])
+            parent_cols = ", ".join(f"`{c}`" for c in fk["parent_cols"])
+            stmt = (
+                f"ALTER TABLE `{fk['child_table']}` "
+                f"ADD CONSTRAINT `{fk['constraint']}` "
+                f"FOREIGN KEY ({child_cols}) "
+                f"REFERENCES `{fk['parent_table']}` ({parent_cols})"
+            )
+            # MySQL's default for omitted ON DELETE/UPDATE is RESTRICT;
+            # only emit a clause when it differs, to keep the SQL clean.
+            if fk["on_delete"] and fk["on_delete"].upper() != "RESTRICT":
+                stmt += f" ON DELETE {fk['on_delete']}"
+            if fk["on_update"] and fk["on_update"].upper() != "RESTRICT":
+                stmt += f" ON UPDATE {fk['on_update']}"
+            f.write(stmt + ";\n")
+        f.write("SET FOREIGN_KEY_CHECKS=1;\n")
+
+    print(f"📥 Re-applying {len(fk_constraints)} FK constraints from {out} ...")
+    load_local(cfg, out, disable_fk_checks=False)
+    print(f"✅ FK constraints re-applied")
+
 
 def load_local(cfg, filename, disable_fk_checks=False):
     # Note: For docker exec, we use environment variable MYSQL_PWD which is less secure
@@ -678,6 +786,22 @@ def main():
             run("python3 cleanup_orphans.py")
         except Exception as e:
             print("⚠️  cleanup_orphans.py failed:", e)
+
+    # Phase C: re-apply foreign key constraints after data is in place
+    # AND orphans have been cleaned up. The schema load stripped FKs
+    # (load_local(..., disable_fk_checks=True)) so the local clone has
+    # been running without prod's referential integrity. By doing this
+    # after cleanup_orphans, the FK creation is the final integrity
+    # check — if anything still fails here, the sampling or cleanup
+    # missed something and we want to know loudly rather than silently.
+    print("\n🔗 Re-applying foreign key constraints from remote schema...")
+    try:
+        fk_constraints = get_foreign_key_constraints(remote_conn, remote["database"])
+        reapply_foreign_keys(cfg, fk_constraints)
+    except Exception as e:
+        print(f"⚠️  Error re-applying FK constraints: {e}", file=sys.stderr)
+        print("    (likely orphan data not handled by cleanup_orphans;"
+              " local clone has weaker FK integrity than prod)")
 
     print("\n🎉 Done. Local clone is ready. Connect to local db as configured.")
 

--- a/containers/sam-sql-dev/bootstrap_clone.py
+++ b/containers/sam-sql-dev/bootstrap_clone.py
@@ -438,6 +438,25 @@ def dump_table_where(cfg, table, where_clause):
     run(cmd)
     return out
 
+def _build_alter_add_fk(fk):
+    """Render a single ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY ... statement."""
+    child_cols  = ", ".join(f"`{c}`" for c in fk["child_cols"])
+    parent_cols = ", ".join(f"`{c}`" for c in fk["parent_cols"])
+    stmt = (
+        f"ALTER TABLE `{fk['child_table']}` "
+        f"ADD CONSTRAINT `{fk['constraint']}` "
+        f"FOREIGN KEY ({child_cols}) "
+        f"REFERENCES `{fk['parent_table']}` ({parent_cols})"
+    )
+    # MySQL's default for omitted ON DELETE/UPDATE is RESTRICT;
+    # only emit a clause when it differs, to keep the SQL clean.
+    if fk["on_delete"] and fk["on_delete"].upper() != "RESTRICT":
+        stmt += f" ON DELETE {fk['on_delete']}"
+    if fk["on_update"] and fk["on_update"].upper() != "RESTRICT":
+        stmt += f" ON UPDATE {fk['on_update']}"
+    return stmt
+
+
 def reapply_foreign_keys(cfg, fk_constraints):
     """Phase C: re-apply prod's FK constraints to the local clone.
 
@@ -447,44 +466,76 @@ def reapply_foreign_keys(cfg, fk_constraints):
     order other than strict topological. After data has been loaded
     in topological order with FK-aware sampling, parent rows for every
     sampled child row are guaranteed to exist, so we can re-apply the
-    constraints as a single batched ALTER TABLE script.
+    constraints from prod here.
 
-    This restores full prod parity for FK metadata in the local clone,
-    which is what the schema-validation tests need to assert against.
+    Tolerant of individual failures — applies each ALTER TABLE in its
+    own statement and logs failures rather than aborting the whole
+    bootstrap. Two common failure modes:
 
-    Acts as a final integrity check: if cleanup_orphans missed anything,
-    the constraint creation will fail loudly here.
+    1. Legacy MySQL/InnoDB permissiveness: prod was created when an FK
+       could reference the leftmost column of a composite PK even
+       though that column alone wasn't unique. MySQL 8.0+ enforces
+       strict matching, so these "grandfathered" FKs fail to recreate.
+       Example: `dav_activity` has PK (`dav_activity_id`, `queue_name`)
+       and prod's `fk_dav_charge_dav_activity` references just
+       `dav_activity_id` — doesn't satisfy MySQL 9's uniqueness rule.
+
+    2. Orphan data not handled by `cleanup_orphans` — sampled child
+       rows pointing at parents that didn't make it into the sample.
+       FK creation fails loudly, which is the desired signal.
+
+    Either way, the local clone ends up with *most* FKs applied and a
+    clear log of what's missing. The bootstrap continues.
     """
     if not fk_constraints:
         print("ℹ️  No FK constraints to re-apply.")
         return
 
+    # Write the full script for reference / inspection / manual replay.
     out = os.path.join(DUMP_DIR, "foreign_keys.sql")
     with open(out, "w") as f:
-        # Wrap the script so MySQL doesn't try to validate constraints
-        # mid-load when adding FKs across already-populated tables.
         f.write("SET FOREIGN_KEY_CHECKS=0;\n")
         for fk in fk_constraints:
-            child_cols  = ", ".join(f"`{c}`" for c in fk["child_cols"])
-            parent_cols = ", ".join(f"`{c}`" for c in fk["parent_cols"])
-            stmt = (
-                f"ALTER TABLE `{fk['child_table']}` "
-                f"ADD CONSTRAINT `{fk['constraint']}` "
-                f"FOREIGN KEY ({child_cols}) "
-                f"REFERENCES `{fk['parent_table']}` ({parent_cols})"
-            )
-            # MySQL's default for omitted ON DELETE/UPDATE is RESTRICT;
-            # only emit a clause when it differs, to keep the SQL clean.
-            if fk["on_delete"] and fk["on_delete"].upper() != "RESTRICT":
-                stmt += f" ON DELETE {fk['on_delete']}"
-            if fk["on_update"] and fk["on_update"].upper() != "RESTRICT":
-                stmt += f" ON UPDATE {fk['on_update']}"
-            f.write(stmt + ";\n")
+            f.write(_build_alter_add_fk(fk) + ";\n")
         f.write("SET FOREIGN_KEY_CHECKS=1;\n")
 
-    print(f"📥 Re-applying {len(fk_constraints)} FK constraints from {out} ...")
-    load_local(cfg, out, disable_fk_checks=False)
-    print(f"✅ FK constraints re-applied")
+    print(f"📥 Re-applying {len(fk_constraints)} FK constraints "
+          f"(individual statements; failures are logged, not fatal) ...")
+
+    # Connect once via pymysql for fine-grained per-statement control.
+    conn = pymysql.connect(
+        host=cfg["local"].get("host", "127.0.0.1"),
+        port=int(cfg["local"].get("port", 3306)),
+        user=cfg["local"]["user"],
+        password=cfg["local"]["password"],
+        database=cfg["local"]["database"],
+        autocommit=True,
+        cursorclass=pymysql.cursors.DictCursor,
+    )
+    succeeded = 0
+    failed = []
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SET FOREIGN_KEY_CHECKS=0")
+            for fk in fk_constraints:
+                stmt = _build_alter_add_fk(fk)
+                try:
+                    cur.execute(stmt)
+                    succeeded += 1
+                except pymysql.MySQLError as e:
+                    failed.append((fk, str(e)))
+            cur.execute("SET FOREIGN_KEY_CHECKS=1")
+    finally:
+        conn.close()
+
+    print(f"✅ {succeeded}/{len(fk_constraints)} FK constraints re-applied")
+    if failed:
+        print(f"⚠️  {len(failed)} FK constraints could NOT be applied:")
+        for fk, err in failed:
+            print(f"    - {fk['child_table']}.{fk['constraint']}: {err}")
+        print(f"  (see {out} for the full SQL; these are typically legacy "
+              f"FKs that no longer satisfy MySQL 9 uniqueness rules, or "
+              f"sampled rows whose parents were pruned)")
 
 
 def load_local(cfg, filename, disable_fk_checks=False):

--- a/scripts/check_db_drift.py
+++ b/scripts/check_db_drift.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Audit prod DB schema vs ORM models — beyond what test_schema_validation.py covers.
+
+Catches the DiskActivity-class drift that PR #209 fixed pointwise:
+indexes, unique constraints, FK actions, and column nullable/default
+mismatches that the existing column/PK checks miss.
+
+Read-only. Connects via PROD_SAM_DB_{SERVER,USERNAME,PASSWORD}. Skips
+gracefully (exit 0) when:
+  - any of those env vars is unset (CI / clean checkout)
+  - the host is unreachable (off-VPN — sam-sql.ucar.edu requires UCAR VPN)
+
+Use --strict to flip skips into hard failures (e.g. nightly job from
+an on-VPN runner that *should* error if it can't reach prod).
+"""
+import argparse
+import os
+import socket
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+# Make 'sam' and 'scripts.lib' importable regardless of cwd
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent / 'src'))
+sys.path.insert(0, str(HERE.parent))
+
+from sqlalchemy import URL, create_engine
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import sessionmaker
+
+from scripts.lib.schema_introspection import (
+    diff_indexes,
+    get_db_columns,
+    get_db_foreign_keys,
+    get_db_indexes,
+    get_orm_indexes,
+    get_table_type,
+    is_acceptable_type_mismatch,
+    iter_table_mappers,
+    normalize_type,
+    TYPE_MAPPINGS,
+)
+
+
+REQUIRED_ENV = ('PROD_SAM_DB_SERVER', 'PROD_SAM_DB_USERNAME', 'PROD_SAM_DB_PASSWORD')
+CONNECT_TIMEOUT_SECS = 5
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--strict', action='store_true',
+                   help='Fail (non-zero exit) on missing env or unreachable host '
+                        'instead of skipping with exit 0.')
+    p.add_argument('--report', default='indexes,fks,columns',
+                   help='Comma-separated checks to run. '
+                        'Default: indexes,fks,columns')
+    return p.parse_args()
+
+
+def skip_or_fail(message: str, *, strict: bool) -> int:
+    """Exit 0 with a skip message, or 1 in --strict mode."""
+    prefix = "ERROR" if strict else "SKIPPED"
+    print(f"[{prefix}] {message}", file=sys.stderr)
+    return 1 if strict else 0
+
+
+def check_env(strict: bool) -> int:
+    missing = [v for v in REQUIRED_ENV if not os.environ.get(v)]
+    if missing:
+        return skip_or_fail(
+            f"prod creds not in environment (missing: {', '.join(missing)}). "
+            f"Set {', '.join(REQUIRED_ENV)} to run this audit.",
+            strict=strict,
+        )
+    return 0
+
+
+def can_reach(host: str, port: int = 3306, timeout: float = CONNECT_TIMEOUT_SECS) -> bool:
+    """TCP-connect probe. Returns False on DNS failure, refusal, or timeout."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except (OSError, socket.gaierror, socket.timeout):
+        return False
+
+
+def build_prod_engine():
+    url = URL.create(
+        drivername='mysql+pymysql',
+        username=os.environ['PROD_SAM_DB_USERNAME'],
+        password=os.environ['PROD_SAM_DB_PASSWORD'],
+        host=os.environ['PROD_SAM_DB_SERVER'],
+        database=os.environ.get('PROD_SAM_DB_NAME', 'sam'),
+    )
+    require_ssl = os.getenv('PROD_SAM_DB_REQUIRE_SSL', 'true').lower() in ('true', '1', 'yes')
+    connect_args = {'connect_timeout': CONNECT_TIMEOUT_SECS}
+    if require_ssl:
+        connect_args['ssl'] = {'ssl_disabled': False}
+    return create_engine(url, pool_pre_ping=True, connect_args=connect_args)
+
+
+# ============================================================================
+# Per-table audits
+# ============================================================================
+
+
+def audit_indexes(session, mapper) -> list:
+    table = mapper.persist_selectable.name
+    db_idx = get_db_indexes(session, table)
+    orm_idx = get_orm_indexes(mapper)
+    diff = diff_indexes(db_idx, orm_idx)
+
+    findings = []
+    for name, cols, uniq in diff['in_db_not_orm']:
+        kind = 'UNIQUE INDEX' if uniq else 'INDEX'
+        findings.append(f"DB has {kind} '{name}' on ({', '.join(cols)}) — ORM does not declare it")
+    for name, cols, uniq in diff['in_orm_not_db']:
+        kind = 'UNIQUE INDEX' if uniq else 'INDEX'
+        findings.append(f"ORM declares {kind} '{name}' on ({', '.join(cols)}) — DB does not have it")
+    for name, (db_cols, db_uniq), (orm_cols, orm_uniq) in diff['mismatched']:
+        findings.append(
+            f"INDEX '{name}' differs: DB=(cols={db_cols}, unique={db_uniq}) "
+            f"vs ORM=(cols={orm_cols}, unique={orm_uniq})"
+        )
+    return findings
+
+
+def audit_foreign_keys(session, mapper) -> list:
+    table = mapper.persist_selectable.name
+    db_fks = get_db_foreign_keys(session, table)
+    findings = []
+
+    orm_fk_cols = set()
+    for fk in mapper.persist_selectable.foreign_keys:
+        orm_fk_cols.add(fk.parent.name)
+
+    db_fk_cols = set()
+    for cname, info in db_fks.items():
+        db_fk_cols.update(info['columns'])
+
+    missing_in_db = orm_fk_cols - db_fk_cols
+    if missing_in_db:
+        findings.append(
+            f"ORM declares FK on column(s) {sorted(missing_in_db)} but DB has no FK constraint"
+        )
+
+    extra_in_db = db_fk_cols - orm_fk_cols
+    if extra_in_db:
+        findings.append(
+            f"DB has FK constraint on column(s) {sorted(extra_in_db)} but ORM does not declare it"
+        )
+
+    return findings
+
+
+def audit_columns(session, mapper) -> list:
+    table = mapper.persist_selectable.name
+    db_cols = get_db_columns(session, table)
+    findings = []
+
+    orm_col_names = {c.name for c in mapper.persist_selectable.columns}
+    db_col_names = set(db_cols.keys())
+
+    missing = orm_col_names - db_col_names
+    if missing:
+        findings.append(f"ORM columns missing from DB: {sorted(missing)}")
+
+    # Type comparison
+    for col in mapper.persist_selectable.columns:
+        if col.name not in db_cols:
+            continue
+        orm_type = type(col.type).__name__
+        db_raw = db_cols[col.name]['type']
+        db_norm = normalize_type(db_raw)
+        acceptable = TYPE_MAPPINGS.get(orm_type, [])
+        if not acceptable or db_norm in acceptable:
+            continue
+        # String → TEXT widening is benign
+        if orm_type == 'String' and db_norm in ('TEXT', 'MEDIUMTEXT', 'LONGTEXT'):
+            continue
+        msg = f"{col.name}: ORM={orm_type} → DB={db_raw}"
+        if not is_acceptable_type_mismatch(msg):
+            findings.append(f"type mismatch — {msg}")
+
+        # Nullability mismatch (warn only — frequently intentional in MySQL)
+        db_nullable = db_cols[col.name]['nullable']
+        if col.nullable != db_nullable:
+            findings.append(
+                f"{col.name}: nullable mismatch — ORM={col.nullable} vs DB={db_nullable}"
+            )
+
+    return findings
+
+
+# ============================================================================
+# Reporting
+# ============================================================================
+
+
+def main() -> int:
+    args = parse_args()
+    checks = {c.strip() for c in args.report.split(',') if c.strip()}
+
+    rc = check_env(strict=args.strict)
+    if rc != 0:
+        return rc
+
+    host = os.environ['PROD_SAM_DB_SERVER']
+    if not can_reach(host):
+        return skip_or_fail(
+            f"cannot reach {host}:3306 within {CONNECT_TIMEOUT_SECS}s "
+            "(VPN required? sam-sql.ucar.edu is only reachable over the UCAR VPN)",
+            strict=args.strict,
+        )
+
+    print(f"[INFO] connecting to {host} (read-only INFORMATION_SCHEMA queries)…")
+    try:
+        engine = build_prod_engine()
+        SessionLocal = sessionmaker(bind=engine)
+    except OperationalError as e:
+        return skip_or_fail(f"connection setup failed: {e}", strict=args.strict)
+
+    # Importing 'sam' loads all ORM models into Base.registry
+    import sam  # noqa: F401
+    from sam.base import Base
+
+    session = SessionLocal()
+    try:
+        rc = run_audit(session, Base, checks)
+    finally:
+        session.close()
+
+    # Also run the existing ORM inventory pass (column coverage + relationship
+    # map) against the same prod engine, so `make check-db-vs-orms` captures
+    # both reports in one invocation.
+    print()
+    print("#" * 72)
+    print("# orm_inventory: full column / relationship coverage report")
+    print("#" * 72)
+    try:
+        from orm_inventory import generate_report
+        generate_report(engine)
+    except Exception as e:
+        print(f"[WARN] orm_inventory failed: {e}", file=sys.stderr)
+    finally:
+        engine.dispose()
+
+    return rc
+
+
+def run_audit(session, Base, checks: set) -> int:
+    print(f"[INFO] checks: {sorted(checks)}\n")
+    total_findings = 0
+    tables_with_findings = 0
+    tables_audited = 0
+
+    for mapper in sorted(iter_table_mappers(Base.registry),
+                         key=lambda m: m.persist_selectable.name):
+        table = mapper.persist_selectable.name
+
+        # Skip if the table doesn't exist in this DB (model coverage problem,
+        # already surfaced by test_all_tables_exist_in_database)
+        if get_table_type(session, table) != 'BASE TABLE':
+            continue
+
+        tables_audited += 1
+        findings = []
+
+        if 'indexes' in checks:
+            findings += [('idx', f) for f in audit_indexes(session, mapper)]
+        if 'fks' in checks:
+            findings += [('fk',  f) for f in audit_foreign_keys(session, mapper)]
+        if 'columns' in checks:
+            findings += [('col', f) for f in audit_columns(session, mapper)]
+
+        if not findings:
+            continue
+
+        tables_with_findings += 1
+        total_findings += len(findings)
+        print(f"TABLE: {table}  ({mapper.class_.__name__})")
+        for kind, msg in findings:
+            print(f"  ⚠️  [{kind}] {msg}")
+        print()
+
+    print("=" * 72)
+    print(f"audited {tables_audited} tables — "
+          f"{tables_with_findings} with findings, {total_findings} total findings")
+
+    # Exit 0 even when there are findings — this is a report tool, not a gate.
+    # The CI guards in test_schema_validation.py are the gate.
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/check_db_drift.py
+++ b/scripts/check_db_drift.py
@@ -31,6 +31,7 @@ from sqlalchemy.orm import sessionmaker
 
 from scripts.lib.schema_introspection import (
     diff_indexes,
+    find_rename_pairs,
     get_db_columns,
     get_db_foreign_keys,
     get_db_indexes,
@@ -106,18 +107,37 @@ def build_prod_engine():
 
 
 def audit_indexes(session, mapper) -> list:
+    """Index findings, with rename pairs collapsed to one line each.
+
+    A "rename" is when DB and ORM both declare an index on the same
+    columns with the same uniqueness, but under different names. That
+    pair shows up as a single RENAME line — actionable as one change
+    (rename the ORM Index to match prod). Unpaired entries surface as
+    real drift.
+    """
     table = mapper.persist_selectable.name
     db_idx = get_db_indexes(session, table)
     orm_idx = get_orm_indexes(mapper)
-    diff = diff_indexes(db_idx, orm_idx)
+    diff = find_rename_pairs(diff_indexes(db_idx, orm_idx))
 
     findings = []
+
+    for cols, uniq, db_name, orm_name in diff['renames']:
+        kind = 'UNIQUE' if uniq else 'index'
+        findings.append(
+            f"RENAME {kind} on ({', '.join(cols)}): "
+            f"DB='{db_name}' vs ORM='{orm_name}' — rename ORM to match prod"
+        )
     for name, cols, uniq in diff['in_db_not_orm']:
         kind = 'UNIQUE INDEX' if uniq else 'INDEX'
-        findings.append(f"DB has {kind} '{name}' on ({', '.join(cols)}) — ORM does not declare it")
+        findings.append(
+            f"DB has {kind} '{name}' on ({', '.join(cols)}) — ORM does not declare it"
+        )
     for name, cols, uniq in diff['in_orm_not_db']:
         kind = 'UNIQUE INDEX' if uniq else 'INDEX'
-        findings.append(f"ORM declares {kind} '{name}' on ({', '.join(cols)}) — DB does not have it")
+        findings.append(
+            f"ORM declares {kind} '{name}' on ({', '.join(cols)}) — DB does not have it"
+        )
     for name, (db_cols, db_uniq), (orm_cols, orm_uniq) in diff['mismatched']:
         findings.append(
             f"INDEX '{name}' differs: DB=(cols={db_cols}, unique={db_uniq}) "

--- a/scripts/check_db_drift.py
+++ b/scripts/check_db_drift.py
@@ -146,6 +146,20 @@ def audit_indexes(session, mapper) -> list:
     return findings
 
 
+# ORM-side FKs that are intentionally declared without a matching DB-level
+# constraint. Each entry is (table_name, frozenset_of_columns) plus a
+# one-line reason. Used to suppress the corresponding finding so the
+# legitimate drift stays visible.
+IGNORED_FK_DRIFT = {
+    # Self-referential FK driving the nested-set parent/children relationship
+    # used by the admin organizations dashboard. Prod doesn't enforce the FK
+    # constraint at the DB level, but the ORM declaration is load-bearing for
+    # SQLAlchemy joins (subqueryload(Organization.children) etc).
+    ('organization', frozenset({'parent_org_id'})): (
+        'self-FK drives Organization.parent/.children nested-set relationship'),
+}
+
+
 def audit_foreign_keys(session, mapper) -> list:
     table = mapper.persist_selectable.name
     db_fks = get_db_foreign_keys(session, table)
@@ -160,7 +174,7 @@ def audit_foreign_keys(session, mapper) -> list:
         db_fk_cols.update(info['columns'])
 
     missing_in_db = orm_fk_cols - db_fk_cols
-    if missing_in_db:
+    if missing_in_db and (table, frozenset(missing_in_db)) not in IGNORED_FK_DRIFT:
         findings.append(
             f"ORM declares FK on column(s) {sorted(missing_in_db)} but DB has no FK constraint"
         )

--- a/scripts/check_db_drift.py
+++ b/scripts/check_db_drift.py
@@ -274,7 +274,7 @@ def main() -> int:
     print("#" * 72)
     try:
         from orm_inventory import generate_report
-        generate_report(engine)
+        generate_report(engine, issues_only=True)
     except Exception as e:
         print(f"[WARN] orm_inventory failed: {e}", file=sys.stderr)
     finally:

--- a/scripts/lib/schema_introspection.py
+++ b/scripts/lib/schema_introspection.py
@@ -1,0 +1,264 @@
+"""Shared helpers for ORM ↔ MySQL schema introspection.
+
+Used by:
+  - scripts/check_db_drift.py — one-shot audit against any DB (prod, staging, local)
+  - tests/integration/test_schema_validation.py — CI guards run against the test container
+
+Pure read-only INFORMATION_SCHEMA queries plus SQLAlchemy mapper inspection.
+No writes, no mocking.
+"""
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+from sqlalchemy import text
+from sqlalchemy.schema import Index, UniqueConstraint
+
+
+# ============================================================================
+# Type mapping (extracted from tests/integration/test_schema_validation.py)
+# ============================================================================
+
+TYPE_MAPPINGS = {
+    'Integer':    ['INT', 'INTEGER', 'TINYINT', 'SMALLINT', 'MEDIUMINT', 'BIGINT'],
+    'BigInteger': ['BIGINT'],
+    'String':     ['VARCHAR', 'CHAR'],
+    'Text':       ['TEXT', 'MEDIUMTEXT', 'LONGTEXT', 'TINYTEXT'],
+    'Float':      ['FLOAT', 'DOUBLE'],
+    'Numeric':    ['DECIMAL', 'NUMERIC', 'FLOAT', 'DOUBLE'],
+    'Boolean':    ['BIT', 'TINYINT'],
+    'DateTime':   ['DATETIME', 'TIMESTAMP'],
+    'Date':       ['DATE'],
+    'TIMESTAMP':  ['TIMESTAMP', 'DATETIME'],
+}
+
+
+def normalize_type(db_type: str) -> str:
+    """'VARCHAR(255) UNSIGNED' → 'VARCHAR'. Strips size + sign."""
+    base = db_type.split('(')[0].upper()
+    base = base.replace(' UNSIGNED', '').replace(' SIGNED', '')
+    return base.strip()
+
+
+def is_acceptable_type_mismatch(mismatch_str: str) -> bool:
+    """Known-good MySQL ↔ SQLAlchemy type pairings we don't flag."""
+    acceptable = (
+        'ORM=String → DB=CHAR',
+        'ORM=Integer → DB=TINYINT',
+        'ORM=Integer → DB=SMALLINT',
+        'ORM=Integer → DB=MEDIUMINT',
+    )
+    return any(p in mismatch_str for p in acceptable)
+
+
+# ============================================================================
+# Index introspection
+# ============================================================================
+
+# DB index records: (name, [columns_in_order], unique:bool)
+DBIndex = Tuple[str, Tuple[str, ...], bool]
+
+
+def get_db_indexes(session, table_name: str) -> List[DBIndex]:
+    """Return all indexes on a table from INFORMATION_SCHEMA, EXCLUDING the PRIMARY key.
+
+    Output: [(index_name, (col1, col2, ...), is_unique), ...]
+    Columns are in SEQ_IN_INDEX order. PRIMARY KEY is excluded — primary keys are
+    validated separately by test_primary_keys_match.
+    """
+    rows = session.execute(text("""
+        SELECT INDEX_NAME, COLUMN_NAME, NON_UNIQUE, SEQ_IN_INDEX
+        FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = :table_name
+          AND INDEX_NAME != 'PRIMARY'
+        ORDER BY INDEX_NAME, SEQ_IN_INDEX
+    """), {'table_name': table_name}).fetchall()
+
+    grouped: Dict[str, Dict] = defaultdict(lambda: {'cols': [], 'non_unique': None})
+    for index_name, col_name, non_unique, _seq in rows:
+        grouped[index_name]['cols'].append(col_name)
+        # NON_UNIQUE is the same for all rows in an index; capture once
+        grouped[index_name]['non_unique'] = int(non_unique)
+
+    return [
+        (name, tuple(info['cols']), info['non_unique'] == 0)
+        for name, info in sorted(grouped.items())
+    ]
+
+
+def get_orm_indexes(mapper) -> List[DBIndex]:
+    """Return all ORM-declared indexes for a mapper, in the same shape as get_db_indexes.
+
+    Picks up:
+      - Index(...) entries in __table_args__
+      - UniqueConstraint(...) entries in __table_args__ (treated as a unique index)
+      - index=True / unique=True on individual columns
+    """
+    table = mapper.persist_selectable
+    out: List[DBIndex] = []
+
+    for idx in table.indexes:
+        cols = tuple(c.name for c in idx.columns)
+        out.append((idx.name, cols, bool(idx.unique)))
+
+    for cons in table.constraints:
+        if isinstance(cons, UniqueConstraint):
+            cols = tuple(c.name for c in cons.columns)
+            # MySQL treats UniqueConstraint as a UNIQUE INDEX; surface for comparison
+            out.append((cons.name or _synthetic_unique_name(table.name, cols), cols, True))
+
+    # De-duplicate: an Index(unique=True) and a UniqueConstraint can both register
+    seen = set()
+    deduped = []
+    for name, cols, uniq in out:
+        key = (name, cols, uniq)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append((name, cols, uniq))
+
+    return sorted(deduped)
+
+
+def _synthetic_unique_name(table: str, cols: Tuple[str, ...]) -> str:
+    """Fallback when a UniqueConstraint is unnamed in the ORM."""
+    return f"<unnamed unique on {table}({','.join(cols)})>"
+
+
+def diff_indexes(
+    db_indexes: List[DBIndex], orm_indexes: List[DBIndex]
+) -> Dict[str, List]:
+    """Compare DB and ORM index sets.
+
+    Returns dict with keys:
+      - 'in_db_not_orm': indexes present in DB but missing from ORM (← DiskActivity bug)
+      - 'in_orm_not_db': indexes declared in ORM but absent from DB
+      - 'mismatched':    same name, different columns or uniqueness
+    """
+    db_by_name = {name: (cols, uniq) for name, cols, uniq in db_indexes}
+    orm_by_name = {name: (cols, uniq) for name, cols, uniq in orm_indexes}
+
+    in_db_not_orm = []
+    in_orm_not_db = []
+    mismatched = []
+
+    for name, (cols, uniq) in db_by_name.items():
+        if name not in orm_by_name:
+            in_db_not_orm.append((name, cols, uniq))
+        elif orm_by_name[name] != (cols, uniq):
+            mismatched.append((name, db_by_name[name], orm_by_name[name]))
+
+    for name, (cols, uniq) in orm_by_name.items():
+        if name not in db_by_name:
+            in_orm_not_db.append((name, cols, uniq))
+
+    return {
+        'in_db_not_orm': in_db_not_orm,
+        'in_orm_not_db': in_orm_not_db,
+        'mismatched': mismatched,
+    }
+
+
+# ============================================================================
+# Foreign key introspection
+# ============================================================================
+
+
+def get_db_foreign_keys(session, table_name: str) -> Dict[str, Dict]:
+    """Return DB-level FK constraints for a table.
+
+    Output: {constraint_name: {
+        'columns': [...], 'referenced_table': str, 'referenced_columns': [...],
+        'on_delete': str, 'on_update': str
+    }}
+    """
+    rows = session.execute(text("""
+        SELECT
+            kcu.CONSTRAINT_NAME,
+            kcu.COLUMN_NAME,
+            kcu.REFERENCED_TABLE_NAME,
+            kcu.REFERENCED_COLUMN_NAME,
+            kcu.ORDINAL_POSITION,
+            rc.DELETE_RULE,
+            rc.UPDATE_RULE
+        FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
+        JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
+          ON kcu.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA
+         AND kcu.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
+        WHERE kcu.TABLE_SCHEMA = DATABASE()
+          AND kcu.TABLE_NAME = :table_name
+          AND kcu.REFERENCED_TABLE_NAME IS NOT NULL
+        ORDER BY kcu.CONSTRAINT_NAME, kcu.ORDINAL_POSITION
+    """), {'table_name': table_name}).fetchall()
+
+    fks: Dict[str, Dict] = {}
+    for cname, col, rtable, rcol, _ord, on_del, on_upd in rows:
+        if cname not in fks:
+            fks[cname] = {
+                'columns': [],
+                'referenced_table': rtable,
+                'referenced_columns': [],
+                'on_delete': on_del,
+                'on_update': on_upd,
+            }
+        fks[cname]['columns'].append(col)
+        fks[cname]['referenced_columns'].append(rcol)
+    return fks
+
+
+# ============================================================================
+# Column introspection (mirror of test_schema_validation.py helpers)
+# ============================================================================
+
+
+def get_db_columns(session, table_name: str) -> Dict[str, Dict]:
+    """Return {column_name: {'type', 'nullable', 'key', 'extra', 'default'}}."""
+    result = session.execute(text("""
+        SELECT COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_KEY, EXTRA, COLUMN_DEFAULT
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = :table_name
+    """), {'table_name': table_name})
+    return {
+        row[0]: {
+            'type':     row[1],
+            'nullable': row[2] == 'YES',
+            'key':      row[3],
+            'extra':    row[4],
+            'default':  row[5],
+        }
+        for row in result
+    }
+
+
+def get_table_type(session, table_name: str):
+    """Return 'BASE TABLE' | 'VIEW' | None."""
+    result = session.execute(text("""
+        SELECT TABLE_TYPE
+        FROM INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = :table_name
+    """), {'table_name': table_name})
+    row = result.fetchone()
+    return row[0] if row else None
+
+
+# ============================================================================
+# ORM table iteration
+# ============================================================================
+
+
+def iter_table_mappers(base_registry):
+    """Yield mappers backed by a real base table on the default bind.
+
+    Excludes views (via info={'is_view': True}) and cross-bind models
+    (e.g. system_status SQLite tables via __bind_key__). Mirrors the
+    filter in test_schema_validation.py:113-123.
+    """
+    for mapper in base_registry.mappers:
+        if mapper.persist_selectable.info.get('is_view', False):
+            continue
+        cls = mapper.class_
+        if hasattr(cls, '__bind_key__') and cls.__bind_key__ is not None:
+            continue
+        yield mapper

--- a/scripts/lib/schema_introspection.py
+++ b/scripts/lib/schema_introspection.py
@@ -159,6 +159,55 @@ def diff_indexes(
     }
 
 
+def find_rename_pairs(diff: Dict[str, List]) -> Dict[str, List]:
+    """Pair up `in_db_not_orm` and `in_orm_not_db` entries that share
+    the same (columns, uniqueness) shape — those are renames, not real
+    drift.
+
+    Returns a new dict with:
+      - 'renames':       [(cols, uniq, db_name, orm_name), ...]
+      - 'in_db_not_orm': filtered (only entries with no rename match)
+      - 'in_orm_not_db': filtered (only entries with no rename match)
+      - 'mismatched':    unchanged from input
+
+    A rename match is shape-identical: same column tuple, same
+    uniqueness flag. This collapses the pairs that prod and ORM
+    differ on by name only.
+    """
+    db_left = list(diff['in_db_not_orm'])
+    orm_left = list(diff['in_orm_not_db'])
+
+    # Bucket ORM-side by shape so each DB entry can find its match in O(1)
+    orm_by_shape: Dict[Tuple[Tuple[str, ...], bool], List[str]] = defaultdict(list)
+    for name, cols, uniq in orm_left:
+        orm_by_shape[(cols, uniq)].append(name)
+
+    renames = []
+    db_unmatched = []
+    consumed_orm_names = set()
+
+    for db_name, cols, uniq in db_left:
+        bucket = orm_by_shape.get((cols, uniq))
+        if bucket:
+            orm_name = bucket.pop(0)
+            consumed_orm_names.add(orm_name)
+            renames.append((cols, uniq, db_name, orm_name))
+        else:
+            db_unmatched.append((db_name, cols, uniq))
+
+    orm_unmatched = [
+        (name, cols, uniq) for name, cols, uniq in orm_left
+        if name not in consumed_orm_names
+    ]
+
+    return {
+        'renames': renames,
+        'in_db_not_orm': db_unmatched,
+        'in_orm_not_db': orm_unmatched,
+        'mismatched': diff['mismatched'],
+    }
+
+
 # ============================================================================
 # Foreign key introspection
 # ============================================================================

--- a/scripts/orm_inventory.py
+++ b/scripts/orm_inventory.py
@@ -1,315 +1,304 @@
 #!/usr/bin/env python3
-"""
-ORM Inventory Script
+"""ORM Inventory Script.
 
-Analyzes all SQLAlchemy ORM models and compares them against the database schema.
-Generates a comprehensive report showing:
-- All ORM models and their table mappings
-- Tables without ORM models
-- Schema mismatches (columns, types)
-- Relationship mappings
+Compares all SQLAlchemy ORM models against a database schema and reports:
+  - Tables present in DB but not modeled
+  - Views present in DB but not modeled
+  - Per-model column drift (missing/extra columns, type mismatches)
+  - Relationship summary
+
+Type-mismatch detection delegates to `scripts/lib/schema_introspection.py`
+so this script and `tests/integration/test_schema_validation.py` use the
+SAME acceptable-pairing rules (e.g. SQLAlchemy `Boolean` ↔ MySQL BIT/TINYINT,
+`Float` ↔ FLOAT/DOUBLE, `String` ↔ VARCHAR/CHAR, `DateTime` ↔ DATETIME/TIMESTAMP).
+
+Two modes:
+  * Called from `scripts/check_db_drift.py` via `generate_report(engine)` —
+    invoked with `issues_only=True` so output is terse.
+  * Run standalone (`python scripts/orm_inventory.py`) — uses the SAM_DB_*
+    environment via `sam.session.create_sam_engine()` (whatever DB the
+    `.env` is currently pointed at). No hardcoded localhost URL.
 """
 
 import sys
-from pathlib import Path
 from collections import defaultdict
-from typing import Dict, List, Set, Tuple
+from pathlib import Path
+from typing import Dict, List
 
-# Add parent directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+# Make `sam` and `scripts.lib` importable regardless of cwd
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent / 'src'))
+sys.path.insert(0, str(HERE.parent))
 
 from sqlalchemy import inspect, text
 from sqlalchemy.orm import class_mapper
-from sam.session import create_sam_engine
-import sam
+
+from scripts.lib.schema_introspection import (
+    is_acceptable_type_mismatch,
+    normalize_type,
+    TYPE_MAPPINGS,
+)
 
 
-def get_all_orm_models():
-    """Find all ORM model classes."""
+# ---------------------------------------------------------------------------
+# ORM / DB inspection helpers
+# ---------------------------------------------------------------------------
+
+
+def get_all_orm_models() -> Dict[str, type]:
+    """Return {table_name: ORM class} for every mapper registered to Base."""
     from sam.base import Base
-
-    models = {}
-    for mapper in Base.registry.mappers:
-        cls = mapper.class_
-        table_name = mapper.mapped_table.name
-        models[table_name] = cls
-
-    return models
+    return {
+        m.mapped_table.name: m.class_
+        for m in Base.registry.mappers
+    }
 
 
 def get_database_tables(engine):
-    """Get all tables and views from the database."""
+    """Return (set_of_tables, set_of_views) from the bound DB."""
     inspector = inspect(engine)
-
-    tables = set(inspector.get_table_names())
-    views = set(inspector.get_view_names())
-
-    return tables, views
+    return set(inspector.get_table_names()), set(inspector.get_view_names())
 
 
 def get_table_columns(engine, table_name: str) -> Dict:
-    """Get column information for a table."""
     inspector = inspect(engine)
-    columns = {}
-
-    for col in inspector.get_columns(table_name):
-        columns[col['name']] = {
+    return {
+        col['name']: {
             'type': str(col['type']),
             'nullable': col['nullable'],
             'default': col.get('default'),
-            'autoincrement': col.get('autoincrement', False)
+            'autoincrement': col.get('autoincrement', False),
         }
-
-    return columns
+        for col in inspector.get_columns(table_name)
+    }
 
 
 def get_orm_columns(model_class) -> Dict:
-    """Get column information from ORM model."""
     mapper = class_mapper(model_class)
-    columns = {}
-
-    for col in mapper.columns:
-        columns[col.name] = {
+    return {
+        col.name: {
             'type': str(col.type),
+            'orm_type_name': type(col.type).__name__,
             'nullable': col.nullable,
             'primary_key': col.primary_key,
-            'foreign_keys': len(col.foreign_keys) > 0
+            'foreign_keys': bool(col.foreign_keys),
         }
-
-    return columns
+        for col in mapper.columns
+    }
 
 
 def get_orm_relationships(model_class) -> Dict:
-    """Get relationship information from ORM model."""
     mapper = class_mapper(model_class)
-    relationships = {}
-
-    for rel in mapper.relationships:
-        relationships[rel.key] = {
+    return {
+        rel.key: {
             'target': rel.mapper.class_.__name__,
             'direction': rel.direction.name,
-            'uselist': rel.uselist
+            'uselist': rel.uselist,
         }
+        for rel in mapper.relationships
+    }
 
-    return relationships
+
+# ---------------------------------------------------------------------------
+# Column comparison — uses shared TYPE_MAPPINGS so this stays in sync with
+# tests/integration/test_schema_validation.py
+# ---------------------------------------------------------------------------
 
 
 def compare_columns(db_cols: Dict, orm_cols: Dict) -> List[str]:
-    """Compare database columns with ORM columns."""
-    issues = []
+    """Return human-readable issues. Empty list = ORM matches DB."""
+    issues: List[str] = []
 
-    # Check for missing columns in ORM
-    db_col_names = set(db_cols.keys())
-    orm_col_names = set(orm_cols.keys())
+    db_names = set(db_cols)
+    orm_names = set(orm_cols)
 
-    missing_in_orm = db_col_names - orm_col_names
+    missing_in_orm = db_names - orm_names
     if missing_in_orm:
         issues.append(f"Missing in ORM: {', '.join(sorted(missing_in_orm))}")
 
-    extra_in_orm = orm_col_names - db_col_names
+    extra_in_orm = orm_names - db_names
     if extra_in_orm:
         issues.append(f"Extra in ORM: {', '.join(sorted(extra_in_orm))}")
 
-    # Check matching columns for type differences
-    for col_name in db_col_names & orm_col_names:
-        db_type = db_cols[col_name]['type'].upper()
-        orm_type = orm_cols[col_name]['type'].upper()
+    for col_name in db_names & orm_names:
+        db_raw = db_cols[col_name]['type']
+        orm_short = orm_cols[col_name]['orm_type_name']
+        db_norm = normalize_type(db_raw)
 
-        # Normalize type names for comparison
-        if 'VARCHAR' in db_type and 'VARCHAR' in orm_type:
-            continue
-        if 'INT' in db_type and 'INT' in orm_type:
-            continue
-        if 'DECIMAL' in db_type and 'NUMERIC' in orm_type:
-            continue
-        if 'DATETIME' in db_type and 'DATETIME' in orm_type:
-            continue
-        if 'TIMESTAMP' in db_type and 'TIMESTAMP' in orm_type:
-            continue
-        if 'TEXT' in db_type and 'TEXT' in orm_type:
-            continue
-        if 'TINYINT' in db_type and ('BOOLEAN' in orm_type or 'TINYINT' in orm_type):
-            continue
-        if 'BIGINT' in db_type and 'BIGINT' in orm_type:
+        acceptable = TYPE_MAPPINGS.get(orm_short)
+        if acceptable is None:
+            # ORM uses a type we don't have rules for (e.g. dialect-specific);
+            # fall back to a loose case-insensitive match.
+            if orm_short.upper() != db_norm:
+                issues.append(
+                    f"Type mismatch '{col_name}': DB={db_raw}, ORM={orm_short}"
+                )
             continue
 
-        # Flag significant differences
-        if db_type != orm_type:
-            issues.append(f"Type mismatch '{col_name}': DB={db_type}, ORM={orm_type}")
+        if db_norm in acceptable:
+            continue
+
+        # SQLAlchemy String → MySQL TEXT widening is a routine no-op.
+        if orm_short == 'String' and db_norm in ('TEXT', 'MEDIUMTEXT', 'LONGTEXT', 'TINYTEXT'):
+            continue
+
+        msg = f"Type mismatch '{col_name}': DB={db_raw}, ORM={orm_short}"
+        if not is_acceptable_type_mismatch(msg):
+            issues.append(msg)
 
     return issues
 
 
-def generate_report(engine):
-    """Generate comprehensive ORM inventory report."""
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
 
-    print("=" * 80)
+
+# Tables we know are present in prod but intentionally have no ORM model
+# (system tables, partitioning helpers, etc.).
+_KNOWN_UNMODELED_TABLES = {
+    'EXPORT_TABLE',
+    'TIME_DIM',
+    'schema_version',
+    'tables_dictionary',
+    'stage_hpc_job',
+    'temp_joey_expired_project',
+}
+
+
+def generate_report(engine, issues_only: bool = True):
+    """Generate the inventory report.
+
+    Args:
+        engine: SQLAlchemy engine bound to the DB to audit.
+        issues_only: When True (default) only print models with findings —
+            best for running alongside `check_db_drift.py`. Set False for
+            a full per-model dump when running this script standalone for
+            exploration.
+    """
+    print("=" * 72)
     print("SAM ORM INVENTORY REPORT")
-    print("=" * 80)
-    print()
+    print("=" * 72)
 
-    # Get all data
     orm_models = get_all_orm_models()
     db_tables, db_views = get_database_tables(engine)
+    orm_table_names = set(orm_models)
 
-    print(f"📊 SUMMARY")
-    print(f"  ORM Models: {len(orm_models)}")
-    print(f"  Database Tables: {len(db_tables)}")
-    print(f"  Database Views: {len(db_views)}")
-    print()
-
-    # Check coverage
-    all_db_objects = db_tables | db_views
-    orm_table_names = set(orm_models.keys())
-
-    tables_without_orms = (db_tables - orm_table_names) - {'EXPORT_TABLE', 'TIME_DIM'}  # Known system tables
+    tables_without_orms = (db_tables - orm_table_names) - _KNOWN_UNMODELED_TABLES
     views_without_orms = db_views - orm_table_names
 
-    print(f"✅ COVERAGE")
-    print(f"  Tables with ORMs: {len(db_tables & orm_table_names)}/{len(db_tables)}")
-    print(f"  Views with ORMs: {len(db_views & orm_table_names)}/{len(db_views)}")
-    print()
+    print(f"\nORM models      : {len(orm_models)}")
+    print(f"DB tables       : {len(db_tables)} "
+          f"({len(db_tables & orm_table_names)} modeled)")
+    print(f"DB views        : {len(db_views)} "
+          f"({len(db_views & orm_table_names)} modeled)")
 
     if tables_without_orms:
-        print(f"⚠️  TABLES WITHOUT ORM MODELS ({len(tables_without_orms)}):")
-        for table in sorted(tables_without_orms):
-            print(f"    - {table}")
-        print()
+        print(f"\n⚠️  Tables without ORM models ({len(tables_without_orms)}):")
+        for t in sorted(tables_without_orms):
+            print(f"    - {t}")
 
     if views_without_orms:
-        print(f"ℹ️  VIEWS WITHOUT ORM MODELS ({len(views_without_orms)}):")
-        for view in sorted(views_without_orms):
-            print(f"    - {view}")
-        print()
+        print(f"\nℹ️  Views without ORM models ({len(views_without_orms)}):")
+        for v in sorted(views_without_orms):
+            print(f"    - {v}")
 
-    # Detailed model analysis
-    print("=" * 80)
-    print("DETAILED MODEL ANALYSIS")
-    print("=" * 80)
     print()
+    print("-" * 72)
+    print("PER-MODEL ANALYSIS" + (" (issues only)" if issues_only else ""))
+    print("-" * 72)
 
+    # Group by category for readable per-domain output (only matters in
+    # full-dump mode).
     models_by_category = defaultdict(list)
-
     for table_name, model_class in sorted(orm_models.items()):
-        module = model_class.__module__
-        category = module.split('.')[-1] if '.' in module else 'other'
+        category = (model_class.__module__.split('.')[-1]
+                    if '.' in model_class.__module__ else 'other')
         models_by_category[category].append((table_name, model_class))
 
     total_issues = 0
-    models_with_issues = []
+    models_with_issues: List[str] = []
 
-    for category in sorted(models_by_category.keys()):
+    for category in sorted(models_by_category):
         models = models_by_category[category]
-        print(f"📁 {category.upper()} ({len(models)} models)")
-        print("-" * 80)
+        category_printed = False
 
         for table_name, model_class in sorted(models):
             is_view = table_name in db_views
-            table_type = "VIEW" if is_view else "TABLE"
 
-            print(f"\n  {model_class.__name__} → {table_name} ({table_type})")
+            if is_view:
+                if not issues_only:
+                    if not category_printed:
+                        print(f"\n📁 {category.upper()} ({len(models)} models)")
+                        category_printed = True
+                    print(f"  {model_class.__name__} → {table_name} (VIEW)")
+                continue
 
-            # Get columns
-            if not is_view:  # Skip column comparison for views
-                try:
-                    db_cols = get_table_columns(engine, table_name)
-                    orm_cols = get_orm_columns(model_class)
-
-                    issues = compare_columns(db_cols, orm_cols)
-
-                    if issues:
-                        total_issues += len(issues)
-                        models_with_issues.append(table_name)
-                        print(f"    ⚠️  Issues found:")
-                        for issue in issues:
-                            print(f"        - {issue}")
-                    else:
-                        print(f"    ✅ Schema matches ({len(orm_cols)} columns)")
-
-                    # Show relationships
-                    relationships = get_orm_relationships(model_class)
-                    if relationships:
-                        print(f"    🔗 Relationships: {len(relationships)}")
-                        for rel_name, rel_info in sorted(relationships.items()):
-                            direction = rel_info['direction']
-                            target = rel_info['target']
-                            many = "List" if rel_info['uselist'] else "Single"
-                            print(f"        - {rel_name} → {target} ({direction}, {many})")
-
-                except Exception as e:
-                    print(f"    ❌ Error analyzing: {e}")
-                    total_issues += 1
-                    models_with_issues.append(table_name)
-            else:
-                # For views, just show basic info
+            try:
+                db_cols = get_table_columns(engine, table_name)
                 orm_cols = get_orm_columns(model_class)
-                print(f"    ℹ️  View with {len(orm_cols)} columns")
-                relationships = get_orm_relationships(model_class)
-                if relationships:
-                    print(f"    🔗 Relationships: {len(relationships)}")
+                issues = compare_columns(db_cols, orm_cols)
+            except Exception as e:
+                issues = [f"Error analyzing: {e}"]
 
-        print()
+            if issues:
+                total_issues += len(issues)
+                models_with_issues.append(table_name)
+                if not category_printed:
+                    print(f"\n📁 {category.upper()}")
+                    category_printed = True
+                print(f"  ⚠️  {model_class.__name__} → {table_name}")
+                for issue in issues:
+                    print(f"        - {issue}")
+            elif not issues_only:
+                if not category_printed:
+                    print(f"\n📁 {category.upper()} ({len(models)} models)")
+                    category_printed = True
+                print(f"  ✅ {model_class.__name__} → {table_name} "
+                      f"({len(orm_cols)} columns)")
 
-    # Summary
-    print("=" * 80)
+    print()
+    print("=" * 72)
     print("FINAL SUMMARY")
-    print("=" * 80)
-    print()
-    print(f"Total ORM Models: {len(orm_models)}")
-    print(f"Models with Issues: {len(models_with_issues)}")
-    print(f"Total Issues Found: {total_issues}")
-    print()
+    print("=" * 72)
+    print(f"Total ORM models      : {len(orm_models)}")
+    print(f"Models with issues    : {len(models_with_issues)}")
+    print(f"Total issues found    : {total_issues}")
 
     if models_with_issues:
-        print("Models requiring attention:")
+        print("\nModels requiring attention:")
         for model in sorted(models_with_issues):
             print(f"  - {model}")
     else:
-        print("✅ All models match database schema!")
+        print("\n✅ All models match database schema.")
 
-    print()
-    print("=" * 80)
+    print("=" * 72)
+    return total_issues
 
 
-def test_connection(engine):
-    """Test basic database connectivity."""
-    print("Testing database connection...")
+# ---------------------------------------------------------------------------
+# Standalone entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    from sam.session import create_sam_engine
+    try:
+        engine, _ = create_sam_engine()
+    except Exception as e:
+        print(f"❌ Failed to create engine from environment: {e}", file=sys.stderr)
+        return 1
 
     try:
         with engine.connect() as conn:
-            result = conn.execute(text("SELECT COUNT(*) as user_count FROM users"))
-            user_count = result.fetchone()[0]
-            print(f"✅ Connection successful! Found {user_count} users in database.")
-            return True
+            conn.execute(text("SELECT 1"))
     except Exception as e:
-        print(f"❌ Connection failed: {e}")
-        return False
-
-
-def main():
-    """Main entry point."""
-    print("Connecting to local MySQL database...")
-    print()
-
-    # Create connection for local MySQL
-    connection_string = 'mysql+pymysql://root:root@127.0.0.1:3306/sam'
-
-    try:
-        engine, SessionLocal = create_sam_engine(connection_string)
-
-        if not test_connection(engine):
-            return 1
-
-        print()
-        generate_report(engine)
-
-        return 0
-
-    except Exception as e:
-        print(f"❌ Fatal error: {e}")
-        import traceback
-        traceback.print_exc()
+        print(f"❌ Connection failed: {e}", file=sys.stderr)
         return 1
+
+    # Standalone runs default to the full dump for exploration.
+    generate_report(engine, issues_only=False)
+    return 0
 
 
 if __name__ == '__main__':

--- a/sql/gen_context.sh
+++ b/sql/gen_context.sh
@@ -109,6 +109,7 @@ for table in \
     factor \
     formula \
     fos_aoi \
+    gid_allocation \
     hpc_activity \
     hpc_charge \
     hpc_charge_summary \

--- a/sql/table_context.txt
+++ b/sql/table_context.txt
@@ -55,6 +55,7 @@ SHOW tables;
 | factor                                |
 | formula                               |
 | fos_aoi                               |
+| gid_allocation                        |
 | hpc_activity                          |
 | hpc_charge                            |
 | hpc_charge_summary                    |
@@ -234,7 +235,7 @@ SELECT * FROM adhoc_group LIMIT 3;
 +----------+------------+----------+--------+---------------------+---------------------+-----------------+
 |        1 | decs       |    73358 |      1 | 2021-07-13 10:00:27 | 2026-03-05 08:02:58 | NULL            |
 |        2 | acd        |     1150 |      1 | 2021-07-13 10:14:07 | 2025-12-05 09:03:52 | NULL            |
-|        3 | accg       |     4124 |      1 | 2021-07-13 10:14:07 | 2024-05-10 13:28:14 | NULL            |
+|        3 | accg       |     4124 |      1 | 2021-07-13 10:14:07 | 2026-04-01 12:25:14 | NULL            |
 +----------+------------+----------+--------+---------------------+---------------------+-----------------+
 
 DESC adhoc_group_tag;
@@ -1251,6 +1252,21 @@ SELECT * FROM fos_aoi LIMIT 3;
 |          3 |  90300 |                  27 | Performance Evaluation and Benchmarking | NULL          | 2023-09-11 14:08:10 |
 +------------+--------+---------------------+-----------------------------------------+---------------+---------------------+
 
+DESC gid_allocation;
++-------------------+-------------+------+-----+-------------------+-----------------------------+
+| Field             | Type        | Null | Key | Default           | Extra                       |
++-------------------+-------------+------+-----+-------------------+-----------------------------+
+| gid_allocation_id | int         | NO   | PRI | NULL              | auto_increment              |
+| startGid          | int         | NO   |     | NULL              |                             |
+| nextGid           | int         | YES  |     | NULL              |                             |
+| endGid            | int         | NO   |     | NULL              |                             |
+| creation_time     | datetime    | NO   |     | CURRENT_TIMESTAMP | DEFAULT_GENERATED           |
+| modified_time     | timestamp   | YES  |     | NULL              | on update CURRENT_TIMESTAMP |
+| idms_sync_token   | varchar(64) | YES  |     | NULL              |                             |
++-------------------+-------------+------+-----+-------------------+-----------------------------+
+
+SELECT * FROM gid_allocation LIMIT 3;
+
 DESC hpc_activity;
 +-------------------+--------------+------+-----+---------+-----------------------------+
 | Field             | Type         | Null | Key | Default | Extra                       |
@@ -1589,7 +1605,7 @@ SELECT * FROM organization LIMIT 3;
 +-----------------+-------------------------------------------------------+-------------+-------------+---------------+--------+---------------------+---------------------+-----------+------------+---------------------------------------+------------+-----------------+------------------+---------+
 | organization_id | name                                                  | description | acronym     | parent_org_id | active | creation_time       | modified_time       | tree_left | tree_right | level                                 | level_code | idms_sync_token | idms_unique_name | deleted |
 +-----------------+-------------------------------------------------------+-------------+-------------+---------------+--------+---------------------+---------------------+-----------+------------+---------------------------------------+------------+-----------------+------------------+---------+
-|               1 | Aviation Applications Program                         | NULL        | AAP         |           128 |      1 | 2012-04-24 16:41:54 | 2026-02-11 09:15:59 |        68 |         69 | Division / Section / Other Department | 0400       | NULL            | NULL             |    NULL |
+|               1 | Aviation Applications Program                         | NULL        | AAP         |           128 |      0 | 2012-04-24 16:41:54 | 2026-04-23 02:10:51 |      NULL |       NULL | Division / Section / Other Department | 0400       | NULL            | NULL             |    NULL |
 |               2 | Atmospheric Chemistry Division                        | NULL        | ACD         |          NULL |      0 | 2012-04-24 16:41:54 | 2024-05-16 12:26:15 |      NULL |       NULL | Division / Section / Other Department | 0400       | NULL            | NULL             |    NULL |
 |               3 | Atmospheric Composition Remote Sensing and Prediction | NULL        | ACRESP -- x |          NULL |      0 | 2012-04-24 16:41:54 | 2024-05-16 12:26:15 |      NULL |       NULL | Sub Division                          | 0500       | NULL            | NULL             |    NULL |
 +-----------------+-------------------------------------------------------+-------------+-------------+---------------+--------+---------------------+---------------------+-----------+------------+---------------------------------------+------------+-----------------+------------------+---------+
@@ -1750,7 +1766,7 @@ SELECT * FROM project_code LIMIT 3;
 +-------------+------------------+--------+
 |           1 |               29 |      3 |
 |           1 |               30 |      2 |
-|           1 |               31 |     81 |
+|           1 |               31 |     82 |
 +-------------+------------------+--------+
 
 DESC project_contract;
@@ -2092,7 +2108,7 @@ SELECT * FROM synchronizer LIMIT 3;
 +-----------------+------+---------------------+
 | synchronizer_id | name | last_run            |
 +-----------------+------+---------------------+
-|               1 | pdb  | 2026-03-12 14:50:00 |
+|               1 | pdb  | 2026-04-28 17:50:00 |
 +-----------------+------+---------------------+
 
 DESC tables_dictionary;

--- a/src/sam/accounting/accounts.py
+++ b/src/sam/accounting/accounts.py
@@ -333,8 +333,11 @@ class ResponsibleParty(Base, TimestampMixin):
     __tablename__ = 'responsible_party'
 
     __table_args__ = (
-        Index('ix_responsible_party_account', 'account_id'),
-        Index('ix_responsible_party_user', 'user_id'),
+        Index('allocation_account_fk', 'account_id'),
+        Index('responsible_party_user_fk', 'user_id'),
+        Index('responsible_party_ux',
+              'account_id', 'user_id', 'responsible_party_type',
+              unique=True),
     )
 
     responsible_party_id = Column(Integer, primary_key=True, autoincrement=True)

--- a/src/sam/accounting/accounts.py
+++ b/src/sam/accounting/accounts.py
@@ -33,9 +33,9 @@ class Account(Base, SoftDeleteMixin, SessionMixin):
     __tablename__ = 'account'
 
     __table_args__ = (
-        Index('ix_account_project', 'project_id'),
-        Index('ix_account_resource', 'resource_id'),
-        Index('ix_account_deleted', 'deleted'),
+        Index('idx_account', 'project_id'),
+        Index('idx_account_1', 'resource_id'),
+        Index('project_resource_ux', 'project_id', 'resource_id', unique=True),
     )
 
     def __eq__(self, other):
@@ -276,9 +276,9 @@ class AccountUser(Base, TimestampMixin, DateRangeMixin):
     __tablename__ = 'account_user'
 
     __table_args__ = (
-        Index('ix_account_user_account', 'account_id'),
-        Index('ix_account_user_user', 'user_id'),
-        Index('ix_account_user_dates', 'start_date', 'end_date'),
+        Index('account_user_account_fk', 'account_id'),
+        Index('account_user_user_fk', 'user_id'),
+        Index('idx_account_id', 'account_id'),
     )
 
     def __eq__(self, other):

--- a/src/sam/accounting/adjustments.py
+++ b/src/sam/accounting/adjustments.py
@@ -26,9 +26,9 @@ class ChargeAdjustment(Base):
     __tablename__ = 'charge_adjustment'
 
     __table_args__ = (
-        Index('ix_charge_adjustment_account', 'account_id'),
-        Index('ix_charge_adjustment_type', 'charge_adjustment_type_id'),
-        Index('ix_charge_adjustment_adjusted_by', 'adjusted_by_id'),
+        Index('idx_charge_adjustment', 'account_id'),
+        Index('idx_charge_adjustment_1', 'charge_adjustment_type_id'),
+        Index('idx_charge_adjustment_2', 'adjusted_by_id'),
     )
 
     charge_adjustment_id = Column(Integer, primary_key=True, autoincrement=True)

--- a/src/sam/accounting/allocations.py
+++ b/src/sam/accounting/allocations.py
@@ -18,10 +18,8 @@ class Allocation(Base, TimestampMixin, SoftDeleteMixin, SessionMixin):
     __tablename__ = 'allocation'
 
     __table_args__ = (
-        Index('ix_allocation_account', 'account_id'),
-        Index('ix_allocation_parent', 'parent_allocation_id'),
-        Index('ix_allocation_dates', 'start_date', 'end_date'),
-        Index('ix_allocation_active', 'deleted', 'start_date', 'end_date'),
+        Index('allocation_account_fk', 'account_id'),
+        Index('allocation_allocation_fk', 'parent_allocation_id'),
     )
 
     def __eq__(self, other):
@@ -228,9 +226,9 @@ class AllocationTransaction(Base):
     __tablename__ = 'allocation_transaction'
 
     __table_args__ = (
-        Index('ix_allocation_transaction_allocation', 'allocation_id'),
-        Index('ix_allocation_transaction_user', 'user_id'),
-        Index('ix_allocation_transaction_related', 'related_transaction_id'),
+        Index('allocation_trans_alloc_fk', 'allocation_id'),
+        Index('allocation_trans_user_fk', 'user_id'),
+        Index('allocation_trans_related_fk', 'related_transaction_id'),
     )
 
     allocation_transaction_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -302,7 +300,7 @@ class AllocationType(Base, TimestampMixin, ActiveFlagMixin, SessionMixin):
     __tablename__ = 'allocation_type'
 
     __table_args__ = (
-        Index('ix_allocation_type_panel', 'panel_id'),
+        Index('idx_allocation_type', 'panel_id'),
     )
 
     allocation_type_id = Column(Integer, primary_key=True, autoincrement=True)

--- a/src/sam/activity/archive.py
+++ b/src/sam/activity/archive.py
@@ -11,8 +11,13 @@ class ArchiveActivity(Base):
     __tablename__ = 'archive_activity'
 
     __table_args__ = (
-        Index('ix_archive_activity_type', 'type_act'),
-        Index('ix_archive_activity_cos', 'archive_cos_id'),
+        Index('idx_archive_activity_uniq',
+              'type_act', 'activity_date', 'unix_uid', 'dns', 'projcode',
+              'archive_cos_id', unique=True),
+        Index('idx_archive_activity', 'archive_cos_id'),
+        Index('idx_processing_status', 'processing_status'),
+        Index('idx_uid_projcode', 'unix_uid', 'projcode'),
+        Index('idx_unix_uid', 'unix_uid'),
     )
 
     archive_activity_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -64,17 +69,17 @@ class ArchiveCharge(Base):
     __tablename__ = 'archive_charge'
 
     __table_args__ = (
-        Index('ix_archive_charge_account', 'account_id'),
-        Index('ix_archive_charge_user', 'user_id'),
-        Index('ix_archive_charge_activity', 'archive_activity_id', unique=True),
-        Index('ix_archive_charge_date', 'charge_date'),
+        Index('idx_archive_charge_1', 'account_id'),
+        Index('idx_archive_charge_2', 'user_id'),
+        Index('udx_archive_charge_uniq', 'archive_activity_id', unique=True),
+        Index('idx_charge_date', 'charge_date'),
     )
 
     archive_charge_id = Column(Integer, primary_key=True, autoincrement=True)
     account_id = Column(Integer, ForeignKey('account.account_id'), nullable=False)
     charge_date = Column(DateTime, nullable=False)
     archive_activity_id = Column(Integer, ForeignKey('archive_activity.archive_activity_id'),
-                                 nullable=False, unique=True)
+                                 nullable=False)
     user_id = Column(Integer, ForeignKey('users.user_id'), nullable=False)
     charge = Column(Float)
     terabyte_year = Column(Float)

--- a/src/sam/activity/computational.py
+++ b/src/sam/activity/computational.py
@@ -22,11 +22,7 @@ class CompJob(Base):
         PrimaryKeyConstraint('era_part_key', 'job_id', 'job_idx',
                              'machine', 'submit_time',
                              name='pk_comp_job'),
-        Index('ix_comp_job_era_job', 'era_part_key', 'job_id', 'job_idx'),
-        Index('ix_comp_job_activity_date', 'activity_date'),
-        Index('ix_comp_job_machine', 'machine'),
-        Index('ix_comp_job_projcode', 'projcode'),
-        Index('ix_comp_job_username', 'username'),
+        Index('idx_comp_job_activity_date', 'activity_date'),
     )
 
     def __eq__(self, other):
@@ -134,16 +130,7 @@ class CompActivity(Base):
              'comp_job.machine', 'comp_job.submit_time'],
             name='fk_comp_activity_job'
         ),
-        Index('ix_comp_activity_era_acct_job', 'era_part_key', 'acct_part_key',
-              'job_id', 'job_idx'),
-        Index('ix_comp_activity_activity_date', 'activity_date'),
-        Index('ix_comp_activity_charge_date', 'charge_date'),
-        Index('ix_comp_activity_processing', 'processing_status'),
-        Index('ix_comp_activity_charge_summary', 'charge_summary_id'),
-        Index('ix_comp_activity_machine', 'machine'),
-        # Index for the join with comp_job
-        Index('ix_comp_activity_job_lookup', 'era_part_key', 'job_id', 'job_idx',
-              'machine', 'submit_time'),
+        Index('idx_comp_act_activity_date', 'activity_date'),
     )
 
     def __eq__(self, other):

--- a/src/sam/activity/computational.py
+++ b/src/sam/activity/computational.py
@@ -71,7 +71,6 @@ class CompJob(Base):
     activity_date = Column(DateTime, nullable=False)
     load_date = Column(DateTime, nullable=False)
 
-    activities = relationship('CompActivity', back_populates='job')
 
     @property
     def wall_time_seconds(self) -> int:
@@ -124,12 +123,6 @@ class CompActivity(Base):
         PrimaryKeyConstraint('era_part_key', 'acct_part_key', 'job_id',
                              'job_idx', 'util_idx', 'machine', 'submit_time',
                              name='pk_comp_activity'),
-        ForeignKeyConstraint(
-            ['era_part_key', 'job_id', 'job_idx', 'machine', 'submit_time'],
-            ['comp_job.era_part_key', 'comp_job.job_id', 'comp_job.job_idx',
-             'comp_job.machine', 'comp_job.submit_time'],
-            name='fk_comp_activity_job'
-        ),
         Index('idx_comp_act_activity_date', 'activity_date'),
     )
 
@@ -191,13 +184,6 @@ class CompActivity(Base):
     # Processing status
     processing_status = Column(Boolean)
     error_comment = Column(Text)
-
-    # Relationship using composite foreign key
-    job = relationship(
-        'CompJob',
-        foreign_keys=[era_part_key, job_id, job_idx, machine, submit_time],
-        back_populates='activities'
-    )
 
     @property
     def cpu_time_seconds(self) -> Optional[float]:

--- a/src/sam/activity/dataset.py
+++ b/src/sam/activity/dataset.py
@@ -11,8 +11,9 @@ class DatasetActivity(Base, TimestampMixin):
     __tablename__ = 'dataset_activity'
 
     __table_args__ = (
-        Index('ix_dataset_activity_date', 'activity_date'),
-        Index('ix_dataset_activity_directory', 'project_directory'),
+        Index('dataset_activity_unique_idx',
+              'activity_date', 'project_directory', 'dataset',
+              unique=True),
     )
 
     activity_id = Column(Integer, primary_key=True, autoincrement=True)

--- a/src/sam/activity/dav.py
+++ b/src/sam/activity/dav.py
@@ -12,9 +12,10 @@ class DavActivity(Base):
 
     __table_args__ = (
         PrimaryKeyConstraint('dav_activity_id', 'queue_name', name='pk_dav_activity'),
-        Index('ix_dav_activity_job', 'job_id'),
-        Index('ix_dav_activity_cos', 'dav_cos_id'),
-        Index('ix_dav_activity_queue', 'queue_name'),
+        Index('dav_activity_unique_idx',
+              'job_id', 'machine', 'submit_time', 'job_idx',
+              unique=True),
+        Index('dav_cos_id', 'dav_cos_id'),
     )
 
     dav_activity_id = Column(Integer, autoincrement=True)
@@ -98,17 +99,18 @@ class DavCharge(Base):
     __tablename__ = 'dav_charge'
 
     __table_args__ = (
-        Index('ix_dav_charge_account', 'account_id'),
-        Index('ix_dav_charge_user', 'user_id'),
-        Index('ix_dav_charge_activity', 'dav_activity_id', unique=True),
-        Index('ix_dav_charge_date', 'charge_date'),
-        Index('ix_dav_charge_activity_date', 'activity_date'),
+        Index('idx_hpc_charge_2', 'account_id'),
+        Index('idx_dav_charge', 'user_id'),
+        Index('udx_dav_charge_uniq', 'dav_activity_id', unique=True),
+        Index('idx_charge_date', 'charge_date'),
+        Index('dav_charge_activity_date_idx', 'activity_date'),
+        Index('idx_hpc_charge_0', 'dav_activity_id'),
     )
 
     dav_charge_id = Column(Integer, primary_key=True, autoincrement=True)
     account_id = Column(Integer, ForeignKey('account.account_id'), nullable=False)
     dav_activity_id = Column(Integer, ForeignKey('dav_activity.dav_activity_id'),
-                             nullable=False, unique=True)
+                             nullable=False)
     user_id = Column(Integer, ForeignKey('users.user_id'), nullable=False)
     charge_date = Column(DateTime, nullable=False)
     activity_date = Column(DateTime)

--- a/src/sam/activity/disk.py
+++ b/src/sam/activity/disk.py
@@ -14,8 +14,7 @@ class DiskActivity(Base, TimestampMixin):
         Index('disk_activity_unique_idx',
               'directory_name', 'username', 'activity_date', 'projcode',
               unique=True),
-        Index('ix_disk_activity_directory', 'directory_name'),
-        Index('ix_disk_activity_cos', 'disk_cos_id'),
+        Index('idx_disk_activity_2', 'disk_cos_id'),
     )
 
     disk_activity_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -64,15 +63,15 @@ class DiskCharge(Base):
     __tablename__ = 'disk_charge'
 
     __table_args__ = (
-        Index('ix_disk_charge_account', 'account_id'),
-        Index('ix_disk_charge_user', 'user_id'),
-        Index('ix_disk_charge_activity', 'disk_activity_id', unique=True),
-        Index('ix_disk_charge_date', 'charge_date'),
+        Index('charge_allocation_fk_0', 'account_id'),
+        Index('idx_disk_charge', 'user_id'),
+        Index('udx_disk_charge_uniq', 'disk_activity_id', unique=True),
+        Index('idx_charge_date', 'charge_date'),
     )
 
     disk_charge_id = Column(Integer, primary_key=True, autoincrement=True)
     disk_activity_id = Column(Integer, ForeignKey('disk_activity.disk_activity_id'),
-                              nullable=False, unique=True)
+                              nullable=False)
     account_id = Column(Integer, ForeignKey('account.account_id'), nullable=False)
     charge_date = Column(DateTime, nullable=False)
     user_id = Column(Integer, ForeignKey('users.user_id'), nullable=False)
@@ -95,6 +94,10 @@ class DiskCharge(Base):
 class DiskCos(Base, TimestampMixin):
     """Disk Class of Service definitions."""
     __tablename__ = 'disk_cos'
+
+    __table_args__ = (
+        Index('pk_disk_cos_1', 'disk_cos_id', unique=True),
+    )
 
     disk_cos_id = Column(Integer, primary_key=True)
     description = Column(String(255), nullable=False)

--- a/src/sam/activity/hpc.py
+++ b/src/sam/activity/hpc.py
@@ -11,9 +11,11 @@ class HPCActivity(Base):
     __tablename__ = 'hpc_activity'
 
     __table_args__ = (
-        Index('ix_hpc_activity_job', 'job_id'),
-        Index('ix_hpc_activity_date', 'activity_date'),
-        Index('ix_hpc_activity_cos', 'hpc_cos_id'),
+        Index('idx_hpc_activity_uniq',
+              'job_id', 'machine', 'submit_time', 'job_idx',
+              unique=True),
+        Index('idx_hpc_activity_date', 'activity_date'),
+        Index('idx_hpc_activity', 'hpc_cos_id'),
     )
 
     hpc_activity_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -80,17 +82,18 @@ class HPCCharge(Base):
     __tablename__ = 'hpc_charge'
 
     __table_args__ = (
-        Index('ix_hpc_charge_account', 'account_id'),
-        Index('ix_hpc_charge_user', 'user_id'),
-        Index('ix_hpc_charge_activity', 'hpc_activity_id', unique=True),
-        Index('ix_hpc_charge_date', 'charge_date'),
-        Index('ix_hpc_charge_activity_date', 'activity_date'),
+        Index('idx_hpc_charge_account_id', 'account_id'),
+        Index('idx_hpc_charge_user_id', 'user_id'),
+        Index('udx_hpc_charge_uniq', 'hpc_activity_id', unique=True),
+        Index('idx_hpc_charge_date', 'charge_date'),
+        Index('hpc_charge_activity_date_idx', 'activity_date'),
+        Index('idx_hpc_charge_hpc_charge_id', 'hpc_charge_id'),
     )
 
     hpc_charge_id = Column(Integer, primary_key=True, autoincrement=True)
     account_id = Column(Integer, ForeignKey('account.account_id'), nullable=False)
     hpc_activity_id = Column(Integer, ForeignKey('hpc_activity.hpc_activity_id'),
-                             nullable=False, unique=True)
+                             nullable=False)
     user_id = Column(Integer, ForeignKey('users.user_id'), nullable=False)
     charge_date = Column(DateTime, nullable=False)
     activity_date = Column(DateTime)

--- a/src/sam/core/groups.py
+++ b/src/sam/core/groups.py
@@ -24,8 +24,8 @@ class AdhocGroup(Base, ActiveFlagMixin):
     __tablename__ = 'adhoc_group'
 
     __table_args__ = (
-        Index('ix_adhoc_group_gid', 'unix_gid'),
-        Index('ix_adhoc_group_name', 'group_name'),
+        Index('adhoc_group_group_name_uk', 'group_name', unique=True),
+        Index('adhoc_group_unix_gid_uk', 'unix_gid', unique=True),
     )
 
     def __eq__(self, other):
@@ -39,8 +39,8 @@ class AdhocGroup(Base, ActiveFlagMixin):
         return hash(self.group_id) if self.group_id is not None else hash(id(self))
 
     group_id = Column(Integer, primary_key=True, autoincrement=True)
-    group_name = Column(String(30), nullable=False, unique=True)
-    unix_gid = Column(Integer, nullable=False, unique=True)
+    group_name = Column(String(30), nullable=False)
+    unix_gid = Column(Integer, nullable=False)
     creation_time = Column(TIMESTAMP, nullable=False, server_default=text('CURRENT_TIMESTAMP'))
     pdb_modified_time = Column(TIMESTAMP)
     idms_sync_token = Column(String(64))
@@ -89,7 +89,7 @@ class AdhocGroupTag(Base):
     __tablename__ = 'adhoc_group_tag'
 
     __table_args__ = (
-        Index('ix_adhoc_group_tag_group', 'group_id'),
+        Index('adhoc_group_tag_uk', 'group_id', 'tag', unique=True),
     )
 
     adhoc_group_tag_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -112,7 +112,9 @@ class AdhocSystemAccountEntry(Base):
     __tablename__ = 'adhoc_system_account_entry'
 
     __table_args__ = (
-        Index('ix_adhoc_system_account_group', 'group_id'),
+        Index('adhoc_system_account_entry_uk',
+              'group_id', 'access_branch_name', 'username',
+              unique=True),
     )
 
     entry_id = Column(Integer, primary_key=True, autoincrement=True)

--- a/src/sam/core/organizations.py
+++ b/src/sam/core/organizations.py
@@ -150,9 +150,8 @@ class UserOrganization(Base, TimestampMixin, DateRangeMixin):
     __tablename__ = 'user_organization'
 
     __table_args__ = (
-        Index('ix_user_organization_user', 'user_id'),
-        Index('ix_user_organization_org', 'organization_id'),
-        Index('ix_user_organization_dates', 'start_date', 'end_date'),
+        Index('user_organization_user_fk', 'user_id'),
+        Index('user_organization_org_fk', 'organization_id'),
     )
 
     user_organization_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -178,6 +177,11 @@ class UserOrganization(Base, TimestampMixin, DateRangeMixin):
 class Institution(Base, TimestampMixin, SessionMixin):
     """Educational and research institutions."""
     __tablename__ = 'institution'
+
+    __table_args__ = (
+        Index('idx_institution', 'state_prov_id'),
+        Index('idx_institution_1', 'institution_type_id'),
+    )
 
     def __eq__(self, other):
         """Two institutions are equal if they have the same institution_id."""
@@ -392,9 +396,8 @@ class UserInstitution(Base, TimestampMixin, DateRangeMixin):
     __tablename__ = 'user_institution'
 
     __table_args__ = (
-        Index('ix_user_institution_user', 'user_id'),
-        Index('ix_user_institution_institution', 'institution_id'),
-        Index('ix_user_institution_dates', 'start_date', 'end_date'),
+        Index('user_institution_user_fk', 'user_id'),
+        Index('user_institution_inst_fk', 'institution_id'),
     )
 
     user_institution_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -421,9 +424,14 @@ class MnemonicCode(Base, TimestampMixin, ActiveFlagMixin, SessionMixin):
     """Mnemonic codes for project naming."""
     __tablename__ = 'mnemonic_code'
 
+    __table_args__ = (
+        Index('mnemonic_code_code_uk', 'code', unique=True),
+        Index('mnemonic_code_description_uk', 'description', unique=True),
+    )
+
     mnemonic_code_id = Column(Integer, primary_key=True, autoincrement=False)
-    code = Column(String(3), nullable=False, unique=True)
-    description = Column(String(200), nullable=False, unique=True)
+    code = Column(String(3), nullable=False)
+    description = Column(String(200), nullable=False)
 
     project_codes = relationship('ProjectCode', back_populates='mnemonic_code')
 
@@ -513,9 +521,8 @@ class ProjectOrganization(Base, TimestampMixin, DateRangeMixin, SessionMixin):
     __tablename__ = 'project_organization'
 
     __table_args__ = (
-        Index('ix_project_organization_project', 'project_id'),
-        Index('ix_project_organization_org', 'organization_id'),
-        Index('ix_project_organization_dates', 'start_date', 'end_date'),
+        Index('project_organization_proj_fk', 'project_id'),
+        Index('project_organization_org_fk', 'organization_id'),
     )
 
     project_organization_id = Column(Integer, primary_key=True, autoincrement=True)

--- a/src/sam/core/organizations.py
+++ b/src/sam/core/organizations.py
@@ -11,8 +11,7 @@ class Organization(Base, TimestampMixin, ActiveFlagMixin, SessionMixin, NestedSe
     __tablename__ = 'organization'
 
     __table_args__ = (
-        Index('ix_organization_tree', 'tree_left', 'tree_right'),
-        Index('ix_organization_parent', 'parent_org_id'),
+        Index('organization_organization_fk', 'parent_org_id'),
     )
 
     # NestedSetMixin config
@@ -35,7 +34,7 @@ class Organization(Base, TimestampMixin, ActiveFlagMixin, SessionMixin, NestedSe
 
     organization_id = Column(Integer, primary_key=True, autoincrement=False)
     name = Column(String(100), nullable=False)
-    acronym = Column(String(15), nullable=False, unique=True)
+    acronym = Column(String(15), nullable=False)
     description = Column(String(255))
     parent_org_id = Column(Integer, ForeignKey('organization.organization_id'))
 

--- a/src/sam/core/organizations.py
+++ b/src/sam/core/organizations.py
@@ -45,6 +45,8 @@ class Organization(Base, TimestampMixin, ActiveFlagMixin, SessionMixin, NestedSe
     level_code = Column(String(10))
 
     idms_sync_token = Column(String(64))
+    idms_unique_name = Column(String(64))
+    deleted = Column(Boolean)
 
     children = relationship('Organization', remote_side=[parent_org_id], back_populates='parent')
     parent = relationship('Organization', remote_side=[organization_id], back_populates='children')
@@ -198,6 +200,7 @@ class Institution(Base, TimestampMixin, SessionMixin):
     institution_id = Column(Integer, primary_key=True, autoincrement=False)
     name = Column(String(80), nullable=False)
     acronym = Column(String(40), nullable=False)
+    deleted = Column(Boolean)
     nsf_org_code = Column(String(200))
     address = Column(String(255))
     city = Column(String(30))

--- a/src/sam/core/users.py
+++ b/src/sam/core/users.py
@@ -11,10 +11,11 @@ class User(Base, TimestampMixin, SessionMixin):
     __tablename__ = 'users'
 
     __table_args__ = (
-        Index('ix_users_username', 'username'),
-        Index('ix_users_upid', 'upid'),
-        Index('ix_users_active_locked', 'active', 'locked'),
-        Index('ix_users_primary_gid', 'primary_gid'),
+        Index('username_uk', 'username', unique=True),
+        Index('idx_users_upid', 'upid', unique=True),
+        Index('idx_users_1', 'primary_gid'),
+        Index('idx_users', 'login_type_id'),
+        Index('user_academic_status_fk', 'academic_status_id'),
     )
 
     def __eq__(self, other):
@@ -29,9 +30,9 @@ class User(Base, TimestampMixin, SessionMixin):
 
     # [All existing column definitions remain the same...]
     user_id = Column(Integer, primary_key=True, autoincrement=True)
-    username = Column(String(35), nullable=False, unique=True)
+    username = Column(String(35), nullable=False)
     locked = Column(Boolean, nullable=False, default=False)
-    upid = Column(Integer, unique=True, nullable=True)
+    upid = Column(Integer, nullable=True)
     unix_uid = Column(Integer, nullable=False)
 
     # Personal information
@@ -603,14 +604,15 @@ class UserAlias(Base):
     __tablename__ = 'user_alias'
 
     __table_args__ = (
-        Index('ix_user_alias_username', 'username'),
-        Index('ix_user_alias_orcid', 'orcid_id'),
-        Index('ix_user_alias_access_global', 'access_global_id'),
+        Index('user_id', 'user_id', unique=True),
+        Index('username', 'username', unique=True),
+        Index('idx_orcid_id', 'orcid_id'),
+        Index('idx_access_global_id', 'access_global_id'),
     )
 
     user_alias_id = Column(Integer, primary_key=True, autoincrement=True)
-    user_id = Column(Integer, ForeignKey('users.user_id'), nullable=False, unique=True)
-    username = Column(String(35), nullable=False, unique=True)
+    user_id = Column(Integer, ForeignKey('users.user_id'), nullable=False)
+    username = Column(String(35), nullable=False)
     orcid_id = Column(String(20))
     access_global_id = Column(String(31))
     creation_time = Column(DateTime, server_default=text('CURRENT_TIMESTAMP'))  # DB: nullable
@@ -631,8 +633,7 @@ class EmailAddress(Base, TimestampMixin):
     __tablename__ = 'email_address'
 
     __table_args__ = (
-        Index('ix_email_address_user', 'user_id'),
-        Index('ix_email_address_email', 'email_address'),
+        Index('email_address_user_fk', 'user_id'),
     )
 
     def __eq__(self, other):

--- a/src/sam/core/users.py
+++ b/src/sam/core/users.py
@@ -49,7 +49,10 @@ class User(Base, TimestampMixin, SessionMixin):
 
     academic_status_id = Column(Integer, ForeignKey('academic_status.academic_status_id'))
     login_type_id = Column(Integer, ForeignKey('login_type.login_type_id'))
-    primary_gid = Column(Integer, ForeignKey('adhoc_group.group_id'))
+    # NOTE: stores a unix_gid value, not adhoc_group.group_id — resolve via
+    # sam.core.groups.resolve_group_name(session, user.primary_gid). The
+    # legacy schema lacks a real FK here; do not declare one.
+    primary_gid = Column(Integer)
     contact_person_upid = Column(Integer)
 
     pdb_modified_time = Column(TIMESTAMP)
@@ -83,7 +86,6 @@ class User(Base, TimestampMixin, SessionMixin):
     organizations = relationship('UserOrganization', back_populates='user', cascade='all, delete-orphan')
     phones = relationship('Phone', back_populates='user', cascade='all, delete-orphan')
     pi_contracts = relationship('Contract', foreign_keys='Contract.principal_investigator_user_id', back_populates='principal_investigator')
-    primary_group = relationship('AdhocGroup', foreign_keys=[primary_gid])
     resource_homes = relationship('UserResourceHome', back_populates='user', cascade='all, delete-orphan')
     resource_shells = relationship('UserResourceShell', back_populates='user', cascade='all, delete-orphan')
     responsible_accounts = relationship('ResponsibleParty', back_populates='user')

--- a/src/sam/core/users.py
+++ b/src/sam/core/users.py
@@ -683,7 +683,8 @@ class Phone(Base, TimestampMixin):
     __tablename__ = 'phone'
 
     __table_args__ = (
-        Index('ix_phone_user', 'user_id'),
+        Index('phone_user_fk', 'user_id'),
+        Index('phone_phone_type_fk', 'ext_phone_type_id'),
     )
 
     ext_phone_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -725,8 +726,8 @@ class UserResourceHome(Base, TimestampMixin):
     __tablename__ = 'user_resource_home'
 
     __table_args__ = (
-        Index('ix_user_resource_home_user', 'user_id'),
-        Index('ix_user_resource_home_resource', 'resource_id'),
+        Index('user_resource_home_users_fk', 'user_id'),
+        Index('user_resource_home_resources_fk', 'resource_id'),
     )
 
     user_resource_home_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -750,8 +751,10 @@ class UserResourceShell(Base, TimestampMixin):
     __tablename__ = 'user_resource_shell'
 
     __table_args__ = (
-        Index('ix_user_resource_shell_user', 'user_id'),
-        Index('ix_user_resource_shell_shell', 'resource_shell_id'),
+        Index('user_resource_shell_users_fk', 'user_id'),
+        Index('user_resource_shell_resource_shell_fk', 'resource_shell_id'),
+        Index('idx_user_resource_shell_uniq',
+              'user_id', 'resource_shell_id', unique=True),
     )
 
     user_resource_shell_id = Column(Integer, primary_key=True, autoincrement=True)

--- a/src/sam/geography.py
+++ b/src/sam/geography.py
@@ -28,6 +28,10 @@ class StateProv(Base, TimestampMixin, SoftDeleteMixin):
     """U.S. states and international provinces."""
     __tablename__ = 'state_prov'
 
+    __table_args__ = (
+        Index('state_prov_country_fk', 'ext_country_id'),
+    )
+
     ext_state_prov_id = Column(Integer, primary_key=True, autoincrement=True)
     ext_country_id = Column(Integer, ForeignKey('country.ext_country_id'), nullable=False)
     name = Column(String(100), nullable=False)

--- a/src/sam/integration/xras.py
+++ b/src/sam/integration/xras.py
@@ -19,8 +19,15 @@ class XrasResourceRepositoryKeyResource(Base):
     """
     __tablename__ = 'xras_resource_repository_key_resource'
 
+    __table_args__ = (
+        Index('xras_resource_repo_key_resource_resource_rid_uniq',
+              'resource_id', unique=True),
+        Index('xras_resource_repo_key_resource_resource_repo_key_uniq',
+              'resource_repository_key', unique=True),
+    )
+
     resource_repository_key = Column(Integer, primary_key=True)
-    resource_id = Column(Integer, ForeignKey('resources.resource_id'), nullable=False, unique=True)
+    resource_id = Column(Integer, ForeignKey('resources.resource_id'), nullable=False)
 
     resource = relationship('Resource', back_populates='xras_resource_keys')
 

--- a/src/sam/operational.py
+++ b/src/sam/operational.py
@@ -27,7 +27,10 @@ class ManualTask(Base):
     __tablename__ = 'manual_task'
 
     __table_args__ = (
-        Index('ix_manual_task_client', 'client'),
+        Index('idx_client_job_name',
+              'client', 'transaction_id', 'job_key', 'name',
+              unique=True),
+        Index('idx_client_key_name', 'client', 'job_alias', 'name'),
     )
 
     manual_task_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -60,7 +63,7 @@ class Product(Base):
     __tablename__ = 'product'
 
     __table_args__ = (
-        Index('ix_product_manual_task', 'manual_task_id'),
+        Index('manual_task_fk', 'manual_task_id'),
     )
 
     product_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -90,9 +93,9 @@ class WallclockExemption(Base, TimestampMixin, SessionMixin):
     __tablename__ = 'wallclock_exemption'
 
     __table_args__ = (
-        Index('ix_wallclock_exemption_user', 'user_id'),
-        Index('ix_wallclock_exemption_queue', 'queue_id'),
-        Index('ix_wallclock_exemption_dates', 'start_date', 'end_date'),
+        Index('user_id_fk', 'user_id'),
+        Index('queue_id_fk', 'queue_id'),
+        Index('idx_user_queue', 'user_id', 'queue_id', 'start_date', unique=True),
     )
 
     wallclock_exemption_id = Column(Integer, primary_key=True, autoincrement=True)

--- a/src/sam/projects/areas.py
+++ b/src/sam/projects/areas.py
@@ -182,12 +182,12 @@ class FosAoi(Base, TimestampMixin):
     __tablename__ = 'fos_aoi'
 
     __table_args__ = (
-        Index('ix_fos_aoi_fos', 'fos_id', unique=True),
-        Index('ix_fos_aoi_area', 'area_of_interest_id'),
+        Index('fos_id', 'fos_id', unique=True),
+        Index('aoi_fk', 'area_of_interest_id'),
     )
 
     fos_aoi_id = Column(Integer, primary_key=True, autoincrement=True)
-    fos_id = Column(Integer, nullable=False, unique=True)
+    fos_id = Column(Integer, nullable=False)
     area_of_interest_id = Column(Integer, ForeignKey('area_of_interest.area_of_interest_id'), nullable=False)
     fos = Column(String(255))  # FOS description/name
 

--- a/src/sam/projects/areas.py
+++ b/src/sam/projects/areas.py
@@ -10,8 +10,13 @@ class AreaOfInterest(Base, TimestampMixin, ActiveFlagMixin, SessionMixin):
     """Research areas for projects."""
     __tablename__ = 'area_of_interest'
 
+    __table_args__ = (
+        Index('area_of_interest_uk', 'area_of_interest', unique=True),
+        Index('aoi_aoi_group_fk', 'area_of_interest_group_id'),
+    )
+
     area_of_interest_id = Column(Integer, primary_key=True, autoincrement=True)
-    area_of_interest = Column(String(255), nullable=False, unique=True)
+    area_of_interest = Column(String(255), nullable=False)
     area_of_interest_group_id = Column(Integer, ForeignKey('area_of_interest_group.area_of_interest_group_id'), nullable=False)
     group = relationship('AreaOfInterestGroup', back_populates='areas')
     projects = relationship('Project', back_populates='area_of_interest')
@@ -98,8 +103,12 @@ class AreaOfInterestGroup(Base, TimestampMixin, ActiveFlagMixin, SessionMixin):
     """Groupings for research areas."""
     __tablename__ = 'area_of_interest_group'
 
+    __table_args__ = (
+        Index('area_of_interest_group_name_unique_idx', 'name', unique=True),
+    )
+
     area_of_interest_group_id = Column(Integer, primary_key=True, autoincrement=True)
-    name = Column(String(100), nullable=False, unique=True)
+    name = Column(String(100), nullable=False)
 
     areas = relationship('AreaOfInterest', back_populates='group')
 

--- a/src/sam/projects/contracts.py
+++ b/src/sam/projects/contracts.py
@@ -11,16 +11,17 @@ class Contract(Base, TimestampMixin, SessionMixin):
     __tablename__ = 'contract'
 
     __table_args__ = (
-        Index('ix_contract_source', 'contract_source_id'),
-        Index('ix_contract_pi', 'principal_investigator_user_id'),
-        Index('ix_contract_monitor', 'contract_monitor_user_id'),
-        Index('ix_contract_nsf_program', 'nsf_program_id'),
+        Index('contract_contract_source_fk', 'contract_source_id'),
+        Index('contract_pi_user_fk', 'principal_investigator_user_id'),
+        Index('contract_contract_monitor_user_fk', 'contract_monitor_user_id'),
+        Index('contract_nsf_program_fk', 'nsf_program_id'),
+        Index('contract_contract_number_uk', 'contract_number', unique=True),
     )
 
     contract_id = Column(Integer, primary_key=True, autoincrement=True)
     contract_source_id = Column(Integer, ForeignKey('contract_source.contract_source_id'),
                                 nullable=False)
-    contract_number = Column(String(50), nullable=False, unique=True)
+    contract_number = Column(String(50), nullable=False)
     title = Column(String(255), nullable=False)
     url = Column(String(1000))
 
@@ -177,8 +178,12 @@ class ContractSource(Base, TimestampMixin, ActiveFlagMixin, SessionMixin):
     """Sources of funding contracts."""
     __tablename__ = 'contract_source'
 
+    __table_args__ = (
+        Index('contract_source_contract_source_uk', 'contract_source', unique=True),
+    )
+
     contract_source_id = Column(Integer, primary_key=True, autoincrement=True)
-    contract_source = Column(String(50), nullable=False, unique=True)
+    contract_source = Column(String(50), nullable=False)
 
     contracts = relationship('Contract', back_populates='contract_source')
 
@@ -247,8 +252,9 @@ class ProjectContract(Base):
     __tablename__ = 'project_contract'
 
     __table_args__ = (
-        Index('ix_project_contract_project', 'project_id'),
-        Index('ix_project_contract_contract', 'contract_id'),
+        Index('project_contract_project_fk', 'project_id'),
+        Index('project_contract_contract_fk', 'contract_id'),
+        Index('project_id_contract_id_uk', 'project_id', 'contract_id', unique=True),
     )
 
     project_contract_id = Column(Integer, primary_key=True, autoincrement=True)

--- a/src/sam/projects/contracts.py
+++ b/src/sam/projects/contracts.py
@@ -299,8 +299,12 @@ class NSFProgram(Base, TimestampMixin, ActiveFlagMixin, SessionMixin):
     """NSF program classifications."""
     __tablename__ = 'nsf_program'
 
+    __table_args__ = (
+        Index('nsf_program_name_uk', 'nsf_program_name', unique=True),
+    )
+
     nsf_program_id = Column(Integer, primary_key=True, autoincrement=True)
-    nsf_program_name = Column(String(255), nullable=False, unique=True)
+    nsf_program_name = Column(String(255), nullable=False)
 
     contracts = relationship('Contract', back_populates='nsf_program')
 

--- a/src/sam/projects/projects.py
+++ b/src/sam/projects/projects.py
@@ -63,12 +63,13 @@ class Project(Base, TimestampMixin, ActiveFlagMixin, SessionMixin, NestedSetMixi
     __tablename__ = 'project'
 
     __table_args__ = (
-        Index('ix_project_projcode', 'projcode'),
-        Index('ix_project_lead', 'project_lead_user_id'),
-        Index('ix_project_admin', 'project_admin_user_id'),
-        Index('ix_project_active', 'active'),
-        Index('ix_project_tree', 'tree_left', 'tree_right'),
-        Index('ix_project_parent', 'parent_id'),
+        Index('project_projcode_uk', 'projcode', unique=True),
+        Index('project_lead_user_fk', 'project_lead_user_id'),
+        Index('project_admin_user_fk', 'project_admin_user_id'),
+        Index('project_project_fk', 'parent_id'),
+        Index('project_allocation_type_fk', 'allocation_type_id'),
+        Index('project_aoi_fk', 'area_of_interest_id'),
+        Index('project_root_fk', 'tree_root'),
     )
 
     # NestedSetMixin config
@@ -88,7 +89,7 @@ class Project(Base, TimestampMixin, ActiveFlagMixin, SessionMixin, NestedSetMixi
         return hash(self.project_id) if self.project_id is not None else hash(id(self))
 
     project_id = Column(Integer, primary_key=True, autoincrement=True)
-    projcode = Column(String(30), nullable=False, unique=True, default='')
+    projcode = Column(String(30), nullable=False, default='')
     title = Column(String(255), nullable=False)
     abstract = Column(Text)
 
@@ -1368,9 +1369,14 @@ class ProjectNumber(Base):
     """Sequential project numbers."""
     __tablename__ = 'project_number'
 
+    __table_args__ = (
+        Index('project_number_project_id_uk', 'project_id', unique=True),
+        Index('project_number_project_fk', 'project_id'),
+    )
+
     project_number_id = Column(Integer, primary_key=True, autoincrement=True)
     project_id = Column(Integer, ForeignKey('project.project_id'),
-                       nullable=False, unique=True)
+                       nullable=False)
 
     project = relationship('Project', back_populates='project_number')
 
@@ -1387,7 +1393,7 @@ class ProjectDirectory(Base, TimestampMixin, DateRangeMixin, SessionMixin):
     __tablename__ = 'project_directory'
 
     __table_args__ = (
-        Index('ix_project_directory_project', 'project_id'),
+        Index('project_directory_project_fk', 'project_id'),
     )
 
     directory_name = Column(String(255), nullable=False)

--- a/src/sam/projects/projects.py
+++ b/src/sam/projects/projects.py
@@ -1458,9 +1458,11 @@ class DefaultProject(Base, TimestampMixin):
     __tablename__ = 'default_project'
 
     __table_args__ = (
-        Index('ix_default_project_user', 'user_id'),
-        Index('ix_default_project_resource', 'resource_id'),
-        Index('ix_default_project_project', 'project_id'),
+        Index('idx_default_project', 'user_id'),
+        Index('idx_default_project_1', 'project_id'),
+        Index('idx_default_project_2', 'resource_id'),
+        Index('idx_default_project_user_resource',
+              'user_id', 'resource_id', unique=True),
     )
 
     default_project_id = Column(Integer, primary_key=True, autoincrement=True)

--- a/src/sam/resources/facilities.py
+++ b/src/sam/resources/facilities.py
@@ -10,9 +10,16 @@ class Facility(Base, TimestampMixin, ActiveFlagMixin, SessionMixin):
     """Facility classifications (NCAR, UNIV, etc.)."""
     __tablename__ = 'facility'
 
+    __table_args__ = (
+        Index('facility_name_uk', 'facility_name', unique=True),
+        Index('facility_code_uk', 'code', unique=True),
+        Index('facility_projcode_abbr_uk', 'code', unique=True),
+        Index('idx_facility', 'code'),
+    )
+
     facility_id = Column(Integer, primary_key=True, autoincrement=True)
-    facility_name = Column(String(30), nullable=False, unique=True)
-    code = Column(String(1), unique=True)
+    facility_name = Column(String(30), nullable=False)
+    code = Column(String(1))
     description = Column(String(255), nullable=False)
     fair_share_percentage = Column(Float)
 
@@ -113,8 +120,8 @@ class FacilityResource(Base):
     __tablename__ = 'facility_resource'
 
     __table_args__ = (
-        Index('ix_facility_resource_facility', 'facility_id'),
-        Index('ix_facility_resource_resource', 'resource_id'),
+        Index('facility_resource_facility_fk', 'facility_id'),
+        Index('facility_resource_resources_fk', 'resource_id'),
     )
 
     facility_resource_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -139,11 +146,12 @@ class Panel(Base, TimestampMixin, ActiveFlagMixin, SessionMixin):
     __tablename__ = 'panel'
 
     __table_args__ = (
-        Index('ix_panel_facility', 'facility_id'),
+        Index('idx_panel', 'facility_id'),
+        Index('panel_name_uk', 'panel_name', unique=True),
     )
 
     panel_id = Column(Integer, primary_key=True, autoincrement=True)
-    panel_name = Column(String(30), nullable=False, unique=True)
+    panel_name = Column(String(30), nullable=False)
     description = Column(String(100))
     facility_id = Column(Integer, ForeignKey('facility.facility_id'), nullable=False)
 
@@ -227,11 +235,12 @@ class PanelSession(Base, TimestampMixin, SessionMixin):
     __tablename__ = 'panel_session'
 
     __table_args__ = (
-        Index('ix_panel_session_panel', 'panel_id'),
+        Index('panel_session_facility_fk', 'panel_id'),
+        Index('panel_session_name_uk', 'name', unique=True),
     )
 
     panel_session_id = Column(Integer, primary_key=True, autoincrement=True)
-    name = Column(String(50), nullable=False, unique=True)
+    name = Column(String(50), nullable=False)
     start_date = Column(DateTime, nullable=False)
     end_date = Column(DateTime)
     panel_meeting_date = Column(DateTime)
@@ -332,6 +341,8 @@ class ProjectCode(Base):
 
     __table_args__ = (
         PrimaryKeyConstraint('facility_id', 'mnemonic_code_id', name='pk_project_code'),
+        Index('project_code_facility_fk', 'facility_id'),
+        Index('project_code_mnemonic_code_fk', 'mnemonic_code_id'),
     )
 
     facility_id = Column(Integer, ForeignKey('facility.facility_id'), nullable=False)

--- a/src/sam/resources/machines.py
+++ b/src/sam/resources/machines.py
@@ -11,7 +11,7 @@ class Machine(Base, TimestampMixin, SessionMixin):
     __tablename__ = 'machine'
 
     __table_args__ = (
-        Index('ix_machine_resource', 'resource_id'),
+        Index('idx_machine', 'resource_id'),
     )
 
     machine_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -155,8 +155,7 @@ class MachineFactor(Base, TimestampMixin):
     __tablename__ = 'machine_factor'
 
     __table_args__ = (
-        Index('ix_machine_factor_machine', 'machine_id'),
-        Index('ix_machine_factor_dates', 'start_date', 'end_date'),
+        Index('idx_resource_factor', 'machine_id'),
     )
 
     machine_factor_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -184,8 +183,8 @@ class Queue(Base, TimestampMixin, SessionMixin):
     __tablename__ = 'queue'
 
     __table_args__ = (
-        Index('ix_queue_resource', 'resource_id'),
-        Index('ix_queue_name', 'queue_name'),
+        Index('queue_resource_fk', 'resource_id'),
+        Index('queue_name_resource_idx', 'queue_name', 'resource_id'),
     )
 
     queue_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -294,8 +293,7 @@ class QueueFactor(Base, TimestampMixin):
     __tablename__ = 'queue_factor'
 
     __table_args__ = (
-        Index('ix_queue_factor_queue', 'queue_id'),
-        Index('ix_queue_factor_dates', 'start_date', 'end_date'),
+        Index('queue_factor_queue_fk', 'queue_id'),
     )
 
     queue_factor_id = Column(Integer, primary_key=True, autoincrement=True)

--- a/src/sam/resources/resources.py
+++ b/src/sam/resources/resources.py
@@ -11,8 +11,11 @@ class Resource(Base, TimestampMixin, SessionMixin):
     __tablename__ = 'resources'
 
     __table_args__ = (
-        Index('ix_resources_type', 'resource_type_id'),
-        Index('ix_resources_name', 'resource_name'),
+        Index('resource_resource_type_fk', 'resource_type_id'),
+        Index('resources_name_unique_idx', 'resource_name', unique=True),
+        Index('resource_primresporgid_fk', 'prim_responsible_org_id'),
+        Index('resource_primsysadm_fk', 'prim_sys_admin_user_id'),
+        Index('resources_resource_shell_fk', 'default_resource_shell_id'),
     )
 
     def __eq__(self, other):
@@ -26,7 +29,7 @@ class Resource(Base, TimestampMixin, SessionMixin):
         return hash(self.resource_id) if self.resource_id is not None else hash(id(self))
 
     resource_id = Column(Integer, primary_key=True, autoincrement=True)
-    resource_name = Column(String(40), nullable=False, unique=True)
+    resource_name = Column(String(40), nullable=False)
     resource_type_id = Column(Integer, ForeignKey('resource_type.resource_type_id'),
                              nullable=False)
     description = Column(String(255))
@@ -262,8 +265,12 @@ class ResourceType(Base, TimestampMixin, ActiveFlagMixin, SessionMixin):
     """Types of resources (HPC, DISK, ARCHIVE, etc.)."""
     __tablename__ = 'resource_type'
 
+    __table_args__ = (
+        Index('resource_type_uk', 'resource_type', unique=True),
+    )
+
     resource_type_id = Column(Integer, primary_key=True, autoincrement=True)
-    resource_type = Column(String(35), nullable=False, unique=True)
+    resource_type = Column(String(35), nullable=False)
     description = Column(String(255))
     grace_period_days = Column(Integer)
 
@@ -337,7 +344,9 @@ class ResourceShell(Base, TimestampMixin):
     __tablename__ = 'resource_shell'
 
     __table_args__ = (
-        Index('ix_resource_shell_resource', 'resource_id'),
+        Index('resource_shell_resources_fk', 'resource_id'),
+        Index('resource_shell_resource_shell_name_uk',
+              'resource_id', 'shell_name', unique=True),
     )
 
     resource_shell_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -361,11 +370,12 @@ class DiskResourceRootDirectory(Base, SessionMixin):
     __tablename__ = 'disk_resource_root_directory'
 
     __table_args__ = (
-        Index('ix_disk_resource_root_resource', 'resource_id'),
+        Index('resource_fk', 'resource_id'),
+        Index('root_directory_uk', 'root_directory', unique=True),
     )
 
     root_directory_id = Column(Integer, primary_key=True, autoincrement=True)
-    root_directory = Column(String(64), nullable=False, unique=True)
+    root_directory = Column(String(64), nullable=False)
     charging_exempt = Column(Boolean, nullable=False, default=False)
     resource_id = Column(Integer, ForeignKey('resources.resource_id'), nullable=False)
     # DB quirk: creation_time has ON UPDATE (semantically swapped with modified_time)

--- a/src/sam/security/access.py
+++ b/src/sam/security/access.py
@@ -10,8 +10,12 @@ class AccessBranch(Base):
     """Access branches for resource access control."""
     __tablename__ = 'access_branch'
 
+    __table_args__ = (
+        Index('access_branch_name_unique_idx', 'name', unique=True),
+    )
+
     access_branch_id = Column(Integer, primary_key=True, autoincrement=True)
-    name = Column(String(40), nullable=False, unique=True)
+    name = Column(String(40), nullable=False)
 
     resources = relationship('AccessBranchResource', back_populates='access_branch')
 
@@ -28,8 +32,7 @@ class AccessBranchResource(Base):
     __tablename__ = 'access_branch_resource'
 
     __table_args__ = (
-        Index('ix_access_branch_resource_branch', 'access_branch_id'),
-        Index('ix_access_branch_resource_resource', 'resource_id'),
+        Index('access_branch_resource_resources_fk', 'resource_id'),
     )
 
     access_branch_id = Column(Integer, ForeignKey('access_branch.access_branch_id'),

--- a/src/sam/security/roles.py
+++ b/src/sam/security/roles.py
@@ -40,8 +40,9 @@ class RoleUser(Base):
     __tablename__ = 'role_user'
 
     __table_args__ = (
-        Index('ix_role_user_role', 'role_id'),
-        Index('ix_role_user_user', 'user_id'),
+        Index('role_user_role_fk', 'role_id'),
+        Index('role_user_user_fk', 'user_id'),
+        Index('role_user_uniq', 'role_id', 'user_id', unique=True),
     )
 
     role_user_id = Column(Integer, primary_key=True, autoincrement=True)
@@ -71,11 +72,11 @@ class ApiCredentials(Base):
     __tablename__ = 'api_credentials'
 
     __table_args__ = (
-        Index('ix_api_credentials_username', 'username', unique=True),
+        Index('idx_api_credentials_uniq', 'username', unique=True),
     )
 
     api_credentials_id = Column(Integer, primary_key=True, autoincrement=True)
-    username = Column(String(11), nullable=False, unique=True)
+    username = Column(String(11), nullable=False)
     password = Column(String(64), nullable=False)  # Hashed password (bcrypt)
     enabled = Column(Boolean)
 
@@ -104,8 +105,9 @@ class RoleApiCredentials(Base):
     __tablename__ = 'role_api_credentials'
 
     __table_args__ = (
-        Index('ix_role_api_credentials_role', 'role_id'),
-        Index('ix_role_api_credentials_api', 'api_credentials_id'),
+        Index('role_api_credentials_role_fk', 'role_id'),
+        Index('role_api_credentials_api_credentials_fk', 'api_credentials_id'),
+        Index('role_api_credentials_uniq', 'role_id', 'api_credentials_id', unique=True),
     )
 
     role_api_credentials_id = Column(Integer, primary_key=True, autoincrement=True)

--- a/src/sam/summaries/archive_summaries.py
+++ b/src/sam/summaries/archive_summaries.py
@@ -17,7 +17,8 @@ class ArchiveChargeSummary(Base):
     )
 
     archive_charge_summary_id = Column(Integer, primary_key=True, autoincrement=True)
-    activity_date = Column(Date, nullable=False)
+    activity_date = Column(Date, ForeignKey('archive_charge_summary_status.activity_date'),
+                           nullable=False)
 
     act_username = Column(String(35))
     unix_uid = Column(Integer)

--- a/src/sam/summaries/archive_summaries.py
+++ b/src/sam/summaries/archive_summaries.py
@@ -11,9 +11,9 @@ class ArchiveChargeSummary(Base):
     __tablename__ = 'archive_charge_summary'
 
     __table_args__ = (
-        Index('ix_archive_charge_summary_date', 'activity_date'),
-        Index('ix_archive_charge_summary_user', 'user_id'),
-        Index('ix_archive_charge_summary_account', 'account_id'),
+        Index('idx_archive_charge_summary_date', 'activity_date'),
+        Index('idx_archive_charge_summary_user_id', 'user_id'),
+        Index('idx_archive_charge_summary_account_id', 'account_id'),
     )
 
     archive_charge_summary_id = Column(Integer, primary_key=True, autoincrement=True)

--- a/src/sam/summaries/comp_summaries.py
+++ b/src/sam/summaries/comp_summaries.py
@@ -22,14 +22,14 @@ class CompChargeSummary(Base):
     __tablename__ = 'comp_charge_summary'
 
     __table_args__ = (
-        Index('ix_comp_charge_summary_date', 'activity_date'),
-        Index('ix_comp_charge_summary_user', 'user_id'),
-        Index('ix_comp_charge_summary_account', 'account_id'),
-        Index('ix_comp_charge_summary_machine', 'machine_id'),
-        Index('ix_comp_charge_summary_queue', 'queue_id'),
-        Index('ix_comp_charge_summary_resource', 'resource'),
-        Index('ix_comp_charge_summary_projcode', 'projcode'),
-        Index('ix_comp_charge_summary_date_account', 'activity_date', 'account_id'),
+        Index('idx_comp_charge_summary_uniq',
+              'activity_date', 'machine', 'queue',
+              'act_projcode', 'act_username', 'act_unix_uid', 'cos',
+              unique=True),
+        Index('fk_comp_charge_summary_user', 'user_id'),
+        Index('fk_comp_charge_summary_account', 'account_id'),
+        Index('fk_comp_charge_summary_machine', 'machine_id'),
+        Index('fk_comp_charge_summary_queue', 'queue_id'),
     )
 
     def __eq__(self, other):
@@ -140,9 +140,8 @@ class CompChargeSummaryStatus(Base):
     __tablename__ = 'comp_charge_summary_status'
 
     __table_args__ = (
-        Index('ix_comp_charge_summary_status_command', 'command_id'),
-        Index('ix_comp_charge_summary_status_summary', 'charge_summary_id'),
-        Index('ix_comp_charge_summary_status_modified', 'modified'),
+        Index('command_id', 'command_id', 'charge_summary_id', unique=True),
+        Index('fk_comp_charge_summary', 'charge_summary_id'),
     )
 
     def __eq__(self, other):

--- a/src/sam/summaries/dav_summaries.py
+++ b/src/sam/summaries/dav_summaries.py
@@ -11,11 +11,11 @@ class DavChargeSummary(Base):
     __tablename__ = 'dav_charge_summary'
 
     __table_args__ = (
-        Index('ix_dav_charge_summary_date', 'activity_date'),
-        Index('ix_dav_charge_summary_user', 'user_id'),
-        Index('ix_dav_charge_summary_account', 'account_id'),
-        Index('ix_dav_charge_summary_machine', 'machine'),
-        Index('ix_dav_charge_summary_queue', 'queue_name'),
+        Index('idx_dav_charge_summary_date', 'activity_date'),
+        Index('idx_dav_charge_user_id', 'user_id'),
+        Index('idx_dav_charge_summary_account_id', 'account_id'),
+        Index('idx_dav_charge_summary_machine', 'machine'),
+        Index('idx_dav_charge_summary_queue_name', 'queue_name'),
     )
 
     dav_charge_summary_id = Column(Integer, primary_key=True, autoincrement=True)

--- a/src/sam/summaries/dav_summaries.py
+++ b/src/sam/summaries/dav_summaries.py
@@ -19,7 +19,8 @@ class DavChargeSummary(Base):
     )
 
     dav_charge_summary_id = Column(Integer, primary_key=True, autoincrement=True)
-    activity_date = Column(Date, nullable=False)
+    activity_date = Column(Date, ForeignKey('dav_charge_summary_status.activity_date'),
+                           nullable=False)
 
     # User identification (actual and recorded)
     act_username = Column(String(35))

--- a/src/sam/summaries/disk_summaries.py
+++ b/src/sam/summaries/disk_summaries.py
@@ -42,7 +42,8 @@ class DiskChargeSummary(Base):
     )
 
     disk_charge_summary_id = Column(Integer, primary_key=True, autoincrement=True)
-    activity_date = Column(Date, nullable=False)
+    activity_date = Column(Date, ForeignKey('disk_charge_summary_status.activity_date'),
+                           nullable=False)
 
     act_username = Column(String(35))
     unix_uid = Column(Integer)

--- a/src/sam/summaries/disk_summaries.py
+++ b/src/sam/summaries/disk_summaries.py
@@ -36,9 +36,9 @@ class DiskChargeSummary(Base):
     __tablename__ = 'disk_charge_summary'
 
     __table_args__ = (
-        Index('ix_disk_charge_summary_date', 'activity_date'),
-        Index('ix_disk_charge_summary_user', 'user_id'),
-        Index('ix_disk_charge_summary_account', 'account_id'),
+        Index('idx_disk_charge_summary_date', 'activity_date'),
+        Index('idx_disk_charge_summary_user_id', 'user_id'),
+        Index('idx_disk_charge_summary_account_id', 'account_id'),
     )
 
     disk_charge_summary_id = Column(Integer, primary_key=True, autoincrement=True)

--- a/src/sam/summaries/hpc_summaries.py
+++ b/src/sam/summaries/hpc_summaries.py
@@ -11,11 +11,11 @@ class HPCChargeSummary(Base):
     __tablename__ = 'hpc_charge_summary'
 
     __table_args__ = (
-        Index('ix_hpc_charge_summary_date', 'activity_date'),
-        Index('ix_hpc_charge_summary_user', 'user_id'),
-        Index('ix_hpc_charge_summary_account', 'account_id'),
-        Index('ix_hpc_charge_summary_machine', 'machine'),
-        Index('ix_hpc_charge_summary_queue', 'queue_name'),
+        Index('idx_hpc_charge_summary_date', 'activity_date'),
+        Index('idx_hpc_charge_summary_user_id', 'user_id'),
+        Index('idx_hpc_charge_summary_account_id', 'account_id'),
+        Index('idx_hpc_charge_summary_machine', 'machine'),
+        Index('idx_hpc_charge_summary_queue_name', 'queue_name'),
     )
 
     hpc_charge_summary_id = Column(Integer, primary_key=True, autoincrement=True)

--- a/src/sam/summaries/hpc_summaries.py
+++ b/src/sam/summaries/hpc_summaries.py
@@ -19,7 +19,8 @@ class HPCChargeSummary(Base):
     )
 
     hpc_charge_summary_id = Column(Integer, primary_key=True, autoincrement=True)
-    activity_date = Column(Date, nullable=False)
+    activity_date = Column(Date, ForeignKey('hpc_charge_summary_status.activity_date'),
+                           nullable=False)
 
     act_username = Column(String(35))
     unix_uid = Column(Integer)

--- a/tests/api/test_allocation_schema_disk_current.py
+++ b/tests/api/test_allocation_schema_disk_current.py
@@ -13,15 +13,35 @@ from sam.accounting.allocations import Allocation
 from sam.resources.resources import ResourceType
 from sam.schemas.allocation import AllocationWithUsageSchema
 from sam.summaries.disk_summaries import (
-    BYTES_PER_TIB, DiskChargeSummary, mark_disk_snapshot_current,
+    BYTES_PER_TIB, DiskChargeSummary, DiskChargeSummaryStatus,
 )
 from factories.core import make_user
 from factories.projects import make_account, make_allocation, make_project
 from factories.resources import make_resource, make_resource_type
-from factories._seq import next_seq
+from factories._seq import next_date, next_seq
 
 
 pytestmark = pytest.mark.unit
+
+
+def _ensure_status(session, activity_date):
+    """FK: disk_charge_summary.activity_date → disk_charge_summary_status.
+    Materialize the parent row before inserting the child summary."""
+    if session.get(DiskChargeSummaryStatus, activity_date) is None:
+        session.add(DiskChargeSummaryStatus(activity_date=activity_date, current=False))
+        session.flush()
+
+
+def _mark_current(session, activity_date):
+    """Test-only narrow alternative to mark_disk_snapshot_current — see
+    note in test_current_disk_usage.py: prod helper does a bulk UPDATE
+    that deadlocks under xdist."""
+    row = session.get(DiskChargeSummaryStatus, activity_date)
+    if row is None:
+        session.add(DiskChargeSummaryStatus(activity_date=activity_date, current=True))
+    else:
+        row.current = True
+    session.flush()
 
 
 def _disk_alloc(session, *, amount_tib: float = 100.0):
@@ -41,8 +61,14 @@ class TestAllocationDiskCurrentFields:
 
     def test_disk_allocation_has_current_used_fields(self, session):
         user, project, account, alloc = _disk_alloc(session, amount_tib=100.0)
-        # Seed today's snapshot at 47 TiB.
-        snap_date = date.today()
+        # Worker-unique snapshot date so xdist workers don't collide on
+        # the disk_charge_summary_status PK. Push the allocation window
+        # back so this date falls inside it.
+        snap_date = next_date("disk_snap")
+        alloc.start_date = datetime(snap_date.year - 1, 1, 1)
+        alloc.end_date = datetime(snap_date.year + 1, 1, 1)
+        session.flush()
+        _ensure_status(session, snap_date)
         session.add(DiskChargeSummary(
             activity_date=snap_date,
             user_id=user.user_id,
@@ -54,7 +80,7 @@ class TestAllocationDiskCurrentFields:
             number_of_files=1,
         ))
         session.flush()
-        mark_disk_snapshot_current(session, snap_date)
+        _mark_current(session, snap_date)
 
         schema = AllocationWithUsageSchema()
         schema.context = {
@@ -101,15 +127,17 @@ class TestAllocationDiskCurrentFields:
         current reflects only the latest. They differ — that's the
         whole point of the new fields."""
         user, project, account, alloc = _disk_alloc(session, amount_tib=100.0)
-        # Push allocation start back so both seeded snapshots fall inside.
-        alloc.start_date = datetime.now() - timedelta(days=30)
+        # Worker-unique snapshot dates so xdist workers don't collide on
+        # the disk_charge_summary_status PK. Set allocation window to
+        # bracket both dates.
+        d2 = next_date("disk_snap")
+        d1 = d2 - timedelta(days=7)
+        alloc.start_date = datetime(d1.year - 1, 1, 1)
+        alloc.end_date = datetime(d2.year + 1, 1, 1)
         session.flush()
-
-        # Snapshot 1: 10 TiB, charges=1.0. Snapshot 2: 20 TiB, charges=2.0.
-        d1 = date.today() - timedelta(days=7)
-        d2 = date.today()
         for d, b, ch in [(d1, 10 * BYTES_PER_TIB, 1.0),
                          (d2, 20 * BYTES_PER_TIB, 2.0)]:
+            _ensure_status(session, d)
             session.add(DiskChargeSummary(
                 activity_date=d,
                 user_id=user.user_id,
@@ -121,7 +149,7 @@ class TestAllocationDiskCurrentFields:
                 number_of_files=1,
             ))
         session.flush()
-        mark_disk_snapshot_current(session, d2)
+        _mark_current(session, d2)
 
         schema = AllocationWithUsageSchema()
         schema.context = {

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -8,7 +8,7 @@ returns the flushed instance with its primary key populated.
 Tests that need "any row from the snapshot" should use the `any_*` Layer 1
 fixtures from conftest.py instead — never blend the two strategies.
 """
-from ._seq import next_int, next_seq, reset_seq
+from ._seq import next_date, next_int, next_seq, reset_seq
 from .core import make_organization, make_user
 from .operational import make_wallclock_exemption
 from .projects import (
@@ -24,6 +24,7 @@ from .projects import (
 from .resources import make_machine, make_queue, make_resource, make_resource_type
 
 __all__ = [
+    "next_date",
     "next_int",
     "next_seq",
     "reset_seq",

--- a/tests/factories/_seq.py
+++ b/tests/factories/_seq.py
@@ -7,6 +7,7 @@ collisions while two workers are concurrently holding write locks on the
 same identifier. So the worker ID is baked into every generated value to
 keep namespaces disjoint across workers.
 """
+import datetime as _dt
 import os
 from collections import defaultdict
 from itertools import count
@@ -40,3 +41,24 @@ def reset_seq(prefix: Optional[str] = None) -> None:
         _counters.clear()
     else:
         _counters.pop(prefix, None)
+
+
+# Worker-namespaced date generator: each xdist worker gets a disjoint
+# slice of dates so concurrent workers don't collide on PKs of small
+# date-keyed parent tables (e.g. *_charge_summary_status). Each worker
+# slice spans 365 days; counters within a slice walk forward.
+_DATE_EPOCH = _dt.date(2090, 1, 1)
+_DATE_SLICE_DAYS = 365
+
+
+def next_date(prefix: str = "date") -> _dt.date:
+    """Return a worker-unique date that walks forward on each call.
+
+    Use for any test that needs a date-typed PK or FK target where
+    parallel workers must not collide. Stays within a worker-specific
+    365-day slice; wraps to slice start after 365 calls (more than
+    enough for any single test run).
+    """
+    worker_offset = int(_WORKER_TAG) * _DATE_SLICE_DAYS
+    counter_offset = next_int(prefix) % _DATE_SLICE_DAYS
+    return _DATE_EPOCH + _dt.timedelta(days=worker_offset + counter_offset)

--- a/tests/integration/test_schema_validation.py
+++ b/tests/integration/test_schema_validation.py
@@ -9,13 +9,40 @@ ideal first port.
 No write operations. No mocking. Runs against the mysql-test container
 via the session fixture in new_tests/conftest.py.
 """
+import sys
+from pathlib import Path
+
 import pytest
 from sqlalchemy import text
 
 from sam.base import Base
 
+# Pull in the shared introspection helpers used by scripts/check_db_drift.py
+# so the CI guard and the prod audit script enforce the *same* drift rules.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+from scripts.lib.schema_introspection import (
+    diff_indexes,
+    get_db_indexes,
+    get_orm_indexes,
+    iter_table_mappers,
+)
+
 
 pytestmark = pytest.mark.integration
+
+
+# ============================================================================
+# Index drift guard — prevents the DiskActivity bug class from regressing
+# ============================================================================
+#
+# If the test container has DBA-added indexes the ORM intentionally doesn't
+# track (e.g. analytics-only indexes), add their (table, index_name) pair
+# here with a comment explaining why.
+IGNORED_DB_INDEXES = {
+    # ('table_name', 'index_name'),
+}
 
 
 # ============================================================================
@@ -342,3 +369,98 @@ class TestCriticalSchemas:
             f"  Actual:   {actual}"
         )
         assert 'PRI' in db_cols['resource_repository_key']['key']
+
+
+# ============================================================================
+# Index alignment — prevents PR #209-style drift (DiskActivity unique index)
+# ============================================================================
+
+
+class TestIndexAlignment:
+    """Every non-PRIMARY index in the DB should be declared in the ORM, and
+    vice versa. Catches the DiskActivity bug class: a UNIQUE index that exists
+    in production but was missing from __table_args__."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Known broad UNIQUE-index drift between prod and ORM — triaged "
+               "in follow-up PRs. When all drift is resolved, this test will "
+               "XPASS, which (with strict=True) will fail the suite — that's "
+               "the signal to remove this xfail marker and promote the guard.",
+    )
+    def test_unique_constraints_match(self, session):
+        """Every UNIQUE index in DB must have a matching ORM declaration.
+
+        Direct regression guard against PR #209 (DiskActivity was missing
+        `disk_activity_unique_idx`). Currently xfail-strict; flips to
+        passing once the existing drift is cleaned up.
+        """
+        problems = []
+        for mapper in iter_table_mappers(Base.registry):
+            table = mapper.persist_selectable.name
+            db_idx = get_db_indexes(session, table)
+            orm_idx = get_orm_indexes(mapper)
+            diff = diff_indexes(db_idx, orm_idx)
+
+            for name, cols, uniq in diff['in_db_not_orm']:
+                if not uniq:
+                    continue
+                if (table, name) in IGNORED_DB_INDEXES:
+                    continue
+                problems.append(
+                    f"{table}: DB has UNIQUE INDEX '{name}' on ({', '.join(cols)}) — "
+                    f"ORM does not declare it"
+                )
+
+        assert not problems, (
+            "Unique constraint drift between DB and ORM:\n"
+            + "\n".join(f"  {p}" for p in problems)
+            + "\n\nFix: declare the missing Index(..., unique=True) or "
+              "UniqueConstraint in the model's __table_args__."
+        )
+
+    def test_indexes_match(self, session):
+        """All non-PRIMARY indexes should align between DB and ORM (informational).
+
+        Reports both directions plus same-name/different-shape mismatches.
+        Currently informational — promote to assertion once known drifts
+        are triaged. Until then, the strict guard above catches the most
+        common bug class (missing UNIQUE).
+        """
+        in_db_not_orm = []
+        in_orm_not_db = []
+        mismatched = []
+
+        for mapper in iter_table_mappers(Base.registry):
+            table = mapper.persist_selectable.name
+            db_idx = get_db_indexes(session, table)
+            orm_idx = get_orm_indexes(mapper)
+            diff = diff_indexes(db_idx, orm_idx)
+
+            for name, cols, uniq in diff['in_db_not_orm']:
+                if (table, name) in IGNORED_DB_INDEXES:
+                    continue
+                kind = 'UNIQUE' if uniq else 'index'
+                in_db_not_orm.append(f"{table}.{name} ({kind}, cols={cols})")
+            for name, cols, uniq in diff['in_orm_not_db']:
+                kind = 'UNIQUE' if uniq else 'index'
+                in_orm_not_db.append(f"{table}.{name} ({kind}, cols={cols})")
+            for name, db_shape, orm_shape in diff['mismatched']:
+                mismatched.append(f"{table}.{name}: DB={db_shape} vs ORM={orm_shape}")
+
+        if in_db_not_orm:
+            print(f"\n⚠️  {len(in_db_not_orm)} indexes in DB not declared in ORM:")
+            for s in in_db_not_orm[:20]:
+                print(f"  {s}")
+            if len(in_db_not_orm) > 20:
+                print(f"  ... and {len(in_db_not_orm) - 20} more")
+        if in_orm_not_db:
+            print(f"\n⚠️  {len(in_orm_not_db)} indexes in ORM not present in DB:")
+            for s in in_orm_not_db[:20]:
+                print(f"  {s}")
+        if mismatched:
+            print(f"\n⚠️  {len(mismatched)} same-name indexes with different shape:")
+            for s in mismatched[:20]:
+                print(f"  {s}")
+        if not (in_db_not_orm or in_orm_not_db or mismatched):
+            print("✅ All indexes align between DB and ORM")

--- a/tests/integration/test_schema_validation.py
+++ b/tests/integration/test_schema_validation.py
@@ -24,6 +24,7 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 from scripts.lib.schema_introspection import (
     diff_indexes,
+    get_db_foreign_keys,
     get_db_indexes,
     get_orm_indexes,
     iter_table_mappers,
@@ -43,6 +44,66 @@ pytestmark = pytest.mark.integration
 IGNORED_DB_INDEXES = {
     # ('table_name', 'index_name'),
 }
+
+
+# ============================================================================
+# Foreign-key drift allowlists
+# ============================================================================
+#
+# Promote-aware allowlists for test_foreign_keys_exist /
+# test_foreign_key_actions_match. Mirrors scripts/check_db_drift.py's
+# IGNORED_FK_DRIFT — keep the two in sync when adding entries.
+
+# ORM-declared FKs that intentionally have no DB-level constraint.
+# Keyed by (table_name, frozenset(columns)) → reason.
+IGNORED_ORM_FK_DRIFT = {
+    # Self-FK drives Organization.parent / .children nested-set relationship.
+    # Prod doesn't enforce the FK at the DB level (cycles in the tree during
+    # bulk reorgs), but the ORM declaration is load-bearing for SQLAlchemy
+    # joins (subqueryload(Organization.children) etc).
+    ('organization', frozenset({'parent_org_id'})):
+        'self-FK drives Organization nested-set relationship',
+    # dav_activity has composite PK (dav_activity_id, queue_name); MySQL
+    # rejects a single-column FK to one half of a composite key, so the
+    # DB-level constraint can't exist. The ORM-side FK still lets
+    # SQLAlchemy resolve DavCharge.dav_activity for object-graph loads.
+    ('dav_charge', frozenset({'dav_activity_id'})):
+        'composite PK on dav_activity prevents single-column DB FK',
+}
+
+# DB-side FKs whose ON DELETE / ON UPDATE rules are non-default.
+# Keyed by (table_name, constraint_name) → (delete_rule, update_rule, reason).
+# Seed: every FK in the test container whose action pair isn't ('NO ACTION',
+# 'NO ACTION'). Default MySQL behaviour ('RESTRICT' / 'NO ACTION') is treated
+# as the implicit baseline and not allowlisted.
+#
+# When an ORM model eventually adds matching ondelete=/onupdate= to its
+# ForeignKey(...) declaration, drop the corresponding entry here and the
+# test will start asserting the ORM declaration matches the DB instead.
+IGNORED_FK_ACTION_DRIFT = {
+    ('access_branch_resource', 'access_branch_resource_access_branch_fk'):
+        ('CASCADE', 'CASCADE', 'access-branch sweep cascades to membership rows'),
+    ('access_branch_resource', 'access_branch_resource_resources_fk'):
+        ('CASCADE', 'CASCADE', 'access-branch sweep cascades to membership rows'),
+    ('adhoc_group_tag', 'adhoc_group_tag_id_fk'):
+        ('CASCADE', 'CASCADE', 'tag rows are owned by adhoc_group; delete-with-parent'),
+    ('adhoc_system_account_entry', 'adhoc_system_account_entry_group_id_fk'):
+        ('CASCADE', 'CASCADE', 'entry rows are owned by adhoc_group; delete-with-parent'),
+    ('archive_charge_summary', 'fk_archive_charge_summary_date'):
+        ('CASCADE', 'NO ACTION', 'TIME_DIM rebuild cascades summary cleanup'),
+    ('dav_charge_summary', 'fk_dav_charge_summary_date'):
+        ('CASCADE', 'NO ACTION', 'TIME_DIM rebuild cascades summary cleanup'),
+    ('disk_charge_summary', 'fk_disk_charge_summary_date'):
+        ('CASCADE', 'NO ACTION', 'TIME_DIM rebuild cascades summary cleanup'),
+    ('hpc_charge_summary', 'fk_hpc_charge_summary_date'):
+        ('CASCADE', 'NO ACTION', 'TIME_DIM rebuild cascades summary cleanup'),
+}
+
+# MySQL reports unset action rules as 'NO ACTION'; the SQLAlchemy default
+# (no ondelete=/onupdate= argument) is also conceptually 'NO ACTION'.
+# 'RESTRICT' is a synonym (per MySQL docs §13.1.20.5). Collapse all three
+# into a single canonical sentinel for comparison.
+_DEFAULT_FK_ACTIONS = {None, 'NO ACTION', 'RESTRICT'}
 
 
 # ============================================================================
@@ -239,30 +300,91 @@ class TestSchemaAlignment:
         print("✅ All primary keys match")
 
     def test_foreign_keys_exist(self, session, table_models):
-        """Informational — not all ORMs require DB-level FK constraints."""
-        warnings = []
+        """Every ORM-declared FK must have a matching DB-level constraint.
+
+        Promoted from informational to assertive after the test container
+        gained prod-faithful FK constraints (containers/sam-sql-dev/
+        bootstrap_clone.py reapply step). Legitimate ORM-only FKs go in
+        IGNORED_ORM_FK_DRIFT at module scope with a one-line reason.
+        """
+        problems = []
         for mapper in table_models:
             name = mapper.persist_selectable.name
-            for fk in mapper.persist_selectable.foreign_keys:
-                fk_col = fk.parent.name
-                result = session.execute(text("""
-                    SELECT CONSTRAINT_NAME
-                    FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
-                    WHERE TABLE_SCHEMA = DATABASE()
-                      AND TABLE_NAME = :table_name
-                      AND COLUMN_NAME = :fk_column
-                      AND REFERENCED_TABLE_NAME IS NOT NULL
-                """), {'table_name': name, 'fk_column': fk_col})
-                if not result.fetchone():
-                    warnings.append(f"{name}.{fk_col} (ORM FK, no DB constraint)")
-        if warnings:
-            print(f"\n⚠️  {len(warnings)} foreign keys in ORM but no DB constraint")
-            for w in warnings[:10]:
-                print(f"  {w}")
-            if len(warnings) > 10:
-                print(f"  ... and {len(warnings) - 10} more")
-        else:
-            print("✅ All foreign keys have database constraints")
+            db_fks = get_db_foreign_keys(session, name)
+            db_fk_cols = set()
+            for info in db_fks.values():
+                db_fk_cols.update(info['columns'])
+            orm_fk_cols = {fk.parent.name for fk in mapper.persist_selectable.foreign_keys}
+            missing = orm_fk_cols - db_fk_cols
+            if not missing:
+                continue
+            if (name, frozenset(missing)) in IGNORED_ORM_FK_DRIFT:
+                continue
+            problems.append(
+                f"{name}: ORM declares FK on column(s) {sorted(missing)} "
+                f"but DB has no constraint"
+            )
+
+        assert not problems, (
+            "Foreign-key drift between ORM and DB:\n"
+            + "\n".join(f"  {p}" for p in problems)
+            + "\n\nFix: add the FK to the DB schema (and to "
+              "containers/sam-sql-dev/bootstrap_clone.py's reapply set), "
+              "or add (table, frozenset({...})) to IGNORED_ORM_FK_DRIFT "
+              "with a comment."
+        )
+
+    def test_foreign_key_actions_match(self, session, table_models):
+        """Every DB-level FK action pair must be the default or allowlisted.
+
+        Catches surprise CASCADE / SET NULL drift in the prod-faithful
+        FK set. Each non-default rule pair must appear in
+        IGNORED_FK_ACTION_DRIFT keyed by (table, constraint_name) with
+        the expected (delete_rule, update_rule, reason).
+
+        ORM models currently don't declare ondelete=/onupdate= on any
+        ForeignKey, so this is a one-direction guard: DB → allowlist.
+        Once a model adds matching ondelete=/onupdate=, drop its
+        allowlist entry and this test will start verifying the ORM
+        declaration tracks the DB.
+        """
+        problems = []
+        for mapper in table_models:
+            table = mapper.persist_selectable.name
+            db_fks = get_db_foreign_keys(session, table)
+            for cname, info in db_fks.items():
+                db_del = info['on_delete']
+                db_upd = info['on_update']
+                is_default = (
+                    db_del in _DEFAULT_FK_ACTIONS
+                    and db_upd in _DEFAULT_FK_ACTIONS
+                )
+                if is_default:
+                    continue
+
+                allow = IGNORED_FK_ACTION_DRIFT.get((table, cname))
+                if allow is None:
+                    problems.append(
+                        f"{table}.{cname}: DB has non-default actions "
+                        f"(ON DELETE {db_del}, ON UPDATE {db_upd}) "
+                        f"but no IGNORED_FK_ACTION_DRIFT entry"
+                    )
+                    continue
+
+                allow_del, allow_upd, _reason = allow
+                if (allow_del, allow_upd) != (db_del, db_upd):
+                    problems.append(
+                        f"{table}.{cname}: allowlisted as "
+                        f"({allow_del}, {allow_upd}) but DB now reports "
+                        f"({db_del}, {db_upd})"
+                    )
+
+        assert not problems, (
+            "Foreign-key action drift between DB and allowlist:\n"
+            + "\n".join(f"  {p}" for p in problems)
+            + "\n\nFix: update IGNORED_FK_ACTION_DRIFT to match the "
+              "intended action pair, or align the DB schema."
+        )
 
 
 # ============================================================================

--- a/tests/integration/test_schema_validation.py
+++ b/tests/integration/test_schema_validation.py
@@ -381,19 +381,15 @@ class TestIndexAlignment:
     vice versa. Catches the DiskActivity bug class: a UNIQUE index that exists
     in production but was missing from __table_args__."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Known broad UNIQUE-index drift between prod and ORM — triaged "
-               "in follow-up PRs. When all drift is resolved, this test will "
-               "XPASS, which (with strict=True) will fail the suite — that's "
-               "the signal to remove this xfail marker and promote the guard.",
-    )
     def test_unique_constraints_match(self, session):
         """Every UNIQUE index in DB must have a matching ORM declaration.
 
         Direct regression guard against PR #209 (DiskActivity was missing
-        `disk_activity_unique_idx`). Currently xfail-strict; flips to
-        passing once the existing drift is cleaned up.
+        `disk_activity_unique_idx`). Promoted to assertive after the
+        domain-batched drift cleanup eliminated all known UNIQUE drift.
+        Add (table, index_name) entries to IGNORED_DB_INDEXES at the top
+        of this file for any DBA-added UNIQUE the ORM intentionally won't
+        track.
         """
         problems = []
         for mapper in iter_table_mappers(Base.registry):

--- a/tests/unit/test_current_disk_usage.py
+++ b/tests/unit/test_current_disk_usage.py
@@ -1,6 +1,6 @@
 """Tests for Account.current_disk_usage / Project.current_disk_usage / mark_disk_snapshot_current."""
 
-from datetime import date
+from datetime import date, timedelta
 
 import pytest
 
@@ -13,7 +13,7 @@ from sam.summaries.disk_summaries import (
 from factories.core import make_user
 from factories.projects import make_account, make_project
 from factories.resources import make_resource, make_resource_type
-from factories._seq import next_seq
+from factories._seq import next_date, next_seq
 
 
 def _disk_account(session):
@@ -29,6 +29,11 @@ def _disk_account(session):
 
 
 def _seed_summary(session, account, user, *, activity_date, bytes_, ty=1.0, files=10):
+    # FK: disk_charge_summary.activity_date → disk_charge_summary_status.activity_date.
+    # Ensure the parent status row exists before inserting the child summary.
+    if session.get(DiskChargeSummaryStatus, activity_date) is None:
+        session.add(DiskChargeSummaryStatus(activity_date=activity_date, current=False))
+        session.flush()
     row = DiskChargeSummary(
         activity_date=activity_date,
         user_id=user.user_id,
@@ -44,26 +49,49 @@ def _seed_summary(session, account, user, *, activity_date, bytes_, ty=1.0, file
     return row
 
 
+def _mark_current(session, activity_date):
+    """Test-only narrow alternative to mark_disk_snapshot_current.
+
+    The prod helper does a bulk UPDATE on every row where current=true, which
+    deadlocks under xdist when two workers run it concurrently. These read-path
+    tests only need *their* row marked current; per-test SAVEPOINT rollback
+    means we don't need to clear others. Use the real helper only in tests
+    that are testing it (TestMarkSnapshotCurrent).
+    """
+    row = session.get(DiskChargeSummaryStatus, activity_date)
+    if row is None:
+        session.add(DiskChargeSummaryStatus(activity_date=activity_date, current=True))
+    else:
+        row.current = True
+    session.flush()
+
+
 class TestMarkSnapshotCurrent:
 
     def test_first_call_creates_row(self, session):
-        mark_disk_snapshot_current(session, date(2098, 7, 1))
+        d = next_date("disk_snap")
+        mark_disk_snapshot_current(session, d)
         rows = session.query(DiskChargeSummaryStatus).filter(
+            DiskChargeSummaryStatus.activity_date == d,
             DiskChargeSummaryStatus.current == True  # noqa: E712
         ).all()
         assert len(rows) == 1
-        assert rows[0].activity_date == date(2098, 7, 1)
+        assert rows[0].activity_date == d
 
     def test_subsequent_call_clears_prior(self, session):
-        mark_disk_snapshot_current(session, date(2098, 7, 1))
-        mark_disk_snapshot_current(session, date(2098, 7, 8))
-        # Only the new date should be current.
+        d1 = next_date("disk_snap")
+        d2 = d1 + timedelta(days=7)
+        mark_disk_snapshot_current(session, d1)
+        mark_disk_snapshot_current(session, d2)
+        # Only the new date should be current — among rows for these
+        # specific dates (other workers may have their own current rows).
         currents = session.query(DiskChargeSummaryStatus).filter(
+            DiskChargeSummaryStatus.activity_date.in_((d1, d2)),
             DiskChargeSummaryStatus.current == True  # noqa: E712
         ).all()
-        assert [r.activity_date for r in currents] == [date(2098, 7, 8)]
+        assert [r.activity_date for r in currents] == [d2]
         # The prior row exists but is False.
-        prior = session.get(DiskChargeSummaryStatus, date(2098, 7, 1))
+        prior = session.get(DiskChargeSummaryStatus, d1)
         assert prior is not None and prior.current is False
 
 
@@ -73,27 +101,30 @@ class TestAccountCurrentDiskUsage:
         """Two snapshots, only the later marked current → answer is the
         later snapshot's bytes, NOT the sum."""
         user, project, account = _disk_account(session)
-        _seed_summary(session, account, user, activity_date=date(2098, 7, 1),
+        d1 = next_date("disk_snap")
+        d2 = d1 + timedelta(days=7)
+        _seed_summary(session, account, user, activity_date=d1,
                       bytes_=1 * 1024 ** 4)
-        _seed_summary(session, account, user, activity_date=date(2098, 7, 8),
+        _seed_summary(session, account, user, activity_date=d2,
                       bytes_=2 * 1024 ** 4)
-        mark_disk_snapshot_current(session, date(2098, 7, 8))
+        _mark_current(session, d2)
 
         usage = account.current_disk_usage(session)
         assert isinstance(usage, CurrentDiskUsage)
-        assert usage.activity_date == date(2098, 7, 8)
+        assert usage.activity_date == d2
         assert usage.bytes == 2 * 1024 ** 4
         assert usage.used_tib == pytest.approx(2.0)
 
     def test_falls_back_to_max_date_when_no_status(self, session):
         """If status table has no current row, fall back to MAX(activity_date)."""
         user, project, account = _disk_account(session)
-        _seed_summary(session, account, user, activity_date=date(2098, 8, 1),
+        d = next_date("disk_snap")
+        _seed_summary(session, account, user, activity_date=d,
                       bytes_=3 * 1024 ** 4)
         # Note: NOT calling mark_disk_snapshot_current
         usage = account.current_disk_usage(session)
         assert usage is not None
-        assert usage.activity_date == date(2098, 8, 1)
+        assert usage.activity_date == d
         assert usage.bytes == 3 * 1024 ** 4
 
     def test_returns_none_for_non_disk_resource(self, session):
@@ -112,12 +143,13 @@ class TestAccountCurrentDiskUsage:
         same account_id, different user_ids — sum bytes."""
         user, project, account = _disk_account(session)
         other_user = make_user(session)
+        d = next_date("disk_snap")
 
-        _seed_summary(session, account, user, activity_date=date(2098, 9, 1),
+        _seed_summary(session, account, user, activity_date=d,
                       bytes_=1 * 1024 ** 4)
-        _seed_summary(session, account, other_user, activity_date=date(2098, 9, 1),
+        _seed_summary(session, account, other_user, activity_date=d,
                       bytes_=4 * 1024 ** 4)
-        mark_disk_snapshot_current(session, date(2098, 9, 1))
+        _mark_current(session, d)
 
         usage = account.current_disk_usage(session)
         assert usage.bytes == 5 * 1024 ** 4
@@ -128,13 +160,14 @@ class TestProjectCurrentDiskUsage:
 
     def test_keyed_by_resource_name(self, session):
         user, project, account = _disk_account(session)
-        _seed_summary(session, account, user, activity_date=date(2098, 10, 1),
+        d = next_date("disk_snap")
+        _seed_summary(session, account, user, activity_date=d,
                       bytes_=7 * 1024 ** 4)
-        mark_disk_snapshot_current(session, date(2098, 10, 1))
+        _mark_current(session, d)
 
         result = project.current_disk_usage()
         res_name = account.resource.resource_name
         assert res_name in result
         assert result[res_name]['bytes'] == 7 * 1024 ** 4
         assert result[res_name]['current_used_tib'] == pytest.approx(7.0)
-        assert result[res_name]['activity_date'] == date(2098, 10, 1)
+        assert result[res_name]['activity_date'] == d

--- a/tests/unit/test_manage_summaries.py
+++ b/tests/unit/test_manage_summaries.py
@@ -40,9 +40,9 @@ from sam.schemas.charges import (
     CompChargeSummaryInputSchema,
     DiskChargeSummaryInputSchema,
 )
-from sam.summaries.archive_summaries import ArchiveChargeSummary
+from sam.summaries.archive_summaries import ArchiveChargeSummary, ArchiveChargeSummaryStatus
 from sam.summaries.comp_summaries import CompChargeSummary
-from sam.summaries.disk_summaries import DiskChargeSummary
+from sam.summaries.disk_summaries import DiskChargeSummary, DiskChargeSummaryStatus
 
 from factories import (
     make_account,
@@ -52,6 +52,7 @@ from factories import (
     make_resource,
     make_resource_type,
     make_user,
+    next_date,
     next_seq,
 )
 
@@ -112,8 +113,18 @@ def _build_storage_graph(session, *, resource_type_name: str):
     )
     resource = make_resource(session, resource_type=rt)
     make_account(session, project=project, resource=resource)
+    # FK: *_charge_summary.activity_date → *_charge_summary_status.activity_date.
+    # Materialize the parent status rows so upsert_*_charge_summary can insert
+    # the child summary without violating the constraint. Use next_date() to
+    # get a worker-unique date so parallel xdist workers don't collide on the
+    # status row's PK.
+    activity_date = next_date("storage_test_date")
+    for status_cls in (DiskChargeSummaryStatus, ArchiveChargeSummaryStatus):
+        if session.get(status_cls, activity_date) is None:
+            session.add(status_cls(activity_date=activity_date, current=False))
+    session.flush()
     return dict(
-        activity_date=date(2098, 6, 15),
+        activity_date=activity_date,
         act_username=user.username,
         act_projcode=project.projcode,
         act_unix_uid=user.unix_uid,

--- a/tests/unit/test_reconcile_quotas.py
+++ b/tests/unit/test_reconcile_quotas.py
@@ -890,27 +890,31 @@ class TestTreeRollup:
         alloc = make_allocation(session, account=acct, amount=30.0)
 
         # Both filesets map to the same project via different paths;
-        # neither projcode-named, so both must hit pass 2.
+        # neither projcode-named, so both must hit pass 2. Use unique
+        # paths so we don't collide with snapshot ProjectDirectory rows
+        # (e.g. P43713000 owns /gpfs/csfs1/collections/gdex/{data,work}
+        # in the obfuscated snapshot, and `dir_to_projcode.setdefault`
+        # keeps the snapshot's mapping → our quotas would attach to the
+        # snapshot project instead of this test's project).
+        fs_a = next_seq('fsmulti_a').lower()
+        fs_b = next_seq('fsmulti_b').lower()
+        path_a = f'/gpfs/csfs1/test/{fs_a}'
+        path_b = f'/gpfs/csfs1/test/{fs_b}'
         ProjectDirectory.create(
-            session, project_id=proj.project_id,
-            directory_name='/gpfs/csfs1/collections/gdex/data',
+            session, project_id=proj.project_id, directory_name=path_a,
         )
         ProjectDirectory.create(
-            session, project_id=proj.project_id,
-            directory_name='/gpfs/csfs1/collections/gdex/work',
+            session, project_id=proj.project_id, directory_name=path_b,
         )
         quota_path = _write_quota_file(
             tmp_path,
             {
-                'rda_data': {'limit': str(_kib_for(10.0)),
-                             'usage': '0', 'files': '0'},
-                'rda_work': {'limit': str(_kib_for(20.0)),
-                             'usage': '0', 'files': '0'},
+                fs_a: {'limit': str(_kib_for(10.0)),
+                       'usage': '0', 'files': '0'},
+                fs_b: {'limit': str(_kib_for(20.0)),
+                       'usage': '0', 'files': '0'},
             },
-            paths={
-                'rda_data': '/gpfs/csfs1/collections/gdex/data',
-                'rda_work': '/gpfs/csfs1/collections/gdex/work',
-            },
+            paths={fs_a: path_a, fs_b: path_b},
         )
         admin = make_user(session)
         monkeypatch.setenv('SAM_ADMIN_USER', admin.username)

--- a/tests/unit/test_upsert_disk_pre_resolved.py
+++ b/tests/unit/test_upsert_disk_pre_resolved.py
@@ -12,10 +12,11 @@ import pytest
 
 from sam.manage.summaries import upsert_disk_charge_summary
 from sam.resources.resources import ResourceType
+from sam.summaries.disk_summaries import DiskChargeSummaryStatus
 from factories.core import make_user
 from factories.projects import make_account, make_project
 from factories.resources import make_resource, make_resource_type
-from factories._seq import next_seq
+from factories._seq import next_date, next_seq
 
 
 def _build_disk_graph(session):
@@ -33,6 +34,13 @@ def _build_disk_graph(session):
     return user, project, resource
 
 
+def _ensure_status(session, activity_date):
+    """FK: disk_charge_summary.activity_date → disk_charge_summary_status."""
+    if session.get(DiskChargeSummaryStatus, activity_date) is None:
+        session.add(DiskChargeSummaryStatus(activity_date=activity_date, current=False))
+        session.flush()
+
+
 class TestPreResolvedOverride:
 
     def test_act_username_is_audit_label_user_is_lead(self, session):
@@ -44,9 +52,11 @@ class TestPreResolvedOverride:
         account = Account.get_by_project_and_resource(
             session, project.project_id, resource.resource_id
         )
+        d = next_date("disk_pre_resolved")
+        _ensure_status(session, d)
         record, action = upsert_disk_charge_summary(
             session,
-            activity_date=date(2098, 6, 15),
+            activity_date=d,
             act_username='<unidentified>',
             act_projcode=None,
             act_unix_uid=None,
@@ -81,9 +91,11 @@ class TestPreResolvedOverride:
         # would raise. The override should make this succeed.
         # (DB column is varchar(35); use a short bogus literal.)
         bogus = 'no_such_user_xyz'
+        d = next_date("disk_pre_resolved")
+        _ensure_status(session, d)
         record, _ = upsert_disk_charge_summary(
             session,
-            activity_date=date(2098, 6, 16),
+            activity_date=d,
             act_username=bogus,
             act_projcode=None,
             act_unix_uid=None,
@@ -101,9 +113,11 @@ class TestPreResolvedOverride:
     def test_no_override_falls_back_to_resolver(self, session):
         """Without the override, the standard resolver path still works."""
         user, project, resource = _build_disk_graph(session)
+        d = next_date("disk_pre_resolved")
+        _ensure_status(session, d)
         record, action = upsert_disk_charge_summary(
             session,
-            activity_date=date(2098, 6, 17),
+            activity_date=d,
             act_username=user.username,
             act_projcode=project.projcode,
             act_unix_uid=user.unix_uid,


### PR DESCRIPTION
## Overview

Three big things land here, in order:

1. **A read-only audit tool** (`scripts/check_db_drift.py`, `make check-db-vs-orms`) that compares prod's MySQL schema against our SQLAlchemy ORM models — indexes, unique constraints, FK constraints (with `ON DELETE`/`ON UPDATE` actions), and column types/nullability — VPN-aware so it skips cleanly off-VPN or in CI.
2. **All of the drift it found, fixed in the ORM**, batched as one commit per domain so each diff is reviewable in a slice.
3. **A faithful FK-bearing local DB clone** — `containers/sam-sql-dev/bootstrap_clone.py` now re-applies all 116 prod FK constraints to the local DB after data loads, instead of silently stripping them. The local clone now mirrors prod exactly for every metadata category that matters: tables, views, columns, types, indexes, uniqueness, FKs, and `ON DELETE`/`ON UPDATE` rules.

`make check-db-vs-orms` started this PR reporting **382 findings across 74 of 91 tables** (plus 20 type/coverage issues from the `orm_inventory.py` half). It now reports **0 findings** in both halves; **full pytest is green**.

## What's added

### `scripts/check_db_drift.py` — read-only prod auditor
Compares every prod base-table against its ORM model. Reports:
- Indexes (with rename-pair clustering — same `(columns, uniqueness)` shape under different names is reported as a single `RENAME` line, collapsing ~150 mechanical renames into one each)
- FK constraints (with `IGNORED_FK_DRIFT` allowlist for legitimately-intentional ORM-only FKs)
- Column types / nullability

**Connectivity contract — VPN-aware, CI-safe.** Reads `PROD_SAM_DB_{SERVER,USERNAME,PASSWORD}` from env. Any missing → exit 0 with `[SKIPPED]`. Host unreachable within 5s → exit 0 with `[SKIPPED]`. `--strict` flips skips to errors for nightly jobs that should fail loudly. After its own audit it invokes `orm_inventory.generate_report(engine, issues_only=True)` against the same prod engine so a single invocation captures both reports.

### `scripts/orm_inventory.py` — rewritten
Old `compare_columns()` had its own ad-hoc type rules that fired false positives on pairings already considered acceptable elsewhere (CHAR/VARCHAR, FLOAT/DOUBLE, BIT/BOOLEAN, DATETIME/TIMESTAMP). Rewritten to delegate to the shared `TYPE_MAPPINGS` table so this script and `tests/integration/test_schema_validation.py` use the same rules. Hardcoded `mysql+pymysql://root:root@127.0.0.1` URL replaced with `create_sam_engine()`-from-env. New `issues_only=True` mode for terse output when piggybacking on `check_db_drift`.

### `scripts/lib/schema_introspection.py` — shared helpers
`get_db_indexes` / `get_orm_indexes` / `diff_indexes` / `find_rename_pairs` / `get_db_foreign_keys` / `iter_table_mappers` plus the canonical `TYPE_MAPPINGS`. Used by both the audit script and the CI guards so they enforce the **same** rules.

### `Makefile` — `check-db-vs-orms` target
Same shape as `perf`. The script's own skip behavior makes it a no-op on any box without prod creds or VPN, including GitHub Actions.

### `tests/integration/test_schema_validation.py` — `TestIndexAlignment` + assertive FK guards
- **`test_unique_constraints_match`** — assertive regression guard against the PR #209 (DiskActivity) bug class. Was `xfail(strict=True)` while broad drift existed; promoted to a hard assertion in commit `70e4548` once cleanup was complete.
- **`test_indexes_match`** — informational, reports drift in both directions plus same-name/different-shape mismatches.
- **`test_foreign_keys_exist`** — **promoted to assertive in commit `a80d81e`** now that the test container has prod-faithful FKs. Backed by `IGNORED_ORM_FK_DRIFT` allowlist for legitimately ORM-only FKs (`organization.parent_org_id`, `dav_charge.dav_activity_id`).
- **`test_foreign_key_actions_match`** — **new in commit `a80d81e`**. Asserts every DB-side FK's `(ON DELETE, ON UPDATE)` pair is either MySQL's default or recorded in `IGNORED_FK_ACTION_DRIFT` with a reason. Catches surprise `CASCADE` / `SET NULL` drift. Seeded with the 8 non-default FK-action pairs in prod (`adhoc_group_tag`, `adhoc_system_account_entry`, `access_branch_resource ×2`, `*_charge_summary → TIME_DIM ×4`).
- `IGNORED_DB_INDEXES` allowlist for any DBA-added analytics indexes the ORM intentionally won't track.

### `containers/sam-sql-dev/bootstrap_clone.py` — Phase C: FK re-apply
The script's `load_local(..., disable_fk_checks=True)` had been regex-stripping every `CONSTRAINT … FOREIGN KEY …` clause from the schema dump (justified as "MySQL 9 has issues" with FKs during multi-table CREATE TABLE) — leaving the local clone with **0 of 116** prod FKs.

New post-data phase queries `INFORMATION_SCHEMA.{KEY_COLUMN_USAGE, REFERENTIAL_CONSTRAINTS}` to extract every FK including composite columns and `ON DELETE`/`ON UPDATE` rules, then runs `ALTER TABLE … ADD CONSTRAINT …` per FK individually via PyMySQL — failures are logged-and-continued, not fatal. Two expected non-fatal failure modes:

1. **Legacy MySQL/InnoDB permissiveness** — pre-MySQL-8 InnoDB allowed FKs to reference the leftmost prefix of any index regardless of uniqueness; MySQL 8.0+ enforces strict matching. One FK in prod (`fk_dav_charge_dav_activity` → `dav_activity.dav_activity_id` where `dav_activity` has composite PK `(dav_activity_id, queue_name)`) was created when the rule was lax and is grandfathered in. We get **115/116**, log the one skip with a clear reason.
2. **Orphan-data FKs** that escaped `cleanup_orphans.py` — ALTER fails loudly, which is the desired signal.

The Makefile's post-bootstrap `TRUNCATE TABLE api_credentials` was wrapped in `SET FOREIGN_KEY_CHECKS=0/1` so it works alongside the now-restored `role_api_credentials` FK.

## ORM drift fixes

Each domain landed as its own commit so the diff is reviewable in slices:

| Commit | Domain | Findings before | Findings after |
|---|---|---:|---:|
| `ab4aee9` audit: rename-pair clustering | tooling | 382 | 246 |
| `62ea383` accounting | account, allocation*, charge_adjustment | 246 | 227 |
| `ca9c17f` HPC/DAV/comp/dataset activity | comp_*, hpc_*, dav_*, dataset | 227 | 190 |
| `8833b8f` disk/archive activity | disk_*, archive_* | 190 | 171 |
| `d1e8da8` charge summaries | *_charge_summary, *_charge_summary_status | 171 | 142 |
| `2e176d9` core + security | users, groups, orgs, roles, access | 142 | 105 |
| `f256553` projects + resources | project, contract, resource, machine, facility | 105 | 36 |
| `7563762` remaining tables | operational, geography, xras, misc | 36 | 7 |
| `70e4548` activity_date FKs + xfail removal | summaries (FK) + test guard | 7 | 3 |
| `c671029` drop dead FK declarations + allowlist | comp_activity, users, organization | 3 | **0** |
| `df83d34` orm_inventory rewrite + 3 missing cols | institution.deleted, organization.{deleted,idms_unique_name} | 20 inv. issues | **0** inv. issues |

### Patterns applied across these commits

1. **Naming convention sync** — ORM's `ix_<table>_<col>` renamed to prod's `idx_<table>` / `<table>_<col>_fk` / `<table>_<col>_uk` forms. ~150 mechanical renames.
2. **`Column(unique=True)` → explicit `Index('<prod_name>', col, unique=True)`** — 31+ occurrences. SQLAlchemy's unnamed `UniqueConstraint` couldn't match prod's named indexes; explicit declarations now do.
3. **Missing UNIQUE constraints added** — including the original DiskActivity case plus large composite UNIQUE indexes that prod has but the ORM was silent about (`idx_archive_activity_uniq` 6-col, `idx_comp_charge_summary_uniq` 7-col, `dav_activity_unique_idx`, `idx_hpc_activity_uniq`, `dataset_activity_unique_idx`, etc).
4. **Dead ORM-only indexes dropped** — ~30 indexes the ORM was declaring that prod doesn't have.
5. **4× `activity_date` FKs added** to `*_charge_summary` tables to match prod.
6. **3 dead ORM-only FKs dropped after git-blame review:**
   - `users.primary_gid → adhoc_group.group_id` — semantically wrong (column actually stores `unix_gid`, not `group_id`, per CLAUDE.md and `AdhocGroup.get_by_unix_gid` docstring) and the `User.primary_group` relationship was unused. Dropped both.
   - `comp_activity` 5-col composite FK to `comp_job` and the `CompActivity.job` / `CompJob.activities` relationships — never used in `src/` or `tests/` (only auto-exposed in SQLAdmin). Per the user, those tables are slated for removal anyway.
   - `organization.parent_org_id` self-FK — kept (load-bearing for `Organization.parent`/`.children` nested-set relationship used in admin dashboards). Documented in `IGNORED_FK_DRIFT`.
7. **3 missing columns added**: `institution.deleted`, `organization.deleted`, `organization.idms_unique_name`.

## Local clone now mirrors prod

Verified after a fresh `make clone`:

| Metric | Prod | Local | Drift |
|---|---:|---:|---|
| Tables | 98 | 98 | ✅ exact |
| Views | 7 | 7 | ✅ exact |
| Non-PK indexes | 188 | 188 | ✅ **0 differences** (columns + uniqueness all match) |
| Of which UNIQUE | 53 | 53 | ✅ exact |
| FK constraints | 116 | 115 | 1 documented skip (legacy `fk_dav_charge_dav_activity` MySQL 9 strict-mode case) |

The 3 reported FK "shape mismatches" between prod and local are MySQL's `RESTRICT` ↔ `NO ACTION` synonyms (semantically identical in MySQL InnoDB) showing up under both names in `INFORMATION_SCHEMA` due to a data-dictionary quirk on the prod side — not real drift.

## Test fixes

Adding the `activity_date` FK on `*_charge_summary` tables exposed 15 tests across 4 files that were inserting summary rows without ensuring the parent `*_charge_summary_status` row existed. With prod-faithful FKs now enforced locally, those tests broke. Fixed in commit `325bb23` by:

- Adding `next_date()` to `tests/factories/_seq.py` — worker-namespaced date generator (each xdist worker gets a 365-day slice starting at 2090) so concurrent workers can't collide on the small date-keyed parent tables.
- Updating test seed helpers / fixtures to materialize the parent status row before inserting the child summary.
- For tests that called the prod helper `mark_disk_snapshot_current` only as setup (not testing the helper itself), substituting a narrow test-local `_mark_current()` to avoid the bulk `UPDATE … WHERE current=True` deadlock under xdist.

The `test_reconcile_quotas.py::test_project_with_multiple_filesets_sums_all` failure was traced to the now-prod-faithful snapshot containing real `ProjectDirectory` rows for `/gpfs/csfs1/collections/gdex/{data,work}` (P43713000), which won the `dir_to_projcode.setdefault()` race against the test's own newly-created project. Fixed in commit `413d78d` by switching the test to `next_seq`-generated unique paths so it can't collide with snapshot data.

## Verification

- `make check-db-vs-orms` against prod (on-VPN): **0 findings** in both halves (`check_db_drift` and `orm_inventory`).
- `pytest`: **all green** — 1902 passed, 23 skipped, 1 xfailed, 0 failed.
- `pytest tests/integration/test_schema_validation.py`: 22 passed (was 20; +2 from the assertive-FK promotion + new action-drift guard).
- Skip paths (no creds → exit 0, off-VPN → exit 0 within 5s) wired in code; ready for any CI runner that lacks prod creds or VPN access.
- `make clone` end-to-end: 115/116 FKs re-applied, 1 documented skip, downstream truncate + obfuscation pipeline still works.

## Test plan

- [x] `make check-db-vs-orms` from on-VPN box with `PROD_SAM_DB_*` exported → 0 findings
- [x] `make check-db-vs-orms` with `PROD_SAM_DB_*` unset → `[SKIPPED]`, exit 0
- [x] `make check-db-vs-orms` with `PROD_SAM_DB_*` set but VPN disconnected → `[SKIPPED]` within ~5s, exit 0
- [x] `make clone` rebuilds the local clone with 115/116 prod FKs re-applied
- [x] `pytest tests/integration/test_schema_validation.py` passes
- [x] Full `pytest` green — no failures, no regressions
- [x] CI green on this branch

## Done in this PR (was previously listed as follow-ups)

1. ✅ `test_foreign_keys_exist` promoted from informational to assertive (commit `a80d81e`).
2. ✅ `test_foreign_key_actions_match` added (commit `a80d81e`).

## Remaining follow-ups

1. Investigate the legacy `fk_dav_charge_dav_activity` FK with the DBA: either drop it from prod (it doesn't satisfy current MySQL referential integrity rules anyway) or restructure `dav_activity`'s PK so the FK becomes valid under MySQL 9 strict mode.
2. Triage the 1 unmodeled prod table (`gid_allocation`) — separate concern.
3. Sweep ORM `ForeignKey(...)` declarations to add explicit `ondelete=`/`onupdate=` matching the 8 entries in `IGNORED_FK_ACTION_DRIFT`. Each entry can be dropped from the allowlist as the matching ORM declaration lands; the test then starts verifying the ORM tracks the DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
