### PR TITLE
Disk dashboard perf: bulk current_disk_usage + drop disk_charge from queries

### DIFF
--- a/src/sam/accounting/accounts.py
+++ b/src/sam/accounting/accounts.py
@@ -196,72 +196,28 @@ class Account(Base, SoftDeleteMixin, SessionMixin):
         Sums across all rows for the snapshot date — so when the
         ``<unidentified>`` reconciliation is on, the lead-attributed
         gap row is included in the total.
-        """
-        # Lazy imports to avoid cycles (DiskChargeSummary lives in
-        # sam.summaries which imports Account through relationships).
-        from sam.summaries.disk_summaries import (
-            DiskChargeSummary, DiskChargeSummaryStatus,
-        )
 
+        Thin wrapper over :func:`sam.queries.disk_usage.bulk_current_disk_usage`
+        so single- and multi-account paths share the same fixed-query
+        kernel. Use the bulk helper directly whenever loading >1
+        account at a time (``build_disk_subtree``,
+        ``Project.current_disk_usage``).
+        """
         s = session or self.session
         if s is None:
             return None
 
         # Disk resource gate: skip when the account's resource isn't disk.
-        # Use string compare to avoid an enum import; matches the constant
-        # used elsewhere in the codebase ('DISK').
+        # Match the bulk helper's contract — caller filters by resource
+        # type so the helper itself doesn't need a per-row check.
         if self.resource and self.resource.resource_type and \
                 self.resource.resource_type.resource_type != 'DISK':
             return None
 
-        # Defensive: in legacy / test DBs there may be multiple rows with
-        # current=True. Pick the most recent and proceed.
-        current_row = (
-            s.query(DiskChargeSummaryStatus.activity_date)
-             .filter(DiskChargeSummaryStatus.current == True)  # noqa: E712
-             .order_by(DiskChargeSummaryStatus.activity_date.desc())
-             .first()
-        )
-        candidate_date = current_row[0] if current_row else None
-
-        # The "current" snapshot may not include this account (e.g. project
-        # had no usage that day, or the snapshot file was filtered). Fall
-        # back to the most recent date this account itself has a row for.
-        target_date = None
-        if candidate_date is not None:
-            has_row = (
-                s.query(DiskChargeSummary.disk_charge_summary_id)
-                 .filter(
-                     DiskChargeSummary.account_id == self.account_id,
-                     DiskChargeSummary.activity_date == candidate_date,
-                 ).first()
-            )
-            if has_row is not None:
-                target_date = candidate_date
-
-        if target_date is None:
-            target_date = s.query(func.max(DiskChargeSummary.activity_date)).filter(
-                DiskChargeSummary.account_id == self.account_id
-            ).scalar()
-
-        if target_date is None:
-            return None
-
-        agg = s.query(
-            func.coalesce(func.sum(DiskChargeSummary.bytes), 0).label('bytes'),
-            func.coalesce(func.sum(DiskChargeSummary.terabyte_years), 0).label('ty'),
-            func.coalesce(func.sum(DiskChargeSummary.number_of_files), 0).label('files'),
-        ).filter(
-            DiskChargeSummary.account_id == self.account_id,
-            DiskChargeSummary.activity_date == target_date,
-        ).one()
-
-        return CurrentDiskUsage(
-            activity_date=target_date,
-            bytes=int(agg.bytes or 0),
-            terabyte_years=float(agg.ty or 0.0),
-            number_of_files=int(agg.files or 0),
-        )
+        # Lazy import: sam.queries.disk_usage already imports Account at
+        # module level, so a top-level import here would be circular.
+        from sam.queries.disk_usage import bulk_current_disk_usage
+        return bulk_current_disk_usage(s, [self.account_id]).get(self.account_id)
 
     def __str__(self):
         return f"{self.project.projcode if self.project else None} - {self.resource.resource_name if self.resource else None}"

