### PR TITLE
Extend OIDC SSO to samuel.k8s.ucar.edu (Helm chart) + FLASK_SECRET_KEY security fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,15 +90,29 @@ FLASK_SECRET_KEY=your_generated_64_character_hex_string_here
 
 #-------------------------------------------------
 # OIDC Authentication (when AUTH_PROVIDER=oidc)
-# Leave AUTH_PROVIDER=stub (default) for development.
-# Set to 'oidc' when Microsoft Entra credentials are available and HTTPS is configured.
+# Leave AUTH_PROVIDER=stub (default) for development -- DISABLE_AUTH=1 plus
+# the stub provider auto-logs you in as DEV_AUTO_LOGIN_USER without any IdP.
+# Real OIDC is used in deployed environments only:
+#   - Fargate staging:   https://sam-staging.csgsam.ucar.edu (env from AWS SSM)
+#   - CIRRUS k8s:        https://samuel.k8s.ucar.edu        (env from OpenBao via External Secrets)
+#
+# Local OIDC against a real IdP (rare, only for protocol-level debugging):
+#   1. Use a SEPARATE dev Entra app registration (NOT the staging/prod one) --
+#      ask UCAR IT for a dev app with redirect URI http://localhost:5050/auth/oidc/callback.
+#      Microsoft Entra allows http://localhost as a special exception for confidential apps.
+#   2. Uncomment and fill the values below.
+#   3. compose.yaml does NOT pass these envs through to the webdev container by default.
+#      Add explicit env entries to compose.yaml's webdev service or `docker compose run -e`.
+#   4. Use FLASK_CONFIG=development so SESSION_COOKIE_SECURE=False (HTTP loopback works).
+#
 # AUTH_PROVIDER=oidc
-# OIDC_CLIENT_ID=your-entra-client-id
-# OIDC_CLIENT_SECRET=your-entra-client-secret
+# OIDC_CLIENT_ID=your-DEV-entra-client-id
+# OIDC_CLIENT_SECRET=your-DEV-entra-client-secret
 # OIDC_ISSUER=https://login.microsoftonline.com/{tenant-id}/v2.0
-# OIDC_REDIRECT_URI=https://your-app-url/auth/oidc/callback
+# OIDC_REDIRECT_URI=http://localhost:5050/auth/oidc/callback
 # OIDC_SCOPES=openid email profile
 # OIDC_USERNAME_CLAIM=preferred_username
+# FLASK_CONFIG=development
 
 #-------------------------------------------------
 # MCP Server Configuration

--- a/.github/workflows/ci-staging.yaml
+++ b/.github/workflows/ci-staging.yaml
@@ -94,6 +94,38 @@ jobs:
       - name: Terraform fmt check
         run: terraform fmt -check -recursive infrastructure/staging/
 
