### PR TITLE
status_dashboard: system-wide user/project chart on landing page

### DIFF
--- a/src/system_status/queries/__init__.py
+++ b/src/system_status/queries/__init__.py
@@ -22,7 +22,7 @@ from system_status.models import (
 
 from .user_proj_queues import (  # noqa: F401
     get_latest_user_proj_queue_snapshot,
-    get_user_proj_queue_timeseries,
+    get_user_proj_timeseries,
 )
 
 

--- a/src/system_status/queries/user_proj_queues.py
+++ b/src/system_status/queries/user_proj_queues.py
@@ -76,6 +76,13 @@ def _resolve_queue_id(session: Session, system: str, queue_name: str) -> Optiona
     ).scalar_one_or_none()
 
 
+def _resolve_system_id(session: Session, system: str) -> Optional[int]:
+    """Return the system_id for ``system``, or ``None`` if absent."""
+    return session.execute(
+        select(System.system_id).where(System.name == system)
+    ).scalar_one_or_none()
+
+
 def get_latest_user_proj_queue_snapshot(
     session: Session,
     *,
@@ -155,11 +162,11 @@ def get_latest_user_proj_queue_snapshot(
     ]
 
 
-def get_user_proj_queue_timeseries(
+def get_user_proj_timeseries(
     session: Session,
     *,
     system: str,
-    queue_name: str,
+    queue_name: Optional[str] = None,
     start_date: datetime,
     end_date: datetime,
     state: str,
@@ -167,7 +174,17 @@ def get_user_proj_queue_timeseries(
     group_by: str,
     top_n: int = 15,
 ) -> Dict[str, Any]:
-    """Top-N + Others time series for one queue, ranked by peak in window.
+    """Top-N + Others time series for one queue, or one system, ranked
+    by peak in window.
+
+    Scope is determined by ``queue_name``:
+
+    - ``queue_name='main'`` → filter on a single ``(system, queue)``,
+      one ``UserProjQueueStatus`` row per (timestamp, user, project)
+      already aggregated to that queue.
+    - ``queue_name=None`` → sum across **all** queues for ``system``,
+      so per-tick values reflect the user/project's load on the
+      whole system.
 
     `(state, metric)` selects the underlying column via
     ``_STATE_METRIC_TO_COLUMN``:
@@ -228,13 +245,20 @@ def get_user_proj_queue_timeseries(
     metric_label = _label_for(state, metric)
     group_by_label = 'User' if group_by == 'user' else 'Project code'
 
-    queue_id = _resolve_queue_id(session, system, queue_name)
     empty = {
         'dates': [], 'series': [],
         'state': state, 'metric': metric, 'metric_label': metric_label,
         'group_by': group_by, 'group_by_label': group_by_label,
     }
-    if queue_id is None:
+
+    # Resolve scope: single queue if queue_name given, else system-wide.
+    if queue_name is not None:
+        scope_id = _resolve_queue_id(session, system, queue_name)
+        scope_filter = UserProjQueueStatus.queue_id == scope_id
+    else:
+        scope_id = _resolve_system_id(session, system)
+        scope_filter = UserProjQueueStatus.system_id == scope_id
+    if scope_id is None:
         return empty
 
     metric_col = getattr(UserProjQueueStatus, column_name)
@@ -249,8 +273,9 @@ def get_user_proj_queue_timeseries(
         )
 
     # Sum the metric within each (timestamp, label) bucket — multiple
-    # (user, project) rows may collapse to a single series row when
-    # grouping by just one of those keys.
+    # (user, project, queue) rows collapse to a single series row when
+    # grouping by just one of those keys (and, in system-wide scope,
+    # across all queues for that system).
     from sqlalchemy import func
     rows = session.execute(
         select(
@@ -260,7 +285,7 @@ def get_user_proj_queue_timeseries(
         )
         .join(join_target, join_cond)
         .where(
-            UserProjQueueStatus.queue_id == queue_id,
+            scope_filter,
             UserProjQueueStatus.timestamp >= start_date,
             UserProjQueueStatus.timestamp <= end_date,
         )

--- a/src/webapp/dashboards/status/blueprint.py
+++ b/src/webapp/dashboards/status/blueprint.py
@@ -82,6 +82,22 @@ def index():
     # Get upcoming reservations
     reservations = status_queries.get_upcoming_reservations(session)
 
+    # Gate the new system-wide user/project chart cards (rendered in
+    # derecho.html / casper.html) on VIEW_SYSTEM_STATUS_USER_INFO.
+    # Same flag pattern as the queue_history drill-down view.
+    from webapp.utils.rbac import has_permission
+    can_view_user_info = (
+        current_user.is_authenticated
+        and has_permission(current_user, Permission.VIEW_SYSTEM_STATUS_USER_INFO)
+    )
+
+    # Default the landing-page chart window to 7 days when no
+    # ?hours= override is in the URL — matches the drill-down default
+    # so the time_range_picker on each chart card reads sensibly on
+    # first load. selected_hours stays None when absent (other code
+    # paths that introspect it still get the same signal).
+    chart_hours = selected_hours if selected_hours is not None else 168
+
     return render_template(
         'dashboards/status/dashboard.html',
         user=current_user,
@@ -100,6 +116,8 @@ def index():
         google_calendar_embed_url=current_app.config.get('GOOGLE_CALENDAR_EMBED_URL', ''),
         now=datetime.now(),
         selected_hours=selected_hours,
+        can_view_user_info=can_view_user_info,
+        chart_hours=chart_hours,
     )
 
 
@@ -290,16 +308,15 @@ def queue_history(system, queue_name):
     )
 
 
-@bp.route('/htmx/queue-history/<system>/<queue_name>/user-proj-chart')
-@login_required
-@require_permission(Permission.VIEW_SYSTEM_STATUS_USER_INFO)
-def htmx_user_proj_chart(system, queue_name):
-    """Render one of the six (group_by × metric) stacked-area charts.
+def _render_user_proj_chart(*, system, queue_name, endpoint_name, endpoint_kwargs):
+    """Shared body for the queue-scoped and system-scoped chart endpoints.
 
-    Used by selector buttons in the queue-history drill-down. Time
-    window comes from the same ``hours`` param the parent chart uses,
-    so toggling the time-range picker re-fires this endpoint via
-    ``hx-include`` and the two charts stay in sync.
+    Reads selector params from ``request.args`` (``state``, ``metric``,
+    ``group_by``, ``hours``), validates + clamps invalid combos, calls
+    the aggregator (queue-scoped if ``queue_name`` set, else
+    system-wide), and renders the chart partial. ``endpoint_name`` and
+    ``endpoint_kwargs`` are passed to the partial so its selector
+    buttons emit URLs against the right route.
     """
     valid_states = ('running', 'pending', 'held')
     valid_metrics = ('jobs', 'cores', 'gpus', 'nodes')
@@ -338,7 +355,7 @@ def htmx_user_proj_chart(system, queue_name):
     end_date = datetime.now()
     start_date = end_date - timedelta(hours=hours)
 
-    timeseries = status_queries.get_user_proj_queue_timeseries(
+    timeseries = status_queries.get_user_proj_timeseries(
         db.session,
         system=system,
         queue_name=queue_name,
@@ -363,6 +380,43 @@ def htmx_user_proj_chart(system, queue_name):
         group_by_label=timeseries.get('group_by_label', group_by),
         top_n=top_n,
         chart_svg=chart_svg,
+        endpoint_name=endpoint_name,
+        endpoint_kwargs=endpoint_kwargs,
+    )
+
+
+@bp.route('/htmx/queue-history/<system>/<queue_name>/user-proj-chart')
+@login_required
+@require_permission(Permission.VIEW_SYSTEM_STATUS_USER_INFO)
+def htmx_user_proj_chart(system, queue_name):
+    """Render the user/project chart scoped to one queue.
+
+    Used by selector buttons in the queue-history drill-down.
+    """
+    return _render_user_proj_chart(
+        system=system,
+        queue_name=queue_name,
+        endpoint_name='status_dashboard.htmx_user_proj_chart',
+        endpoint_kwargs={'system': system, 'queue_name': queue_name},
+    )
+
+
+@bp.route('/htmx/system/<system>/user-proj-chart')
+@login_required
+@require_permission(Permission.VIEW_SYSTEM_STATUS_USER_INFO)
+def htmx_user_proj_chart_system(system):
+    """Render the user/project chart summed across all queues for ``system``.
+
+    Used by the chart card on the system landing page (Derecho /
+    Casper tabs of the status dashboard). Same selector behaviour as
+    the per-queue endpoint, but the aggregator filters on system_id
+    rather than queue_id.
+    """
+    return _render_user_proj_chart(
+        system=system,
+        queue_name=None,
+        endpoint_name='status_dashboard.htmx_user_proj_chart_system',
+        endpoint_kwargs={'system': system},
     )
 
 

--- a/src/webapp/templates/dashboards/status/casper.html
+++ b/src/webapp/templates/dashboards/status/casper.html
@@ -102,6 +102,11 @@
         {{ queues.queue_table(casper_queues, show_gpus=true, system='casper', hours=selected_hours) }}
         {% endif %}
 
+        {% if can_view_user_info %}
+        {% set _chart_system = 'casper' %}
+        {% include 'dashboards/status/partials/system_user_proj_chart_card.html' %}
+        {% endif %}
+
         <!-- Reservations -->
         {% set casper_reservations = reservations|selectattr('system_name', 'equalto', 'casper')|list %}
         {% if casper_reservations %}

--- a/src/webapp/templates/dashboards/status/derecho.html
+++ b/src/webapp/templates/dashboards/status/derecho.html
@@ -65,6 +65,17 @@
         {{ queues.queue_table(derecho_queues, show_gpus=true, system='derecho', hours=selected_hours) }}
         {% endif %}
 
+        {% if can_view_user_info %}
+        {# User/project load chart, summed across all queues for derecho.
+           Time-range picker lives inline in this card's header — clicking
+           a preset reloads the landing page with ?hours=N (the existing
+           passthrough); the casper card's picker emits the same param
+           so toggling either updates both. Tab persistence keeps the
+           operator on this tab across reloads. #}
+        {% set _chart_system = 'derecho' %}
+        {% include 'dashboards/status/partials/system_user_proj_chart_card.html' %}
+        {% endif %}
+
         <!-- Reservations -->
         {% set derecho_reservations = reservations|selectattr('system_name', 'equalto', 'derecho')|list %}
         {% if derecho_reservations %}

--- a/src/webapp/templates/dashboards/status/partials/system_user_proj_chart_card.html
+++ b/src/webapp/templates/dashboards/status/partials/system_user_proj_chart_card.html
@@ -1,0 +1,42 @@
+{# System-wide user/project load chart card.
+
+   Included by derecho.html and casper.html (one card per system tab).
+   The including template sets `_chart_system` to 'derecho' / 'casper'.
+   `chart_hours` and `can_view_user_info` come from the index() route
+   context — the includer is already inside an `if can_view_user_info`
+   guard, so this partial doesn't re-check.
+
+   Picker is a 7-button strip in the card header. Each button is a
+   plain link back to the landing page with ?hours=N. The existing
+   `selected_hours` passthrough on index() picks that up; tab
+   persistence (nav-view-persistence.js) keeps the operator on this
+   tab across reloads. The chart endpoint is HTMX-fetched on card
+   load with the resolved `chart_hours` so initial render matches the
+   active picker preset. #}
+<div class="card mb-4">
+    <div class="card-header d-flex justify-content-between align-items-center flex-wrap gap-2">
+        <h6 class="mb-0">
+            <i class="fas fa-chart-area"></i> User / project load over time
+            <span class="text-muted fw-normal small ms-2">all queues, top 15 + Others</span>
+        </h6>
+        <div class="btn-group btn-group-sm" role="group" aria-label="Time range">
+            {% for label, h in [('6h', 6), ('12h', 12), ('1d', 24), ('3d', 72), ('7d', 168), ('14d', 336), ('30d', 720)] %}
+            <a href="{{ url_for('status_dashboard.index', hours=h) }}"
+               class="btn {% if chart_hours == h %}btn-secondary active{% else %}btn-outline-secondary{% endif %}">{{ label }}</a>
+            {% endfor %}
+        </div>
+    </div>
+    <div class="card-body">
+        <div hx-get="{{ url_for('status_dashboard.htmx_user_proj_chart_system',
+                                system=_chart_system,
+                                hours=chart_hours,
+                                state='running', metric='jobs',
+                                group_by='user') }}"
+             hx-trigger="load"
+             hx-swap="innerHTML">
+            <div class="text-center text-muted py-5">
+                <i class="fas fa-spinner fa-spin"></i> Loading chart…
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/webapp/templates/dashboards/status/partials/user_proj_chart.html
+++ b/src/webapp/templates/dashboards/status/partials/user_proj_chart.html
@@ -1,5 +1,4 @@
-{# Stacked-area chart fragment for the queue-history drill-down.
-   Returned by status_dashboard.htmx_user_proj_chart.
+{# Stacked-area chart fragment for the user/project queue load chart.
 
    Three btn-groups (group_by, state, metric) live INSIDE the swap
    target so each click re-renders both the buttons (with the new
@@ -11,9 +10,15 @@
    for state='running' — when state is pending or held the Nodes
    button is disabled, and a state button that switches AWAY from
    running while the current metric is `nodes` clamps metric back to
-   `cores` in its hx-get URL. #}
-{% set _kwargs = {
-    'system': system, 'queue_name': queue_name,
+   `cores` in its hx-get URL.
+
+   Used by two endpoints:
+     - status_dashboard.htmx_user_proj_chart        (per-queue, drill-down)
+     - status_dashboard.htmx_user_proj_chart_system (per-system, landing)
+   The route passes `endpoint_name` + `endpoint_kwargs` so the partial
+   builds selector URLs against whichever endpoint owns it. `queue_name`
+   is None in the system-wide case; the title suffix omits it. #}
+{% set _selector_kwargs = {
     'group_by': group_by, 'state': state, 'metric': metric, 'hours': hours,
 } %}
 <div id="upq-chart-inner">
@@ -24,8 +29,8 @@
                 {% for opt_val, opt_lbl in [('user', 'User'), ('project', 'Project code')] %}
                 <button type="button"
                         class="btn btn-{% if group_by == opt_val %}primary{% else %}outline-primary{% endif %}"
-                        hx-get="{{ url_for('status_dashboard.htmx_user_proj_chart',
-                                           **dict(_kwargs, group_by=opt_val)) }}"
+                        hx-get="{{ url_for(endpoint_name,
+                                           **dict(endpoint_kwargs, **dict(_selector_kwargs, group_by=opt_val))) }}"
                         hx-target="#upq-chart-inner"
                         hx-swap="outerHTML">
                     {{ opt_lbl }}
@@ -43,8 +48,8 @@
                 {% set _state_metric = 'cores' if (metric == 'nodes' and opt_val != 'running') else metric %}
                 <button type="button"
                         class="btn btn-{% if state == opt_val %}primary{% else %}outline-primary{% endif %}"
-                        hx-get="{{ url_for('status_dashboard.htmx_user_proj_chart',
-                                           **dict(_kwargs, state=opt_val, metric=_state_metric)) }}"
+                        hx-get="{{ url_for(endpoint_name,
+                                           **dict(endpoint_kwargs, **dict(_selector_kwargs, state=opt_val, metric=_state_metric))) }}"
                         hx-target="#upq-chart-inner"
                         hx-swap="outerHTML">
                     {{ opt_lbl }}
@@ -68,8 +73,8 @@
                           disabled
                           title="Nodes only available for state=Running"
                         {% else %}
-                          hx-get="{{ url_for('status_dashboard.htmx_user_proj_chart',
-                                             **dict(_kwargs, metric=opt_val)) }}"
+                          hx-get="{{ url_for(endpoint_name,
+                                             **dict(endpoint_kwargs, **dict(_selector_kwargs, metric=opt_val))) }}"
                           hx-target="#upq-chart-inner"
                           hx-swap="outerHTML"
                         {% endif %}>
@@ -83,7 +88,7 @@
     <div class="chart-container">
         <h6 class="text-center fw-bold mb-2">
             Top {{ top_n }} {{ group_by_label }}s by {{ metric_label }}
-            <span class="text-muted fw-normal">— {{ system|upper }} · {{ queue_name }}</span>
+            <span class="text-muted fw-normal">— {{ system|upper }}{% if queue_name %} · {{ queue_name }}{% endif %}</span>
         </h6>
         {{ chart_svg | safe }}
     </div>


### PR DESCRIPTION
## Summary

Brings the user/project stacked-area chart shipped in #225 to the **Derecho and Casper landing-page tabs** of the system_status dashboard, summed across all queues for that system. Operators can now answer *"for the past N hours, who has been loading Derecho?"* without drilling into a specific queue.

The chart card sits under the Queue Status table in each system tab, gated on `Permission.VIEW_SYSTEM_STATUS_USER_INFO` (the same permission as the per-queue drill-down chart). A 7-button time-range picker (6h … 30d) lives inline in each card's header.

## What changed

### Refactor for reuse

The Phase B chart (#225) was queue-specific in three places. Each was widened to handle either scope:

| Layer | Before | After |
|---|---|---|
| Query helper | `get_user_proj_queue_timeseries(... queue_name)` | `get_user_proj_timeseries(... queue_name=None)` — when `None`, filters on `system_id` instead of `queue_id`. Existing GROUP BY on `(timestamp, label)` already collapses across queues correctly. |
| Route | One route, body inline | Body extracted to `_render_user_proj_chart(system, queue_name, endpoint_name, endpoint_kwargs)`. Two endpoints call it: `htmx_user_proj_chart` (queue scope) and new `htmx_user_proj_chart_system` (system scope). |
| Partial | Hard-coded `url_for('...htmx_user_proj_chart', ..., queue_name=queue_name)` | Reads `endpoint_name` + `endpoint_kwargs` from context. Title suffix is conditional: `— DERECHO · main` (queue) vs `— DERECHO` (system). |

The matplotlib chart renderer was already pure (no scope coupling) — no changes needed there.

### Landing page

- `index()` route now computes `can_view_user_info` (mirrors the `queue_history` pattern) and `chart_hours` (defaults to 168h when the URL has no `?hours=`).
- New thin partial `system_user_proj_chart_card.html` included by both `derecho.html` and `casper.html` with `_chart_system` set to the relevant system. Each include is wrapped in `{% if can_view_user_info %}` so unauthorised users see no card and no picker — landing page otherwise unchanged.
- Each card's picker writes the same `?hours=N` query param so toggling either re-renders both charts on next page reload. Tab persistence (`nav-view-persistence.js`) keeps the operator on the active tab.

## Test plan

- [ ] As `benkirk` (full perms), visit `/status/`. Both Derecho and Casper tabs show a new chart card under Queue Status, picker in the header.
- [ ] Default chart shows top-15 users by Running jobs across all queues for that system, last 7 days.
- [ ] Cycle `(state × metric × group_by)` selectors — single HTMX swap each click. Title reads e.g. `Top 15 Users by Pending cores — DERECHO` (no queue suffix).
- [ ] Click 24h on either picker → page reloads, stays on current tab, both system charts now show 24h data.
- [ ] Per-queue drill-down (`/status/queue-history/...`) still works exactly as before — title still reads e.g. `... — DERECHO · main`.
- [ ] As a user without `VIEW_SYSTEM_STATUS_USER_INFO`: landing page loads, both new chart cards absent, queue tables unchanged.
- [ ] Hit `/status/htmx/system/derecho/user-proj-chart` directly without permission → 403.
- [ ] Reconciliation: for one tick, sum a column across queue-scoped data and compare to the system-scoped query result — must match modulo any tick-level row gaps.
- [ ] `pytest` green (run by maintainer per CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)