--- a/src/sam/projects/projects.py
+++ b/src/sam/projects/projects.py
@@ -786,7 +786,11 @@ class Project(Base, TimestampMixin, ActiveFlagMixin, SessionMixin, NestedSetMixi
 
         ``resource_name`` filters to a single disk resource if given.
         """
-        results: Dict[str, Any] = {}
+        # Gather disk-account candidates once, then a single bulk
+        # snapshot query covers them all (matches single-account
+        # semantics in Account.current_disk_usage but with fixed query
+        # count instead of N+1).
+        candidates = []
         for account in self.accounts:
             if account.deleted:
                 continue
@@ -795,7 +799,22 @@ class Project(Base, TimestampMixin, ActiveFlagMixin, SessionMixin, NestedSetMixi
             res_name = account.resource.resource_name
             if resource_name and res_name != resource_name:
                 continue
-            usage = account.current_disk_usage(self.session)
+            rt = account.resource.resource_type
+            if rt and rt.resource_type != 'DISK':
+                continue
+            candidates.append((account, res_name))
+
+        if not candidates:
+            return {}
+
+        from sam.queries.disk_usage import bulk_current_disk_usage
+        snapshots = bulk_current_disk_usage(
+            self.session, [a.account_id for a, _ in candidates],
+        )
+
+        results: Dict[str, Any] = {}
+        for account, res_name in candidates:
+            usage = snapshots.get(account.account_id)
             if usage is None:
                 continue
             results[res_name] = {

--- a/src/sam/queries/disk_usage.py
+++ b/src/sam/queries/disk_usage.py
@@ -20,12 +20,12 @@ Two helpers:
 from __future__ import annotations
 
 from datetime import date as _stdlib_date
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import Session
 
-from sam.accounting.accounts import Account
+from sam.accounting.accounts import Account, CurrentDiskUsage
 from sam.activity.disk import DiskActivity, DiskCharge
 from sam.core.users import User
 from sam.projects.projects import Project, ProjectDirectory
@@ -40,6 +40,123 @@ _EMPTY_CAP: Dict[str, Any] = {
     'activity_date': None,
     'account_ids':   [],
 }
+
+
+def _load_disk_snapshot_by_account(
+    session: Session,
+    account_ids: Iterable[int],
+) -> Dict[int, CurrentDiskUsage]:
+    """Per-account latest disk snapshot in a fixed number of queries.
+
+    Shared kernel for :meth:`Account.current_disk_usage`,
+    :func:`bulk_current_disk_usage`, and the snapshot phase of
+    :func:`bulk_get_subtree_disk_capacity`. Semantics match the
+    single-account method exactly:
+
+      1. ONE ``DiskChargeSummaryStatus`` lookup for the most recent
+         ``current=True`` row.
+      2. ONE bulk aggregate over ``DiskChargeSummary`` at that date,
+         keyed by ``account_id`` (sums bytes, terabyte_years, files).
+      3. ONE ``max(activity_date)`` per account that lacked a row at
+         the candidate date.
+      4. ONE bulk aggregate for those (account_id, max_date) fallback
+         pairs.
+
+    Returns ``{account_id: CurrentDiskUsage}``. Accounts with no rows
+    at all are absent from the dict — matches the single-account
+    method's ``None`` return semantics.
+    """
+    aids = {int(a) for a in account_ids if a is not None}
+    if not aids:
+        return {}
+
+    out: Dict[int, CurrentDiskUsage] = {}
+
+    # 1) Current snapshot date.
+    current_row = (
+        session.query(DiskChargeSummaryStatus.activity_date)
+        .filter(DiskChargeSummaryStatus.current == True)  # noqa: E712
+        .order_by(DiskChargeSummaryStatus.activity_date.desc())
+        .first()
+    )
+    candidate_date = current_row[0] if current_row else None
+
+    # 2) Bulk aggregate at the candidate date.
+    if candidate_date is not None:
+        rows = session.query(
+            DiskChargeSummary.account_id,
+            func.coalesce(func.sum(DiskChargeSummary.bytes), 0).label('bytes'),
+            func.coalesce(func.sum(DiskChargeSummary.terabyte_years), 0).label('ty'),
+            func.coalesce(func.sum(DiskChargeSummary.number_of_files), 0).label('files'),
+        ).filter(
+            DiskChargeSummary.account_id.in_(aids),
+            DiskChargeSummary.activity_date == candidate_date,
+        ).group_by(DiskChargeSummary.account_id).all()
+        for r in rows:
+            out[r.account_id] = CurrentDiskUsage(
+                activity_date=candidate_date,
+                bytes=int(r.bytes or 0),
+                terabyte_years=float(r.ty or 0.0),
+                number_of_files=int(r.files or 0),
+            )
+
+    # 3) Per-account max() fallback for accounts without a row on the
+    #    current snapshot date. One query covers them all.
+    missing = aids - out.keys()
+    if missing:
+        max_dates = dict(session.query(
+            DiskChargeSummary.account_id,
+            func.max(DiskChargeSummary.activity_date),
+        ).filter(
+            DiskChargeSummary.account_id.in_(missing),
+        ).group_by(DiskChargeSummary.account_id).all())
+        if max_dates:
+            # 4) ONE aggregate query for all (account_id, max_date) pairs.
+            ors = [
+                and_(
+                    DiskChargeSummary.account_id == aid,
+                    DiskChargeSummary.activity_date == d,
+                )
+                for aid, d in max_dates.items()
+            ]
+            rows = session.query(
+                DiskChargeSummary.account_id,
+                DiskChargeSummary.activity_date,
+                func.coalesce(func.sum(DiskChargeSummary.bytes), 0).label('bytes'),
+                func.coalesce(func.sum(DiskChargeSummary.terabyte_years), 0).label('ty'),
+                func.coalesce(func.sum(DiskChargeSummary.number_of_files), 0).label('files'),
+            ).filter(or_(*ors)).group_by(
+                DiskChargeSummary.account_id, DiskChargeSummary.activity_date,
+            ).all()
+            for r in rows:
+                out[r.account_id] = CurrentDiskUsage(
+                    activity_date=r.activity_date,
+                    bytes=int(r.bytes or 0),
+                    terabyte_years=float(r.ty or 0.0),
+                    number_of_files=int(r.files or 0),
+                )
+
+    return out
+
+
+def bulk_current_disk_usage(
+    session: Session,
+    account_ids: Iterable[int],
+) -> Dict[int, CurrentDiskUsage]:
+    """Bulk twin of :meth:`Account.current_disk_usage`.
+
+    Returns ``{account_id: CurrentDiskUsage}`` for every requested
+    ``account_id`` that has at least one ``disk_charge_summary`` row.
+    Use this whenever you need snapshots for >1 account
+    (``build_disk_subtree``, ``Project.current_disk_usage``, …) — the
+    single-account path delegates here too, so all callers share one
+    code path with a fixed query count.
+
+    Caller is responsible for filtering to disk-resource accounts; this
+    helper does not check resource type because it's typically called
+    after a bulk ``Account`` load that already enforced the filter.
+    """
+    return _load_disk_snapshot_by_account(session, account_ids)
 
 
 def get_subtree_disk_capacity(
@@ -69,10 +186,8 @@ def bulk_get_subtree_disk_capacity(
       1. ONE ``Resource`` lookup for the distinct resource names.
       2. ONE OR-combined ``Account``/``Project`` subtree query covering
          every pair's NestedSet range (or fallback project_id match).
-      3. ONE ``DiskChargeSummaryStatus`` lookup for the current snapshot date.
-      4. ONE bulk ``DiskChargeSummary`` aggregate keyed by account_id.
-      5. ONE per-account fallback aggregate for accounts not on the
-         current snapshot date (only fires if such accounts exist).
+      3-6. Per-account snapshot via :func:`_load_disk_snapshot_by_account`
+         (status row + bulk aggregate + per-account max() fallback).
 
     Returns ``{(project_id, resource_name): cap_dict}``. Pairs whose
     resource doesn't exist or whose subtree has no disk accounts get an
@@ -160,68 +275,10 @@ def bulk_get_subtree_disk_capacity(
             out[key] = {**_EMPTY_CAP, 'account_ids': aids}
         return out
 
-    # 3) Current snapshot date.
-    current_row = (
-        session.query(DiskChargeSummaryStatus.activity_date)
-        .filter(DiskChargeSummaryStatus.current == True)  # noqa: E712
-        .order_by(DiskChargeSummaryStatus.activity_date.desc())
-        .first()
-    )
-    candidate_date = current_row[0] if current_row else None
-
-    # 4) Bulk aggregate at the candidate date.
-    snap_by_account: Dict[int, Dict[str, Any]] = {}
-    if candidate_date is not None:
-        rows = session.query(
-            DiskChargeSummary.account_id,
-            func.coalesce(func.sum(DiskChargeSummary.bytes), 0).label('bytes'),
-            func.coalesce(func.sum(DiskChargeSummary.number_of_files), 0).label('files'),
-        ).filter(
-            DiskChargeSummary.account_id.in_(all_account_ids),
-            DiskChargeSummary.activity_date == candidate_date,
-        ).group_by(DiskChargeSummary.account_id).all()
-        for r in rows:
-            snap_by_account[r.account_id] = {
-                'bytes':         int(r.bytes or 0),
-                'files':         int(r.files or 0),
-                'activity_date': candidate_date,
-            }
-
-    # 5) Fallback: any account without a row on the current snapshot date
-    #    falls back to its own most-recent row (matches single-account
-    #    semantics in Account.current_disk_usage). One query covers all
-    #    fallback accounts at once.
-    missing = [aid for aid in all_account_ids if aid not in snap_by_account]
-    if missing:
-        max_dates = dict(session.query(
-            DiskChargeSummary.account_id,
-            func.max(DiskChargeSummary.activity_date),
-        ).filter(
-            DiskChargeSummary.account_id.in_(missing),
-        ).group_by(DiskChargeSummary.account_id).all())
-        if max_dates:
-            # ONE aggregate query for all (account_id, max_date) pairs.
-            ors = [
-                and_(
-                    DiskChargeSummary.account_id == aid,
-                    DiskChargeSummary.activity_date == d,
-                )
-                for aid, d in max_dates.items()
-            ]
-            rows = session.query(
-                DiskChargeSummary.account_id,
-                DiskChargeSummary.activity_date,
-                func.coalesce(func.sum(DiskChargeSummary.bytes), 0).label('bytes'),
-                func.coalesce(func.sum(DiskChargeSummary.number_of_files), 0).label('files'),
-            ).filter(or_(*ors)).group_by(
-                DiskChargeSummary.account_id, DiskChargeSummary.activity_date,
-            ).all()
-            for r in rows:
-                snap_by_account[r.account_id] = {
-                    'bytes':         int(r.bytes or 0),
-                    'files':         int(r.files or 0),
-                    'activity_date': r.activity_date,
-                }
+    # 3-5) Per-account snapshot in a fixed number of queries (status row
+    #      + bulk aggregate + per-account max() fallback). Shared with
+    #      Account.current_disk_usage / bulk_current_disk_usage.
+    snap_by_account = _load_disk_snapshot_by_account(session, all_account_ids)
 
     # 6) Roll up per-pair.
     for (pid, rn), aids in accounts_per_pair.items():
@@ -232,10 +289,10 @@ def bulk_get_subtree_disk_capacity(
             snap = snap_by_account.get(aid)
             if snap is None:
                 continue
-            used_bytes += snap['bytes']
-            files += snap['files']
-            if latest is None or snap['activity_date'] > latest:
-                latest = snap['activity_date']
+            used_bytes += snap.bytes
+            files += snap.number_of_files
+            if latest is None or snap.activity_date > latest:
+                latest = snap.activity_date
         out[(pid, rn)] = {
             'used_bytes':    used_bytes,
             'used_tib':      used_bytes / (1024 ** 4),
@@ -722,6 +779,14 @@ def build_disk_subtree(
     for d in dirs:
         dirs_by_project_id.setdefault(d.project_id, []).append(d.directory_name)
 
+    # ONE bulk snapshot lookup covers every account on this resource —
+    # avoids the N+1 from calling Account.current_disk_usage() per
+    # descendant (each call would issue 2-4 queries; on a 20-account
+    # subtree that's 60+ queries this single helper replaces).
+    snap_by_account_id = bulk_current_disk_usage(
+        session, [a.account_id for a in accounts],
+    )
+
     # Build a flat node map, then thread parents → children using the
     # parent_id FK (works alongside the NestedSet coords).
     node_by_pid: Dict[int, Dict[str, Any]] = {}
@@ -731,7 +796,10 @@ def build_disk_subtree(
     multifs_by_date: Dict[Any, List[int]] = {}
     for proj in descendants:
         account = account_by_project_id.get(proj.project_id)
-        snapshot = account.current_disk_usage() if account is not None else None
+        snapshot = (
+            snap_by_account_id.get(account.account_id)
+            if account is not None else None
+        )
         node = _node_dict(
             proj,
             account=account,

--- a/src/sam/queries/disk_usage.py
+++ b/src/sam/queries/disk_usage.py
@@ -26,7 +26,7 @@ from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import Session
 
 from sam.accounting.accounts import Account, CurrentDiskUsage
-from sam.activity.disk import DiskActivity, DiskCharge
+from sam.activity.disk import DiskActivity
 from sam.core.users import User
 from sam.projects.projects import Project, ProjectDirectory
 from sam.resources.resources import Resource
@@ -416,7 +416,6 @@ def get_disk_usage_timeseries_by_user(
 def get_disk_usage_timeseries_for_directory(
     session: Session,
     *,
-    account_ids: List[int],
     resource_name: str,
     directory_name: str,
     start_date: Optional[_stdlib_date] = None,
@@ -427,35 +426,29 @@ def get_disk_usage_timeseries_for_directory(
 
     Same return shape and ranking semantics as
     :func:`get_disk_usage_timeseries_by_user`, but reads from
-    ``disk_activity`` (joined through ``disk_charge`` for ``user_id``)
-    so it can filter by ``directory_name``. Used by the dashboard
-    when the user clicks a fileset row to scope the chart.
+    ``disk_activity`` directly so it can filter by ``directory_name``.
+    Used by the dashboard when the user clicks a fileset row to scope
+    the chart.
 
-    Accepts ``account_ids`` (not a single ``project_id``) so it works
-    for any subtree slice — a fileset can belong to a child project
-    deeper in the tree, but the scope's account set still bounds it
-    correctly.
+    Filtering by ``directory_name`` is a range seek on the existing
+    ``disk_activity_unique_idx`` (which leads with ``directory_name``);
+    no join through ``disk_charge`` / ``account`` is needed since the
+    fileset name itself uniquely identifies the data we want. The
+    chart only displays the username string, so we don't resolve
+    ``user_id`` here — saves a ``users`` join too.
 
     History depth is bounded by what the importer has populated in
     ``disk_activity`` — older snapshots that pre-date Layer 2 won't
     appear. The summary path stays as the chart source for
     project-level views.
     """
-    if not account_ids:
-        return {'dates': [], 'series': []}
     q = session.query(
         DiskActivity.activity_date,
-        DiskCharge.user_id,
-        User.username,
+        DiskActivity.username,
         func.coalesce(func.sum(DiskActivity.bytes), 0).label('bytes'),
-    ).join(
-        DiskCharge, DiskCharge.disk_activity_id == DiskActivity.disk_activity_id,
-    ).join(
-        User, User.user_id == DiskCharge.user_id,
     ).filter(
-        DiskCharge.account_id.in_(account_ids),
-        DiskActivity.resource_name == resource_name,
         DiskActivity.directory_name == directory_name,
+        DiskActivity.resource_name == resource_name,
     )
     if start_date is not None:
         q = q.filter(DiskActivity.activity_date >= start_date)
@@ -463,23 +456,21 @@ def get_disk_usage_timeseries_for_directory(
         q = q.filter(DiskActivity.activity_date <= end_date)
     rows = q.group_by(
         DiskActivity.activity_date,
-        DiskCharge.user_id,
-        User.username,
+        DiskActivity.username,
     ).all()
 
     if not rows:
         return {'dates': [], 'series': []}
 
-    per_user: Dict[int, Dict[str, Any]] = {}
+    # Pivot keyed by username — disk_activity has no user_id column,
+    # only the username string. The chart legend shows usernames so
+    # this is sufficient.
+    per_user: Dict[str, Dict[str, Any]] = {}
     dates_set: set = set()
-    for activity_date, user_id, username, b in rows:
+    for activity_date, username, b in rows:
         dates_set.add(activity_date)
-        u = per_user.setdefault(
-            user_id,
-            {'username': username or f'uid_{user_id}', 'by_date': {}},
-        )
-        if username and not u['username'].startswith('uid_'):
-            u['username'] = username
+        key = username or '<unknown>'
+        u = per_user.setdefault(key, {'username': key, 'by_date': {}})
         u['by_date'][activity_date] = int(b or 0)
 
     dates = sorted(dates_set)
@@ -496,11 +487,11 @@ def get_disk_usage_timeseries_for_directory(
     series: List[Dict[str, Any]] = []
     if rest_users:
         others_values = [0] * len(dates)
-        for _uid, info in rest_users:
+        for _key, info in rest_users:
             for i, d in enumerate(dates):
                 others_values[i] += info['by_date'].get(d, 0)
         series.append({'username': 'Others', 'values': others_values})
-    for _uid, info in reversed(top_users):
+    for _key, info in reversed(top_users):
         series.append({
             'username': info['username'],
             'values':   [info['by_date'].get(d, 0) for d in dates],
@@ -511,7 +502,6 @@ def get_disk_usage_timeseries_for_directory(
 def get_directory_user_breakdown_at(
     session: Session,
     *,
-    account_ids: List[int],
     resource_name: str,
     directory_name: str,
     activity_date,
@@ -519,28 +509,32 @@ def get_directory_user_breakdown_at(
     """Per-user bytes/files for a single fileset at one snapshot date.
 
     Used by the dashboard's per-user table when scoped to a fileset.
-    Returns one row per resolved (tier-2-linked) user, sorted desc
-    by bytes. Accepts an ``account_ids`` set so it works for any
-    subtree slice (matching :func:`get_disk_usage_timeseries_for_directory`).
+    Returns one row per username found in ``disk_activity`` for the
+    given fileset/date/resource, sorted desc by bytes.
+
+    Reads ``disk_activity`` directly (range seek on
+    ``disk_activity_unique_idx`` via ``directory_name``). The
+    ``users`` table is OUTER-joined on ``username`` solely to surface
+    ``user_id`` in the result for the dashboard's per-user link;
+    rows whose username has no matching ``users`` row simply get
+    ``user_id = None`` instead of being dropped.
     """
-    if activity_date is None or not account_ids:
+    if activity_date is None:
         return []
     rows = (
         session.query(
-            User.username.label('username'),
-            DiskCharge.user_id.label('user_id'),
+            DiskActivity.username.label('username'),
+            User.user_id.label('user_id'),
             func.sum(DiskActivity.bytes).label('bytes'),
             func.sum(DiskActivity.number_of_files).label('files'),
         )
-        .join(DiskCharge, DiskCharge.disk_activity_id == DiskActivity.disk_activity_id)
-        .join(User, User.user_id == DiskCharge.user_id)
+        .outerjoin(User, User.username == DiskActivity.username)
         .filter(
-            DiskCharge.account_id.in_(account_ids),
-            DiskActivity.resource_name == resource_name,
             DiskActivity.directory_name == directory_name,
+            DiskActivity.resource_name == resource_name,
             DiskActivity.activity_date == activity_date,
         )
-        .group_by(User.username, DiskCharge.user_id)
+        .group_by(DiskActivity.username, User.user_id)
         .all()
     )
     return sorted(
@@ -556,80 +550,36 @@ def get_directory_user_breakdown_at(
 def get_subtree_directory_usage_at(
     session: Session,
     *,
-    account_ids: List[int],
+    directory_to_projcode: Dict[str, str],
     resource_name: str,
     activity_date,
 ) -> List[Dict[str, Any]]:
     """Per-directory snapshot summed across an entire subtree.
 
-    Like :func:`get_directory_usage_at` but takes ``account_ids``
-    (typically every disk account in the scoped subtree) instead of
-    a single ``project_id``. Each result row also carries the owning
-    project's ``projcode`` so the dashboard can show which child
-    project a directory belongs to when the scope spans multiple
-    projects.
+    The caller passes ``directory_to_projcode`` — a map from
+    ``directory_name`` to its owning ``projcode``, typically built by
+    walking the in-memory tree returned by :func:`build_disk_subtree`.
+    The query then becomes a single ``disk_activity`` aggregate
+    filtered by ``directory_name IN (...)``, which is a range seek on
+    the existing ``disk_activity_unique_idx`` (leading column
+    ``directory_name``). No join through ``disk_charge`` /
+    ``account`` / ``project`` is needed; the projcode mapping happens
+    in Python from data the caller already has.
 
     Returns ``[{name, bytes, files, projcode}, ...]`` sorted desc
-    by bytes. Empty list if ``account_ids`` is empty or
-    ``activity_date`` is None.
+    by bytes. Empty list if no directories or ``activity_date`` is None.
     """
-    if activity_date is None or not account_ids:
+    if activity_date is None or not directory_to_projcode:
         return []
-    rows = (
-        session.query(
-            DiskActivity.directory_name.label('name'),
-            Project.projcode.label('projcode'),
-            func.sum(DiskActivity.bytes).label('bytes'),
-            func.sum(DiskActivity.number_of_files).label('files'),
-        )
-        .join(DiskCharge, DiskCharge.disk_activity_id == DiskActivity.disk_activity_id)
-        .join(Account, Account.account_id == DiskCharge.account_id)
-        .join(Project, Project.project_id == Account.project_id)
-        .filter(
-            DiskCharge.account_id.in_(account_ids),
-            DiskActivity.resource_name == resource_name,
-            DiskActivity.activity_date == activity_date,
-        )
-        .group_by(DiskActivity.directory_name, Project.projcode)
-        .all()
-    )
-    return sorted(
-        [{'name': r.name,
-          'projcode': r.projcode,
-          'bytes': int(r.bytes or 0),
-          'files': int(r.files or 0)} for r in rows],
-        key=lambda d: d['bytes'],
-        reverse=True,
-    )
-
-
-def get_directory_usage_at(
-    session: Session,
-    *,
-    project_id: int,
-    resource_name: str,
-    activity_date,
-) -> List[Dict[str, Any]]:
-    """Per-directory snapshot for one ``(project, resource, date)``.
-
-    Joins ``disk_activity`` → ``disk_charge`` → ``account`` so unresolved
-    rows (no tier-2 row) are excluded. Returns a list of
-    ``{'name', 'bytes', 'files'}`` dicts, one per ``directory_name``,
-    sorted descending by bytes.
-    """
-    if activity_date is None:
-        return []
+    directory_names = list(directory_to_projcode.keys())
     rows = (
         session.query(
             DiskActivity.directory_name.label('name'),
             func.sum(DiskActivity.bytes).label('bytes'),
             func.sum(DiskActivity.number_of_files).label('files'),
         )
-        .join(DiskCharge,
-              DiskCharge.disk_activity_id == DiskActivity.disk_activity_id)
-        .join(Account, Account.account_id == DiskCharge.account_id)
         .filter(
-            Account.project_id == project_id,
+            DiskActivity.directory_name.in_(directory_names),
             DiskActivity.resource_name == resource_name,
             DiskActivity.activity_date == activity_date,
         )
@@ -638,6 +588,7 @@ def get_directory_usage_at(
     )
     return sorted(
         [{'name': r.name,
+          'projcode': directory_to_projcode.get(r.name),
           'bytes': int(r.bytes or 0),
           'files': int(r.files or 0)} for r in rows],
         key=lambda d: d['bytes'],
@@ -648,61 +599,62 @@ def get_directory_usage_at(
 def bulk_get_directory_usage_at(
     session: Session,
     *,
-    project_resource_pairs: List[Tuple[int, str]],
+    directories_by_project_id: Dict[int, List[str]],
+    resource_name: str,
     activity_date,
-) -> Dict[Tuple[int, str], List[Dict[str, Any]]]:
-    """Bulk variant of :func:`get_directory_usage_at`.
+) -> Dict[int, List[Dict[str, Any]]]:
+    """Per-project per-directory bytes/files at one snapshot.
 
-    One query covers many ``(project_id, resource_name)`` pairs. Result
-    is keyed by the input tuple; pairs with no rows map to an empty list.
+    ``directories_by_project_id`` maps each project_id of interest to
+    its list of active fileset ``directory_name`` strings (typically
+    sourced from ``ProjectDirectory`` rows the caller has already
+    loaded). Returns ``{project_id: [{name, bytes, files}, ...]}``
+    sorted desc by bytes; project_ids with no matching activity rows
+    map to an empty list.
+
+    Single ``disk_activity`` aggregate query — range seek on
+    ``disk_activity_unique_idx`` via ``directory_name IN (...)``. The
+    project_id mapping happens in Python from the input dict.
     """
-    out: Dict[Tuple[int, str], List[Dict[str, Any]]] = {
-        pair: [] for pair in project_resource_pairs
+    out: Dict[int, List[Dict[str, Any]]] = {
+        pid: [] for pid in directories_by_project_id
     }
-    if not project_resource_pairs or activity_date is None:
+    if not directories_by_project_id or activity_date is None:
         return out
 
-    project_ids = sorted({pid for pid, _ in project_resource_pairs})
-    resource_names = sorted({rn for _, rn in project_resource_pairs})
+    project_id_by_directory: Dict[str, int] = {}
+    for pid, dirs in directories_by_project_id.items():
+        for d in dirs:
+            project_id_by_directory[d] = pid
+    if not project_id_by_directory:
+        return out
 
     rows = (
         session.query(
-            Account.project_id.label('project_id'),
-            DiskActivity.resource_name.label('resource_name'),
             DiskActivity.directory_name.label('name'),
             func.sum(DiskActivity.bytes).label('bytes'),
             func.sum(DiskActivity.number_of_files).label('files'),
         )
-        .join(DiskCharge,
-              DiskCharge.disk_activity_id == DiskActivity.disk_activity_id)
-        .join(Account, Account.account_id == DiskCharge.account_id)
         .filter(
-            Account.project_id.in_(project_ids),
-            DiskActivity.resource_name.in_(resource_names),
+            DiskActivity.directory_name.in_(project_id_by_directory.keys()),
+            DiskActivity.resource_name == resource_name,
             DiskActivity.activity_date == activity_date,
         )
-        .group_by(
-            Account.project_id,
-            DiskActivity.resource_name,
-            DiskActivity.directory_name,
-        )
+        .group_by(DiskActivity.directory_name)
         .all()
     )
 
-    bucket: Dict[Tuple[int, str], List[Dict[str, Any]]] = {}
     for r in rows:
-        key = (r.project_id, r.resource_name)
-        if key not in out:
-            # Pair wasn't requested but slipped through the broad IN
-            # filter. Skip — caller only asked for specific pairs.
+        pid = project_id_by_directory.get(r.name)
+        if pid is None:
             continue
-        bucket.setdefault(key, []).append(
+        out[pid].append(
             {'name': r.name,
              'bytes': int(r.bytes or 0),
              'files': int(r.files or 0)}
         )
-    for key, dirs in bucket.items():
-        out[key] = sorted(dirs, key=lambda d: d['bytes'], reverse=True)
+    for pid in out:
+        out[pid].sort(key=lambda d: d['bytes'], reverse=True)
     return out
 
 
@@ -817,15 +769,21 @@ def build_disk_subtree(
 
     # Per-fileset bytes lookup — only for projects that have >1 active
     # fileset on this resource. Single-fileset projects keep the
-    # current per-project rendering and pay nothing.
+    # current per-project rendering and pay nothing. We already have
+    # the active fileset names per project in dirs_by_project_id from
+    # the ProjectDirectory load above; pass those directly so the
+    # bulk helper avoids re-querying ProjectDirectory.
     for activity_dt, pids in multifs_by_date.items():
         per_fs = bulk_get_directory_usage_at(
             session,
-            project_resource_pairs=[(pid, resource_name) for pid in pids],
+            directories_by_project_id={
+                pid: dirs_by_project_id.get(pid, []) for pid in pids
+            },
+            resource_name=resource_name,
             activity_date=activity_dt,
         )
         for pid in pids:
-            dirs = per_fs.get((pid, resource_name), [])
+            dirs = per_fs.get(pid, [])
             if dirs:
                 node_by_pid[pid]['directories'] = dirs
 

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -584,16 +584,24 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
     scope_node = _find_disk_node(full_tree, scope) or full_tree
     scope_account_ids = _collect_disk_account_ids(scope_node)
 
+    # Build the {directory_name → projcode} map by walking the scoped
+    # subtree's in-memory ProjectDirectory data (already loaded by
+    # build_disk_subtree). Lets the Filesets-card query hit
+    # disk_activity directly via directory_name IN (...) — a range
+    # seek on disk_activity_unique_idx with no disk_charge / account
+    # / project join.
+    directory_to_projcode = _collect_directory_to_projcode(scope_node)
+
     # Aggregate per-fileset rows across the entire scoped subtree at
-    # the latest snapshot date — single query covering every disk
-    # account in the scope. This populates the Filesets card on
-    # *both* leaf-project and tree pages (replacing the per-node
+    # the latest snapshot date — single query covering every fileset
+    # in the scope. This populates the Filesets card on *both*
+    # leaf-project and tree pages (replacing the per-node
     # `directories` payload that build_disk_subtree only attached
     # for the multi-fileset case).
     subtree_activity_date = _disk_subtree_latest_activity_date(scope_node)
     fileset_dirs = get_subtree_directory_usage_at(
         db.session,
-        account_ids=scope_account_ids,
+        directory_to_projcode=directory_to_projcode,
         resource_name=resource_name,
         activity_date=subtree_activity_date,
     )
@@ -635,12 +643,11 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
         )
     else:
         # Fileset-scoped rendering: chart + per-user table read from
-        # `disk_activity` (joined through `disk_charge` for `user_id`)
-        # filtered by `directory_name`. Capacity card numbers come
-        # from the aggregated per-fileset row. The fileset may belong
-        # to a child project deeper in the subtree — `scope_account_ids`
-        # bounds the query correctly without needing the owner's
-        # project_id explicitly.
+        # `disk_activity` filtered by `directory_name` directly — a
+        # range seek on the existing unique index, no join through
+        # `disk_charge`. The fileset name itself uniquely identifies
+        # the data we want; subtree containment was already
+        # validated when we constructed `fileset_dirs`.
         fileset_row = next(d for d in fileset_dirs if d['name'] == fileset)
         used_bytes = fileset_row['bytes']
         used_tib = used_bytes / (1024 ** 4)
@@ -648,7 +655,6 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
         activity_date = subtree_activity_date
         timeseries = get_disk_usage_timeseries_for_directory(
             db.session,
-            account_ids=scope_account_ids,
             resource_name=resource_name,
             directory_name=fileset,
             start_date=start_date.date() if hasattr(start_date, 'date') else start_date,
@@ -657,7 +663,6 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
         )
         breakdown = get_directory_user_breakdown_at(
             db.session,
-            account_ids=scope_account_ids,
             resource_name=resource_name,
             directory_name=fileset,
             activity_date=activity_date,
@@ -707,6 +712,22 @@ def _collect_disk_account_ids(node) -> list:
         out.append(node['account_id'])
     for c in node.get('children', []):
         out.extend(_collect_disk_account_ids(c))
+    return out
+
+
+def _collect_directory_to_projcode(node) -> dict:
+    """Walk a build_disk_subtree node and return ``{directory_name: projcode}``.
+
+    The map covers every node in the subtree that has at least one
+    active fileset. Used by the disk dashboard to call
+    ``get_subtree_directory_usage_at`` without a database round-trip
+    for the projcode mapping.
+    """
+    out = {}
+    for d in node.get('fileset_paths', []):
+        out[d] = node.get('projcode')
+    for c in node.get('children', []):
+        out.update(_collect_directory_to_projcode(c))
     return out
 
 

--- a/tests/perf/baselines.json
+++ b/tests/perf/baselines.json
@@ -80,5 +80,9 @@
     "fstree_api_route": {
         "queries": 65,
         "notes": "measured 44 \u2014 full GET /api/v1/fstree_access/ (all resources); cached 5min in prod"
+    },
+    "resource_details_disk_route": {
+        "queries": 50,
+        "notes": "measured 34 (test snapshot, smallest disk-root subtree) post bulk_current_disk_usage refactor. Flat regardless of subtree size \u2014 was 83 on prod (NMMM0003, 21-node subtree) and scaled with node_count_with_account before the fix. ~50% headroom for snapshot variance."
     }
 }

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -131,3 +131,42 @@ def perf_hpc_resource(session, _hpc_resource_id):
     """An active HPC resource for perf tests."""
     from sam import Resource
     return session.get(Resource, _hpc_resource_id)
+
+
+@pytest.fixture(scope="session")
+def _disk_target(engine):
+    """``(projcode, disk_resource_name)`` for the smallest active tree-root
+    project that has at least one disk-resource account anywhere in its
+    subtree. Session-scoped so the lookup runs once per worker.
+
+    Used by the resource-details disk-path route test. Picking the
+    *root* (``project_id == tree_root``) is what exercises
+    ``build_disk_subtree``'s descendant walk — which is the path the
+    bulk_current_disk_usage refactor was meant to flatten.
+    """
+    from sqlalchemy import text as _text
+    from sqlalchemy.orm import sessionmaker
+
+    Session = sessionmaker(bind=engine, autoflush=False, future=True)
+    with Session() as s:
+        row = s.execute(_text("""
+            SELECT p.projcode, r.resource_name
+            FROM project p
+            JOIN project descendant
+              ON descendant.tree_root = p.project_id
+             AND descendant.tree_left BETWEEN p.tree_left AND p.tree_right
+            JOIN account a
+              ON a.project_id = descendant.project_id AND a.deleted = 0
+            JOIN resources r ON r.resource_id = a.resource_id
+            JOIN resource_type rt ON rt.resource_type_id = r.resource_type_id
+            WHERE rt.resource_type = 'DISK'
+              AND p.project_id = p.tree_root
+              AND p.active = 1
+            GROUP BY p.projcode, r.resource_name
+            ORDER BY p.project_id, r.resource_name
+            LIMIT 1
+        """)).first()
+    assert row is not None, (
+        "snapshot has no active tree-root projects with disk-resource accounts"
+    )
+    return row[0], row[1]

--- a/tests/perf/test_resource_details_disk.py
+++ b/tests/perf/test_resource_details_disk.py
@@ -1,0 +1,56 @@
+"""Resource Usage Details (disk path) — query count regression test.
+
+Locks in the ``bulk_current_disk_usage`` refactor that eliminated the
+per-descendant N+1 in ``build_disk_subtree``. Before the fix, query
+count scaled linearly with ``node_count_with_account``: NMMM0003 (20
+disk accounts in a 21-node subtree) measured 83 queries on prod;
+post-fix it measured 21, regardless of subtree size.
+
+Mirrors ``utils/profiling/profile_resource_details.py`` — that script
+breaks the same call chain into per-phase reports for ad-hoc
+investigation; this test gates the full route.
+
+Run::
+
+    pytest -m perf -n 0 -v
+    make perf
+"""
+
+import pytest
+
+from .conftest import get_baseline
+
+pytestmark = pytest.mark.perf
+
+
+def test_resource_details_disk_route(
+    auth_client, route_count_queries, _disk_target,
+):
+    """Full-stack query count for ``/user/resource-details`` on a disk
+    resource for an active tree-root project from the snapshot.
+
+    Catches a re-introduction of the ``Account.current_disk_usage()``
+    N+1 inside ``build_disk_subtree`` — query count would jump from
+    its post-fix flat constant back to ~3 × ``node_count_with_account``,
+    which on the snapshot's biggest disk subtree would blow past the
+    baseline.
+    """
+    projcode, resource_name = _disk_target
+    baseline = get_baseline("resource_details_disk_route")
+
+    with route_count_queries() as stats:
+        response = auth_client.get(
+            f'/user/resource-details?projcode={projcode}&resource={resource_name}'
+        )
+
+    assert response.status_code == 200, (
+        f"GET /user/resource-details for {projcode}/{resource_name} "
+        f"returned {response.status_code}"
+    )
+    assert stats.count <= baseline, (
+        f"Disk resource-details route query regression: "
+        f"{stats.count} queries > {baseline} baseline. "
+        f"Subtree fanout in build_disk_subtree may have regressed — "
+        f"check that Account.current_disk_usage callers still go "
+        f"through bulk_current_disk_usage. {stats.summary()}"
+    )

--- a/tests/unit/test_current_disk_usage.py
+++ b/tests/unit/test_current_disk_usage.py
@@ -5,6 +5,7 @@ from datetime import date, timedelta
 import pytest
 
 from sam.accounting.accounts import Account, CurrentDiskUsage
+from sam.queries.disk_usage import bulk_current_disk_usage
 from sam.resources.resources import ResourceType
 from sam.summaries.disk_summaries import (
     DiskChargeSummary, DiskChargeSummaryStatus,
@@ -171,3 +172,96 @@ class TestProjectCurrentDiskUsage:
         assert result[res_name]['bytes'] == 7 * 1024 ** 4
         assert result[res_name]['current_used_tib'] == pytest.approx(7.0)
         assert result[res_name]['activity_date'] == d
+
+
+class TestBulkCurrentDiskUsage:
+    """Tests for the bulk variant that backs build_disk_subtree, the
+    Project method, and Account.current_disk_usage itself."""
+
+    def test_empty_input_returns_empty_dict(self, session):
+        assert bulk_current_disk_usage(session, []) == {}
+
+    def test_returns_per_account_snapshots_at_current_date(self, session):
+        """Multiple accounts on the same current snapshot date — each
+        gets its own entry keyed by account_id."""
+        user_a, _, acct_a = _disk_account(session)
+        user_b, _, acct_b = _disk_account(session)
+        d = next_date("disk_snap")
+        _seed_summary(session, acct_a, user_a, activity_date=d,
+                      bytes_=1 * 1024 ** 4, ty=1.0, files=10)
+        _seed_summary(session, acct_b, user_b, activity_date=d,
+                      bytes_=3 * 1024 ** 4, ty=3.0, files=30)
+        _mark_current(session, d)
+
+        out = bulk_current_disk_usage(
+            session, [acct_a.account_id, acct_b.account_id],
+        )
+        assert set(out.keys()) == {acct_a.account_id, acct_b.account_id}
+        assert isinstance(out[acct_a.account_id], CurrentDiskUsage)
+        assert out[acct_a.account_id].bytes == 1 * 1024 ** 4
+        assert out[acct_a.account_id].terabyte_years == pytest.approx(1.0)
+        assert out[acct_a.account_id].number_of_files == 10
+        assert out[acct_a.account_id].activity_date == d
+        assert out[acct_b.account_id].bytes == 3 * 1024 ** 4
+        assert out[acct_b.account_id].terabyte_years == pytest.approx(3.0)
+        assert out[acct_b.account_id].number_of_files == 30
+
+    def test_mixed_current_and_fallback_accounts(self, session):
+        """Some accounts have rows on the current snapshot date; others
+        only have older rows. The bulk helper must apply the per-account
+        max() fallback for the latter, in the same call."""
+        user_curr, _, acct_curr = _disk_account(session)
+        user_old, _, acct_old = _disk_account(session)
+        d_current = next_date("disk_snap")
+        d_old = d_current - timedelta(days=14)
+
+        _seed_summary(session, acct_curr, user_curr, activity_date=d_current,
+                      bytes_=2 * 1024 ** 4)
+        # acct_old has NO row at d_current — only at d_old
+        _seed_summary(session, acct_old, user_old, activity_date=d_old,
+                      bytes_=5 * 1024 ** 4)
+        _mark_current(session, d_current)
+
+        out = bulk_current_disk_usage(
+            session, [acct_curr.account_id, acct_old.account_id],
+        )
+        assert out[acct_curr.account_id].activity_date == d_current
+        assert out[acct_curr.account_id].bytes == 2 * 1024 ** 4
+        # Fallback path picked up the older row.
+        assert out[acct_old.account_id].activity_date == d_old
+        assert out[acct_old.account_id].bytes == 5 * 1024 ** 4
+
+    def test_account_with_no_rows_is_absent(self, session):
+        """An account with no disk_charge_summary rows is omitted from
+        the result dict — matches Account.current_disk_usage's None."""
+        _, _, acct_with = _disk_account(session)
+        _, _, acct_without = _disk_account(session)
+        user, _, _ = _disk_account(session)
+        d = next_date("disk_snap")
+        _seed_summary(session, acct_with, user, activity_date=d,
+                      bytes_=1 * 1024 ** 4)
+        _mark_current(session, d)
+
+        out = bulk_current_disk_usage(
+            session, [acct_with.account_id, acct_without.account_id],
+        )
+        assert acct_with.account_id in out
+        assert acct_without.account_id not in out
+
+    def test_aggregates_multiple_rows_for_same_date(self, session):
+        """Same (account_id, activity_date), multiple users — bytes are
+        summed (matches single-account semantics for the gap-row case)."""
+        user_a, _, account = _disk_account(session)
+        user_b = make_user(session)
+        d = next_date("disk_snap")
+        _seed_summary(session, account, user_a, activity_date=d,
+                      bytes_=1 * 1024 ** 4, ty=1.0, files=5)
+        _seed_summary(session, account, user_b, activity_date=d,
+                      bytes_=4 * 1024 ** 4, ty=4.0, files=20)
+        _mark_current(session, d)
+
+        out = bulk_current_disk_usage(session, [account.account_id])
+        usage = out[account.account_id]
+        assert usage.bytes == 5 * 1024 ** 4
+        assert usage.terabyte_years == pytest.approx(5.0)
+        assert usage.number_of_files == 25

--- a/tests/unit/test_disk_usage_queries.py
+++ b/tests/unit/test_disk_usage_queries.py
@@ -15,16 +15,15 @@ import pytest
 
 from sam import ResourceType
 from sam.projects.projects import ProjectDirectory
-from sam.activity.disk import DiskActivity, DiskCharge
+from sam.activity.disk import DiskActivity
 from sam.queries.disk_usage import (
     build_disk_subtree,
     bulk_get_directory_usage_at,
-    get_directory_usage_at,
     get_disk_usage_timeseries_by_user,
 )
 from sam.summaries.disk_summaries import (
     DiskChargeSummary,
-    mark_disk_snapshot_current,
+    DiskChargeSummaryStatus,
 )
 
 from factories import (
@@ -52,6 +51,23 @@ def _disk_resource(session):
         session, resource_type=rt,
         resource_name=f"Campaign_Store_{next_seq('cs')}",
     )
+
+
+def _mark_current(session, activity_date):
+    """Test-only narrow alternative to ``mark_disk_snapshot_current``.
+
+    The prod helper does a bulk ``UPDATE ... WHERE current=true``, which
+    deadlocks under xdist when two workers run it concurrently. These
+    read-path tests only need *their* own row marked current; per-test
+    SAVEPOINT rollback means we don't need to clear others. (Same
+    pattern as ``tests/unit/test_current_disk_usage.py:_mark_current``.)
+    """
+    row = session.get(DiskChargeSummaryStatus, activity_date)
+    if row is None:
+        session.add(DiskChargeSummaryStatus(activity_date=activity_date, current=True))
+    else:
+        row.current = True
+    session.flush()
 
 
 def _seed_row(session, *, account, user, snap, bytes_, files=10):
@@ -205,7 +221,7 @@ class TestBuildDiskSubtree:
         _seed_row(session, account=account, user=lead, snap=snap,
                   bytes_=10 * BYTES_PER_TIB)
         session.flush()
-        mark_disk_snapshot_current(session, snap)
+        _mark_current(session, snap)
 
         result = build_disk_subtree(session, project, resource.resource_name)
         tree = result['tree']
@@ -234,7 +250,7 @@ class TestBuildDiskSubtree:
         _seed_row(session, account=account_b, user=child_b.lead, snap=snap,
                   bytes_=3 * BYTES_PER_TIB)
         session.flush()
-        mark_disk_snapshot_current(session, snap)
+        _mark_current(session, snap)
 
         result = build_disk_subtree(session, parent, resource.resource_name)
         tree = result['tree']
@@ -260,7 +276,7 @@ class TestBuildDiskSubtree:
         _seed_row(session, account=account_child, user=child.lead, snap=snap,
                   bytes_=2 * BYTES_PER_TIB)
         session.flush()
-        mark_disk_snapshot_current(session, snap)
+        _mark_current(session, snap)
 
         result = build_disk_subtree(session, parent, resource.resource_name)
         tree = result['tree']
@@ -310,7 +326,7 @@ class TestBuildDiskSubtree:
 
 
 # ============================================================================
-# get_directory_usage_at / bulk_get_directory_usage_at  (Layer 2 tier-1/-2)
+# bulk_get_directory_usage_at  (disk_activity-only query path)
 # ============================================================================
 
 
@@ -318,7 +334,14 @@ def _seed_disk_activity(
     session, *, account, user, directory, snap, bytes_, files=10,
     resource_name=None,
 ):
-    """Insert one disk_activity + matching disk_charge row."""
+    """Insert one disk_activity row.
+
+    The dashboard's directory-aggregation queries read disk_activity
+    directly (no disk_charge join), so we don't bother seeding a
+    disk_charge row here. Keeping ``account``/``user`` params for
+    test readability — they only feed into ``username`` /
+    ``projcode`` columns on disk_activity.
+    """
     activity = DiskActivity(
         directory_name=directory,
         username=user.username,
@@ -335,22 +358,16 @@ def _seed_disk_activity(
     )
     session.add(activity)
     session.flush()
-    session.add(DiskCharge(
-        disk_activity_id=activity.disk_activity_id,
-        account_id=account.account_id,
-        user_id=user.user_id,
-        charge_date=datetime.now(),
-        activity_date=snap,
-        terabyte_year=0.0,
-        charge=0.0,
-    ))
-    session.flush()
     return activity
 
 
-class TestPerDirectoryQuery:
+class TestBulkPerDirectoryQuery:
+    """``bulk_get_directory_usage_at`` returns per-project per-directory
+    bytes/files at one snapshot, given a ``directories_by_project_id``
+    map. Reads ``disk_activity`` directly (range seek on
+    ``disk_activity_unique_idx`` via ``directory_name``)."""
 
-    def test_get_directory_usage_at_returns_per_directory_rows(self, session):
+    def test_returns_per_directory_rows(self, session):
         resource = _disk_resource(session)
         lead = make_user(session)
         project = make_project(session, lead=lead)
@@ -369,12 +386,18 @@ class TestPerDirectoryQuery:
             resource_name=resource.resource_name,
         )
 
-        rows = get_directory_usage_at(
+        out = bulk_get_directory_usage_at(
             session,
-            project_id=project.project_id,
+            directories_by_project_id={
+                project.project_id: [
+                    '/gpfs/csfs1/test/data',
+                    '/gpfs/csfs1/test/work',
+                ],
+            },
             resource_name=resource.resource_name,
             activity_date=snap,
         )
+        rows = out[project.project_id]
         # Sorted desc by bytes.
         assert [r['name'] for r in rows] == [
             '/gpfs/csfs1/test/work',
@@ -385,8 +408,15 @@ class TestPerDirectoryQuery:
         assert rows[1]['bytes'] == 2 * BYTES_PER_TIB
         assert rows[1]['files'] == 200
 
-    def test_get_directory_usage_at_filters_by_resource(self, session):
-        """Rows on a different resource on the same date must not leak in."""
+    def test_filters_by_resource(self, session):
+        """Rows on a different resource on the same date must not leak in.
+
+        The disk_activity unique index is
+        ``(directory_name, username, activity_date, projcode)`` — note
+        ``resource_name`` is NOT in the key, so different filesets are
+        used for the two resources (matches reality: a path lives on
+        exactly one filesystem).
+        """
         resource_a = _disk_resource(session)
         resource_b = _disk_resource(session)
         lead = make_user(session)
@@ -405,29 +435,35 @@ class TestPerDirectoryQuery:
             resource_name=resource_b.resource_name,
         )
 
-        rows_a = get_directory_usage_at(
+        out = bulk_get_directory_usage_at(
             session,
-            project_id=project.project_id,
+            directories_by_project_id={
+                project.project_id: ['/cs/data', '/quasar/data'],
+            },
             resource_name=resource_a.resource_name,
             activity_date=snap,
         )
+        rows_a = out[project.project_id]
+        # Only the resource_a row passes the resource filter.
         assert [r['name'] for r in rows_a] == ['/cs/data']
+        assert rows_a[0]['bytes'] == BYTES_PER_TIB
 
-    def test_get_directory_usage_at_unresolved_excluded(self, session):
-        """A disk_activity row with no disk_charge (unresolved) is excluded
-        — the join filter requires both tiers."""
+    def test_unknown_directories_excluded(self, session):
+        """A disk_activity row whose directory_name isn't in the input
+        map is excluded — the directory_name IN (...) filter is the
+        scope boundary."""
         resource = _disk_resource(session)
         lead = make_user(session)
         project = make_project(session, lead=lead)
         account = make_account(session, project=project, resource=resource)
         snap = _date(2026, 4, 11)
-        # Resolved row (writes both tiers).
         _seed_disk_activity(
             session, account=account, user=lead,
             directory='/cs/data', snap=snap, bytes_=BYTES_PER_TIB,
             resource_name=resource.resource_name,
         )
-        # Tier-1-only row (no tier-2 — simulates unresolved import).
+        # Activity row for a directory NOT in the project's fileset list
+        # — should be filtered out.
         session.add(DiskActivity(
             directory_name='/cs/orphan',
             username='ghost',
@@ -445,18 +481,17 @@ class TestPerDirectoryQuery:
         ))
         session.flush()
 
-        rows = get_directory_usage_at(
+        out = bulk_get_directory_usage_at(
             session,
-            project_id=project.project_id,
+            directories_by_project_id={project.project_id: ['/cs/data']},
             resource_name=resource.resource_name,
             activity_date=snap,
         )
-        # Only the resolved row.
-        assert [r['name'] for r in rows] == ['/cs/data']
+        # Only the row for the requested directory.
+        assert [r['name'] for r in out[project.project_id]] == ['/cs/data']
 
-    def test_bulk_per_directory_query_pairs(self, session):
-        """Bulk variant returns a dict keyed by (project_id, resource_name);
-        unrequested pairs are absent or empty."""
+    def test_multiple_projects(self, session):
+        """Map covers multiple project_ids; each gets its own list."""
         resource = _disk_resource(session)
         lead = make_user(session)
         proj_a = make_project(session, lead=lead)
@@ -482,27 +517,24 @@ class TestPerDirectoryQuery:
 
         out = bulk_get_directory_usage_at(
             session,
-            project_resource_pairs=[
-                (proj_a.project_id, resource.resource_name),
-                (proj_b.project_id, resource.resource_name),
-            ],
+            directories_by_project_id={
+                proj_a.project_id: ['/cs/a/data', '/cs/a/work'],
+                proj_b.project_id: ['/cs/b/data'],
+            },
+            resource_name=resource.resource_name,
             activity_date=snap,
         )
-        assert set(out.keys()) == {
-            (proj_a.project_id, resource.resource_name),
-            (proj_b.project_id, resource.resource_name),
-        }
-        names_a = [d['name'] for d in out[(proj_a.project_id,
-                                           resource.resource_name)]]
+        assert set(out.keys()) == {proj_a.project_id, proj_b.project_id}
+        names_a = [d['name'] for d in out[proj_a.project_id]]
         assert names_a == ['/cs/a/work', '/cs/a/data']
-        names_b = [d['name'] for d in out[(proj_b.project_id,
-                                           resource.resource_name)]]
+        names_b = [d['name'] for d in out[proj_b.project_id]]
         assert names_b == ['/cs/b/data']
 
-    def test_bulk_per_directory_query_empty_input(self, session):
+    def test_empty_input(self, session):
         out = bulk_get_directory_usage_at(
             session,
-            project_resource_pairs=[],
+            directories_by_project_id={},
+            resource_name='whatever',
             activity_date=_date(2026, 4, 11),
         )
         assert out == {}
@@ -545,7 +577,7 @@ class TestBuildDiskSubtreeMultifileset:
             snap=snap, bytes_=3 * BYTES_PER_TIB, files=300,
             resource_name=resource.resource_name,
         )
-        mark_disk_snapshot_current(session, snap)
+        _mark_current(session, snap)
         session.flush()
 
         result = build_disk_subtree(session, project, resource.resource_name)
@@ -582,7 +614,7 @@ class TestBuildDiskSubtreeMultifileset:
             snap=snap, bytes_=BYTES_PER_TIB,
             resource_name=resource.resource_name,
         )
-        mark_disk_snapshot_current(session, snap)
+        _mark_current(session, snap)
         session.flush()
 
         result = build_disk_subtree(session, project, resource.resource_name)

--- a/utils/profiling/profile_resource_details.py
+++ b/utils/profiling/profile_resource_details.py
@@ -1,0 +1,462 @@
+"""
+Profiling script for the Resource Usage Details (disk) route
+``/user/resource-details?projcode=...&resource=Campaign_Store``.
+
+Mirrors the structure of profile_user_dashboard.py — fetches data and
+renders the disk template in the same request context so SQLAlchemy
+lazy loads triggered during template rendering are visible to the SQL
+counter.
+
+Default targets contrast a multi-tier subtree project with a leaf:
+    NRAL0002    — multi-tier subtree (exercises descendant fanout)
+    P43713000   — flat / leaf project (isolates Layer-2 join cost)
+
+Each target is profiled in three phases:
+    1. build_disk_subtree            (walks descendants, snapshot per node)
+    2. get_subtree_directory_usage_at (Layer-2 disk_activity / disk_charge join)
+    3. full Flask request render     (template + lazy loads)
+
+Default login user: bdobbins (matches profile_user_dashboard.py).
+
+Usage:
+    source etc/config_env.sh
+    python utils/profiling/profile_resource_details.py 2>&1 | tee profile_resource_details.txt
+    python utils/profiling/profile_resource_details.py --projcode NRAL0002 --resource Campaign_Store
+    python utils/profiling/profile_resource_details.py --user benkirk
+"""
+
+import argparse
+import os
+os.environ.setdefault('FLASK_CONFIG', 'development')
+os.environ.setdefault('FLASK_SECRET_KEY', 'profiling-key-not-for-production')
+os.environ.setdefault('AUDIT_ENABLED', '0')
+
+import cProfile
+import io
+import pstats
+import sys
+import time
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from typing import Dict, List, Tuple
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO = os.path.join(_HERE, '..', '..')
+sys.path.insert(0, os.path.join(_REPO, 'src'))
+# Reuse the canonical SQLStats helper used by tests/perf rather than
+# duplicating it inline.
+sys.path.insert(0, _REPO)
+
+from tests.perf._query_count import SQLStats  # noqa: E402
+
+from webapp.run import create_app  # noqa: E402
+from webapp.extensions import db  # noqa: E402
+from flask_login import login_user  # noqa: E402
+
+from sam.core.users import User  # noqa: E402
+from sam.projects.projects import Project  # noqa: E402
+from sam.resources.resources import Resource  # noqa: E402
+from sam.accounting.accounts import Account  # noqa: E402
+from sam.queries.disk_usage import (  # noqa: E402
+    build_disk_subtree,
+    get_subtree_directory_usage_at,
+)
+from webapp.auth.models import AuthUser  # noqa: E402
+from webapp.dashboards.user.blueprint import (  # noqa: E402
+    _render_disk_resource_details,
+    _disk_subtree_latest_activity_date,
+    _find_disk_node,
+    _collect_disk_account_ids,
+)
+
+
+DEFAULT_USERNAME = 'bdobbins'
+DEFAULT_TARGETS: List[Tuple[str, str]] = [
+    ('NRAL0002', 'Campaign_Store'),
+    ('P43713000', 'Campaign_Store'),
+]
+
+
+def discover_root_projects(session, resource_name: str) -> List[str]:
+    """Return projcodes of root projects whose subtree has accounts on *resource_name*.
+
+    A "root" is a project whose own ``project_id`` equals its ``tree_root``
+    (MPPT root). We find every project with a non-deleted account on the
+    given resource, take ``DISTINCT tree_root``, and resolve back to the
+    root projcodes. Order by projcode for deterministic output.
+    """
+    tree_root_ids = [
+        row[0] for row in (
+            session.query(Project.tree_root)
+            .join(Account, Account.project_id == Project.project_id)
+            .join(Resource, Resource.resource_id == Account.resource_id)
+            .filter(
+                Resource.resource_name == resource_name,
+                Account.deleted == False,  # noqa: E712 — SQL expression
+            )
+            .distinct()
+            .all()
+        )
+        if row[0] is not None
+    ]
+    if not tree_root_ids:
+        return []
+    roots = (
+        session.query(Project)
+        .filter(
+            Project.project_id.in_(tree_root_ids),
+            Project.is_active,
+        )
+        .order_by(Project.projcode)
+        .all()
+    )
+    return [r.projcode for r in roots]
+
+
+# ---------------------------------------------------------------------------
+# cProfile helper
+# ---------------------------------------------------------------------------
+
+@contextmanager
+def _cprofiled():
+    pr = cProfile.Profile()
+    pr.enable()
+    yield pr
+    pr.disable()
+
+
+def _print_cprofile(pr, label, top_n=20):
+    buf = io.StringIO()
+    ps = pstats.Stats(pr, stream=buf).sort_stats('cumulative')
+    ps.print_stats(top_n)
+    print(f"\n{'='*72}")
+    print(f"cProfile — {label}  (top {top_n} by cumtime)")
+    print('=' * 72)
+    print(buf.getvalue())
+
+
+# ---------------------------------------------------------------------------
+# Per-phase scoped capture using the shared SQLStats. We attach a fresh
+# SQLStats per phase so per-table buckets and slowest lists don't bleed
+# across phases — easier to reason about than reset() in the middle.
+# ---------------------------------------------------------------------------
+
+@contextmanager
+def _phase(engine):
+    """Yield (stats, elapsed_ref). On exit, fills elapsed_ref[0]."""
+    stats = SQLStats()
+    stats.attach(engine)
+    elapsed_ref = [0.0]
+    t0 = time.perf_counter()
+    try:
+        yield stats, elapsed_ref
+    finally:
+        elapsed_ref[0] = time.perf_counter() - t0
+        stats.detach(engine)
+
+
+# ---------------------------------------------------------------------------
+# Tree shape helpers — surface "how big is the subtree" so the reader
+# can interpret query counts as a fanout ratio.
+# ---------------------------------------------------------------------------
+
+def _count_nodes(node) -> int:
+    return 1 + sum(_count_nodes(c) for c in node.get('children', []))
+
+
+def _count_nodes_with_account(node) -> int:
+    n = 1 if node.get('account_id') is not None else 0
+    for c in node.get('children', []):
+        n += _count_nodes_with_account(c)
+    return n
+
+
+# ---------------------------------------------------------------------------
+# Scenario runner
+# ---------------------------------------------------------------------------
+
+def run_scenario(app, engine, username: str, projcode: str, resource_name: str):
+    """Profile the disk path of /user/resource-details for one target.
+
+    Returns a dict with phase metrics and tree shape info.
+    """
+    url = f'/user/resource-details?projcode={projcode}&resource={resource_name}'
+
+    with app.test_request_context(url):
+        session = db.session
+
+        user = session.query(User).filter_by(username=username).first()
+        if user is None:
+            raise SystemExit(f"User {username!r} not found in database")
+        login_user(AuthUser(user))
+
+        project = Project.get_by_projcode(session, projcode)
+        if project is None:
+            raise SystemExit(f"Project {projcode!r} not found in database")
+
+        resource = session.query(Resource).filter(
+            Resource.resource_name == resource_name,
+        ).first()
+        if resource is None:
+            raise SystemExit(
+                f"Resource {resource_name!r} not found in database"
+            )
+
+        end_date = datetime.now()
+        start_date = end_date - timedelta(days=90)
+
+        # ----- Phase 1: build_disk_subtree (descendant walk + snapshot) -----
+        with _phase(engine) as (s1, e1):
+            tree_payload = build_disk_subtree(session, project, resource_name)
+        full_tree = tree_payload['tree']
+        node_count = _count_nodes(full_tree)
+        node_count_with_account = _count_nodes_with_account(full_tree)
+        scope_account_ids = _collect_disk_account_ids(full_tree)
+
+        # ----- Phase 2: get_subtree_directory_usage_at (Layer-2 join) -----
+        snapshot_date = _disk_subtree_latest_activity_date(full_tree)
+        with _phase(engine) as (s2, e2):
+            fileset_dirs = get_subtree_directory_usage_at(
+                session,
+                account_ids=scope_account_ids,
+                resource_name=resource_name,
+                activity_date=snapshot_date,
+            )
+
+        # ----- Phase 3: full template render via _render_disk_resource_details -----
+        # This re-runs build_disk_subtree + get_subtree_directory_usage_at
+        # internally (so phase 3's count overlaps phases 1+2) and adds
+        # the timeseries/user-table queries plus any template lazy loads.
+        with _phase(engine) as (s3, e3):
+            _render_disk_resource_details(
+                project=project,
+                resource=resource,
+                start_date=start_date,
+                end_date=end_date,
+            )
+
+    return {
+        'projcode': projcode,
+        'resource': resource_name,
+        'user_id': user.user_id,
+        'project_id': project.project_id,
+        'node_count': node_count,
+        'node_count_with_account': node_count_with_account,
+        'scope_account_ids_len': len(scope_account_ids),
+        'snapshot_date': snapshot_date,
+        'fileset_dirs_len': len(fileset_dirs),
+        'phases': [
+            {
+                'name': 'build_disk_subtree',
+                'elapsed': e1[0],
+                'stats': s1,
+            },
+            {
+                'name': 'get_subtree_directory_usage_at',
+                'elapsed': e2[0],
+                'stats': s2,
+            },
+            {
+                'name': '_render_disk_resource_details (full route)',
+                'elapsed': e3[0],
+                'stats': s3,
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def _print_by_table(stats: SQLStats, indent: str = '      '):
+    if not stats.by_table:
+        return
+    rows = sorted(stats.by_table.items(), key=lambda kv: -len(kv[1]))
+    print(f"{indent}Per-table query distribution:")
+    print(f"{indent}  {'table':<40s}  {'count':>5s}  {'total ms':>10s}")
+    for table, elapsed_list in rows:
+        print(
+            f"{indent}  {table:<40s}  {len(elapsed_list):>5d}  "
+            f"{sum(elapsed_list)*1000:>9.1f}"
+        )
+
+
+def _print_slowest(stats: SQLStats, indent: str = '      '):
+    if not stats.slowest:
+        return
+    print(f"{indent}Top slowest queries this phase:")
+    for i, (t, sql) in enumerate(stats.slowest[:5], 1):
+        print(f"{indent}  [{i}] {t*1000:7.1f} ms  {sql!r}")
+
+
+def _print_report(result: Dict):
+    label = f"{result['projcode']}  /  {result['resource']}"
+    print(f"\n{'#'*72}")
+    print(f"SCENARIO: {label}")
+    print(f"{'#'*72}")
+    print(f"  project_id          : {result['project_id']}")
+    print(f"  tree node count     : {result['node_count']}  "
+          f"({result['node_count_with_account']} with disk account on this resource)")
+    print(f"  subtree account_ids : {result['scope_account_ids_len']}")
+    print(f"  latest snapshot date: {result['snapshot_date']}")
+    print(f"  filesets at snapshot: {result['fileset_dirs_len']}")
+    print()
+
+    total_elapsed = sum(p['elapsed'] for p in result['phases'])
+    total_q = sum(p['stats'].count for p in result['phases'])
+    total_q_time = sum(p['stats'].total_time for p in result['phases'])
+
+    print(f"  {'phase':<46s} {'wall ms':>9s} {'queries':>8s} {'sql ms':>9s}")
+    print(f"  {'-'*46} {'-'*9} {'-'*8} {'-'*9}")
+    for phase in result['phases']:
+        s = phase['stats']
+        print(
+            f"  {phase['name']:<46s} {phase['elapsed']*1000:>9.1f} "
+            f"{s.count:>8d} {s.total_time*1000:>9.1f}"
+        )
+    print(f"  {'-'*46} {'-'*9} {'-'*8} {'-'*9}")
+    print(
+        f"  {'TOTAL (phases sum, P3 overlaps P1+P2)':<46s} "
+        f"{total_elapsed*1000:>9.1f} {total_q:>8d} {total_q_time*1000:>9.1f}"
+    )
+
+    # Fanout ratio: queries during build_disk_subtree per descendant.
+    p1 = result['phases'][0]
+    if result['node_count'] > 0:
+        ratio = p1['stats'].count / result['node_count']
+        flag = '  ← FANOUT SUSPECT' if ratio > 3.0 else ''
+        print(
+            f"\n  build_disk_subtree fanout: "
+            f"{p1['stats'].count} queries / {result['node_count']} nodes = "
+            f"{ratio:.2f} q/node{flag}"
+        )
+
+    for phase in result['phases']:
+        print(f"\n  --- {phase['name']} ---")
+        print(f"      summary: {phase['stats'].summary()}")
+        _print_slowest(phase['stats'])
+        _print_by_table(phase['stats'])
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Profile /user/resource-details disk path.'
+    )
+    parser.add_argument(
+        '--user',
+        default=DEFAULT_USERNAME,
+        help=f'Username to log in as (default: {DEFAULT_USERNAME})',
+    )
+    parser.add_argument(
+        '--projcode',
+        action='append',
+        default=None,
+        help='Project code to profile (repeatable). Defaults to NRAL0002 + P43713000.',
+    )
+    parser.add_argument(
+        '--resource',
+        default='Campaign_Store',
+        help='Resource name (default: Campaign_Store). Applies to all --projcode args.',
+    )
+    parser.add_argument(
+        '--no-cprofile',
+        action='store_true',
+        help='Skip the per-target cProfile breakdown (cuts noise for SQL-only diff).',
+    )
+    parser.add_argument(
+        '--discover-roots',
+        action='store_true',
+        help='Auto-enumerate root projects with accounts on --resource and profile each.',
+    )
+    parser.add_argument(
+        '--max-targets',
+        type=int,
+        default=10,
+        help='Cap on number of targets when --discover-roots is set (default: 10).',
+    )
+    parser.add_argument(
+        '--include',
+        action='append',
+        default=[],
+        help='Force-include a projcode even when --discover-roots is set (repeatable).',
+    )
+    args = parser.parse_args()
+
+    app = create_app()
+    with app.app_context():
+        engine = db.engine
+
+        if args.discover_roots:
+            with app.test_request_context('/'):
+                discovered = discover_root_projects(db.session, args.resource)
+            # Keep --include projcodes at the front so they're profiled first
+            # (coldest cache slot). De-dupe while preserving order.
+            ordered = list(args.include)
+            for pc in discovered:
+                if pc not in ordered:
+                    ordered.append(pc)
+            ordered = ordered[:args.max_targets]
+            targets = [(pc, args.resource) for pc in ordered]
+            print(f"Discovered {len(discovered)} candidate roots; "
+                  f"profiling {len(targets)} (cap={args.max_targets}).")
+        elif args.projcode:
+            targets = [(pc, args.resource) for pc in args.projcode]
+        else:
+            targets = list(DEFAULT_TARGETS)
+
+        print(f"Profiling date  : {datetime.now().isoformat(timespec='seconds')}")
+        print(f"Login user      : {args.user}")
+        print(f"DB URL          : {engine.url}")
+        print(f"Targets         : {targets}")
+        print()
+        print("NOTE: Phase 3 re-invokes build_disk_subtree +")
+        print("      get_subtree_directory_usage_at internally, so its query")
+        print("      count overlaps phases 1+2. The standalone phases 1 and 2")
+        print("      are there to attribute SQL traffic to the specific call site.")
+        print("      Cache caveat: only the FIRST target's P1 query reflects a")
+        print("      truly cold InnoDB buffer pool. Subsequent targets reuse cached")
+        print("      disk_activity pages for the same activity_date+resource_name.")
+
+        all_results = []
+        for projcode, resource_name in targets:
+            label = f"{projcode}/{resource_name}"
+            if args.no_cprofile:
+                result = run_scenario(app, engine, args.user, projcode, resource_name)
+            else:
+                with _cprofiled() as pr:
+                    result = run_scenario(
+                        app, engine, args.user, projcode, resource_name,
+                    )
+            _print_report(result)
+            if not args.no_cprofile:
+                _print_cprofile(pr, label)
+            all_results.append(result)
+
+        # Compact cross-target summary
+        print(f"\n{'='*72}")
+        print("CROSS-TARGET SUMMARY")
+        print(f"{'='*72}")
+        print(
+            f"  {'target':<32s} {'nodes':>6s} {'P1 q':>6s} {'P2 q':>6s} "
+            f"{'P3 q':>6s} {'P3 ms':>9s}"
+        )
+        print(f"  {'-'*32} {'-'*6} {'-'*6} {'-'*6} {'-'*6} {'-'*9}")
+        for r in all_results:
+            phases = r['phases']
+            print(
+                f"  {r['projcode'] + '/' + r['resource']:<32s} "
+                f"{r['node_count']:>6d} "
+                f"{phases[0]['stats'].count:>6d} "
+                f"{phases[1]['stats'].count:>6d} "
+                f"{phases[2]['stats'].count:>6d} "
+                f"{phases[2]['elapsed']*1000:>9.1f}"
+            )
+
+
+if __name__ == '__main__':
+    main()

--- a/utils/profiling/profile_resource_details.py
+++ b/utils/profiling/profile_resource_details.py
@@ -67,6 +67,7 @@ from webapp.dashboards.user.blueprint import (  # noqa: E402
     _disk_subtree_latest_activity_date,
     _find_disk_node,
     _collect_disk_account_ids,
+    _collect_directory_to_projcode,
 )
 
 
@@ -212,13 +213,14 @@ def run_scenario(app, engine, username: str, projcode: str, resource_name: str):
         node_count = _count_nodes(full_tree)
         node_count_with_account = _count_nodes_with_account(full_tree)
         scope_account_ids = _collect_disk_account_ids(full_tree)
+        directory_to_projcode = _collect_directory_to_projcode(full_tree)
 
-        # ----- Phase 2: get_subtree_directory_usage_at (Layer-2 join) -----
+        # ----- Phase 2: get_subtree_directory_usage_at (disk_activity-only) -----
         snapshot_date = _disk_subtree_latest_activity_date(full_tree)
         with _phase(engine) as (s2, e2):
             fileset_dirs = get_subtree_directory_usage_at(
                 session,
-                account_ids=scope_account_ids,
+                directory_to_projcode=directory_to_projcode,
                 resource_name=resource_name,
                 activity_date=snapshot_date,
             )


### PR DESCRIPTION
## Summary

Two-phase application-side rewrite of the disk path of
`/user/resource-details`. Both phases are pure code, no schema
changes, no DBA coordination required.

  - **Phase 1** — bulk `current_disk_usage` loader; eliminates the
    per-descendant N+1 inside `build_disk_subtree`.
  - **Phase 2** — rewrite the directory-aggregation queries to read
    `disk_activity` directly via `directory_name IN (...)`;
    drops the join through `disk_charge → account → project`.

Each phase reproduces independently and stacks: Phase 1 made query
counts flat, Phase 2 made cold-cache wall times sub-second.

## Why

Profiling on prod (`utils/profiling/profile_resource_details.py`)
found the disk path was slow on the staging→prod hop for two
independent reasons:

  1. **Per-descendant N+1**: `Account.current_disk_usage()` was
     called once per project in the subtree from
     `build_disk_subtree`. NMMM0003 (20 disk accounts in a 21-node
     subtree) issued 74 queries inside `build_disk_subtree` alone,
     83 through the full route. At 25-35 ms per round trip that's
     1.5-2.5 s of pure latency.
  2. **Cold-cache join chain**: a single query inside
     `bulk_get_directory_usage_at` cost 11-75 s on a fully cold prod
     buffer pool. EXPLAIN showed this was 13K random fetches in
     `disk_charge` (account_id loop) + 13K disk_activity PK
     lookups, NOT a missing disk_activity index.

## Phase 1 (commit 7592911)

### `src/sam/queries/disk_usage.py`
  - New `_load_disk_snapshot_by_account` kernel — fixed 4-query
    budget (status row + bulk aggregate + per-account `max()`
    fallback + bulk fallback aggregate), keyed by `account_id`.
  - New public `bulk_current_disk_usage(session, account_ids)`.
  - `bulk_get_subtree_disk_capacity` now delegates to the kernel.
  - `build_disk_subtree` does one bulk call before the descendant
    loop instead of calling the property per descendant.

### `src/sam/accounting/accounts.py`
  - `Account.current_disk_usage` is now a thin wrapper over
    `bulk_current_disk_usage` with `[self.account_id]`.

### `src/sam/projects/projects.py`
  - `Project.current_disk_usage` makes one bulk call instead of
    looping `account.current_disk_usage()`.

### Tests
  - `TestBulkCurrentDiskUsage` in
    `tests/unit/test_current_disk_usage.py` (5 cases).
  - `tests/perf/test_resource_details_disk.py` regression gate at
    50 queries; wired into `make perf`.

## Phase 2 (commit 010227b)

EXPLAIN-on-prod ruled out the originally proposed ALTER TABLE
indexes — the planner already preferred `account → disk_charge →
disk_activity` and never scanned disk_activity by date. Three
prod-data findings drove a different fix:

  1. `disk_activity.projcode` is unusable as a project-ownership
     key — 78% of rows have NULL/blank, and 0 of 934K joined rows
     match what the account chain reports.
  2. `disk_charge.terabyte_year` (the only thing disk_charge adds
     beyond disk_activity) is unused dashboard-side — only writer
     and admin CLI touch it.
  3. `build_disk_subtree` already loads the active fileset list
     from `ProjectDirectory` for every node, so the
     directory_name → projcode mapping is in memory before any of
     these queries run.

So the directory-aggregation queries can filter
`disk_activity.directory_name IN (...)` directly. The existing
4-column unique index on
`(directory_name, username, activity_date, projcode)` leads with
`directory_name` and supports this as a range seek (EXPLAIN
confirms `type: range`, `rows: <IN-list size>`).

### `src/sam/queries/disk_usage.py`
  - `get_subtree_directory_usage_at` — takes
    `directory_to_projcode: Dict[str, str]`; single
    `disk_activity` aggregate.
  - `bulk_get_directory_usage_at` — takes
    `directories_by_project_id: Dict[int, List[str]]` +
    `resource_name`; single `disk_activity` aggregate.
  - `get_disk_usage_timeseries_for_directory` — drops
    `account_ids`; filters by `directory_name` directly. The
    chart renders username strings only, so the `users` join is
    unnecessary.
  - `get_directory_user_breakdown_at` — drops `account_ids`;
    OUTER JOINs `users` on username solely to surface `user_id`
    for the per-user dashboard link.
  - `get_directory_usage_at` deleted (unused in production).
  - `DiskCharge` import removed — no remaining references.

### `src/webapp/dashboards/user/blueprint.py`
  - New `_collect_directory_to_projcode` walks a tree node and
    returns `{directory_name: projcode}`.
  - `_render_disk_resource_details` builds the map and passes it
    to the query helper instead of `account_ids`.

## Measured prod results

NMMM0003 P3 (full route render):

```
Pre-fix:                                  2,529 ms
After Phase 1 (bulk_current_disk_usage):    696 ms
After Phase 2 (this PR's final state):      398 ms
```

NMMM0003 `build_disk_subtree` cold-cache (Phase 1 of profiler):

```
Pre-fix:                                 11,498 ms
After Phase 1:                            6,504 ms
After Phase 2:                              112 ms   (~58×)
```

Cross-target post-PR P3 ms (10 distinct Campaign_Store roots):

| target    | nodes | P1 q | P3 q | P3 ms |
|-----------|-------|------|------|-------|
| NMMM0003  |    21 |   11 |   21 |   398 |
| NCGD0006  |    17 |   10 |   20 |   446 |
| NEOL0001  |    11 |   10 |   20 |   188 |
| NHAO0003  |     6 |   11 |   21 |   299 |
| NACD0001  |     3 |   11 |   21 |   314 |
| CESM0002  |    19 |   11 |   21 |   349 |
| NCIS0001  |     7 |   11 |   21 |   285 |
| NASP0001  |     3 |   11 |   21 |   245 |
| NHAP0009  |     1 |    9 |   18 |   188 |
| NHAO0028  |     1 |    8 |   16 |    91 |

P1 query count is now a flat ~10-11 regardless of subtree size, and
P3 wall times are all under 500 ms even on cold cache.

## Scope change vs original PR description

The original PR description (now obsolete) proposed two new MySQL
indexes for Phase 2 — `disk_activity(activity_date, resource_name)`
and `disk_charge(account_id, charge_date)` — requiring DBA
coordination. EXPLAIN-on-prod found neither would have helped given
the planner's chosen access path.

This final state lands as **zero new indexes, zero DBA coordination
needed** — both phases are pure application code.

## Test plan

- [x] `pytest tests/unit/test_current_disk_usage.py tests/unit/test_disk_usage_queries.py -v` — 30/30 pass.
- [x] `pytest -m perf -n 0 -v` — 20/20 pass, including `test_resource_details_disk_route`.
- [x] Reprofile on prod via `python utils/profiling/profile_resource_details.py --no-cprofile --discover-roots --include NMMM0003 --max-targets 10` — confirmed flat query counts and sub-second wall times.
- [x] `docker compose up webdev --watch` and visit `/user/resource-details?projcode=<known-disk-project>&resource=Campaign_Store` — page renders, capacity card and project tree match pre-fix output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