+  helm-render:
+    name: Helm Chart Render
+    # Skip on [skip ci] / [ci skip] / [no ci] in commit message or PR title
+    if: >-
+      !contains(github.event.head_commit.message, '[skip ci]')
+      && !contains(github.event.head_commit.message, '[ci skip]')
+      && !contains(github.event.head_commit.message, '[no ci]')
+      && !contains(github.event.pull_request.title, '[skip ci]')
+      && !contains(github.event.pull_request.title, '[ci skip]')
+      && !contains(github.event.pull_request.title, '[no ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Helm lint (chart)
+        run: helm lint helm/
+
+      - name: Helm template renders cleanly (production values)
+        run: helm template samuel helm/ -f helm/values.yaml > /dev/null
+
+      - name: Helm template renders cleanly (local dev values)
+        run: helm template samuel helm/ -f helm/values.yaml -f helm/values-local.yaml > /dev/null
+
+      - name: OIDC + ExternalSecret render assertions
+        run: bash helm/tests/test-oidc-render.sh
+
   test:
     name: Test Suite
     # Skip on [skip ci] / [ci skip] / [no ci] in commit message or PR title

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -1,0 +1,554 @@
+# Authentication & SSO
+
+How users sign in to SAM Queries -- written for the curious, not just the
+on-call. If you've never touched OIDC before, start at the top. If you
+just need to rotate a secret, jump straight to [Operations](#operations).
+
+> **TL;DR**: Real users sign in with their UCAR account through Microsoft
+> Single Sign-On. Behind the scenes, that's OIDC (OpenID Connect) talking
+> to Microsoft Entra. Locally and in tests, we skip all of that with a
+> stub provider so developers don't have to deal with login during
+> day-to-day work. Where the secrets live and how the app finds them
+> depends on which deployment you're looking at -- there's a matrix
+> further down.
+
+---
+
+## What you see as a user
+
+You're a CISL staff member. You point your browser at one of our
+deployments (e.g. `https://samuel.k8s.ucar.edu`). What happens?
+
+1. **You land on a login page.** Nothing fancy -- just a button that
+   says "Sign in with UCAR SSO". No username, no password fields. If
+   you've ever clicked "Continue with Google" on a third-party website,
+   it's the same idea.
+
+2. **You click the button.** Your browser bounces over to
+   `login.microsoftonline.com` -- Microsoft's sign-in page. If you're
+   already signed in to your UCAR account (because you used Outlook or
+   Teams earlier today), this might flash by so fast you don't notice
+   it. Otherwise you'll see Microsoft's standard sign-in form. UCAR's
+   normal MFA rules apply -- Authenticator app prompts, conditional
+   access, the works.
+
+3. **Microsoft signs you in and bounces you back.** Your browser ends
+   up at `https://samuel.k8s.ucar.edu/auth/oidc/callback` with a
+   one-time code. The SAM webapp swaps that code for an ID token,
+   reads your username out of the token, looks you up in the SAM
+   database, and creates a session.
+
+4. **You're in.** You see either the user dashboard or the admin
+   dashboard, depending on your POSIX group memberships -- the same
+   group memberships that decide everything else in SAM.
+
+5. **You log out.** Clicking "Logout" in the nav bar clears the SAM
+   session AND bounces you to Microsoft's sign-out page so the next
+   person who uses the browser doesn't inherit your Entra session.
+
+### What if I'm not in SAM?
+
+If your Microsoft sign-in succeeds but your username doesn't match an
+active SAM user record, you'll see "Your account was not found in SAM
+or is inactive" and bounce back to the login page. We don't
+auto-provision accounts -- this is intentional. Being a UCAR employee
+isn't enough; you have to also be in the SAM database. Talk to a SAM
+admin if you think this is wrong.
+
+### What about logging in locally?
+
+When you run the app on your laptop with `docker compose up` or
+`helm install -f values-local.yaml`, you don't see the login screen at
+all -- the app auto-logs you in as a test user (`benkirk` by default,
+configurable via `DEV_AUTO_LOGIN_USER`). This is intentional. Local dev
+shouldn't depend on Microsoft being reachable, and we don't want
+developers's laptops talking to UCAR's identity provider with shared
+production credentials. See [Local development](#local-development) for
+how to opt into a "real" OIDC flow if you ever need to debug a
+Microsoft-side issue.
+
+---
+
+## What's actually happening (the technical flow)
+
+```mermaid
+sequenceDiagram
+    participant U as User browser
+    participant App as SAM webapp<br/>(Flask)
+    participant Entra as Microsoft Entra<br/>(login.microsoftonline.com)
+    participant DB as SAM database
+
+    U->>App: GET /auth/login
+    App-->>U: Render "Sign in with UCAR SSO" button
+
+    U->>App: GET /auth/oidc/login
+    App-->>U: 302 Redirect to Entra<br/>(with state, nonce, PKCE challenge)
+
+    U->>Entra: GET /authorize?...
+    Entra-->>U: Sign-in form / MFA prompt
+    U->>Entra: Submit credentials
+    Entra-->>U: 302 Redirect to /auth/oidc/callback?code=...
+
+    U->>App: GET /auth/oidc/callback?code=...
+    App->>Entra: POST /token (exchange code + PKCE verifier)
+    Entra-->>App: id_token + access_token + userinfo
+    App->>DB: SELECT user WHERE username = preferred_username
+
+    alt User exists and is active
+        DB-->>App: User row
+        App-->>U: 302 Redirect to dashboard<br/>(Set-Cookie: session=signed)
+    else User missing / locked / inactive
+        DB-->>App: nothing
+        App-->>U: 302 Redirect to /auth/login<br/>(flash: account not found)
+    end
+```
+
+The four moving pieces:
+
+- **The browser** -- holds the session cookie after login. The cookie
+  is signed by `FLASK_SECRET_KEY` so it can't be forged.
+- **The Flask webapp** -- uses the [Authlib](https://docs.authlib.org/)
+  library to talk OIDC. The relevant code lives in
+  [`src/webapp/auth/blueprint.py`](../src/webapp/auth/blueprint.py)
+  (the routes) and
+  [`src/webapp/auth/providers.py`](../src/webapp/auth/providers.py)
+  (the OIDC claim-to-SAM-user mapping).
+- **Microsoft Entra** -- UCAR's identity provider. We have an "app
+  registration" there that lists which URLs we're allowed to redirect
+  back to, what scopes we ask for, and a client secret we use to prove
+  it's really us during the code exchange.
+- **The SAM database** -- the source of truth for who counts as a
+  valid user. The OIDC layer just authenticates; SAM still authorizes.
+
+### What the app uses to make this work
+
+A handful of environment variables, all read at startup:
+
+| Variable | What it does |
+|---|---|
+| `AUTH_PROVIDER` | `oidc` to enable SSO; `stub` for dev (any password works) |
+| `OIDC_CLIENT_ID` | Identifies our app to Entra |
+| `OIDC_CLIENT_SECRET` | Proves our app to Entra during the token exchange |
+| `OIDC_ISSUER` | Where to discover all the Entra endpoints (e.g. `https://login.microsoftonline.com/{tenant}/v2.0`) |
+| `OIDC_REDIRECT_URI` | The exact URL Entra should bounce users back to after login (must match what's registered on the Entra app) |
+| `OIDC_USERNAME_CLAIM` | Which OIDC claim contains the SAM username (default: `preferred_username`) |
+| `OIDC_SCOPES` | What we ask Entra for (default: `openid email profile`) |
+| `FLASK_SECRET_KEY` | Signs the session cookie. Per-deployment, never shared |
+| `FLASK_CONFIG` | `production` enables `SESSION_COOKIE_SECURE=True` (HTTPS-only cookies) |
+
+In production deployments, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`,
+`OIDC_ISSUER`, and `FLASK_SECRET_KEY` are pulled from a secret store
+(AWS SSM for ECS, OpenBao for Kubernetes) -- never written into git or
+Docker images. The other values are plain config.
+
+---
+
+## Where it runs (the deployment matrix)
+
+Same code, four deployment shapes. The only thing that changes is
+*where* the OIDC config comes from.
+
+| Deployment | URL | How auth works | OIDC creds source | Reply URL on Entra |
+|---|---|---|---|---|
+| **Local Docker Compose** (`docker compose up webdev`) | `http://localhost:5050` | Stub auto-login (`DISABLE_AUTH=1`) | n/a | n/a |
+| **Local k8s** (Docker Desktop, `values-local.yaml`) | port-forwarded | Stub auto-login (`DISABLE_AUTH=1`) | n/a | n/a |
+| **Fargate staging** | `https://sam-staging.csgsam.ucar.edu` | OIDC | AWS SSM `/sam/staging/oidc-*` | `https://sam-staging.csgsam.ucar.edu/auth/oidc/callback` |
+| **CIRRUS k8s** (samuel) | `https://samuel.k8s.ucar.edu` | OIDC | OpenBao `csg/sam-oidc` | `https://samuel.k8s.ucar.edu/auth/oidc/callback` |
+| Future ECS production | tbd | OIDC | AWS SSM `/sam/production/oidc-*` | tbd |
+| Future k8s staging | tbd | OIDC | OpenBao `csg/sam-staging-oidc` | tbd |
+
+### Why two paths to OIDC?
+
+Two different deployment platforms (AWS ECS vs Kubernetes on CIRRUS),
+two different secret stores. They don't share infrastructure -- they
+share *only* the Entra app registration. As of this writing, both
+deployments use the same Entra app (so the same `client_id`/
+`client_secret`/`issuer` flows into both via different stores). Before
+we stand up an ECS production environment, we plan to ask UCAR IT for
+a separate Entra app per environment so a leak in staging can't
+affect production.
+
+### How the secrets get into the app
+
+**On Fargate** (ECS, staging today):
+
+```
+Terraform writes -> AWS SSM (SecureString)
+                        v
+ECS task definition references SSM ARN in its `secrets` block
+                        v
+ECS injects values as env vars into the container at task start
+                        v
+Flask reads from os.environ at startup
+```
+
+**On Kubernetes** (CIRRUS, samuel.k8s.ucar.edu):
+
+```
+Operator writes -> OpenBao (csg/sam-oidc path)
+                        v
+External Secrets Operator (every 1h) reads OpenBao
+                        v
+ESO creates/updates the k8s Secret `samuel-oidc-credentials`
+                        v
+Pod env block references that Secret via secretKeyRef
+                        v
+Flask reads from os.environ at startup
+```
+
+Either way, the Flask app sees plain environment variables. The
+plumbing differs entirely depending on which platform you deploy to.
+
+---
+
+## Local development
+
+Most of the time you don't think about authentication locally -- it's
+out of your way by design.
+
+### What you'll see in normal local development
+
+```bash
+# Start everything
+docker compose up
+
+# Browse to http://localhost:5050
+# You're auto-logged in as benkirk (or whoever DEV_AUTO_LOGIN_USER says).
+# No login page, no password, no Microsoft involvement.
+```
+
+This works because `compose.yaml` sets `DISABLE_AUTH=1`, which
+activates a small Flask middleware
+([`src/webapp/utils/dev_auth.py`](../src/webapp/utils/dev_auth.py))
+that auto-authenticates every request as the configured user via the
+stub provider. The stub provider accepts any password for any active
+SAM user -- never run it in production.
+
+To impersonate a different user locally:
+
+```bash
+# In .env or as a docker compose env override:
+DEV_AUTO_LOGIN_USER=someone_else
+```
+
+### Running real OIDC locally (rare)
+
+You should only need this if you're debugging a Microsoft-side issue
+(token-format weirdness, claim-mapping bug, etc.). For everyday
+development, **stay on stub**.
+
+If you really need to:
+
+1. **Get a separate dev Entra app from UCAR IT.** Do *not* use the
+   shared staging/production app. Ask IT for a new "SAM dev" app
+   registration with redirect URI
+   `http://localhost:5050/auth/oidc/callback`. (Microsoft Entra allows
+   `http://localhost` as a special exception for confidential apps;
+   most other IdPs don't.)
+
+2. **Add to your `.env`** (these are the placeholders in
+   [`.env.example`](../.env.example)):
+
+   ```bash
+   AUTH_PROVIDER=oidc
+   OIDC_CLIENT_ID=<dev-app-client-id>
+   OIDC_CLIENT_SECRET=<dev-app-client-secret>
+   OIDC_ISSUER=https://login.microsoftonline.com/{tenant}/v2.0
+   OIDC_REDIRECT_URI=http://localhost:5050/auth/oidc/callback
+   FLASK_CONFIG=development
+   ```
+
+3. **Pass these envs through to the container.** `compose.yaml`
+   doesn't forward them by default (intentional, to avoid silent
+   misconfigurations). Either edit the `webdev` service's `environment`
+   block to add them, or use:
+
+   ```bash
+   docker compose run -e AUTH_PROVIDER -e OIDC_CLIENT_ID -e OIDC_CLIENT_SECRET \
+     -e OIDC_ISSUER -e OIDC_REDIRECT_URI -e FLASK_CONFIG webdev
+   ```
+
+`FLASK_CONFIG=development` is important here -- it keeps
+`SESSION_COOKIE_SECURE=False` so the session cookie can ride over plain
+HTTP on `localhost`. With `FLASK_CONFIG=production`, the browser will
+silently drop the cookie and login will appear to "succeed" then
+immediately bounce back to the login page. Confusing failure mode;
+worth knowing.
+
+### Local Kubernetes
+
+Same idea but with `helm install -f values-local.yaml`. The local
+values file pins `DISABLE_AUTH=1` and `oidcCredentials.enabled=false`
+so the chart skips the OpenBao-based ExternalSecret entirely. You
+won't be able to opt into real OIDC on local k8s without manually
+creating a `samuel-oidc-credentials` Kubernetes Secret and flipping
+the values back on. We chose not to support this in the chart; if you
+need to test the chart's OIDC wiring, exercise it via the helm
+template render assertions
+([`helm/tests/test-oidc-render.sh`](../helm/tests/test-oidc-render.sh))
+rather than a live local cluster.
+
+---
+
+## Operations
+
+### Where each secret lives, by environment
+
+| What | Fargate (staging) | k8s (samuel) |
+|---|---|---|
+| OIDC client ID | AWS SSM `/sam/staging/oidc-client-id` | OpenBao `csg/sam-oidc.client_id` |
+| OIDC client secret | AWS SSM `/sam/staging/oidc-client-secret` | OpenBao `csg/sam-oidc.client_secret` |
+| OIDC issuer URL | AWS SSM `/sam/staging/oidc-issuer` | OpenBao `csg/sam-oidc.issuer` |
+| Flask session key | AWS SSM `/sam/staging/flask-secret-key` | OpenBao `csg/sam-oidc.flask_secret_key` |
+
+Both stores require auth. AWS SSM is gated by IAM (the `terraform`
+user can read/write under `/sam/`); OpenBao is gated by the team's
+internal access policies. No human should ever paste these values into
+git or Slack.
+
+### Reading staging values (when needed for ops)
+
+```bash
+# Requires AWS CLI configured against the project account (842264312439)
+aws ssm get-parameter --with-decryption \
+  --name /sam/staging/oidc-client-id \
+  --query Parameter.Value --output text
+```
+
+You can also use the project AWS MCP from Cursor with the same
+operation -- preferred when you're investigating without leaving the
+IDE.
+
+### Rotating the Entra client secret
+
+This is the most common rotation scenario.
+
+1. **Generate a new secret in Microsoft Entra.** UCAR IT does this on
+   the app registration's "Certificates & secrets" page. They'll send
+   you the new value via a secure channel.
+2. **Update both secret stores.** They must be updated together, or
+   one deployment will start failing.
+
+   ```bash
+   # AWS SSM (staging Fargate)
+   aws ssm put-parameter --name /sam/staging/oidc-client-secret \
+     --type SecureString --overwrite --value '<new-secret>'
+
+   # OpenBao (samuel k8s) -- via your team's normal OpenBao tooling.
+   # Update csg/sam-oidc.client_secret to the new value.
+   ```
+
+3. **Restart the apps so they pick up the new value.**
+
+   ```bash
+   # Fargate -- new task definition revision picks up SSM at task start
+   aws ecs update-service --cluster sam-staging --service sam-staging-webapp \
+     --force-new-deployment
+
+   # k8s -- ExternalSecret refreshes hourly; force immediately:
+   kubectl annotate externalsecret samuel-oidc-credentials-esos -n <ns> \
+     force-sync=$(date +%s) --overwrite
+   kubectl rollout restart deployment/samuel -n <ns>
+   ```
+
+4. **Test the login flow on both URLs.** Don't trust that "the pod
+   restarted, so it must work". Click through to confirm.
+
+If you forget step 3, the old client_secret stays in the running
+process's memory and you won't notice the rotation worked until the
+next pod restart -- or worse, until a deploy fails.
+
+### Adding a new redirect URI (e.g. a new deployment hostname)
+
+UCAR IT adds it to the existing Entra app registration. No code change
+needed. You just need to:
+
+1. **File a ticket** asking for the new reply URL on the existing app.
+   See `infrastructure/README.md` "OIDC SSO Integration" section for
+   the IT handoff checklist.
+2. **Once IT confirms**, set `OIDC_REDIRECT_URI` to the new URL in the
+   relevant deployment config (`infrastructure/staging/ecs.tf` for
+   Fargate, `helm/values.yaml` for k8s).
+3. **Redeploy.**
+
+### Common failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Login bounces to Entra error: "AADSTS50011 reply URL mismatch" | `OIDC_REDIRECT_URI` doesn't exactly match what's registered on the Entra app (trailing slash, http vs https, typo) | Compare byte-for-byte with the value on the app's "Authentication" blade |
+| Login bounces back to `/auth/login` immediately after Entra success | `FLASK_CONFIG=production` set but the browser is on HTTP, so it dropped the `Secure` cookie | Ensure HTTPS is in front (or use `FLASK_CONFIG=development` for HTTP-only deployments) |
+| Login bounces with "account not found in SAM or is inactive" | The username from `preferred_username` doesn't match an active row in the `users` table | Check the username in SAM (`sam-search user <username>`); confirm `active=1` and `locked=0` |
+| App fails to start with `EnvironmentError: missing required env vars` | `AUTH_PROVIDER=oidc` but one of `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_ISSUER` is empty | Check the secret store; confirm pod/task env actually has the values (`kubectl exec` / `aws ecs describe-tasks`) |
+| `kind: ExternalSecret` exists but `samuel-oidc-credentials` k8s Secret never appears | OpenBao path or property name typo, or ESO can't reach OpenBao | `kubectl describe externalsecret samuel-oidc-credentials-esos` shows the error in `Status.Conditions` |
+| Logout fails with Entra error | `post_logout_redirect_uri` isn't allowlisted on the Entra app | Ask IT to add it; it's the same form as adding a reply URL |
+
+### Logs to check
+
+```bash
+# k8s
+kubectl logs -n <ns> -l app=samuel | grep -E '(OIDC|auth|login)'
+
+# Fargate
+aws logs tail /ecs/sam-staging-webapp --since 30m --filter-pattern OIDC
+```
+
+The app emits an info log line on each successful and failed login,
+which is usually the fastest way to confirm whether the issue is at
+the OIDC layer or the SAM authorization layer.
+
+---
+
+## Security
+
+What we worry about, what we don't, and why.
+
+### What protects users
+
+- **HTTPS everywhere** in production. Session cookies are marked
+  `Secure; HttpOnly; SameSite=Lax` so they can't be sniffed in transit
+  or stolen by JavaScript.
+- **Per-environment session keys.** Each deployment has its own
+  `FLASK_SECRET_KEY` -- a session minted in staging cannot be replayed
+  against the k8s deployment, and vice versa.
+- **Microsoft handles the actual authentication.** UCAR's MFA rules,
+  conditional access policies, password complexity, and account
+  lockout all apply transparently. We never see the user's password
+  and don't need to.
+- **PKCE on the auth code flow.** Even if the authorization code
+  leaked from the URL bar, an attacker can't exchange it for a token
+  without the code verifier we generated client-side.
+- **State and nonce parameters** prevent CSRF and token-replay
+  attacks. Authlib handles these automatically.
+- **No auto-provisioning.** A valid Microsoft token isn't enough --
+  the user has to also exist in SAM and be active. If someone leaves
+  CISL, removing them from the SAM database revokes their access
+  immediately, even if their UCAR account is still alive.
+- **Open-redirect protection.** The `?next=` query param is validated
+  to reject external hosts (no `?next=https://evil.com/`), tested at
+  [`tests/unit/test_oidc_auth.py`](../tests/unit/test_oidc_auth.py)
+  lines 319-353.
+- **VPN gating.** The Fargate ALB is restricted to the UCAR VPN CIDR
+  (`128.117.0.0/16`); samuel.k8s.ucar.edu is internal-ingress only.
+  External attackers can't even reach the login page.
+
+### What we worry about (and what we're doing)
+
+- **Shared Entra app between staging and samuel.** Today the same
+  client_secret protects both. A compromise of either secret store
+  compromises both. Mitigation: when production lands, we'll register
+  a separate Entra app per environment.
+- **Session cookies aren't encrypted, just signed.** A user holding
+  their own cookie can read its contents -- but they're already
+  authenticated, so that's not a leak vector. A network attacker
+  *cannot* read it (HTTPS) or forge it (`FLASK_SECRET_KEY` is per-env
+  and 32 bytes random).
+- **Logout doesn't fully clear the Flask session.** Flask-Login's
+  `logout_user()` clears the user ID but leaves any other session keys
+  (`oidc_next`, etc.) in place. Low risk -- nothing sensitive is
+  stored there -- but tracked as a hardening follow-up.
+
+### What we don't worry about (and why)
+
+- **Brute-force on the login page.** There isn't one to brute-force --
+  it's a button. Microsoft handles password attempts, and the VPN
+  gates external access anyway.
+- **CSRF on the OIDC routes.** They're GET-initiated and protected by
+  the OIDC `state` parameter (handled by Authlib).
+- **Leaked secrets in git.** `.env`, `secrets.auto.tfvars`, and
+  `.cursor/mcp.json` are all gitignored. Pre-commit hooks
+  (TruffleHog + GitGuardian) catch accidental commits before they
+  push. CI rejects PRs with secrets verified against known patterns.
+
+---
+
+## Future plans
+
+In rough priority order:
+
+1. **Per-environment Entra app registrations.** Before
+   `infrastructure/production/` exists, ask UCAR IT to register a
+   separate `sam-production` app. This isolates blast radius and
+   simplifies audit. The app-side change is zero (the chart and
+   Terraform already read environment-specific paths); the IT-side
+   change is a new app registration.
+2. **`FLASK_CONFIG=production` on Fargate staging.** Currently unset
+   on staging Fargate, so it runs `DevelopmentConfig` (DEBUG=True,
+   `SESSION_COOKIE_SECURE=False`). Masked today because staging is
+   HTTP-only behind UCAR VPN. Will need to be set when HTTPS is added
+   on staging (see
+   [`.cursor/rules/infrastructure-overview.mdc`](../.cursor/rules/infrastructure-overview.mdc)
+   "DNS Subdomain Readiness Checklist" item #2).
+3. **Mock OIDC IdP for integration tests.** Today the tests at
+   [`tests/unit/test_oidc_auth.py`](../tests/unit/test_oidc_auth.py)
+   mock Authlib at the function boundary -- they catch code-path
+   regressions but don't validate the actual OIDC protocol round-trip.
+   Adding a `dexidp/dex` or `navikt/mock-oauth2-server` Docker service
+   to the test compose profile would let us drive the full flow
+   against a fake IdP.
+4. **`session.clear()` on logout.** One-line hardening.
+5. **HTTPS on Fargate staging (DNS dependency).** Awaiting UCAR DNS
+   team for the staging subdomain CNAME. Once that lands, we can
+   request an ACM cert and flip the ALB listener from HTTP to HTTPS.
+
+None of these block the current k8s deployment.
+
+---
+
+## Glossary
+
+A few terms that get used a lot:
+
+- **OIDC** -- OpenID Connect. The standardized protocol that lets a
+  web app delegate "who is this user" to a third-party identity
+  provider. Built on top of OAuth 2.0.
+- **IdP / Identity Provider** -- the system that authenticates users.
+  For us, that's Microsoft Entra (Azure AD).
+- **Entra / Azure AD** -- Microsoft's identity service. UCAR uses it
+  for staff accounts. Same login as Outlook, Teams, etc.
+- **App Registration** -- a record in Entra that says "this web app
+  is allowed to authenticate users; here are its callback URLs and
+  here's a secret it'll use to prove its identity".
+- **Client ID / Client Secret** -- a non-secret identifier and a
+  secret password that together identify our app to Entra. Issued by
+  IT when they register the app.
+- **Issuer** -- a URL that points at Entra's metadata document; the
+  app uses it to discover all the other endpoints (authorize, token,
+  end_session, etc.).
+- **Redirect URI / Reply URL** -- the exact URL Entra sends users to
+  after they log in. Must match a value registered on the app.
+- **PKCE** (pronounced "pixie") -- Proof Key for Code Exchange. An
+  extra layer of protection on the authorization-code flow that
+  prevents a stolen code from being usable.
+- **Authlib** -- the Python OIDC library we use. Hides most of the
+  protocol mechanics behind a few function calls.
+- **External Secrets Operator (ESO)** -- a Kubernetes addon that
+  syncs secrets from an external store (OpenBao for us) into native
+  Kubernetes Secrets, refreshed on a schedule.
+- **OpenBao** -- UCAR's internal HashiCorp-Vault-compatible secret
+  store. The k8s deployment reads OIDC creds from here.
+- **AWS SSM Parameter Store** -- AWS's managed key-value store for
+  config and secrets. The Fargate deployment reads OIDC creds from
+  here.
+- **Stub provider** -- the dev-mode auth provider that accepts any
+  password for any active SAM user. Used locally and in tests; never
+  in production.
+
+---
+
+## Where to look for more
+
+- [`infrastructure/README.md`](../infrastructure/README.md) -- the
+  Terraform side of staging, including the IT handoff checklist for
+  registering an OIDC app.
+- [`docs/README-k8s.md`](README-k8s.md) -- Helm chart deployment guide
+  with the per-environment matrix and force-sync runbook.
+- [`docs/STAGING.md`](STAGING.md) -- staging Fargate access and
+  deployment.
+- [`docs/WEBAPP_SETUP.md`](WEBAPP_SETUP.md) -- local webapp setup.
+- [`src/webapp/auth/blueprint.py`](../src/webapp/auth/blueprint.py) --
+  the routes (`/auth/login`, `/auth/oidc/login`, `/auth/oidc/callback`,
+  `/auth/logout`).
+- [`src/webapp/auth/providers.py`](../src/webapp/auth/providers.py) --
+  the `OIDCAuthProvider` claim-to-user mapping.
+- [`tests/unit/test_oidc_auth.py`](../tests/unit/test_oidc_auth.py) --
+  46 tests covering the full auth surface.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -20,6 +20,14 @@ Complete index of all documentation in the SAM Queries project.
   - AWS credentials
   - Security best practices
 
+- **[AUTHENTICATION.md](AUTHENTICATION.md)** - Authentication & SSO guide
+  - How users sign in (UX walkthrough for non-engineers)
+  - Technical OIDC flow with Microsoft Entra
+  - Per-environment deployment matrix (local, staging, k8s)
+  - Operations: secret rotation, troubleshooting, common failures
+  - Security model and future plans
+  - Glossary of terms
+
 - **[DATABASE_SWITCHING.md](DATABASE_SWITCHING.md)** - Switching between databases
   - Local vs production
   - Switch scripts
@@ -116,6 +124,8 @@ sam-search project SCSG0001
 
 - **Set up locally?** → [LOCAL_SETUP.md](LOCAL_SETUP.md)
 - **Configure credentials?** → [CREDENTIALS.md](CREDENTIALS.md)
+- **Understand login / SSO?** → [AUTHENTICATION.md](AUTHENTICATION.md)
+- **Rotate the OIDC client secret?** → [AUTHENTICATION.md#operations](AUTHENTICATION.md#operations)
 - **Switch databases?** → [DATABASE_SWITCHING.md](DATABASE_SWITCHING.md)
 - **Use setup scripts?** → [SCRIPTS.md](SCRIPTS.md) or [scripts/setup/README.md](../scripts/setup/README.md)
 - **Fix Docker issues?** → [DOCKER_TROUBLESHOOTING.md](DOCKER_TROUBLESHOOTING.md)

--- a/docs/README-k8s.md
+++ b/docs/README-k8s.md
@@ -164,7 +164,7 @@ helm install samuel ./helm -f helm/values.yaml -n <namespace>
 
 ### How Secrets Work on CIRRUS
 
-The three `ExternalSecret` CRD resources rendered by the chart instruct ESO to pull
+The four `ExternalSecret` CRD resources rendered by the chart instruct ESO to pull
 credentials from OpenBao and create k8s Secrets automatically:
 
 | k8s Secret | OpenBao Path | Contains |
@@ -172,9 +172,53 @@ credentials from OpenBao and create k8s Secrets automatically:
 | `samuel-db-credentials` | `csg/pg-superuser` | `STATUS_DB_USERNAME`, `STATUS_DB_PASSWORD` |
 | `samuel-sam-db-credentials` | `csg/sam-readuser` | `SAM_DB_USERNAME`, `SAM_DB_PASSWORD` |
 | `samuel-jh-credentials` | `csg/jh-api-token` | `JUPYTERHUB_API_TOKEN` |
+| `samuel-oidc-credentials` | `csg/sam-oidc` | `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_ISSUER`, `FLASK_SECRET_KEY` |
 
 ESO refreshes these every hour (`refreshInterval: 1h`). You never manage these secrets
 manually on CIRRUS — rotating credentials in OpenBao is sufficient.
+
+**Force an immediate sync** (after rotating a value in OpenBao instead of waiting up to 1h):
+
+```bash
+kubectl annotate externalsecret samuel-oidc-credentials-esos -n <ns> \
+  force-sync=$(date +%s) --overwrite
+kubectl rollout restart deployment/samuel -n <ns>
+```
+
+### OIDC SSO
+
+The k8s deployment authenticates via Microsoft Entra (Azure AD) OIDC. Config:
+
+| Env var | Source | Purpose |
+|---|---|---|
+| `AUTH_PROVIDER=oidc` | `values.yaml` | Selects OIDC provider in the Flask app |
+| `OIDC_REDIRECT_URI` | `values.yaml` | Set to `https://samuel.k8s.ucar.edu/auth/oidc/callback` |
+| `OIDC_USERNAME_CLAIM` | `values.yaml` | Default `preferred_username`; SAM resolves on the part before `@` |
+| `OIDC_SCOPES` | `values.yaml` | Default `openid email profile` |
+| `FLASK_CONFIG=production` | `values.yaml` | Required for HTTPS — sets `SESSION_COOKIE_SECURE=True` |
+| `OIDC_CLIENT_ID` | `samuel-oidc-credentials` Secret | Microsoft Entra app client ID |
+| `OIDC_CLIENT_SECRET` | `samuel-oidc-credentials` Secret | Microsoft Entra app client secret |
+| `OIDC_ISSUER` | `samuel-oidc-credentials` Secret | e.g. `https://login.microsoftonline.com/{tenant}/v2.0` |
+| `FLASK_SECRET_KEY` | `samuel-oidc-credentials` Secret | Per-environment session signing key (32-byte hex) |
+
+The Entra app's reply URLs must include `https://samuel.k8s.ucar.edu/auth/oidc/callback`.
+The post-logout redirect URI `https://samuel.k8s.ucar.edu/` must also be allowlisted
+(see `infrastructure/README.md` "OIDC SSO Integration" for the IT handoff checklist).
+
+### Per-environment matrix
+
+| Deployment | URL | Auth provider | OIDC creds source | Reply URL on Entra |
+|---|---|---|---|---|
+| Local Docker Compose (`webdev`) | `http://localhost:5050` | stub (`DISABLE_AUTH=1`) | n/a | n/a |
+| Local k8s (Docker Desktop, `values-local.yaml`) | port-forwarded | stub (`DISABLE_AUTH=1`) | n/a | n/a |
+| Fargate staging | `https://sam-staging.csgsam.ucar.edu` | oidc | AWS SSM `/sam/staging/oidc-*` | `https://sam-staging.csgsam.ucar.edu/auth/oidc/callback` |
+| CIRRUS k8s (this chart) | `https://samuel.k8s.ucar.edu` | oidc | OpenBao `csg/sam-oidc` | `https://samuel.k8s.ucar.edu/auth/oidc/callback` |
+| Future: ECS production | tbd | oidc | AWS SSM `/sam/production/oidc-*` | tbd |
+| Future: k8s staging | tbd | oidc | OpenBao `csg/sam-staging-oidc` | tbd |
+
+When the per-environment Entra app strategy is adopted (separate `sam-production`
+and `sam-staging` Entra apps), only the OpenBao / SSM values change — the chart
+templates and Terraform modules stay identical.
 
 ### Accessing the App
 

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -16,7 +16,11 @@ The staging site is only accessible from the UCAR network. Connect to VPN before
 - **MySQL 8.0** on RDS with obfuscated SAM data
 - **ALB** handling HTTP traffic on port 80
 
-Auth is disabled in staging (`DISABLE_AUTH=1`, auto-login as `benkirk`).
+Auth: **OIDC SSO via Microsoft Entra** (`AUTH_PROVIDER=oidc`,
+`OIDC_REDIRECT_URI=https://sam-staging.csgsam.ucar.edu/auth/oidc/callback`).
+Credentials are pulled from AWS SSM SecureString parameters under
+`/sam/staging/oidc-*`. See [AUTHENTICATION.md](AUTHENTICATION.md) for the
+full auth model and the per-environment deployment matrix.
 
 ## Deployment
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       - name: {{ .Values.webapp.name }}
         image: {{ .Values.webapp.container.image }}
         imagePullPolicy: IfNotPresent
-        {{- if or .Values.webapp.env (or .Values.webapp.dbCredentials.enabled (or .Values.webapp.samDbCredentials.enabled .Values.webapp.jupyterhubCredentials.enabled)) }}
+        {{- if or .Values.webapp.env (or .Values.webapp.dbCredentials.enabled (or .Values.webapp.samDbCredentials.enabled (or .Values.webapp.jupyterhubCredentials.enabled .Values.webapp.oidcCredentials.enabled))) }}
         env:
           {{- range $key, $value := .Values.webapp.env }}
           - name: {{ $key }}
@@ -56,6 +56,28 @@ spec:
               secretKeyRef:
                 name: {{ .Values.webapp.name }}-jh-credentials
                 key: token
+          {{- end }}
+          {{- if .Values.webapp.oidcCredentials.enabled }}
+          - name: OIDC_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.webapp.name }}-oidc-credentials
+                key: client_id
+          - name: OIDC_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.webapp.name }}-oidc-credentials
+                key: client_secret
+          - name: OIDC_ISSUER
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.webapp.name }}-oidc-credentials
+                key: issuer
+          - name: FLASK_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.webapp.name }}-oidc-credentials
+                key: flask_secret_key
           {{- end }}
         {{- end }}
         resources:

