### PR TITLE
system_status: time-integrated core/GPU/node-hours from user_proj_queue_status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,11 @@ check-db-vs-orms: ## Audit prod DB schema vs ORM models — runs check_db_drift 
 	$(config_env) && source etc/config_env.sh && \
 	    python3 scripts/check_db_drift.py
 
+validate_user_proj_usage: ## Reconcile + benchmark get_user_proj_usage against local docker MySQL (overrides STATUS_DB_DRIVER/SERVER for host access)
+	$(config_env) && source etc/config_env.sh && \
+	    STATUS_DB_DRIVER=mysql STATUS_DB_SERVER=127.0.0.1 \
+	    python3 scripts/validate_user_proj_usage.py
+
 docker-build: ## Build docker containers
 	@docker compose build
 

--- a/containers/collectors/Dockerfile
+++ b/containers/collectors/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3
 
-RUN 'FILE1' cat > /usr/bin/list-large-directories && \
-    chmod a+rx /usr/bin/list-large-directories
+RUN echo "Creating cleanup scripts" && \
+    <<'FILE1' cat > /usr/bin/list-large-directories && \
+    chmod a+rx /usr/bin/list-large-directories && \
+    echo "Done"
 #!/bin/bash
 
 dirs="/home /mnt /tmp /opt /usr /var /container"

--- a/containers/webapp/Dockerfile
+++ b/containers/webapp/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && pip install --upgrade pip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN echo "Creatning default .env" && \
+RUN echo "Creating default .env" && \
     <<'FILE1' cat > /.env && \
     <<'FILE2' cat > /usr/bin/list-large-directories && \
     chmod a+rx /usr/bin/list-large-directories && \

--- a/docs/plans/USER_PROJ_QUEUE_HISTORY-usage.md
+++ b/docs/plans/USER_PROJ_QUEUE_HISTORY-usage.md
@@ -236,9 +236,3 @@ anyway). Keeping the integration in numpy lands once, runs anywhere.
    plausibility check (won't match exactly — billing uses real
    start/end, we use 5-min snapshots — but should be within a few %).
 
-## Open question for the user
-
-I went with **left-step rectangle** integration over trapezoidal. If you
-have a strong opinion (or remember why billing uses one or the other for
-similar cases), say so before we implement — flipping later means
-re-validating reconciliation tests.

