### PR TITLE
Fix API key auth on samuel.k8s.ucar.edu (set API_KEYS_COLLECTOR in Helm)

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -40,7 +40,7 @@ webapp:
     OIDC_SCOPES: "openid email profile"
     # API keys for HPC status collectors (bcrypt hashes — safe to store here).
     # Generate with: python scripts/gen_api_key.py --username collector
-    # API_KEYS_COLLECTOR: "$2b$12$replace_with_real_hash_from_gen_script"
+    API_KEYS_COLLECTOR: "$2b$12$X8NQvOUvyrj80Ud3N6Y.0uZs70ZC6lJYy/zfka/v7uQQFKJhds0b2"
 
   dbCredentials:
     enabled: true                         # Enable syncing credentials from OpenBao


### PR DESCRIPTION
## Summary

Restores Basic Auth on `/api/v1/*` against samuel.k8s.ucar.edu, which broke after PR #216 switched the deployment to `FLASK_CONFIG=production`.

## Root cause

- The `collector` API key bcrypt hash is hardcoded on `DevelopmentConfig.API_KEYS` (`src/webapp/config.py:74-76`).
- `ProductionConfig` does **not** override `API_KEYS`; it inherits the base `SAMWebappConfig.API_KEYS`, which is built from `API_KEYS_*` env vars only.
- PR #216 added `FLASK_CONFIG: "production"` to `helm/values.yaml`, but the matching `API_KEYS_COLLECTOR` env var was still commented out — so `app.config['API_KEYS']` was empty on the cluster and every Basic Auth request hit the `Invalid credentials` branch in `src/webapp/utils/api_auth.py:135-140`.

Symptom (before this PR):

```
$ python utils/parity/check_legacy_apis.py
ERROR: GET https://samuel.k8s.ucar.edu/api/v1/directory_access/ returned HTTP 401: {"error":"Invalid credentials"}
```

## Change

One line in `helm/values.yaml`: uncomment `API_KEYS_COLLECTOR` and paste the bcrypt hash already committed at `src/webapp/config.py:75`. The Deployment env block already iterates `range $key, $value := .Values.webapp.env`, so no template change is needed.

## Test plan

- [ ] `helm template ./helm | grep API_KEYS_COLLECTOR` shows the env var on the Deployment
- [ ] After deploy: `kubectl exec deploy/samuel -- env | grep API_KEYS_COLLECTOR` prints the hash
- [ ] `STATUS_API_USER=collector STATUS_API_KEY=… SAM_NEW_API_USER=collector SAM_NEW_API_PASS=… python utils/parity/check_legacy_apis.py` returns 200 on `/api/v1/directory_access/` and completes the parity diff
- [ ] Browser OIDC login at https://samuel.k8s.ucar.edu/ still works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)