--- a/helm/templates/external_secret.yaml
+++ b/helm/templates/external_secret.yaml
@@ -76,3 +76,39 @@ spec:
         key: {{ .Values.webapp.jupyterhubCredentials.secretPath }}
         property: {{ .Values.webapp.jupyterhubCredentials.tokenKey }}
 {{- end }}
+
+{{- if and .Values.webapp.oidcCredentials.enabled .Values.webapp.oidcCredentials.useExternalSecret }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.webapp.name }}-oidc-credentials-esos
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.webapp.name }}
+    group: {{ .Values.webapp.group }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: {{ .Values.webapp.oidcCredentials.secretStoreRefName }}
+    kind: SecretStore
+  target:
+    name: {{ .Values.webapp.name }}-oidc-credentials
+  data:
+    - secretKey: client_id
+      remoteRef:
+        key: {{ .Values.webapp.oidcCredentials.secretPath }}
+        property: {{ .Values.webapp.oidcCredentials.clientIdKey }}
+    - secretKey: client_secret
+      remoteRef:
+        key: {{ .Values.webapp.oidcCredentials.secretPath }}
+        property: {{ .Values.webapp.oidcCredentials.clientSecretKey }}
+    - secretKey: issuer
+      remoteRef:
+        key: {{ .Values.webapp.oidcCredentials.secretPath }}
+        property: {{ .Values.webapp.oidcCredentials.issuerKey }}
+    - secretKey: flask_secret_key
+      remoteRef:
+        key: {{ .Values.webapp.oidcCredentials.secretPath }}
+        property: {{ .Values.webapp.oidcCredentials.flaskSecretKeyKey }}
+{{- end }}

--- a/helm/tests/test-oidc-render.sh
+++ b/helm/tests/test-oidc-render.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Helm template render assertions for OIDC SSO + ExternalSecret wiring.
+#
+# Asserts:
+#   1. values.yaml renders the expected OIDC env vars and ExternalSecret CRD.
+#   2. values-local.yaml does NOT render the OIDC ExternalSecret (local dev
+#      uses DISABLE_AUTH=1 + stub provider; OpenBao is unavailable locally).
+#
+# Usage:
+#   bash helm/tests/test-oidc-render.sh
+#
+# Exit codes:
+#   0  all assertions passed
+#   1  one or more assertions failed (specific failure logged to stderr)
+#
+# Requires: helm v3+ in PATH.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="${SCRIPT_DIR}/.."
+RELEASE_NAME="samuel"
+
+red()   { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+assert_contains() {
+  local haystack="$1" needle="$2" msg="$3"
+  if ! printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    red "FAIL: $msg"
+    red "  expected to find: $needle"
+    return 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" msg="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    red "FAIL: $msg"
+    red "  unexpectedly found: $needle"
+    return 1
+  fi
+}
+
+if ! command -v helm >/dev/null 2>&1; then
+  red "FAIL: helm not found in PATH (needed for template rendering)"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Production render (values.yaml only)
+# ---------------------------------------------------------------------------
+
+prod_out=$(helm template "$RELEASE_NAME" "$CHART_DIR" -f "$CHART_DIR/values.yaml")
+
+assert_contains "$prod_out" "name: AUTH_PROVIDER"               "values.yaml: AUTH_PROVIDER env not rendered"
+assert_contains "$prod_out" "name: OIDC_REDIRECT_URI"           "values.yaml: OIDC_REDIRECT_URI env not rendered"
+assert_contains "$prod_out" "name: OIDC_USERNAME_CLAIM"         "values.yaml: OIDC_USERNAME_CLAIM env not rendered"
+assert_contains "$prod_out" "name: OIDC_SCOPES"                 "values.yaml: OIDC_SCOPES env not rendered"
+assert_contains "$prod_out" "name: FLASK_CONFIG"                "values.yaml: FLASK_CONFIG env not rendered"
+
+assert_contains "$prod_out" "samuel.k8s.ucar.edu/auth/oidc/callback" \
+  "values.yaml: OIDC_REDIRECT_URI value missing or wrong host"
+
+assert_contains "$prod_out" "name: OIDC_CLIENT_ID"      "values.yaml: OIDC_CLIENT_ID secretKeyRef not rendered"
+assert_contains "$prod_out" "name: OIDC_CLIENT_SECRET"  "values.yaml: OIDC_CLIENT_SECRET secretKeyRef not rendered"
+assert_contains "$prod_out" "name: OIDC_ISSUER"         "values.yaml: OIDC_ISSUER secretKeyRef not rendered"
+assert_contains "$prod_out" "name: FLASK_SECRET_KEY"    "values.yaml: FLASK_SECRET_KEY secretKeyRef not rendered"
+
+assert_contains "$prod_out" "samuel-oidc-credentials"   "values.yaml: oidc Secret name not referenced"
+assert_contains "$prod_out" "kind: ExternalSecret"      "values.yaml: ExternalSecret CRD not rendered"
+assert_contains "$prod_out" "samuel-oidc-credentials-esos" "values.yaml: oidc ExternalSecret CRD not rendered"
+assert_contains "$prod_out" "csg/sam-oidc"              "values.yaml: oidc OpenBao secretPath not rendered"
+
+# Critical security assertion: ensure the dev-only insecure key is NOT in prod render.
+assert_not_contains "$prod_out" "dev-only-insecure-key" \
+  "values.yaml: insecure FLASK_SECRET_KEY leaked into production render (S1)"
+# In prod render, FLASK_SECRET_KEY must come from secretKeyRef, never a literal value.
+assert_not_contains "$prod_out" 'value: "dev-only-insecure-key-change-for-production"' \
+  "values.yaml: insecure FLASK_SECRET_KEY value present"
+
+# ---------------------------------------------------------------------------
+# Local dev render (values.yaml + values-local.yaml)
+# ---------------------------------------------------------------------------
+
+local_out=$(helm template "$RELEASE_NAME" "$CHART_DIR" \
+  -f "$CHART_DIR/values.yaml" \
+  -f "$CHART_DIR/values-local.yaml")
+
+# Local must NOT render the OIDC ExternalSecret (no OpenBao locally).
+assert_not_contains "$local_out" "samuel-oidc-credentials-esos" \
+  "values-local.yaml: OIDC ExternalSecret rendered in local dev (oidcCredentials.enabled should be false)"
+
+# Local must NOT inject OIDC_CLIENT_ID/SECRET/ISSUER from a non-existent secret.
+assert_not_contains "$local_out" "name: OIDC_CLIENT_ID" \
+  "values-local.yaml: OIDC_CLIENT_ID secretKeyRef rendered in local dev"
+assert_not_contains "$local_out" "name: OIDC_CLIENT_SECRET" \
+  "values-local.yaml: OIDC_CLIENT_SECRET secretKeyRef rendered in local dev"
+
+# Local must use stub auth provider (defense-in-depth alongside DISABLE_AUTH=1).
+assert_contains "$local_out" 'value: "stub"' \
+  "values-local.yaml: AUTH_PROVIDER not overridden to stub for local dev"
+
+green "OK: helm renders match expectations"

--- a/helm/values-local.yaml
+++ b/helm/values-local.yaml
@@ -16,6 +16,7 @@ webapp:
   env:
     DISABLE_AUTH: "1"                     # Skip auth for local dev
     FLASK_DEBUG: "1"
+    FLASK_CONFIG: "development"           # Override production default; DEBUG=True, SESSION_COOKIE_SECURE=False (HTTP works locally)
     FLASK_SECRET_KEY: "68e6044431211026738c8c77d7696046e9d6c440b14993557c576d66e6d03fe3"
     AUDIT_ENABLED: "0"
     AUDIT_LOG_PATH: "/tmp/model_audit.log"
@@ -26,6 +27,12 @@ webapp:
     JUPYTERHUB_API_URL: "https://jupyterhub.hpc.ucar.edu"
     JUPYTERHUB_INSTANCE: "stable"
     JUPYTERHUB_CACHE_TTL: "300"
+    # Override production OIDC envs back to stub so OAuth client never registers
+    # locally (DISABLE_AUTH=1 already short-circuits auth, this is defense-in-depth).
+    AUTH_PROVIDER: "stub"
+    OIDC_REDIRECT_URI: ""
+    OIDC_USERNAME_CLAIM: ""
+    OIDC_SCOPES: ""
 
   dbCredentials:
     enabled: true
@@ -38,3 +45,6 @@ webapp:
   jupyterhubCredentials:
     enabled: true
     useExternalSecret: false
+
+  oidcCredentials:
+    enabled: false                        # Local k8s uses DISABLE_AUTH=1 stub; no OpenBao/OIDC dependency

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -21,7 +21,7 @@ webapp:
   env:
     DISABLE_AUTH: "0"                     # Explicitly disabled — must remain 0 in production
     FLASK_DEBUG: "0"
-    FLASK_SECRET_KEY: "dev-only-insecure-key-change-for-production"
+    FLASK_CONFIG: "production"            # Selects ProductionConfig (DEBUG=False, SESSION_COOKIE_SECURE=True)
     AUDIT_ENABLED: "1"
     AUDIT_LOG_PATH: "/var/log/sam/model_audit.log"
     JUPYTERHUB_API_URL: "https://jupyterhub.hpc.ucar.edu"
@@ -32,6 +32,12 @@ webapp:
     STATUS_DB_DRIVER: "postgresql"
     STATUS_DB_SERVER: "csg-postgres.k8s.ucar.edu"
     GOOGLE_CALENDAR_EMBED_URL: "https://calendar.google.com/calendar/embed?src=ucar.edu_o09r1n89tid1b8jkrvurc8qio4%40group.calendar.google.com&ctz=America%2FDenver"
+    # OIDC SSO via Microsoft Entra. Client ID/secret/issuer and FLASK_SECRET_KEY
+    # are injected via secretKeyRef from the oidcCredentials ExternalSecret below.
+    AUTH_PROVIDER: "oidc"
+    OIDC_REDIRECT_URI: "https://samuel.k8s.ucar.edu/auth/oidc/callback"
+    OIDC_USERNAME_CLAIM: "preferred_username"
+    OIDC_SCOPES: "openid email profile"
     # API keys for HPC status collectors (bcrypt hashes — safe to store here).
     # Generate with: python scripts/gen_api_key.py --username collector
     # API_KEYS_COLLECTOR: "$2b$12$replace_with_real_hash_from_gen_script"
@@ -58,3 +64,17 @@ webapp:
     secretStoreRefName: csg-ro            # Name of the SecretStore to use
     secretPath: csg/jh-api-token          # Path in OpenBao where JupyterHub credentials are stored
     tokenKey: token                       # Key in OpenBao for the token
+
+  # OIDC SSO credentials + Flask session-signing key.
+  # secretPath convention: csg/sam-{env}-oidc when multiple environments coexist.
+  # csg/sam-oidc is shorthand for the production-equivalent (samuel.k8s.ucar.edu) deployment.
+  # Future staging k8s deployment should override secretPath: csg/sam-staging-oidc in values-staging.yaml.
+  oidcCredentials:
+    enabled: true                         # Enable syncing OIDC credentials from OpenBao
+    useExternalSecret: true               # Create ExternalSecret CRD (set false to inject secrets manually)
+    secretStoreRefName: csg-ro            # Name of the SecretStore to use
+    secretPath: csg/sam-oidc              # Path in OpenBao for OIDC client + Flask session key
+    clientIdKey: client_id                # OIDC client ID (Microsoft Entra app registration)
+    clientSecretKey: client_secret        # OIDC client secret
+    issuerKey: issuer                     # OIDC issuer URL (e.g. https://login.microsoftonline.com/{tenant}/v2.0)
+    flaskSecretKeyKey: flask_secret_key   # Per-environment Flask session signing key (32-byte hex)

--- a/tests/unit/test_oidc_auth.py
+++ b/tests/unit/test_oidc_auth.py
@@ -252,6 +252,32 @@ class TestOIDCLoginRoute:
             app.config['AUTH_PROVIDER'] = 'stub'
             app.extensions.pop('oauth', None)
 
+    def test_oidc_login_uses_configured_redirect_uri(self, app):
+        """Configured OIDC_REDIRECT_URI is passed verbatim to authorize_redirect.
+
+        Locks in the contract that the per-environment redirect URI from env
+        (e.g. https://samuel.k8s.ucar.edu/auth/oidc/callback) is what Authlib
+        sends to the IdP, regardless of any X-Forwarded-* header weirdness.
+        """
+        mock_oauth = MagicMock()
+        mock_redirect_resp = MagicMock()
+        mock_redirect_resp.status_code = 302
+        mock_oauth.entra.authorize_redirect.return_value = mock_redirect_resp
+
+        configured_uri = 'https://samuel.k8s.ucar.edu/auth/oidc/callback'
+        app.extensions['oauth'] = mock_oauth
+        app.config['AUTH_PROVIDER'] = 'oidc'
+        original_redirect_uri = app.config.get('OIDC_REDIRECT_URI', '')
+        app.config['OIDC_REDIRECT_URI'] = configured_uri
+        try:
+            with app.test_client() as c:
+                c.get('/auth/oidc/login')
+                mock_oauth.entra.authorize_redirect.assert_called_once_with(configured_uri)
+        finally:
+            app.config['AUTH_PROVIDER'] = 'stub'
+            app.config['OIDC_REDIRECT_URI'] = original_redirect_uri
+            app.extensions.pop('oauth', None)
+
 
 class TestOIDCCallbackRoute:
     """Test /auth/oidc/callback token exchange and session creation."""


### PR DESCRIPTION
## Hi Ben

You asked me to look into what it'd take to extend the OIDC SSO that's already working on `sam-staging.csgsam.ucar.edu` over to our CIRRUS k8s deployment at `samuel.k8s.ucar.edu`. I treated this as a discovery / spike first to make sure the existing patterns were really the right fit, then went ahead and implemented it once it was clear they were.

**TL;DR:** The chart was the only missing piece. No new Entra app, no code rewrite, no infra rework on the Fargate side. NCAR IT needs to add one redirect URI to our existing app registration, we drop the credentials into OpenBao, then `helm upgrade` and we're done.

While in the chart I also caught a critical security issue (**S1**) and fixed it as part of this PR -- `helm/values.yaml` was shipping a hardcoded plaintext `FLASK_SECRET_KEY` (`dev-only-insecure-key-change-for-production`) that signs every session cookie on the running deployment. Now sourced from OpenBao per environment.

## Read this for the full picture

**[`docs/AUTHENTICATION.md`](https://github.com/benkirk/sam-queries/blob/feature/oidc-samuel-k8s/docs/AUTHENTICATION.md)** -- single source of truth, written for both engineers and managers. Has:

- A UX walkthrough ("what users actually see")
- A mermaid sequence diagram of the full OIDC flow
- The deployment matrix (local / Fargate staging / k8s samuel / future production)
- Operations runbook (secret rotation, common failure modes -> fixes, log locations)
- Security model (what's protected, what I'd still like to harden)
- A glossary so non-engineers can follow along

## What I discovered (the spike)

1. **The Fargate staging implementation is already production-shaped** -- Authlib + PKCE, ProxyFix wired correctly, claims->user mapping with active+unlocked enforcement, open-redirect protection on the `next` param. No code changes needed for the new deployment.
2. **The Entra app registration only needs an additional Reply URL** -- registration is multi-URL by design. We can reuse the same `client_id` / `client_secret` / `issuer`. No rotation, no new app, no scope or claim changes.
3. **The existing Helm chart was the only blocker.** It had no OIDC env vars, no `ExternalSecret` for OIDC credentials, and (separately) was shipping a hardcoded plaintext `FLASK_SECRET_KEY`. The pattern for fixing it was already in the chart -- the JupyterHub credentials block does exactly the same OpenBao -> External Secrets Operator -> `secretKeyRef` plumbing.
4. **No Fargate rework required.** The new deployment is additive. Staging keeps using SSM; samuel uses OpenBao. They never touch each other's secrets.

## What I implemented

### Helm chart
- `values.yaml`: add `AUTH_PROVIDER=oidc`, `OIDC_REDIRECT_URI=https://samuel.k8s.ucar.edu/auth/oidc/callback`, `OIDC_USERNAME_CLAIM`, `OIDC_SCOPES`, `FLASK_CONFIG=production`. New `oidcCredentials` block (mirrors `jupyterhubCredentials` shape) pointing at OpenBao path `csg/sam-oidc`.
- `values.yaml`: **REMOVE** the hardcoded insecure `FLASK_SECRET_KEY` (S1 fix). Now sourced from OpenBao via `secretKeyRef`.
- `templates/deployment.yaml`: add `OIDC_CLIENT_ID/SECRET/ISSUER` + `FLASK_SECRET_KEY` `secretKeyRef` envs.
- `templates/external_secret.yaml`: add fourth `ExternalSecret` block (`samuel-oidc-credentials-esos`).
- `values-local.yaml`: explicitly set `oidcCredentials.enabled=false`, override `AUTH_PROVIDER=stub` and `FLASK_CONFIG=development` so local Docker Desktop runs (`DISABLE_AUTH=1`) skip the OpenBao dependency entirely. Helm's deep-merge requires the explicit override.

### CI
- New `helm-render` job in `.github/workflows/ci-staging.yaml`: `helm lint`, `helm template` for both prod and local value sets, plus 13 render assertions.
- New `helm/tests/test-oidc-render.sh`: regression-guards the S1 plaintext-key fix and verifies the local override correctly suppresses the OIDC `ExternalSecret`.

### Tests
- New `test_oidc_login_uses_configured_redirect_uri` in `tests/unit/test_oidc_auth.py` -- locks in the contract that `OIDC_REDIRECT_URI` is passed verbatim to Authlib's `authorize_redirect`, regardless of any `X-Forwarded-*` header weirdness.

### Documentation
- New `docs/AUTHENTICATION.md` (~554 lines).
- `docs/INDEX.md`: link new auth doc.
- `docs/README-k8s.md`: secrets table now includes `samuel-oidc-credentials`, plus a per-environment matrix and a force-sync runbook.
- `docs/STAGING.md`: corrected outdated "auth disabled" claim.
- `.env.example`: expanded OIDC opt-in section with a note about `compose.yaml` not currently passing OIDC envs through.

## Impact on Fargate staging

**None. Staging keeps working unchanged.**

- Entra reply URLs are additive -- adding the new k8s URL leaves the existing staging URL alone.
- AWS SSM `/sam/staging/oidc-*` parameters untouched (Version 2, last modified 2026-04-14).
- No `.tf` files edited -- `terraform plan` shows clean.
- No image rebuild needed -- same code, same env-var contract.

Merging this PR will trigger `deploy-staging.yaml` (Fargate redeploy) but that does **not** affect `samuel.k8s.ucar.edu` -- the chart change is consumed only when `helm upgrade` is run on CIRRUS.

## What is there left to do?

This PR gets the chart, code, CI, and docs into shape. **Two operational steps still need to happen** before we can `helm upgrade` and have actual users sign in. Neither is in our hands alone.

### 1. NCAR IT request -- one redirect URI on the existing Entra app

This needs to go to:

> **Andrew Tamagni**
> Systems Administrator III
> OCIO -- Enterprise Infrastructure and Platforms
> The National Center for Atmospheric Research

I've drafted the email separately and will send it once you give the green light. The ask is intentionally minimal -- on the **same** Entra app registration that already has `https://sam-staging.csgsam.ucar.edu/auth/oidc/callback`, please **add** (do not replace):

- Reply URL: `https://samuel.k8s.ucar.edu/auth/oidc/callback`
- Front-channel logout URL: `https://samuel.k8s.ucar.edu/`

No new app, no new client secret, no scope or claim changes.

### 2. OpenBao secret

Write to OpenBao path `csg/sam-oidc` with four properties:

| key | value |
|---|---|
| `client_id` | copy from AWS SSM `/sam/staging/oidc-client-id` |
| `client_secret` | copy from AWS SSM `/sam/staging/oidc-client-secret` |
| `issuer` | copy from AWS SSM `/sam/staging/oidc-issuer` |
| `flask_secret_key` | freshly generated -- **do not share with staging** (`python -c 'import secrets; print(secrets.token_hex(32))'`) |

I can do this myself once I have OpenBao write access at that path, or coordinate with whoever owns the path. ~5 minutes of work either way.

Once both are done, deploy is a single `helm upgrade samuel ./helm -n <ns>` and a 6-step browser smoke test -- detailed in the docs.

## How to test

### Locally, right now (chart logic only -- no cluster, no IdP needed)

```bash
git fetch origin && git checkout feature/oidc-samuel-k8s

# Helm rendering (uses Docker if helm isn't installed)
helm lint helm/
helm template samuel helm/ -f helm/values.yaml > /dev/null
helm template samuel helm/ -f helm/values.yaml -f helm/values-local.yaml > /dev/null
bash helm/tests/test-oidc-render.sh

# OIDC unit tests
docker compose --profile test up -d mysql-test
export SAM_TEST_DB_URL='mysql+pymysql://root:root@127.0.0.1:3307/sam'
source etc/config_env.sh
pytest tests/unit/test_oidc_auth.py -v
# Expected: 46 passed
```

The webapp itself still runs locally with `DISABLE_AUTH=1` auto-login (Docker Compose) -- nothing about everyday local dev changes.

### Fargate staging (sanity check after merge)

The merge will redeploy `sam-staging.csgsam.ucar.edu`. From the UCAR VPN:

```bash
open https://sam-staging.csgsam.ucar.edu
```

Click **Sign in with UCAR SSO** -> normal Entra flow -> dashboard. If anything looks off, rollback is `git revert` + the deploy workflow re-runs.

### `samuel.k8s.ucar.edu` (after IT + OpenBao steps)

```bash
helm upgrade samuel ./helm -n <namespace>
```

Then 6-step browser smoke test (full version with kubectl commands in [`docs/AUTHENTICATION.md#operations`](https://github.com/benkirk/sam-queries/blob/feature/oidc-samuel-k8s/docs/AUTHENTICATION.md#operations)):

1. `kubectl get externalsecret samuel-oidc-credentials-esos` -> `SecretSyncedReady=True`
2. `kubectl get secret samuel-oidc-credentials -o json | jq '.data | keys'` -> 4 keys
3. `kubectl exec deploy/samuel -- env | grep -E '^(AUTH_PROVIDER|OIDC_|FLASK_CONFIG|FLASK_SECRET_KEY=)'`
4. `curl -sI https://samuel.k8s.ucar.edu/auth/login | grep -i 'Set-Cookie'` -> has `Secure; HttpOnly; SameSite=Lax`
5. End-to-end SSO in browser -> dashboard authenticated as the SSO user
6. Logout -> redirects through Entra end-session -> back to status dashboard

If any step fails, the **Common failure modes** table in the doc maps symptoms -> fixes.

## Out of scope (separate follow-up issues to open)

- Register a separate `sam-production` Entra app before `infrastructure/production/` comes online (per-env blast-radius isolation).
- Set `FLASK_CONFIG=production` in `infrastructure/staging/ecs.tf` when HTTPS lands on Fargate staging.
- Add `mock-oauth2-server` / `dexidp/dex` integration tests for the full OIDC round-trip.
- `session.clear()` on logout (S8 hardening).

## Verification done locally

- [x] `helm lint helm/` -- passes
- [x] `helm template` (prod values) -- `FLASK_SECRET_KEY` from `secretKeyRef`, no plaintext leak
- [x] `helm template` (prod + local values) -- local correctly suppresses OIDC `ExternalSecret`, uses `AUTH_PROVIDER=stub`
- [x] `bash helm/tests/test-oidc-render.sh` -- 13/13 assertions pass
- [x] `pytest tests/unit/test_oidc_auth.py` -- 46 passed

## CI on this PR will exercise

- [ ] TruffleHog secret scan
- [ ] MegaLinter
- [ ] `terraform fmt -check -recursive` (no `.tf` files touched)
- [ ] New `helm-render` job
- [ ] Full pytest via Docker Compose

## Rollback

`git revert` on this PR. If something subtle slips through after deploy: set `webapp.oidcCredentials.enabled: false` in `values.yaml` (chart will drop the OIDC envs), or temporarily flip `AUTH_PROVIDER` back to `stub` -- both are quick disables that don't require coordinated infra changes.