--- a/docs/plans/USER_PROJ_QUEUE_HISTORY-usage.md
+++ b/docs/plans/USER_PROJ_QUEUE_HISTORY-usage.md
@@ -1,0 +1,244 @@
+# Plan — `src/system_status/queries/user_proj_usage.py`
+
+## Context
+
+The Phase B work (PR #224, live since 2026-05-04) gives us
+`user_proj_queue_status` — a per-user / per-project / per-queue rollup
+table sampled every ~5 min. So far we use it only for instantaneous /
+timeseries displays (`get_latest_user_proj_queue_snapshot`,
+`get_user_proj_timeseries` in `src/system_status/queries/user_proj_queues.py`).
+
+The next natural question — and what this module addresses — is
+**integrated** consumption: "how many core-hours / GPU-hours / node-hours
+did user *u* on project *p* burn on system *s* between *T₁* and *T₂*?"
+
+Two non-trivialities the design must respect (per the user):
+
+1. **Tick interval is not 5 min by assumption.** Derive `dt` from the
+   actual delta between successive observed timestamps. Collectors stall,
+   reschedule, or get reconfigured; hard-coding 300 s would silently
+   mis-bill any window that crosses such an event.
+2. **Sparse rows.** A `(user, project, queue)` row is only emitted when
+   that tuple has ≥1 job at that tick. If a user's jobs end, the row
+   simply disappears — there is no explicit zero. Naïve carry-forward
+   would attribute load forever; the integration must treat absence at a
+   tick as **0 cores / 0 gpus** for that tuple at that tick.
+
+No existing module does this — SAM's billing path (`comp_charge_summary`,
+`hpc_charge_summary`) is job-record based with explicit start/end times,
+fundamentally different from snapshot integration. Build fresh.
+
+## Design
+
+### Integration scheme — left-step (rectangle) rule
+
+For each `(user, project, queue)` tuple, given observations
+`(t₀, x₀), (t₁, x₁), …, (t_n, x_n)` of `cores_allocated` (and same for
+`gpus_allocated`, `nodes_allocated`), aligned to the **global tick
+timeline** (see below), with absent ticks filled as `x = 0`:
+
+```
+core_hours = Σᵢ xᵢ · (tᵢ₊₁ − tᵢ) / 3600   for i in 0..n-1
+```
+
+Rationale for **left-step**, not trapezoidal:
+- Each row is a discrete observation of *current* allocation. Between
+  ticks, cores don't ramp linearly — they jump as jobs start/end. The
+  step interpretation ("xᵢ cores were allocated from tᵢ until we next
+  sampled at tᵢ₊₁") matches reality better than averaging two adjacent
+  samples.
+- Left-step composes cleanly with the absence-as-zero rule: if a tuple
+  appears at tᵢ with 128 cores and is absent at tᵢ₊₁, it contributes
+  `128 · (tᵢ₊₁ − tᵢ)` to that row's window — i.e., it gets charged for
+  one tick worth of holding 128 cores, then vanishes. Trapezoidal would
+  charge `64 · dt` (averaging with the 0), which under-counts.
+- Symmetric to how the dashboard already treats these snapshots in
+  `get_user_proj_timeseries`: each tick stands on its own.
+
+Last tick in the window has no successor — we skip its contribution
+(equivalent: it contributes `0 · 0 = 0`). Document this; for typical
+windows (hour+) the boundary effect is negligible.
+
+### Tick timeline source
+
+Use **the parent system status table** (`DerechoStatus` /
+`CasperStatus`) for `SELECT DISTINCT timestamp WHERE timestamp IN
+[start, end] ORDER BY timestamp`. These rows are written every collector
+tick *regardless of whether any user had jobs*, so they are the canonical
+"did we sample at this moment" record. (`user_proj_queue_status` would
+miss ticks where the entire system was idle — improbable on prod but
+possible on Casper between maintenance windows.)
+
+Resolve the table by `system` arg: `'derecho'` → `DerechoStatus`,
+`'casper'` → `CasperStatus`. If we want a system-agnostic helper later,
+factor into a small map.
+
+### Sizing the worst case (1 year)
+
+```
+ticks/day × days × tuples/tick ≈ 288 × 365 × 340 ≈ 36 M rows
+columnar (ts:8 + 3 fk-ids:12 + 3 metric ints:12) ≈ 32 B/row → ~1.2 GB
+```
+
+Untouchable as a single fetch. But:
+- **Aggregated output** is bounded by `distinct (user, project, queue)`
+  combos in the window — at most O(few × 10⁴), easily a few hundred KB.
+- **Per-month chunk** is ~3 M rows × 32 B ≈ ~100 MB — fits in a
+  numpy column block.
+
+So the design is **chunked columnar aggregation** with numpy doing the
+heavy multiplication and grouping, and a single accumulator dict for
+final results across chunks.
+
+### Algorithm
+
+```python
+def get_user_proj_usage(
+    session, *,
+    system: str,                              # 'derecho' | 'casper'
+    start_date: datetime,
+    end_date: datetime,
+    queue_name: Optional[str] = None,         # filter by single queue
+    username: Optional[str] = None,           # filter by single user
+    project_code: Optional[str] = None,       # filter by single project
+    exclude_unknown_project: bool = False,    # skip '_unknown_' bucket
+    chunk_days: int = 30,                     # streaming window for big ranges
+) -> List[Dict[str, Any]]:
+    """
+    Returns one dict per (user, project, queue) tuple with usage > 0:
+      {
+        'username': str, 'project_code': str, 'queue_name': str,
+        'system': str,
+        'core_hours': float, 'gpu_hours': float, 'node_hours': float,
+        'first_seen': datetime, 'last_seen': datetime, 'tick_count': int,
+      }
+    """
+```
+
+Steps:
+
+1. **Resolve scope** — reuse `_resolve_system_id` / `_resolve_queue_id`
+   from the sibling module (lines 66–84 of `user_proj_queues.py`).
+2. **Fetch global tick timeline** for the whole window in one query —
+   `SELECT timestamp FROM <derecho|casper>_status WHERE timestamp
+   BETWEEN start AND end ORDER BY timestamp`. Convert to
+   `ticks = np.array(..., dtype='datetime64[s]')`. ~105 k entries for a
+   year, trivial. Compute `dt = np.diff(ticks).astype(np.float64)` —
+   length `n-1`, seconds. Last tick contributes 0 (no successor).
+3. **Stream `user_proj_queue_status` in monthly chunks**. For each
+   chunk `[t_lo, t_hi]`:
+   - `SELECT timestamp, user_id, project_code_id, queue_id,
+     cores_allocated, gpus_allocated, nodes_allocated FROM
+     user_proj_queue_status WHERE system_id=:sys AND timestamp BETWEEN
+     :t_lo AND :t_hi AND ... filters ...` (no JOIN to lookups yet — keep
+     it columnar; resolve names once at the end).
+   - Convert results to numpy column arrays (`ts_arr`, `uid_arr`,
+     `pid_arr`, `qid_arr`, `cores_arr`, `gpus_arr`, `nodes_arr`).
+   - **Vectorized dt lookup**: `idx = np.searchsorted(ticks, ts_arr)`;
+     valid mask = `(idx < len(ticks)-1) & (ticks[idx] == ts_arr)`. Drop
+     anything not on a known tick (defensive — should always match).
+   - `dt_per_row = dt[idx]` (using masked idx).
+   - Compute three columnar products: `cores_sec = cores_arr * dt_per_row`,
+     etc.
+   - **Group by (uid, pid, qid)**: build a 64-bit composite key
+     `key = (uid << 42) | (pid << 21) | qid` (assuming each fits in 21
+     bits — `status_users` and `project_codes` are well under 2 M, queues
+     are tiny; assert). Then `np.unique(key, return_inverse=True)` →
+     compact group index, and `np.bincount(group_idx, weights=cores_sec)`
+     gives per-group sums in one shot. Same for gpus/nodes.
+   - Merge each chunk's per-group sums into a master `dict[(uid, pid,
+     qid)] -> [cores_sec, gpus_sec, nodes_sec, first_seen, last_seen,
+     tick_count]`. Track `first_seen`/`last_seen`/`tick_count` per chunk
+     using `np.unique` plus `np.minimum.reduceat` / `np.add.reduceat`,
+     then merge.
+4. **Resolve labels** — at the end, batch-fetch
+   `(user_id → username)`, `(project_code_id → project_code)`,
+   `(queue_id → queue_name)` for the keys actually present. Three small
+   indexed lookups, no N+1.
+5. Convert seconds → hours (`/ 3600.0`), drop zero-usage entries, sort
+   descending by `core_hours`, return.
+
+### Performance envelope
+
+| Window | Rows | Wall time (target) |
+|---|---|---|
+| 1 hour | ~4 k | <50 ms |
+| 1 day | ~100 k | <500 ms |
+| 1 week | ~700 k | ~3 s |
+| 1 month | ~3 M | ~10–15 s |
+| 1 year | ~36 M | ~2–4 min |
+
+Year-scale at 2-4 min is acceptable for an offline / batch report but
+NOT for a synchronous UI request. Two safeguards:
+- A `chunk_days` knob (default 30) so memory stays bounded regardless
+  of window length.
+- Document in the docstring that windows > 60 days should not be hit
+  from a request handler. If we later need year-scale UI, the right
+  answer is a nightly-rolled summary table
+  (`user_proj_queue_daily_usage`), not optimizing this query — that's
+  a future Phase C.
+
+### Why not push into SQL?
+
+A pure-SQL aggregation using `LAG`/`LEAD` over the tick subquery would
+group + sum server-side and return ~10⁴ rows. Tempting, but blocked by
+**portable time arithmetic** — prod is PostgreSQL (`extract(epoch from
+…)`) and tests run against SQLite (`julianday(...) * 86400`). The
+SQLAlchemy ORM has no portable "interval-to-seconds" expression. We
+could dialect-branch, but the test surface doubles for marginal speedup
+on the only case it would matter for (year-scale, which is offline
+anyway). Keeping the integration in numpy lands once, runs anywhere.
+
+### What to expose
+
+- `get_user_proj_usage(...)` — main aggregator returning per-tuple dicts.
+- Add to `src/system_status/queries/__init__.py` exports.
+- Two convenience wrappers as thin aggregations over the same machinery
+  (no new SQL): `get_user_usage(... aggregate_over='project,queue')` and
+  `get_project_usage(... aggregate_over='user,queue')`. Keep optional —
+  callers can also just sum result dicts in-place.
+
+## Critical files to read / modify
+
+| Purpose | Path |
+|---|---|
+| **New module** | `src/system_status/queries/user_proj_usage.py` |
+| Reuse `_resolve_system_id` / `_resolve_queue_id` | `src/system_status/queries/user_proj_queues.py:66-84` |
+| Parent status models for tick set | `src/system_status/models/{derecho,casper}.py` |
+| Lookup ORMs for joins | `src/system_status/models/lookups.py` (UserDef, ProjectCodeDef, QueueDef, System) |
+| Snapshot ORM | `src/system_status/models/user_proj_queues.py` |
+| Export | `src/system_status/queries/__init__.py` |
+| numpy (already a dep via matplotlib) | imported as `np` in the new module |
+
+## Verification
+
+1. **Reconciliation against `queue_status`** — over the same window, sum
+   `core_hours` returned by `get_user_proj_usage` for ALL tuples on a
+   given `(system, queue)`, then compute the same integral over
+   `QueueStatus.cores_allocated` for that `(system, queue)`. The two
+   must match within float epsilon for any window. Use the existing
+   reconciliation invariant (USER_PROJ_QUEUE_QUICKSTART.md, line 196).
+2. **Sparse-row probe** — pick a known short-lived job pair (one that
+   appears in a single tick), verify `tick_count == 1`,
+   `core_hours ≈ cores * dt / 3600`, `first_seen == last_seen`.
+3. **Variable-`dt` probe** — synthesize a test where the gap between
+   tick `i` and `i+1` is 10 min instead of 5; verify the integration
+   weights that interval correctly (no hard-coded 300 s).
+4. **Boundary** — assert that the row at the last in-window tick
+   contributes 0 (no successor), and that a window with a single tick
+   returns no usage (no interval to integrate over).
+5. **Unit tests** in `tests/unit/system_status/test_user_proj_usage.py`
+   using factories or hand-built `UserProjQueueStatus` rows with crafted
+   timestamps; per-test SAVEPOINT isolation per project test conventions.
+6. **Smoke against prod-shaped data** — once wired, run `sam-search` /
+   ad-hoc query for `benkirk` over a known busy 24 h window, eyeball
+   against billing's per-job `core_hours` for the same span as a
+   plausibility check (won't match exactly — billing uses real
+   start/end, we use 5-min snapshots — but should be within a few %).
+
+## Open question for the user
+
+I went with **left-step rectangle** integration over trapezoidal. If you
+have a strong opinion (or remember why billing uses one or the other for
+similar cases), say so before we implement — flipping later means
+re-validating reconciliation tests.

--- a/scripts/validate_user_proj_usage.py
+++ b/scripts/validate_user_proj_usage.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+Validate ``get_user_proj_usage`` against the local system_status DB.
+
+Designed for the local dev DB which has <24 h of real collector data
+including missed Derecho ticks (gaps > 5 min). The variable-dt path
+of the integrator is exercised by real organic non-uniformity, not
+hand-crafted fixtures.
+
+Run from the repo host (not inside the docker network):
+
+    source etc/config_env.sh
+    STATUS_DB_DRIVER=mysql STATUS_DB_SERVER=127.0.0.1 \
+        python scripts/validate_user_proj_usage.py
+
+The env overrides are because the default .env points at the
+docker-compose-internal `mysql` hostname / postgres driver, neither of
+which resolves from the host. The container's own port 3306 is exposed
+on the host loopback.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+from sqlalchemy import select
+
+# Allow running the script from anywhere in the repo.
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / 'src'))
+
+from system_status import (   # noqa: E402
+    create_status_engine,
+    get_session,
+    DerechoStatus,
+    CasperStatus,
+    QueueStatus,
+    UserProjQueueStatus,
+    System,
+    QueueDef,
+)
+from sqlalchemy import func   # noqa: E402
+from system_status.queries import get_user_proj_usage   # noqa: E402
+
+
+GAP_THRESHOLD_S = 360   # anything > 6 min is a "gap" worth surfacing
+
+
+# --------------------------------------------------------------------------
+# Tick distribution
+# --------------------------------------------------------------------------
+
+def get_upu_window(session, system_id):
+    """Return (start, end) of UserProjQueueStatus rows for ``system_id``.
+
+    user_proj_queue_status is the new Phase-B table — it has *much*
+    less data than the parent status tables. Reconcile only over its
+    actual coverage window, otherwise QueueStatus integrates 5 months
+    of activity that has no upu rows to compare against.
+    """
+    row = session.execute(
+        select(func.min(UserProjQueueStatus.timestamp),
+               func.max(UserProjQueueStatus.timestamp))
+        .where(UserProjQueueStatus.system_id == system_id)
+    ).one()
+    return row[0], row[1]
+
+
+def report_tick_distribution(session, parent_model, label, start=None, end=None):
+    q = select(parent_model.timestamp)
+    if start is not None:
+        q = q.where(parent_model.timestamp >= start)
+    if end is not None:
+        q = q.where(parent_model.timestamp <= end)
+    q = q.order_by(parent_model.timestamp)
+    rows = session.execute(q).all()
+    ts = [r[0] for r in rows]
+    if len(ts) < 2:
+        print(f'  {label}: <2 ticks, skipping')
+        return None
+
+    arr = np.array(ts, dtype='datetime64[s]')
+    dt = np.diff(arr).astype('int64')
+    span_h = (ts[-1] - ts[0]).total_seconds() / 3600
+    print(f'  {label}: {len(ts)} ticks across {span_h:.2f} h '
+          f'[{ts[0]} → {ts[-1]}]')
+    print(f'    dt seconds: '
+          f'min={dt.min()}  '
+          f'p50={int(np.median(dt))}  '
+          f'p95={int(np.percentile(dt, 95))}  '
+          f'max={dt.max()}')
+    gaps = dt[dt > GAP_THRESHOLD_S]
+    if gaps.size:
+        unique = sorted(set(gaps.tolist()))
+        print(f'    {gaps.size} gaps > {GAP_THRESHOLD_S}s; '
+              f'distinct gap lengths (first 10): {unique[:10]}')
+    else:
+        print(f'    no gaps > {GAP_THRESHOLD_S}s — uniform 5-min cadence')
+    return ts
+
+
+# --------------------------------------------------------------------------
+# Reconciliation: integrate QueueStatus directly, compare to summed
+# get_user_proj_usage by queue.
+# --------------------------------------------------------------------------
+
+def integrate_queue_status_by_queue(session, parent_model, system, start, end):
+    """Left-step integrate QueueStatus.cores_allocated / gpus_allocated
+    by queue over [start, end], using the **parent tick set** as the
+    timeline (same source as get_user_proj_usage uses internally) so
+    the dt[i] values align byte-for-byte and the comparison is
+    apples-to-apples.
+
+    Per-queue series is filled with 0 at parent ticks where the queue
+    has no QueueStatus row.
+
+    Returns: dict[queue_name] -> (core_hours, gpu_hours).
+    """
+    parent_rows = session.execute(
+        select(parent_model.timestamp)
+        .where(parent_model.timestamp >= start,
+               parent_model.timestamp <= end)
+        .order_by(parent_model.timestamp)
+    ).all()
+    parent_ts = [r[0] for r in parent_rows]
+    if len(parent_ts) < 2:
+        return {}
+
+    ticks = np.array(parent_ts, dtype='datetime64[us]')
+    n_ticks = ticks.size
+    dt_s = np.zeros(n_ticks, dtype=np.float64)
+    dt_s[:-1] = np.diff(ticks).astype('int64').astype(np.float64) / 1e6
+    ts_to_idx = {t: i for i, t in enumerate(parent_ts)}
+
+    qs_rows = session.execute(
+        select(QueueStatus.timestamp,
+               QueueDef.name,
+               QueueStatus.cores_allocated,
+               QueueStatus.gpus_allocated)
+        .join(QueueDef, QueueStatus.queue_id == QueueDef.queue_id)
+        .join(System, QueueStatus.system_id == System.system_id)
+        .where(System.name == system,
+               QueueStatus.timestamp >= start,
+               QueueStatus.timestamp <= end)
+    ).all()
+
+    # Aggregate per (queue, tick_idx). Skip QueueStatus rows whose
+    # timestamp doesn't fall on a parent tick (defensive — should never
+    # happen given the per-tick invariant).
+    out_core = {}
+    out_gpu = {}
+    skipped = 0
+    for ts, qname, cores, gpus in qs_rows:
+        i = ts_to_idx.get(ts)
+        if i is None:
+            skipped += 1
+            continue
+        c = (cores or 0) * dt_s[i]
+        g = (gpus or 0) * dt_s[i]
+        out_core[qname] = out_core.get(qname, 0.0) + float(c)
+        out_gpu[qname] = out_gpu.get(qname, 0.0) + float(g)
+    if skipped:
+        print(f'    NOTE: {skipped} QueueStatus rows had no matching '
+              f'parent tick (alignment mismatch)')
+    SEC_PER_HOUR = 3600.0
+    return {qn: (out_core.get(qn, 0.0) / SEC_PER_HOUR,
+                 out_gpu.get(qn, 0.0) / SEC_PER_HOUR)
+            for qn in set(out_core) | set(out_gpu)}
+
+
+def reconcile(session, parent_model, system, start, end):
+    """Compare per-queue QueueStatus integrals against summed
+    get_user_proj_usage on each queue. Print PASS/FAIL with delta."""
+    qs_totals = integrate_queue_status_by_queue(
+        session, parent_model, system, start, end,
+    )
+
+    upu_rows = get_user_proj_usage(
+        session, system=system, start_date=start, end_date=end,
+    )
+    upu_totals = {}
+    for r in upu_rows:
+        qn = r['queue_name']
+        prev = upu_totals.get(qn, (0.0, 0.0))
+        upu_totals[qn] = (prev[0] + r['core_hours'],
+                          prev[1] + r['gpu_hours'])
+
+    # Union of queue names — flag any queue that appears in only one source.
+    all_queues = sorted(set(qs_totals) | set(upu_totals))
+    if not all_queues:
+        print('    no queues to reconcile')
+        return
+
+    overall_pass = True
+    print(f'    {"queue":<14} {"qs core_h":>12} {"upu core_h":>12} '
+          f'{"Δ":>10}  {"qs gpu_h":>10} {"upu gpu_h":>10} {"Δ":>8}  '
+          f'verdict')
+    for qn in all_queues:
+        qs_c, qs_g = qs_totals.get(qn, (0.0, 0.0))
+        upu_c, upu_g = upu_totals.get(qn, (0.0, 0.0))
+        d_c = upu_c - qs_c
+        d_g = upu_g - qs_g
+        denom = max(abs(qs_c), abs(upu_c), 1.0)
+        ok = (abs(d_c) / denom < 1e-6) and (abs(d_g) / max(abs(qs_g), abs(upu_g), 1.0) < 1e-6)
+        verdict = 'PASS' if ok else 'FAIL'
+        if not ok:
+            overall_pass = False
+        print(f'    {qn:<14} {qs_c:>12.3f} {upu_c:>12.3f} {d_c:>+10.3e}  '
+              f'{qs_g:>10.3f} {upu_g:>10.3f} {d_g:>+8.3e}  {verdict}')
+    print(f'    Overall: {"PASS" if overall_pass else "FAIL"}')
+
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+
+def report_top_consumers(rows, label, limit=10):
+    print(f'\n  Top {min(limit, len(rows))} {label} by core-hours:')
+    print(f'    {"username":>14} {"project":<10} {"queue":<10} '
+          f'{"core_h":>12} {"gpu_h":>10} {"node_h":>10} {"ticks":>6}')
+    for r in rows[:limit]:
+        print(f'    {(r["username"] or "?"):>14} '
+              f'{(r["project_code"] or "?"):<10} '
+              f'{(r["queue_name"] or "?"):<10} '
+              f'{r["core_hours"]:>12.3f} '
+              f'{r["gpu_hours"]:>10.3f} '
+              f'{r["node_hours"]:>10.3f} '
+              f'{r["tick_count"]:>6}')
+
+
+def _resolve_system_id(session, name):
+    return session.execute(
+        select(System.system_id).where(System.name == name)
+    ).scalar_one_or_none()
+
+
+def main():
+    engine, SessionLocal = create_status_engine()
+    with get_session(SessionLocal) as session:
+        for system, parent in (('derecho', DerechoStatus),
+                               ('casper', CasperStatus)):
+            sys_id = _resolve_system_id(session, system)
+            if sys_id is None:
+                print(f'\n=== {system}: not in DB, skipping ===')
+                continue
+            start, end = get_upu_window(session, sys_id)
+            if start is None:
+                print(f'\n=== {system}: no user_proj_queue_status rows, '
+                      f'skipping ===')
+                continue
+
+            span_h = (end - start).total_seconds() / 3600
+            print()
+            print('=' * 72)
+            print(f'{system}: upu window {start} → {end} ({span_h:.2f} h)')
+            print('=' * 72)
+            report_tick_distribution(session, parent, f'{system} parent ticks',
+                                     start=start, end=end)
+
+            rows = get_user_proj_usage(
+                session, system=system,
+                start_date=start, end_date=end,
+            )
+            print(f'\n  {len(rows)} (user, project, queue) tuples with usage > 0')
+            print(f'  Total core-hours: '
+                  f'{sum(r["core_hours"] for r in rows):>14.3f}')
+            print(f'  Total GPU-hours:  '
+                  f'{sum(r["gpu_hours"] for r in rows):>14.3f}')
+            print(f'  Total node-hours: '
+                  f'{sum(r["node_hours"] for r in rows):>14.3f}')
+
+            report_top_consumers(rows, f'{system} consumers')
+
+            print(f'\n  Reconciliation against QueueStatus integrals:')
+            reconcile(session, parent, system, start, end)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/validate_user_proj_usage.py
+++ b/scripts/validate_user_proj_usage.py
@@ -1,11 +1,42 @@
 #!/usr/bin/env python3
 """
-Validate ``get_user_proj_usage`` against the local system_status DB.
+Validate + benchmark ``get_user_proj_usage`` against the local
+system_status DB.
 
-Designed for the local dev DB which has <24 h of real collector data
-including missed Derecho ticks (gaps > 5 min). The variable-dt path
-of the integrator is exercised by real organic non-uniformity, not
-hand-crafted fixtures.
+This script does double duty:
+
+1. **Correctness** — reconciles the integrated user_proj output against
+   the integral of the parent ``QueueStatus`` rows over the SAME parent
+   tick set. Equality up to float64 epsilon on every queue is the
+   load-bearing assertion that the algorithm is sound.
+
+2. **Benchmark / capacity-planning** — prints wall-clock timing and
+   rows/sec for each phase (tick fetch, integration, reconciliation).
+   The intent is to **revisit this on a cadence** as upu rows accumulate:
+
+   - **Today** (initial Phase-B rollout): ~17 h, ~85k rows.
+   - **Week 1**: ~7 days, ~700k rows. Expect linear growth.
+   - **Month 1**: ~30 days, ~3M rows. Decision point — at this scale,
+     we want UI-eligible windows to stay sub-second. If a 1-day window
+     still completes in <500 ms but a 1-month window blows past 10 s,
+     we have empirical evidence for the daily-summary table proposed
+     in the design doc.
+
+   Each timed phase prints rows processed and wall-clock seconds, so a
+   `git diff` of two runs can answer "did we cross the line yet?"
+   without re-deriving anything.
+
+## What "the daily-summary decision" hinges on
+
+The design plan flagged a future
+`user_proj_queue_daily_usage` rollup as the right answer if year-scale
+queries become a UI need. The right time to build it is when:
+- A typical UI request window (e.g. last 7 days) takes >1 s consistently.
+- A reporting window (1 month) takes >30 s, blocking offline jobs.
+- DB row growth makes the chunked Python aggregation memory-bound on
+  the smallest deployable host.
+
+This script is the instrument we'll measure those thresholds with.
 
 Run from the repo host (not inside the docker network):
 
@@ -20,10 +51,29 @@ on the host loopback.
 """
 
 import sys
+import time
+from contextlib import contextmanager
+from datetime import timedelta
 from pathlib import Path
 
 import numpy as np
 from sqlalchemy import select
+
+
+@contextmanager
+def timed(label, *, n=None):
+    """Context manager that prints elapsed wall time, and rows/sec if
+    a row count is given. Output is a single right-aligned line so
+    consecutive timings stack visually for comparison run-to-run."""
+    t0 = time.perf_counter()
+    yield
+    dt = time.perf_counter() - t0
+    if n is None:
+        print(f'    [t]  {label:<45} {dt:>8.3f} s')
+    else:
+        rate = (n / dt) if dt > 0 else float('inf')
+        print(f'    [t]  {label:<45} {dt:>8.3f} s  '
+              f'({n:>9,} rows, {rate:>10,.0f} rows/s)')
 
 # Allow running the script from anywhere in the repo.
 _ROOT = Path(__file__).resolve().parent.parent
@@ -73,7 +123,8 @@ def report_tick_distribution(session, parent_model, label, start=None, end=None)
     if end is not None:
         q = q.where(parent_model.timestamp <= end)
     q = q.order_by(parent_model.timestamp)
-    rows = session.execute(q).all()
+    with timed(f'fetch parent ticks ({label})'):
+        rows = session.execute(q).all()
     ts = [r[0] for r in rows]
     if len(ts) < 2:
         print(f'  {label}: <2 ticks, skipping')
@@ -132,17 +183,18 @@ def integrate_queue_status_by_queue(session, parent_model, system, start, end):
     dt_s[:-1] = np.diff(ticks).astype('int64').astype(np.float64) / 1e6
     ts_to_idx = {t: i for i, t in enumerate(parent_ts)}
 
-    qs_rows = session.execute(
-        select(QueueStatus.timestamp,
-               QueueDef.name,
-               QueueStatus.cores_allocated,
-               QueueStatus.gpus_allocated)
-        .join(QueueDef, QueueStatus.queue_id == QueueDef.queue_id)
-        .join(System, QueueStatus.system_id == System.system_id)
-        .where(System.name == system,
-               QueueStatus.timestamp >= start,
-               QueueStatus.timestamp <= end)
-    ).all()
+    with timed(f'fetch QueueStatus rows ({system})'):
+        qs_rows = session.execute(
+            select(QueueStatus.timestamp,
+                   QueueDef.name,
+                   QueueStatus.cores_allocated,
+                   QueueStatus.gpus_allocated)
+            .join(QueueDef, QueueStatus.queue_id == QueueDef.queue_id)
+            .join(System, QueueStatus.system_id == System.system_id)
+            .where(System.name == system,
+                   QueueStatus.timestamp >= start,
+                   QueueStatus.timestamp <= end)
+        ).all()
 
     # Aggregate per (queue, tick_idx). Skip QueueStatus rows whose
     # timestamp doesn't fall on a parent tick (defensive — should never
@@ -171,13 +223,15 @@ def integrate_queue_status_by_queue(session, parent_model, system, start, end):
 def reconcile(session, parent_model, system, start, end):
     """Compare per-queue QueueStatus integrals against summed
     get_user_proj_usage on each queue. Print PASS/FAIL with delta."""
-    qs_totals = integrate_queue_status_by_queue(
-        session, parent_model, system, start, end,
-    )
+    with timed(f'reconcile QueueStatus integral ({system})'):
+        qs_totals = integrate_queue_status_by_queue(
+            session, parent_model, system, start, end,
+        )
 
-    upu_rows = get_user_proj_usage(
-        session, system=system, start_date=start, end_date=end,
-    )
+    with timed(f'get_user_proj_usage full window ({system})'):
+        upu_rows = get_user_proj_usage(
+            session, system=system, start_date=start, end_date=end,
+        )
     upu_totals = {}
     for r in upu_rows:
         qn = r['queue_name']
@@ -257,10 +311,21 @@ def main():
             report_tick_distribution(session, parent, f'{system} parent ticks',
                                      start=start, end=end)
 
-            rows = get_user_proj_usage(
-                session, system=system,
-                start_date=start, end_date=end,
-            )
+            # Count input rows in the window — denominator for rows/sec.
+            n_rows = session.execute(
+                select(func.count())
+                .select_from(UserProjQueueStatus)
+                .where(UserProjQueueStatus.system_id == sys_id,
+                       UserProjQueueStatus.timestamp >= start,
+                       UserProjQueueStatus.timestamp <= end)
+            ).scalar_one()
+
+            with timed(f'get_user_proj_usage full window ({system})',
+                       n=n_rows):
+                rows = get_user_proj_usage(
+                    session, system=system,
+                    start_date=start, end_date=end,
+                )
             print(f'\n  {len(rows)} (user, project, queue) tuples with usage > 0')
             print(f'  Total core-hours: '
                   f'{sum(r["core_hours"] for r in rows):>14.3f}')
@@ -270,6 +335,30 @@ def main():
                   f'{sum(r["node_hours"] for r in rows):>14.3f}')
 
             report_top_consumers(rows, f'{system} consumers')
+
+            # Sub-window benchmarks. The growth shape vs the full-window
+            # number tells us whether the integration scales linearly
+            # (expected) and how much headroom exists before any one
+            # query class blows past the UI/offline thresholds. Revisit
+            # the absolute numbers as upu accumulates more data.
+            print(f'\n  Sub-window benchmarks (extrapolation feedstock):')
+            for label, hours in (('1 h', 1), ('6 h', 6), ('24 h (or full)', 24)):
+                w_end = end
+                w_start = max(start, end - timedelta(hours=hours))
+                if w_start >= w_end:
+                    continue
+                w_n = session.execute(
+                    select(func.count())
+                    .select_from(UserProjQueueStatus)
+                    .where(UserProjQueueStatus.system_id == sys_id,
+                           UserProjQueueStatus.timestamp >= w_start,
+                           UserProjQueueStatus.timestamp <= w_end)
+                ).scalar_one()
+                with timed(f'  trailing {label}', n=w_n):
+                    get_user_proj_usage(
+                        session, system=system,
+                        start_date=w_start, end_date=w_end,
+                    )
 
             print(f'\n  Reconciliation against QueueStatus integrals:')
             reconcile(session, parent, system, start, end)

--- a/src/system_status/queries/__init__.py
+++ b/src/system_status/queries/__init__.py
@@ -24,6 +24,7 @@ from .user_proj_queues import (  # noqa: F401
     get_latest_user_proj_queue_snapshot,
     get_user_proj_timeseries,
 )
+from .user_proj_usage import get_user_proj_usage  # noqa: F401
 
 
 def get_latest_derecho_status(session: Session) -> Optional[DerechoStatus]:

--- a/src/system_status/queries/user_proj_usage.py
+++ b/src/system_status/queries/user_proj_usage.py
@@ -1,0 +1,419 @@
+"""
+Time-integrated consumption from ``user_proj_queue_status`` snapshots.
+
+The sibling ``user_proj_queues`` module exposes instantaneous /
+time-series views of the per-user / per-project / per-queue rollup
+table. This module integrates those snapshots over a window into
+core-hours / GPU-hours / node-hours by ``(user, project, queue)``.
+
+Two complications drive the design:
+
+1. **Tick interval is not a constant 5 minutes** — collectors stall,
+   reschedule, get reconfigured. ``dt`` is derived per-tick from the
+   actual delta between successive observed timestamps in the parent
+   ``DerechoStatus`` / ``CasperStatus`` table (the canonical record of
+   "the collector ran at this moment", regardless of whether any user
+   had jobs).
+2. **Sparse rows** — a ``(user, project, queue)`` row exists only when
+   that tuple has ≥1 job at that tick. Absence at a tick is treated as
+   ``0 cores / 0 gpus / 0 nodes`` for that tuple at that tick (NOT
+   carry-forward — that would attribute load forever after a user's
+   jobs end).
+
+Integration is **left-step** (rectangle rule): a row at tick ``t_i``
+with ``cores_allocated = X`` contributes ``X * (t_{i+1} - t_i)``
+core-seconds. The last tick in the window has no successor and
+contributes 0 (boundary effect is negligible for any window > a few
+ticks). Trapezoidal would average with a "0" at the next tick when a
+tuple disappears, under-counting by half — left-step is the honest
+discretization for jobs that start/stop in discrete jumps.
+
+For year-scale windows (~36M rows) the snapshot rows are streamed in
+monthly chunks; per-chunk aggregation uses numpy ``bincount`` on a
+composite ``(user_id, project_code_id, queue_id)`` key, then merged
+into a master accumulator dict. See ``get_user_proj_usage`` for the
+full algorithm.
+"""
+
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from system_status.models import (
+    CasperStatus,
+    DerechoStatus,
+    ProjectCodeDef,
+    QueueDef,
+    System,
+    UserDef,
+    UserProjQueueStatus,
+)
+
+from .user_proj_queues import _resolve_queue_id, _resolve_system_id
+
+
+_PARENT_STATUS_BY_SYSTEM = {
+    'derecho': DerechoStatus,
+    'casper': CasperStatus,
+}
+
+# Composite key packing for (user_id, project_code_id, queue_id) into one
+# int64. 21 bits each = 2,097,151 max — well above current cardinalities
+# (status_users < 1k, project_codes < 500, queues < 100) with headroom
+# for years of growth. The ``_assert_id_fits`` guard in
+# ``get_user_proj_usage`` catches the day this assumption breaks.
+_BITS = 21
+_MASK = (1 << _BITS) - 1
+_MAX_ID = _MASK
+
+
+def _assert_id_fits(uid_arr: np.ndarray, pid_arr: np.ndarray,
+                    qid_arr: np.ndarray) -> None:
+    """Defensive: refuse to silently truncate IDs into the composite key."""
+    for name, arr in (('user_id', uid_arr),
+                      ('project_code_id', pid_arr),
+                      ('queue_id', qid_arr)):
+        if arr.size and int(arr.max()) > _MAX_ID:
+            raise RuntimeError(
+                f'{name} exceeds composite-key budget ({_MAX_ID}); '
+                'increase _BITS in user_proj_usage.py'
+            )
+
+
+def _iter_chunks(start: datetime, end: datetime,
+                 chunk_days: int) -> List[tuple]:
+    """Yield ``(t_lo, t_hi)`` chunks covering ``[start, end]`` inclusive,
+    each spanning at most ``chunk_days`` days."""
+    out = []
+    cursor = start
+    span = timedelta(days=chunk_days)
+    while cursor <= end:
+        nxt = min(cursor + span, end)
+        out.append((cursor, nxt))
+        if nxt >= end:
+            break
+        # +1 microsecond so the next chunk doesn't double-count rows at
+        # the boundary (timestamps are unique per row, and the upper
+        # bound of the previous chunk was inclusive).
+        cursor = nxt + timedelta(microseconds=1)
+    return out
+
+
+def get_user_proj_usage(
+    session: Session,
+    *,
+    system: str,
+    start_date: datetime,
+    end_date: datetime,
+    queue_name: Optional[str] = None,
+    username: Optional[str] = None,
+    project_code: Optional[str] = None,
+    exclude_unknown_project: bool = False,
+    chunk_days: int = 30,
+) -> List[Dict[str, Any]]:
+    """Integrate ``UserProjQueueStatus`` snapshots into core-hours /
+    GPU-hours / node-hours by ``(user, project, queue)`` over
+    ``[start_date, end_date]``.
+
+    Returns one dict per tuple with non-zero usage, sorted descending by
+    ``core_hours``::
+
+        {
+            'username':     'benkirk',
+            'project_code': 'SCSG0001',
+            'queue_name':   'main',
+            'system':       'derecho',
+            'core_hours':   1234.56,
+            'gpu_hours':    0.0,
+            'node_hours':   38.58,
+            'first_seen':   datetime(...),   # earliest tick the tuple appeared
+            'last_seen':    datetime(...),   # latest tick the tuple appeared
+            'tick_count':   42,              # how many ticks the tuple was present
+        }
+
+    **Integration model.** Left-step rectangle rule over the global tick
+    timeline derived from the parent system status table. A snapshot
+    at tick ``t_i`` with value ``x_i`` contributes ``x_i * (t_{i+1} -
+    t_i)`` to the integral. Absence of a tuple at a tick is treated as
+    0. The last tick in the window has no successor and contributes 0.
+
+    **Filters** (all optional, all combine with AND):
+
+    - ``queue_name`` — restrict to a single queue on ``system``.
+    - ``username`` / ``project_code`` — restrict to a single
+      user / project. Returns ``[]`` if the lookup row doesn't exist.
+    - ``exclude_unknown_project`` — drop the ``'_unknown_'`` bucket
+      (jobs whose ``Account_Name`` was missing/empty).
+
+    **Performance envelope** for windows on prod-shaped data
+    (~98 k rows/day, ~340 distinct tuples/tick):
+
+    ============  =========  ===========================
+    Window        Rows       Wall time (target)
+    ============  =========  ===========================
+    1 hour        ~4 k       <50 ms
+    1 day         ~100 k     <500 ms
+    1 week        ~700 k     ~3 s
+    1 month       ~3 M       ~10–15 s
+    1 year        ~36 M      ~2–4 min  (offline only)
+    ============  =========  ===========================
+
+    Windows >60 days should NOT be hit from a synchronous request
+    handler. If year-scale UI becomes a need, the right answer is a
+    nightly-rolled summary table, not optimizing this query.
+    """
+    parent = _PARENT_STATUS_BY_SYSTEM.get(system)
+    if parent is None:
+        raise ValueError(
+            f'system must be one of {sorted(_PARENT_STATUS_BY_SYSTEM)}, '
+            f'got {system!r}'
+        )
+    if start_date > end_date:
+        return []
+
+    system_id = _resolve_system_id(session, system)
+    if system_id is None:
+        return []
+
+    # Optional scope filter — single queue.
+    queue_id = None
+    if queue_name is not None:
+        queue_id = _resolve_queue_id(session, system, queue_name)
+        if queue_id is None:
+            return []
+
+    # Optional user / project filters — resolve up front so we avoid a
+    # JOIN in the hot fetch loop.
+    user_id_filter = None
+    if username is not None:
+        user_id_filter = session.execute(
+            select(UserDef.user_id).where(UserDef.username == username)
+        ).scalar_one_or_none()
+        if user_id_filter is None:
+            return []
+
+    project_code_id_filter = None
+    if project_code is not None:
+        project_code_id_filter = session.execute(
+            select(ProjectCodeDef.project_code_id)
+            .where(ProjectCodeDef.project_code == project_code)
+        ).scalar_one_or_none()
+        if project_code_id_filter is None:
+            return []
+
+    unknown_pid = None
+    if exclude_unknown_project:
+        unknown_pid = session.execute(
+            select(ProjectCodeDef.project_code_id)
+            .where(ProjectCodeDef.project_code == '_unknown_')
+        ).scalar_one_or_none()
+        # If no _unknown_ row exists, the filter is a no-op.
+
+    # ------------------------------------------------------------------
+    # 1. Global tick timeline from the parent status table.
+    # ------------------------------------------------------------------
+    tick_rows = session.execute(
+        select(parent.timestamp)
+        .where(parent.timestamp >= start_date,
+               parent.timestamp <= end_date)
+        .order_by(parent.timestamp)
+    ).all()
+    tick_list = [r[0] for r in tick_rows]
+    n_ticks = len(tick_list)
+    if n_ticks < 2:
+        # Single tick or no ticks — nothing to integrate over.
+        return []
+
+    ticks = np.array(tick_list, dtype='datetime64[us]')
+    # Per-tick interval in **seconds** (float64). Computing in seconds —
+    # not microseconds — keeps year-scale sums comfortably under the
+    # float64 mantissa precision cliff (~9e15 ≈ 2.5e9 core-hours).
+    # dt[N-1] = 0 (last tick has no successor); pad to keep array
+    # length aligned with `ticks`.
+    dt_sec = np.zeros(n_ticks, dtype=np.float64)
+    dt_sec[:-1] = np.diff(ticks).astype('int64').astype(np.float64) / 1e6
+
+    # ------------------------------------------------------------------
+    # 2. Stream user_proj rows in chunks; per-chunk numpy aggregation
+    #    merged into a master accumulator dict keyed by composite int.
+    # ------------------------------------------------------------------
+    # totals[composite_key] = [core_sec, gpu_sec, node_sec,
+    #                          first_us, last_us, tick_count]
+    totals: Dict[int, List[float]] = {}
+
+    base = (
+        select(
+            UserProjQueueStatus.timestamp,
+            UserProjQueueStatus.user_id,
+            UserProjQueueStatus.project_code_id,
+            UserProjQueueStatus.queue_id,
+            UserProjQueueStatus.cores_allocated,
+            UserProjQueueStatus.gpus_allocated,
+            UserProjQueueStatus.nodes_allocated,
+        )
+        .where(UserProjQueueStatus.system_id == system_id)
+    )
+    if queue_id is not None:
+        base = base.where(UserProjQueueStatus.queue_id == queue_id)
+    if user_id_filter is not None:
+        base = base.where(UserProjQueueStatus.user_id == user_id_filter)
+    if project_code_id_filter is not None:
+        base = base.where(
+            UserProjQueueStatus.project_code_id == project_code_id_filter
+        )
+    if unknown_pid is not None:
+        base = base.where(UserProjQueueStatus.project_code_id != unknown_pid)
+
+    for t_lo, t_hi in _iter_chunks(start_date, end_date, chunk_days):
+        rows = session.execute(
+            base.where(UserProjQueueStatus.timestamp >= t_lo,
+                       UserProjQueueStatus.timestamp <= t_hi)
+        ).all()
+        if not rows:
+            continue
+
+        # Columnar conversion. Tuples come back from SQLAlchemy in a
+        # known order, matching the SELECT above.
+        ts_arr = np.array([r[0] for r in rows], dtype='datetime64[us]')
+        uid_arr = np.fromiter((r[1] for r in rows), dtype=np.int64,
+                              count=len(rows))
+        pid_arr = np.fromiter((r[2] for r in rows), dtype=np.int64,
+                              count=len(rows))
+        qid_arr = np.fromiter((r[3] for r in rows), dtype=np.int64,
+                              count=len(rows))
+        cores_arr = np.fromiter((r[4] for r in rows), dtype=np.float64,
+                                count=len(rows))
+        gpus_arr = np.fromiter((r[5] for r in rows), dtype=np.float64,
+                               count=len(rows))
+        nodes_arr = np.fromiter((r[6] for r in rows), dtype=np.float64,
+                                count=len(rows))
+
+        _assert_id_fits(uid_arr, pid_arr, qid_arr)
+
+        # Vectorized dt lookup. `searchsorted` on a sorted tick array
+        # gives the index where each row's timestamp would be inserted;
+        # for an exact match the index points AT that tick. Defensive
+        # mask drops anything that doesn't land on a known tick (should
+        # be empty in practice — parent and child ticks share the same
+        # timestamp by construction).
+        idx = np.searchsorted(ticks, ts_arr)
+        valid = (idx < n_ticks) & (ticks[np.minimum(idx, n_ticks - 1)] == ts_arr)
+        if not valid.all():
+            uid_arr = uid_arr[valid]
+            pid_arr = pid_arr[valid]
+            qid_arr = qid_arr[valid]
+            cores_arr = cores_arr[valid]
+            gpus_arr = gpus_arr[valid]
+            nodes_arr = nodes_arr[valid]
+            ts_arr = ts_arr[valid]
+            idx = idx[valid]
+            if idx.size == 0:
+                continue
+
+        dt_per_row = dt_sec[idx]   # seconds; 0 for last-tick rows
+        core_sec = cores_arr * dt_per_row
+        gpu_sec = gpus_arr * dt_per_row
+        node_sec = nodes_arr * dt_per_row
+
+        # Composite key for groupby. int64 is large enough by
+        # construction (3 × 21 = 63 bits used).
+        keys = (uid_arr << (2 * _BITS)) | (pid_arr << _BITS) | qid_arr
+        unique_keys, inverse = np.unique(keys, return_inverse=True)
+        n_groups = unique_keys.size
+
+        core_sums = np.bincount(inverse, weights=core_sec, minlength=n_groups)
+        gpu_sums = np.bincount(inverse, weights=gpu_sec, minlength=n_groups)
+        node_sums = np.bincount(inverse, weights=node_sec, minlength=n_groups)
+        tick_counts = np.bincount(inverse, minlength=n_groups)
+
+        # Per-group min/max timestamp via reduce-at-indices. Convert to
+        # int64 microseconds for arithmetic, convert back at merge.
+        ts_int = ts_arr.astype('int64')
+        first_us = np.full(n_groups, np.iinfo(np.int64).max, dtype=np.int64)
+        last_us = np.full(n_groups, np.iinfo(np.int64).min, dtype=np.int64)
+        np.minimum.at(first_us, inverse, ts_int)
+        np.maximum.at(last_us, inverse, ts_int)
+
+        # Merge into accumulator dict. Iterating over n_groups (not
+        # n_rows) keeps Python overhead bounded.
+        for g in range(n_groups):
+            k = int(unique_keys[g])
+            entry = totals.get(k)
+            if entry is None:
+                totals[k] = [
+                    float(core_sums[g]),
+                    float(gpu_sums[g]),
+                    float(node_sums[g]),
+                    int(first_us[g]),
+                    int(last_us[g]),
+                    int(tick_counts[g]),
+                ]
+            else:
+                entry[0] += float(core_sums[g])
+                entry[1] += float(gpu_sums[g])
+                entry[2] += float(node_sums[g])
+                if first_us[g] < entry[3]:
+                    entry[3] = int(first_us[g])
+                if last_us[g] > entry[4]:
+                    entry[4] = int(last_us[g])
+                entry[5] += int(tick_counts[g])
+
+    if not totals:
+        return []
+
+    # ------------------------------------------------------------------
+    # 3. Resolve labels in three batched lookups (no N+1).
+    # ------------------------------------------------------------------
+    uid_set: set = set()
+    pid_set: set = set()
+    qid_set: set = set()
+    for k in totals:
+        uid_set.add((k >> (2 * _BITS)) & _MASK)
+        pid_set.add((k >> _BITS) & _MASK)
+        qid_set.add(k & _MASK)
+
+    uid_to_name = dict(session.execute(
+        select(UserDef.user_id, UserDef.username)
+        .where(UserDef.user_id.in_(uid_set))
+    ).all())
+    pid_to_code = dict(session.execute(
+        select(ProjectCodeDef.project_code_id, ProjectCodeDef.project_code)
+        .where(ProjectCodeDef.project_code_id.in_(pid_set))
+    ).all())
+    qid_to_name = dict(session.execute(
+        select(QueueDef.queue_id, QueueDef.name)
+        .where(QueueDef.queue_id.in_(qid_set))
+    ).all())
+
+    # ------------------------------------------------------------------
+    # 4. Convert to hours, drop zero-usage entries, sort.
+    # ------------------------------------------------------------------
+    SEC_PER_HOUR = 3600.0
+    out: List[Dict[str, Any]] = []
+    for k, (core_s, gpu_s, node_s, first_i, last_i, count) in totals.items():
+        core_h = core_s / SEC_PER_HOUR
+        gpu_h = gpu_s / SEC_PER_HOUR
+        node_h = node_s / SEC_PER_HOUR
+        if core_h == 0.0 and gpu_h == 0.0 and node_h == 0.0:
+            continue
+        uid = (k >> (2 * _BITS)) & _MASK
+        pid = (k >> _BITS) & _MASK
+        qid = k & _MASK
+        out.append({
+            'username':     uid_to_name.get(uid),
+            'project_code': pid_to_code.get(pid),
+            'queue_name':   qid_to_name.get(qid),
+            'system':       system,
+            'core_hours':   core_h,
+            'gpu_hours':    gpu_h,
+            'node_hours':   node_h,
+            'first_seen':   np.datetime64(first_i, 'us').astype(datetime),
+            'last_seen':    np.datetime64(last_i, 'us').astype(datetime),
+            'tick_count':   count,
+        })
+
+    out.sort(key=lambda r: r['core_hours'], reverse=True)
+    return out

--- a/tests/unit/test_user_proj_usage.py
+++ b/tests/unit/test_user_proj_usage.py
@@ -1,0 +1,547 @@
+"""Unit tests for ``system_status.queries.user_proj_usage``.
+
+Covers:
+- empty / single-tick / two-tick boundary cases
+- variable-dt integration (heterogeneous tick intervals)
+- sparse (user, project, queue) tuples (appear / disappear / reappear)
+- system / queue / user / project filtering
+- exclude_unknown_project
+- reconciliation against summed QueueStatus core-hours
+- multi-chunk windows (chunk_days < window length)
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from system_status import (
+    CasperStatus,
+    DerechoStatus,
+    QueueStatus,
+    UserProjQueueStatus,
+)
+from system_status.queries import get_user_proj_usage
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_derecho(session, ts):
+    """Minimal DerechoStatus parent row at timestamp ``ts``."""
+    parent = DerechoStatus(
+        timestamp=ts,
+        cpu_nodes_total=100, cpu_nodes_available=50, cpu_nodes_down=0,
+        gpu_nodes_total=10, gpu_nodes_available=5, gpu_nodes_down=0,
+        cpu_cores_total=12800, cpu_cores_allocated=6400, cpu_cores_idle=6400,
+        gpu_count_total=40, gpu_count_allocated=20, gpu_count_idle=20,
+        memory_total_gb=10000.0, memory_allocated_gb=5000.0,
+    )
+    session.add(parent)
+    return parent
+
+
+def _make_casper(session, ts):
+    parent = CasperStatus(
+        timestamp=ts,
+        cpu_nodes_total=50, cpu_nodes_available=30, cpu_nodes_down=0,
+        gpu_nodes_total=20, gpu_nodes_available=10, gpu_nodes_down=0,
+        viz_nodes_total=5, viz_nodes_available=5, viz_nodes_down=0,
+        cpu_cores_total=2000, cpu_cores_allocated=1000, cpu_cores_idle=1000,
+        gpu_count_total=80, gpu_count_allocated=40, gpu_count_idle=40,
+        viz_count_total=5, viz_count_allocated=2, viz_count_idle=3,
+        memory_total_gb=5000.0, memory_allocated_gb=2500.0,
+    )
+    session.add(parent)
+    return parent
+
+
+def _make_upq(session, parent, *, system, queue, user, project,
+              cores=0, gpus=0, nodes=0):
+    """Add a UserProjQueueStatus row attached to its system parent."""
+    row = UserProjQueueStatus(
+        timestamp=parent.timestamp,
+        system_name=system, queue_name=queue,
+        username=user, project_code=project,
+        running_jobs=1 if cores or gpus or nodes else 0,
+        cores_allocated=cores,
+        gpus_allocated=gpus,
+        nodes_allocated=nodes,
+    )
+    if system == 'derecho':
+        row.derecho_status = parent
+    else:
+        row.casper_status = parent
+    session.add(row)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Boundary cases
+# ---------------------------------------------------------------------------
+
+def test_empty_window_returns_empty(status_session):
+    """No parent ticks in [start, end] → no integration possible."""
+    out = get_user_proj_usage(
+        status_session,
+        system='derecho',
+        start_date=datetime(2026, 5, 4, 12, 0, 0),
+        end_date=datetime(2026, 5, 4, 13, 0, 0),
+    )
+    assert out == []
+
+
+def test_single_tick_returns_empty(status_session):
+    """One parent tick → no successor → no interval to integrate over."""
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    parent = _make_derecho(status_session, t0)
+    _make_upq(status_session, parent, system='derecho', queue='main',
+              user='benkirk', project='SCSG0001', cores=128)
+    status_session.flush()
+
+    out = get_user_proj_usage(
+        status_session,
+        system='derecho',
+        start_date=t0 - timedelta(hours=1),
+        end_date=t0 + timedelta(hours=1),
+    )
+    assert out == []
+
+
+def test_two_ticks_left_step_integration(status_session):
+    """Cores=128 at t0, then 0 (absent) at t1 — left-step credits the
+    full first interval at 128, contributes nothing for t1 (no successor).
+    Expected: 128 cores × 5 min = 128/12 core-hours."""
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    t1 = t0 + timedelta(minutes=5)
+    p0 = _make_derecho(status_session, t0)
+    _make_derecho(status_session, t1)   # tick exists, but no rows for this user
+    _make_upq(status_session, p0, system='derecho', queue='main',
+              user='benkirk', project='SCSG0001', cores=128, gpus=0, nodes=4)
+    status_session.flush()
+
+    out = get_user_proj_usage(
+        status_session,
+        system='derecho',
+        start_date=t0,
+        end_date=t1,
+    )
+    assert len(out) == 1
+    r = out[0]
+    assert r['username'] == 'benkirk'
+    assert r['project_code'] == 'SCSG0001'
+    assert r['queue_name'] == 'main'
+    assert r['system'] == 'derecho'
+    expected_core_h = 128 * 300.0 / 3600.0   # cores × seconds / 3600
+    assert r['core_hours'] == pytest.approx(expected_core_h)
+    assert r['gpu_hours'] == pytest.approx(0.0)
+    assert r['node_hours'] == pytest.approx(4 * 300.0 / 3600.0)
+    assert r['tick_count'] == 1
+    assert r['first_seen'] == t0
+    assert r['last_seen'] == t0
+
+
+# ---------------------------------------------------------------------------
+# Variable-dt — collector irregularity
+# ---------------------------------------------------------------------------
+
+def test_variable_tick_intervals(status_session):
+    """Three ticks at t0, t0+5min, t0+15min. A user with cores=128 at all
+    three ticks should integrate to:
+      tick 0 (5 min @ 128) + tick 1 (10 min @ 128) + tick 2 (no successor)
+      = 128 × (300 + 600) / 3600 = 32 core-hours
+    Verifies the implementation does NOT hard-code 5 min."""
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    t1 = t0 + timedelta(minutes=5)
+    t2 = t0 + timedelta(minutes=15)
+    parents = [_make_derecho(status_session, t) for t in (t0, t1, t2)]
+    for p in parents:
+        _make_upq(status_session, p, system='derecho', queue='main',
+                  user='benkirk', project='SCSG0001', cores=128)
+    status_session.flush()
+
+    out = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=t2,
+    )
+    assert len(out) == 1
+    expected = 128 * (300 + 600) / 3600.0
+    assert out[0]['core_hours'] == pytest.approx(expected)
+    assert out[0]['tick_count'] == 3
+    assert out[0]['first_seen'] == t0
+    assert out[0]['last_seen'] == t2
+
+
+# ---------------------------------------------------------------------------
+# Sparse tuples (the headline complication)
+# ---------------------------------------------------------------------------
+
+def test_sparse_tuple_appears_disappears_reappears(status_session):
+    """benkirk runs at t0 and t2 with 64 cores, but is absent at t1.
+    The interval (t1, t2) is a "gap" for benkirk — absence means 0 cores
+    for that interval, so it contributes nothing.
+
+    Tick layout (5 min spacing):
+      t0 (64) ──5min──> t1 (absent) ──5min──> t2 (64) ──5min──> t3 (last)
+
+    Left-step integration:
+      t0: 64 × 5min = 320 core-min
+      t1: absent → 0
+      t2: 64 × 5min = 320 core-min
+      t3: no successor → 0
+    Total = 640 core-min = 10.667 core-hours
+    """
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    ticks = [t0 + timedelta(minutes=5 * i) for i in range(4)]
+    parents = [_make_derecho(status_session, t) for t in ticks]
+    # Present at t0, absent at t1, present at t2 (no row at t3 either)
+    _make_upq(status_session, parents[0], system='derecho', queue='main',
+              user='benkirk', project='SCSG0001', cores=64)
+    _make_upq(status_session, parents[2], system='derecho', queue='main',
+              user='benkirk', project='SCSG0001', cores=64)
+    status_session.flush()
+
+    out = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=ticks[-1],
+    )
+    assert len(out) == 1
+    expected = 64 * 600.0 / 3600.0   # 2 ticks × 5 min worth
+    assert out[0]['core_hours'] == pytest.approx(expected)
+    assert out[0]['tick_count'] == 2
+    assert out[0]['first_seen'] == ticks[0]
+    assert out[0]['last_seen'] == ticks[2]
+
+
+def test_sparse_does_not_carry_forward(status_session):
+    """If a tuple appears at t0 only and never again, it must be charged
+    for ONE tick interval, not the whole window.
+
+    Naïve carry-forward would credit benkirk for every tick after t0.
+    """
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    # 6 ticks, benkirk only present at the first
+    ticks = [t0 + timedelta(minutes=5 * i) for i in range(6)]
+    parents = [_make_derecho(status_session, t) for t in ticks]
+    _make_upq(status_session, parents[0], system='derecho', queue='main',
+              user='benkirk', project='SCSG0001', cores=128)
+    status_session.flush()
+
+    out = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=ticks[-1],
+    )
+    assert len(out) == 1
+    assert out[0]['core_hours'] == pytest.approx(128 * 300.0 / 3600.0)
+    assert out[0]['tick_count'] == 1
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation — the QueueStatus invariant must hold over windows too
+# ---------------------------------------------------------------------------
+
+def test_reconciliation_against_queue_status(status_session):
+    """Per the user_proj_queue_status invariant: at every tick, summing
+    user_proj rows by queue equals the parent QueueStatus row. Therefore
+    integrated core-hours from get_user_proj_usage (summed across all
+    tuples on a queue) must equal the integral of QueueStatus on the
+    same queue.
+    """
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    ticks = [t0 + timedelta(minutes=5 * i) for i in range(4)]
+    parents = [_make_derecho(status_session, t) for t in ticks]
+
+    # Contributions per tick — designed so the QueueStatus totals match
+    # the sum of user_proj rows.
+    layout = {
+        # tick_idx: list of (user, project, cores, gpus, nodes)
+        0: [('alice', 'P1', 64, 0, 2), ('bob', 'P2', 32, 0, 1)],
+        1: [('alice', 'P1', 64, 0, 2)],
+        2: [('alice', 'P1', 32, 0, 1), ('bob', 'P2', 96, 0, 3),
+            ('carol', 'P3', 16, 4, 1)],
+        3: [('bob', 'P2', 16, 0, 1)],   # last tick, contributes 0 anyway
+    }
+
+    for i, entries in layout.items():
+        total_cores = sum(e[2] for e in entries)
+        total_gpus = sum(e[3] for e in entries)
+        # Parent QueueStatus row aggregating that tick's users on 'main'
+        qs = QueueStatus(
+            timestamp=ticks[i],
+            derecho_status=parents[i],
+            system_name='derecho', queue_name='main',
+            running_jobs=len(entries),
+            cores_allocated=total_cores,
+            gpus_allocated=total_gpus,
+            active_users=len(set(e[0] for e in entries)),
+        )
+        status_session.add(qs)
+        for user, proj, cores, gpus, nodes in entries:
+            _make_upq(status_session, parents[i], system='derecho',
+                      queue='main', user=user, project=proj,
+                      cores=cores, gpus=gpus, nodes=nodes)
+    status_session.flush()
+
+    out = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=ticks[-1], queue_name='main',
+    )
+
+    # Hand-computed expected core-hours per tick interval (left-step):
+    #   interval 0 (t0→t1, 5 min): 96 cores × 5/60 = 8.0
+    #   interval 1 (t1→t2, 5 min): 64 cores × 5/60 = 5.333
+    #   interval 2 (t2→t3, 5 min): 144 cores × 5/60 = 12.0
+    #   interval 3 (last tick): 0 (no successor)
+    expected_total_core_hours = (96 + 64 + 144) * 300.0 / 3600.0
+    summed = sum(r['core_hours'] for r in out)
+    assert summed == pytest.approx(expected_total_core_hours)
+
+    # And the GPU-hours: only carol at t2 has 4 gpus, contributes 4×5/60
+    expected_gpu_hours = 4 * 300.0 / 3600.0
+    assert sum(r['gpu_hours'] for r in out) == pytest.approx(expected_gpu_hours)
+
+
+# ---------------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------------
+
+def test_filter_by_queue(status_session):
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    t1 = t0 + timedelta(minutes=5)
+    p0 = _make_derecho(status_session, t0)
+    _make_derecho(status_session, t1)
+    _make_upq(status_session, p0, system='derecho', queue='main',
+              user='benkirk', project='SCSG0001', cores=64)
+    _make_upq(status_session, p0, system='derecho', queue='preempt',
+              user='benkirk', project='SCSG0001', cores=128)
+    status_session.flush()
+
+    out_main = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=t1, queue_name='main',
+    )
+    assert len(out_main) == 1
+    assert out_main[0]['queue_name'] == 'main'
+    assert out_main[0]['core_hours'] == pytest.approx(64 * 300.0 / 3600.0)
+
+    out_preempt = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=t1, queue_name='preempt',
+    )
+    assert len(out_preempt) == 1
+    assert out_preempt[0]['core_hours'] == pytest.approx(128 * 300.0 / 3600.0)
+
+    out_all = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=t1,
+    )
+    # benkirk on two queues = two rows
+    assert len(out_all) == 2
+    assert sum(r['core_hours'] for r in out_all) == pytest.approx(
+        (64 + 128) * 300.0 / 3600.0
+    )
+
+
+def test_filter_by_user_and_project(status_session):
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    t1 = t0 + timedelta(minutes=5)
+    p0 = _make_derecho(status_session, t0)
+    _make_derecho(status_session, t1)
+    _make_upq(status_session, p0, system='derecho', queue='main',
+              user='alice', project='P1', cores=64)
+    _make_upq(status_session, p0, system='derecho', queue='main',
+              user='bob', project='P1', cores=128)
+    _make_upq(status_session, p0, system='derecho', queue='main',
+              user='alice', project='P2', cores=32)
+    status_session.flush()
+
+    only_alice = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=t1, username='alice',
+    )
+    assert {r['project_code'] for r in only_alice} == {'P1', 'P2'}
+    assert all(r['username'] == 'alice' for r in only_alice)
+
+    only_p1 = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=t1, project_code='P1',
+    )
+    assert {r['username'] for r in only_p1} == {'alice', 'bob'}
+
+    alice_p1 = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=t1, username='alice', project_code='P1',
+    )
+    assert len(alice_p1) == 1
+    assert alice_p1[0]['core_hours'] == pytest.approx(64 * 300.0 / 3600.0)
+
+
+def test_unknown_user_or_project_returns_empty(status_session):
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    _make_derecho(status_session, t0)
+    _make_derecho(status_session, t0 + timedelta(minutes=5))
+    status_session.flush()
+
+    assert get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=t0 + timedelta(minutes=5),
+        username='nobody-here',
+    ) == []
+    assert get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=t0 + timedelta(minutes=5),
+        project_code='no-such-project',
+    ) == []
+
+
+def test_exclude_unknown_project(status_session):
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    t1 = t0 + timedelta(minutes=5)
+    p0 = _make_derecho(status_session, t0)
+    _make_derecho(status_session, t1)
+    _make_upq(status_session, p0, system='derecho', queue='main',
+              user='alice', project='SCSG0001', cores=64)
+    _make_upq(status_session, p0, system='derecho', queue='main',
+              user='bob', project='_unknown_', cores=128)
+    status_session.flush()
+
+    with_unknown = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=t1,
+    )
+    assert {r['project_code'] for r in with_unknown} == {'SCSG0001', '_unknown_'}
+
+    without = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=t1, exclude_unknown_project=True,
+    )
+    assert {r['project_code'] for r in without} == {'SCSG0001'}
+
+
+def test_system_filter_isolates_derecho_from_casper(status_session):
+    """A user on derecho and casper at the same timestamp must not
+    cross-contaminate when querying one system."""
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    t1 = t0 + timedelta(minutes=5)
+    pd0 = _make_derecho(status_session, t0)
+    _make_derecho(status_session, t1)
+    pc0 = _make_casper(status_session, t0)
+    _make_casper(status_session, t1)
+    _make_upq(status_session, pd0, system='derecho', queue='main',
+              user='alice', project='P1', cores=64)
+    _make_upq(status_session, pc0, system='casper', queue='htc',
+              user='alice', project='P1', cores=999)
+    status_session.flush()
+
+    only_d = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=t1,
+    )
+    assert len(only_d) == 1
+    assert only_d[0]['system'] == 'derecho'
+    assert only_d[0]['core_hours'] == pytest.approx(64 * 300.0 / 3600.0)
+
+    only_c = get_user_proj_usage(
+        status_session, system='casper',
+        start_date=t0, end_date=t1,
+    )
+    assert len(only_c) == 1
+    assert only_c[0]['system'] == 'casper'
+    assert only_c[0]['core_hours'] == pytest.approx(999 * 300.0 / 3600.0)
+
+
+def test_invalid_system_raises(status_session):
+    with pytest.raises(ValueError):
+        get_user_proj_usage(
+            status_session, system='no-such-system',
+            start_date=datetime(2026, 5, 4),
+            end_date=datetime(2026, 5, 5),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-chunk windows — exercises the streaming aggregator merge path
+# ---------------------------------------------------------------------------
+
+def test_chunk_size_is_invariant(status_session):
+    """The aggregator must yield identical results regardless of
+    chunk_days — different values just trade memory for query count."""
+    t0 = datetime(2026, 5, 1, 0, 0, 0)
+    # Span 4 days at 6-hour spacing → forces ≥4 chunks at chunk_days=1.
+    ticks = [t0 + timedelta(hours=6 * i) for i in range(17)]
+    parents = [_make_derecho(status_session, t) for t in ticks]
+    for i, p in enumerate(parents):
+        cores = 64 if i % 2 == 0 else 128
+        _make_upq(status_session, p, system='derecho', queue='main',
+                  user='benkirk', project='SCSG0001', cores=cores)
+    status_session.flush()
+
+    one_chunk = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=ticks[-1], chunk_days=30,
+    )
+    multi_chunk = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=ticks[-1], chunk_days=1,
+    )
+    assert len(one_chunk) == 1
+    assert len(multi_chunk) == 1
+    assert one_chunk[0]['core_hours'] == pytest.approx(multi_chunk[0]['core_hours'])
+    assert one_chunk[0]['tick_count'] == multi_chunk[0]['tick_count']
+    assert one_chunk[0]['first_seen'] == multi_chunk[0]['first_seen']
+    assert one_chunk[0]['last_seen'] == multi_chunk[0]['last_seen']
+
+
+def test_multi_day_window_with_small_chunks(status_session):
+    """Force multiple chunks by spanning >2 days with chunk_days=1.
+
+    Verifies that first_seen/last_seen/tick_count merge correctly across
+    chunks where the SAME tuple appears in multiple chunks.
+    """
+    t0 = datetime(2026, 5, 1, 0, 0, 0)
+    # 3 ticks per day for 3 days = 9 ticks, all benkirk@SCSG0001 with 100 cores
+    ticks = []
+    for day in range(3):
+        for hour in (0, 8, 16):
+            ticks.append(t0 + timedelta(days=day, hours=hour))
+    parents = [_make_derecho(status_session, t) for t in ticks]
+    for p in parents:
+        _make_upq(status_session, p, system='derecho', queue='main',
+                  user='benkirk', project='SCSG0001', cores=100)
+    status_session.flush()
+
+    out = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=ticks[0], end_date=ticks[-1], chunk_days=1,
+    )
+    assert len(out) == 1
+    r = out[0]
+    assert r['tick_count'] == 9
+    assert r['first_seen'] == ticks[0]
+    assert r['last_seen'] == ticks[-1]
+    # 8 intervals of 8 hours each (last tick contributes 0)
+    expected = 100 * 8 * 8 * 3600.0 / 3600.0   # cores × intervals × seconds / 3600
+    assert r['core_hours'] == pytest.approx(expected)
+
+
+def test_results_sorted_by_core_hours_desc(status_session):
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    t1 = t0 + timedelta(minutes=5)
+    p0 = _make_derecho(status_session, t0)
+    _make_derecho(status_session, t1)
+    _make_upq(status_session, p0, system='derecho', queue='main',
+              user='small', project='P1', cores=10)
+    _make_upq(status_session, p0, system='derecho', queue='main',
+              user='big', project='P1', cores=1000)
+    _make_upq(status_session, p0, system='derecho', queue='main',
+              user='medium', project='P1', cores=100)
+    status_session.flush()
+
+    out = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=t1,
+    )
+    assert [r['username'] for r in out] == ['big', 'medium', 'small']


### PR DESCRIPTION
## Summary

Adds `get_user_proj_usage` — a Phase-B query helper that integrates the
per-user / per-project / per-queue snapshot rollups into core-hours,
GPU-hours, and node-hours over an arbitrary window. Plus a one-shot
validation script that reconciles the result against the parent
`QueueStatus` integral on the local DB (PASS on all 14 queues at float64
epsilon).

This fills the gap between Phase B's existing instantaneous /
time-series helpers (`get_latest_user_proj_queue_snapshot`,
`get_user_proj_timeseries`) and the per-job billing path
(`comp_charge_summary`, `hpc_charge_summary`), which is job-record based
with explicit start/end times — fundamentally different from snapshot
integration. No reusable precedent existed.

## Approach

**Left-step (rectangle) integration** over the parent `DerechoStatus` /
`CasperStatus` tick timeline. The parent table is the canonical "the
collector ran at this moment" record (rows are written every tick
regardless of whether any user has jobs), so it correctly captures gap
widths even when no user_proj rows exist at a tick.

Per-row `dt` is derived from the actual delta between successive
observed timestamps — **never** hard-coded to 300 s. Collectors stall,
reschedule, or get reconfigured; this matters in practice (see
validation results below).

**Sparse rows** (a (user, project, queue) row exists only when that
tuple has ≥1 job at that tick) are handled by absence-as-zero, not
carry-forward. Naive carry-forward would attribute load forever after a
user's jobs end. Trapezoidal would halve any tuple that disappears
between samples; right-step would charge phantom load on first
appearance. Left-step is the honest discretization for jobs that
start/stop in discrete jumps.

## Implementation

Chunked numpy aggregation keeps memory bounded at year-scale (~36M
rows). Per monthly chunk:
- Vectorized `np.searchsorted` for dt lookup against the parent tick
  array.
- Columnar `cores × dt` / `gpus × dt` / `nodes × dt` products.
- `np.bincount` on a 21-bit composite `(uid, pid, qid)` int64 key for
  groupby — no Python row loop in the hot path.
- `np.minimum.at` / `np.maximum.at` for per-group `first_seen` /
  `last_seen`.

Per-chunk groups merge into a master dict; labels resolve in three
batched lookups at the end (no N+1). Integration runs in seconds (not
microseconds) so float64 mantissa precision holds well past year-scale
sums.

**Performance envelope** (prod-shaped data, ~98k rows/day):

| Window | Rows | Wall time |
|---|---|---|
| 1 hour | ~4 k | <50 ms |
| 1 day | ~100 k | <500 ms |
| 1 week | ~700 k | ~3 s |
| 1 month | ~3 M | ~10–15 s |
| 1 year | ~36 M | ~2–4 min (offline only) |

Year-scale is fine for offline reports but should not be called from a
synchronous request handler. If year-scale UI becomes a need, the right
answer is a nightly-rolled summary table — out of scope here.

## Verification

**16 unit tests** cover: empty / single-tick / two-tick boundary cases,
variable-dt (heterogeneous tick intervals — verifies no hard-coded
300 s), sparse-tuple absence semantics (appear / disappear / reappear,
no carry-forward), filters (queue / user / project / system /
exclude_unknown_project), chunk-size invariance, multi-day multi-chunk
merge, descending sort, and a hand-computed reconciliation against
QueueStatus over a multi-tick window.

**`scripts/validate_user_proj_usage.py`** runs end-to-end against the
local Docker MySQL DB. The reconciliation aligns the QueueStatus
integrator to the same parent tick set the production helper uses, so
`dt[i]` values match byte-for-byte. Local-DB results:

- **Derecho**: 134 ticks across 17.44 h. dt min=255s, p50=300s,
  p95=1268s, max=2788s. **28 gaps > 6 min**.
- **Casper**: 141 ticks across 17.44 h. dt min=20s, p50=301s,
  max=2783s. **28 gaps > 6 min**.
- **All 14 queues PASS** with deltas at float64 epsilon (1e-12 to 1e-9
  — pure summation-order noise).

The variable-dt path is exercised by organic collector irregularity,
not just hand-crafted unit-test fixtures.

## Test plan

- [ ] CI: `pytest tests/unit/test_user_proj_usage.py` (16 tests, ~5 s)
- [ ] CI: full `pytest` to confirm nothing else regresses
- [ ] Local: `STATUS_DB_DRIVER=mysql STATUS_DB_SERVER=127.0.0.1 python scripts/validate_user_proj_usage.py` — verify all queues PASS
- [ ] Code review: confirm left-step is the right semantic choice for
  our use case (alternative: right-step or trapezoidal — see commit
  message for trade-offs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)