### PR TITLE
Pace chart: edge-bounded y-axis, per-year units, top_n=15

### DIFF
--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -522,6 +522,7 @@ def generate_allocation_type_pie_chart_matplotlib(type_data: List[Dict]) -> str:
 
 _PACE_OTHER_COLOR = (0.78, 0.78, 0.78, 0.85)
 _PACE_TODAY_LINE_COLOR = (0.2, 0.2, 0.2, 0.7)
+_PACE_RATE_SCALE = 365  # internal per-day rates → per-year axis
 
 
 def _pace_bands(allocations: List[Dict], active_at: datetime,
@@ -590,7 +591,7 @@ def _pace_key_fields(allocations: List[Dict]) -> list:
     ]
 
 
-def _pace_cache_key(allocations, active_at, window_days=180, top_n=10, resource_name=''):
+def _pace_cache_key(allocations, active_at, window_days=180, top_n=15, resource_name=''):
     return _content_hash([_pace_key_fields(allocations), active_at.isoformat(),
                           int(window_days), int(top_n), resource_name])
 
@@ -601,7 +602,7 @@ def generate_pace_chart_matplotlib(
     allocations: List[Dict],
     active_at: datetime,
     window_days: int = 180,
-    top_n: int = 10,
+    top_n: int = 15,
     resource_name: str = '',
 ) -> str:
     """Stacked-area pace chart: one band per allocation, past-rate | future-rate
@@ -614,7 +615,7 @@ def generate_pace_chart_matplotlib(
             ``total_amount``, ``total_used``.
         active_at: chart centerline ("today").
         window_days: half-window on each side of ``active_at`` (default 180).
-        top_n: projects with their own color + legend entry (default 5).
+        top_n: projects with their own color + legend entry (default 15).
         resource_name: used only for cache key disambiguation.
 
     Returns:
@@ -665,7 +666,9 @@ def generate_pace_chart_matplotlib(
     ordered = [(k, group_rates[k]) for k in top_projs] + [(OTHER_KEY, group_rates[OTHER_KEY])]
     ordered = [(k, r) for k, r in ordered if r.any()]
 
-    rates_matrix = [r for _, r in ordered]
+    # Scale per-day rates to per-year for display (users reason about
+    # allocation burn in annual units).
+    rates_matrix = [r * _PACE_RATE_SCALE for _, r in ordered]
     colors = [color_map.get(k, _PACE_OTHER_COLOR) for k, _ in ordered]
 
     fig, ax = plt.subplots(figsize=(10, 4))
@@ -705,7 +708,7 @@ def generate_pace_chart_matplotlib(
     ax.xaxis.set_major_locator(mdates.MonthLocator())
     ax.xaxis.set_major_formatter(mdates.DateFormatter('%b %Y'))
     ax.yaxis.set_major_formatter(fmt.mpl_number_formatter())
-    ax.set_ylabel('Rate (per day)')
+    ax.set_ylabel('Rate (per year)')
     ax.grid(True, alpha=0.2)
     fig.autofmt_xdate()
 

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -672,9 +672,18 @@ def generate_pace_chart_matplotlib(
     ax.stackplot(days, rates_matrix, colors=colors, edgecolor='none',
                  linewidth=0, antialiased=True)
 
-    # Today marker
+    # Clamp ymax to the larger of the stacked totals at the window edges,
+    # plus 25% headroom. Allocations expiring within a day or two of
+    # active_at otherwise produce future-rates of remaining/1d that
+    # dominate the axis and squash the rest of the chart into a flat strip.
+    totals_by_day = np.sum(rates_matrix, axis=0)
+    edge_bound = max(float(totals_by_day[0]), float(totals_by_day[-1]))
+    ax.set_ylim(bottom=0, top=(1.25 * edge_bound) if edge_bound > 0 else None)
+
+    # Today marker — placed after set_ylim so the label sits at the
+    # clamped ymax rather than the auto-scaled spike.
     ax.axvline(active_at, color=_PACE_TODAY_LINE_COLOR, linestyle='--', linewidth=1)
-    ymin, ymax = ax.get_ylim()
+    _, ymax = ax.get_ylim()
     ax.text(active_at, ymax, ' today', color=_PACE_TODAY_LINE_COLOR,
             fontsize=8, va='top', ha='left')
 
@@ -693,7 +702,6 @@ def generate_pace_chart_matplotlib(
 
     # Axes
     ax.set_xlim(window_start, window_end)
-    ax.set_ylim(bottom=0)
     ax.xaxis.set_major_locator(mdates.MonthLocator())
     ax.xaxis.set_major_formatter(mdates.DateFormatter('%b %Y'))
     ax.yaxis.set_major_formatter(fmt.mpl_number_formatter())


### PR DESCRIPTION
Three small refinements to the Allocations dashboard pace chart in `src/webapp/dashboards/charts.py`. First, the y-axis is now clamped to `1.25 × max(stacked_total@xmin, stacked_total@xmax)` so that allocations expiring within a day or two of `active_at` no longer produce a delta-function spike (their `remaining/remaining_days` future-rate explodes as `remaining_days → 1` and would otherwise auto-scale the axis until the rest of the chart collapses into a flat strip); the far-from-today edges reflect steady-state burn and are robust to single-day spikes by construction, and the clamp falls through to auto-scale when both edges are zero. Second, the internal per-day rates are scaled by 365 right before stackplot so the y-axis reads in per-year units (matching how users reason about allocation burn) — the edge clamp inherits the scaling automatically and the y-label updates to "Rate (per year)". Third, the default `top_n` is bumped from 10 → 15 (existing callers in `user/blueprint.py` already pass `top_n=15` explicitly; the `allocations/blueprint.py` calls picked up the new default), and the existing tab10 → tab20 palette branch already covers >10 distinct project colors. Divide-by-zero paths in `_pace_bands` were re-verified — both `past_rate` and `future_rate` guard on `> 0` before dividing.

## Test plan
- [ ] Open Allocations dashboard for a resource with imminent UNIV expirations (Derecho); confirm pace chart no longer looks like a delta function and the legend / today line / band stack are readable
- [ ] Verify y-axis label reads "Rate (per year)" and tick magnitudes match expected annual burn for the resource
- [ ] Verify a resource with no near-term expirations renders essentially unchanged
- [ ] Confirm legend shows up to 15 named projects (resources with >10 unique projcodes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)