### PR TITLE
status_dashboard: scope-unique chart DOM id (fix Casper buttons)

### DIFF
--- a/src/webapp/dashboards/status/blueprint.py
+++ b/src/webapp/dashboards/status/blueprint.py
@@ -368,6 +368,15 @@ def _render_user_proj_chart(*, system, queue_name, endpoint_name, endpoint_kwarg
     )
     chart_svg = generate_user_proj_stacked_area(timeseries)
 
+    # Two of these cards render on the landing page (one per system
+    # tab), so the chart wrapper div needs a scope-unique id —
+    # otherwise the second card's selector-button hx-target=#... lookup
+    # finds the first card's div and swaps the wrong one.
+    if queue_name is not None:
+        chart_dom_id = f'upq-chart-{system}-{queue_name}'
+    else:
+        chart_dom_id = f'upq-chart-{system}'
+
     return render_template(
         'dashboards/status/partials/user_proj_chart.html',
         system=system,
@@ -382,6 +391,7 @@ def _render_user_proj_chart(*, system, queue_name, endpoint_name, endpoint_kwarg
         chart_svg=chart_svg,
         endpoint_name=endpoint_name,
         endpoint_kwargs=endpoint_kwargs,
+        chart_dom_id=chart_dom_id,
     )
 
 

--- a/src/webapp/templates/dashboards/status/partials/user_proj_chart.html
+++ b/src/webapp/templates/dashboards/status/partials/user_proj_chart.html
@@ -21,7 +21,7 @@
 {% set _selector_kwargs = {
     'group_by': group_by, 'state': state, 'metric': metric, 'hours': hours,
 } %}
-<div id="upq-chart-inner">
+<div id="{{ chart_dom_id }}">
     <div class="d-flex flex-wrap gap-3 mb-3 align-items-center">
         <div>
             <label class="form-label small text-muted mb-1 me-2">Group by</label>
@@ -31,7 +31,7 @@
                         class="btn btn-{% if group_by == opt_val %}primary{% else %}outline-primary{% endif %}"
                         hx-get="{{ url_for(endpoint_name,
                                            **dict(endpoint_kwargs, **dict(_selector_kwargs, group_by=opt_val))) }}"
-                        hx-target="#upq-chart-inner"
+                        hx-target="#{{ chart_dom_id }}"
                         hx-swap="outerHTML">
                     {{ opt_lbl }}
                 </button>
@@ -50,7 +50,7 @@
                         class="btn btn-{% if state == opt_val %}primary{% else %}outline-primary{% endif %}"
                         hx-get="{{ url_for(endpoint_name,
                                            **dict(endpoint_kwargs, **dict(_selector_kwargs, state=opt_val, metric=_state_metric))) }}"
-                        hx-target="#upq-chart-inner"
+                        hx-target="#{{ chart_dom_id }}"
                         hx-swap="outerHTML">
                     {{ opt_lbl }}
                 </button>
@@ -75,7 +75,7 @@
                         {% else %}
                           hx-get="{{ url_for(endpoint_name,
                                              **dict(endpoint_kwargs, **dict(_selector_kwargs, metric=opt_val))) }}"
-                          hx-target="#upq-chart-inner"
+                          hx-target="#{{ chart_dom_id }}"
                           hx-swap="outerHTML"
                         {% endif %}>
                     {{ opt_lbl }}

--- a/src/webapp/templates/dashboards/status/queue_history.html
+++ b/src/webapp/templates/dashboards/status/queue_history.html
@@ -111,7 +111,9 @@
     <div class="card-body">
         {# Initial load: HTMX fetches the chart partial (which carries
            its own selector buttons). Subsequent button clicks replace
-           #upq-chart-inner with a freshly-rendered partial. #}
+           the partial's outer div with a freshly-rendered partial.
+           The id is scope-unique (e.g. upq-chart-derecho-main) so the
+           landing-page system cards don't collide on hx-target. #}
         <div hx-get="{{ url_for('status_dashboard.htmx_user_proj_chart',
                                 system=system, queue_name=queue_name,
                                 hours=hours, state='running', metric='jobs',


### PR DESCRIPTION
The user/project chart partial used a hard-coded `id="upq-chart-inner"` for both its outer div and the matching `hx-target` on every selector button. With the landing page rendering the card twice (once per system tab), both Derecho and Casper got the same id — clicking any selector button on the Casper card resolved `hx-target="#upq-chart-inner"` to Derecho's div and swapped the wrong card.

Fix: derive `chart_dom_id` per scope inside `_render_user_proj_chart` and pass it to the partial. Format:

  - queue scope:  `upq-chart-<system>-<queue_name>`
  - system scope: `upq-chart-<system>`

The partial uses the same id on both its outer div and every button's `hx-target`, so swaps always land on the originating card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)