### PR TITLE
caching: unified CacheBase + admin Server Info card + investigation docs

### DIFF
--- a/docs/CIRRUS-k8s-cmds.sh
+++ b/docs/CIRRUS-k8s-cmds.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# ============================================================================
+#  CIRRUS / k8s troubleshooting reference for the SAM webapp deployment.
+#
+#  This is a runbook, NOT a script to execute end-to-end. Pick the section that
+#  matches your symptom and copy/paste the relevant command.
+#
+#  Cluster: nwc1   ·   Namespace: sam-queries   ·   Site: samuel.k8s.ucar.edu
+#
+#  Tested commands from the 2026-05-06 troubleshooting session that traced an
+#  /allocations OOMKill back to a gunicorn worker over-provisioning bug
+#  (multiprocessing.cpu_count() returning the node's 64 cores instead of the
+#  pod's 16-core cgroup limit) and then verified the fix end-to-end.
+# ============================================================================
+
+# Set these once per shell so every command below is short. If you're already
+# on a kubeconfig with a default context, you can drop --context.
+CTX=nwc1
+NS=sam-queries
+DEPLOY=samuel
+
+
+# ── 1. Sanity: am I connected? what's in the namespace? ─────────────────────
+# 'get ns' lists every namespace you can see — confirms cluster access.
+kubectl --context "$CTX" get ns
+# 'get all -n …' shows pods, services, deployments, replicasets in one view.
+kubectl --context "$CTX" -n "$NS" get all
+# 'get pods -o wide' adds the node and pod IP — useful when traffic looks
+# wrongly distributed or one node is suspect.
+kubectl --context "$CTX" -n "$NS" get pods -o wide
+
+
+# ── 2. Snapshot resource usage (CPU / memory) ───────────────────────────────
+# Requires metrics-server in the cluster. Updates ~every 15 s, so two reads
+# 30 s apart give a useful before/after.
+kubectl --context "$CTX" -n "$NS" top pods
+# Per-container view (matters when a pod has sidecars — sam doesn't, but the
+# habit is good).
+kubectl --context "$CTX" -n "$NS" top pods --containers
+# Per-node usage — confirms the node isn't itself starved before blaming the pod.
+kubectl --context "$CTX" top nodes
+
+
+# ── 3. What image / env / limits is the deployment actually using? ─────────
+# The deployment is the source of truth; the pod just inherits.
+kubectl --context "$CTX" -n "$NS" get deploy "$DEPLOY" \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+# Print all environment variables in name=value form.
+kubectl --context "$CTX" -n "$NS" get deploy "$DEPLOY" \
+  -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}'
+# CPU / memory requests + limits (look here when the pod OOMKills — confirm
+# the cgroup limit you THINK is in effect actually is).
+kubectl --context "$CTX" -n "$NS" get deploy "$DEPLOY" \
+  -o jsonpath='{.spec.template.spec.containers[0].resources}{"\n"}' | jq .
+
+# Full deployment dump (verbose; useful for `diff` between branches).
+kubectl --context "$CTX" -n "$NS" get deploy "$DEPLOY" -o yaml > /tmp/deploy.yaml
+
+
+# ── 4. Pod state, restart history, and OOMKill detection ───────────────────
+# 'get pods' shows RESTARTS column at a glance.
+kubectl --context "$CTX" -n "$NS" get pods
+# Drill into one pod: lastState.terminated tells you WHY it died.
+# Look for: reason: OOMKilled, exitCode: 137. That's the smoking gun.
+POD=$(kubectl --context "$CTX" -n "$NS" get pods -l app="$DEPLOY" \
+        -o jsonpath='{.items[0].metadata.name}')
+kubectl --context "$CTX" -n "$NS" get pod "$POD" -o json \
+  | jq -r '.status.containerStatuses[0]
+           | "lastState=\(.lastState)  state=\(.state)  restartCount=\(.restartCount)"'
+
+# 'describe pod' gives a human-readable summary including events at the bottom.
+kubectl --context "$CTX" -n "$NS" describe pod "$POD"
+
+# Recent namespace-wide events (shows OOMKill, FailedScheduling, image pull
+# errors, etc.). --sort-by=.lastTimestamp because default order is meaningless.
+kubectl --context "$CTX" -n "$NS" get events --sort-by=.lastTimestamp | tail -25
+
+
+# ── 5. Inspect what's running INSIDE the pod ───────────────────────────────
+# Process list sorted by RSS — finds memory hogs and confirms gunicorn worker
+# count. The number of `gunicorn -c` lines = master + workers.
+kubectl --context "$CTX" -n "$NS" exec "$POD" -- \
+  ps -eo pid,ppid,rss,etime,cmd --sort=-rss | head -30
+
+# Just the worker count.
+kubectl --context "$CTX" -n "$NS" exec "$POD" -- \
+  sh -c 'ps -e -o cmd | grep -c "gunicorn -c"'
+
+# Total in-pod RSS in MiB (sums all processes — note this is NOT the cgroup
+# accounting, which dedupes COW-shared pages from preload_app=True; it IS what
+# `ps` would show summed naively).
+kubectl --context "$CTX" -n "$NS" exec "$POD" -- \
+  sh -c 'ps -e -o rss | awk "NR>1 {s+=\$1} END {printf \"%.0f MiB\n\", s/1024}"'
+
+# Confirm cgroup vs host CPU — the bug that started this whole investigation.
+# Inside a pod, multiprocessing.cpu_count() returns the host's CPUs (e.g. 64),
+# NOT the cgroup quota (e.g. 16). cpu.max format is "<quota_us> <period_us>";
+# quota / period = effective CPUs.
+kubectl --context "$CTX" -n "$NS" exec "$POD" -- python3 -c '
+import multiprocessing as m
+print("cpu_count:", m.cpu_count())
+print("cgroup_cpu.max:", open("/sys/fs/cgroup/cpu.max").read().strip())
+'
+
+# Drop into a pod for interactive poking.
+kubectl --context "$CTX" -n "$NS" exec -it "$POD" -- bash
+
+
+# ── 6. Logs (current + previous container) ─────────────────────────────────
+# Live tail of stdout/stderr.
+kubectl --context "$CTX" -n "$NS" logs -f "$POD"
+# After a pod restart, --previous shows the dead container's logs (often where
+# the actual error/traceback before the OOMKill lives).
+kubectl --context "$CTX" -n "$NS" logs --previous "$POD"
+# Last N lines (handy for grepping).
+kubectl --context "$CTX" -n "$NS" logs --tail=200 "$POD" | grep -i error
+# Log everything from all pods of the deployment (useful when a load-balancer
+# rotates traffic across pods and you don't know which served the bad request).
+kubectl --context "$CTX" -n "$NS" logs -l app="$DEPLOY" --tail=100 --prefix
+
+
+# ── 7. Rollout history and rollback ────────────────────────────────────────
+# Every prior image / spec change is preserved as a ReplicaSet. Useful when
+# you suspect a recent deploy regressed something.
+kubectl --context "$CTX" -n "$NS" rollout history deploy "$DEPLOY"
+# Show the spec of a specific revision.
+kubectl --context "$CTX" -n "$NS" rollout history deploy "$DEPLOY" --revision=5
+# Show all replicasets — newest is at the top, prior ones have replicas=0.
+# 'IMAGE' column tells you which sha shipped in each.
+kubectl --context "$CTX" -n "$NS" get rs -l app="$DEPLOY" \
+  -o custom-columns=NAME:.metadata.name,IMAGE:.spec.template.spec.containers[0].image,REPLICAS:.spec.replicas,CREATED:.metadata.creationTimestamp
+
+# Rollback to the previous good revision (DESTRUCTIVE — make sure!).
+# kubectl --context "$CTX" -n "$NS" rollout undo deploy "$DEPLOY"
+# Rollback to a specific revision.
+# kubectl --context "$CTX" -n "$NS" rollout undo deploy "$DEPLOY" --to-revision=5
+
+
+# ── 8. Watch a deploy roll out in real time ────────────────────────────────
+# After pushing a new image / Helm upgrade.
+kubectl --context "$CTX" -n "$NS" rollout status deploy "$DEPLOY" --timeout=5m
+# Live watch on pod state changes (handy in a second terminal during deploys).
+kubectl --context "$CTX" -n "$NS" get pods -w
+
+
+# ── 9. Helm-specific (since this app is deployed via Helm) ─────────────────
+# What releases exist?
+helm --kube-context "$CTX" -n "$NS" list
+# Show the values currently in effect for a release.
+helm --kube-context "$CTX" -n "$NS" get values "$DEPLOY"
+# Show every manifest the release rendered (full applied state).
+helm --kube-context "$CTX" -n "$NS" get manifest "$DEPLOY"
+# Render the chart locally without applying — best for verifying that an
+# env-var or limits change templates as you expect BEFORE deploying.
+helm template helm -f helm/values.yaml | grep -A1 GUNICORN_WORKERS
+helm template helm -f helm/values-local.yaml | grep -A1 GUNICORN_WORKERS
+
+# Dry-run an upgrade (computes diff vs cluster, never applies).
+helm --kube-context "$CTX" -n "$NS" upgrade "$DEPLOY" helm \
+  -f helm/values.yaml --dry-run --debug | less
+
+
+# ── 10. The investigation pattern, in summary ───────────────────────────────
+# When a pod is misbehaving and you don't know why, run these in order:
+#   1.  kubectl get pods                  → restart count > 0?
+#   2.  kubectl get pod $POD -o json | jq .status.containerStatuses[0].lastState
+#                                         → exitCode 137 / OOMKilled?
+#   3.  kubectl get events --sort-by=.lastTimestamp
+#                                         → recent OOM / Pull / FailedSchedule?
+#   4.  kubectl top pods                  → memory pressure right now?
+#   5.  kubectl exec $POD -- ps -eo rss,cmd --sort=-rss | head
+#                                         → which process is hogging?
+#   6.  kubectl exec $POD -- cat /sys/fs/cgroup/cpu.max
+#                                         → does the app think it has more
+#                                           CPUs than the cgroup actually grants?
+#   7.  kubectl logs --previous $POD      → what did it say before dying?
+#   8.  kubectl rollout history deploy    → did this only start after a recent
+#                                           deploy? roll back to confirm.
+#
+# References:
+#   - kubectl cheat sheet:    https://kubernetes.io/docs/reference/kubectl/cheatsheet/
+#   - JSONPath syntax:        https://kubernetes.io/docs/reference/kubectl/jsonpath/
+#   - Helm command reference: https://helm.sh/docs/helm/helm/

--- a/docs/plans/SHARED_CACHE_FINDINGS.md
+++ b/docs/plans/SHARED_CACHE_FINDINGS.md
@@ -1,0 +1,107 @@
+# Shared cache findings
+
+Investigation date: 2026-05-06
+Branches probed: `main` (sha-fda98ab), `gunicorn_worker_fix` (sha-cb2ef93, since merged as PR #240), `caching_unified` (sha-8008045, draft PR #238 rebased onto post-#240 staging).
+Site: samuel.k8s.ucar.edu (cluster `nwc1`, namespace `sam-queries`).
+
+## TL;DR
+
+The unified `Caching` facade introduced in `caching_unified` is functionally correct and safely deployable — it doesn't regress memory, doesn't OOM, and surfaces useful admin observability. **But the chart caches it manages don't materially speed up `/allocations` in production.**
+
+The reason isn't the new code — it's a structural property of the deployment that pre-existed the PR: **every gunicorn worker holds its own private `OrderedDict` cache.** With `preload_app = True` and 33 workers per pod × 2 pods = **66 independent caches per deployment**, the best a single user can hope for is a `1/33` hit rate on the warm pod and `0/33` on the cold one.
+
+The PR is mergeable as-is for the operability/visibility benefits. The performance win for `/allocations` requires a separate change: either a shared cache backend (Redis) or a different render strategy (per-chart HTMX fragments cached at the HTTP layer).
+
+## What we measured
+
+Identical playwright probe (8 cold `/allocations` loads, sequential, signed in as `benkirk`) against three deployments, with `kubectl top pods` sampled every 3 seconds.
+
+| Metric | sha-fda98ab (pre-fix) | sha-cb2ef93 (gunicorn fix) | sha-8008045 (+ caching_unified) |
+|---|---|---|---|
+| Workers per pod | 132 | 33 + 1 master | 33 + 1 master |
+| Baseline RSS (fresh boot) | ~3 GiB | ~520 MiB | ~520 MiB |
+| RSS after 8 cold loads | OOMKilled at load 2 | ~1.6 GiB | 1.7–1.9 GiB |
+| Pod restarts during probe | 1 (OOMKilled at 11.4 GiB) | 0 | 0 |
+| Wall time, cold render | 16–19 s | 16–19 s | 16–26 s |
+| Wall time, warm-worker hit | n/a | n/a | **3.1 s** (1 of 8) |
+| Admin Caching card hits/misses | n/a (no card) | n/a | 0 / 0 (on the queried worker) |
+| Admin Caching card entries | n/a | n/a | 0 / N for all 8 chart caches |
+
+The single 3.1 s response on the caching deploy is the load that happened to land on a worker that had served the same request earlier in the probe. Every other request landed on a worker whose cache was still cold.
+
+## Root cause
+
+`containers/webapp/gunicorn_config.py` sets `preload_app = True`. The webapp is imported once in the master, then forked. Every module-level singleton — including `caching = Caching()` in `webapp/caching/__init__.py`, the `flask_caching.Cache()` SimpleCache backing dict, and each `ChartCache(name=…, maxsize=…)` registered via `caching.chart_cached(...)` — is a copy-on-write inheritance from the master into each worker.
+
+The first time a worker calls `cache.put(key, svg)`, the COW page is broken and the OrderedDict becomes uniquely the property of that worker. A second worker serving the next request has its own pristine OrderedDict; it pays full matplotlib cost, dirties its own COW page, and stores the result locally.
+
+There is no IPC between workers. There is no shared backend. SimpleCache is `cachelib.simple.SimpleCache`, which is in-process. cachetools.TTLCache likewise.
+
+So the effective cache behaviour at the deployment level:
+- 66 independent caches (2 pods × 33 workers)
+- Each user's repeated requests are spread across workers by the load balancer / gunicorn's request distribution
+- A cache entry warmed in worker N is invisible to workers ≠ N
+- The admin Caching card queries whichever single worker happens to handle the request — its `0 / 0` is correct for that worker, just not representative of the deployment
+
+## Per-worker memory evidence
+
+A `kubectl exec ... ps -eo pid,rss,cmd | grep gunicorn` snapshot during the probe on the caching deploy showed most workers around 170–190 MiB RSS, with a single outlier at ~388 MiB. That outlier is the worker that warmed its chart cache. The COW divergence is real and observable.
+
+## Why `/allocations` rendering is expensive in the first place
+
+A single `/allocations` page renders ~30 SVGs synchronously inside the template:
+- 10 facility pies (Allocated tab) — `facility_pie_chart` cache
+- 10 facility pies (Usage tab)
+- 10 pace charts (Pace tab) — `pace_chart` cache
+- plus assorted timeseries, stacked-area, allocation-type pies
+
+Each SVG is a matplotlib figure → `savefig(format='svg')` round-trip. matplotlib first-render on a cold worker is dominated by font discovery, locator setup, and axes layout. That's where the 16–19 s comes from. Caching at the SVG-string level (what `ChartCache` does) is exactly the right shape — but only useful if the cache is shared.
+
+## Recommendations
+
+### Option A: Move to a shared backend (the proper fix)
+
+Configure Flask-Caching with a Redis or Memcached backend, and route the chart caches through it. With Helm we can add a Redis sidecar or use an existing cluster Redis.
+
+- Pros: One cache shared across all 66 workers. First user warms; everyone else benefits. Hit rate goes from `1/66` to ~`100%` for stable URLs.
+- Cons: Adds an infrastructure dependency. Need to handle Redis being unreachable (fallback to per-worker).
+
+The unified `Caching` facade in this PR is the right place to plumb this. `webapp/caching/flask_adapter.py` already abstracts the backend; we'd swap `CACHE_TYPE=SimpleCache` for `CACHE_TYPE=RedisCache` plus a `CACHE_REDIS_URL`. The `ChartCache` instances would need to be re-implemented as Redis-backed (or replaced by a `flask-caching` decorator). The `CacheBase` contract already gives us the abstraction layer.
+
+### Option B: Per-chart HTMX fragments cached at the HTTP layer
+
+Instead of inlining 30 SVGs in the `/allocations` HTML, return a skeleton page that loads each chart via an HTMX endpoint. Apply `@cache.cached(timeout=N, query_string=True)` per endpoint.
+
+- Pros: Initial page load returns instantly (the 30 SVGs load progressively). Cache works at the URL level — same caveat about per-worker SimpleCache, but with Redis (option A) becomes truly shared. Each chart cacheable independently with its own TTL.
+- Cons: Bigger refactor. Changes user-visible behaviour (progressive rendering vs single-shot).
+
+### Option C: Accept the limitation; document it
+
+Merge `caching_unified` for the observability benefits. Accept that chart caching only helps power users who hit `/allocations` frequently enough to keep multiple workers warm. Document in the admin card that the displayed stats are per-worker.
+
+- Pros: Zero additional work. The gunicorn fix already ships the big production win.
+- Cons: Doesn't solve the underlying problem. Future "why is /allocations still slow?" debugging will rediscover this.
+
+### Suggested ordering
+
+1. Merge `caching_unified` (PR #238) — it's the foundation, regardless of which path we take next.
+2. Open a follow-up issue tracking option A (Redis-backed shared cache) as the medium-term fix.
+3. Lightly clarify the admin Caching card to say "per-worker (this process only)" so future readers don't repeat this confusion.
+
+## Reproducing the per-worker effect
+
+```bash
+CTX=nwc1; NS=sam-queries
+POD=$(kubectl --context $CTX -n $NS get pods -l app=samuel -o jsonpath='{.items[0].metadata.name}')
+
+# Worker RSS distribution during traffic — look for outlier (warmed worker).
+kubectl --context $CTX -n $NS exec $POD -- \
+  sh -c 'ps -eo pid,rss,cmd | grep "gunicorn -c" | sort -k2 -n -r | head'
+```
+
+If you see most workers within ~20% of each other and one or two ~2× larger, those outliers are warmed. That's the structural shape of the per-worker cache problem.
+
+## Out of scope for this writeup
+
+- Choice of shared backend (Redis vs Memcached vs disk-cache) — should be decided alongside the rate-limiting plan in `docs/plans/RATE_LIMITING.md`, since the same shared backend can serve both.
+- Hit-rate measurement: `cachetools.TTLCache` doesn't natively count hits/misses, so the admin card surfaces `None` for those today. Worth fixing in the per-worker counters so we can validate any future shared-cache work has the expected effect.

--- a/src/sam/caching/__init__.py
+++ b/src/sam/caching/__init__.py
@@ -1,0 +1,16 @@
+"""
+Framework-agnostic cache primitives shared by sam (CLI/ORM) and webapp.
+
+Every cache layer in the SAM ecosystem implements the `CacheBase` contract:
+a uniform `info() -> dict` and `clear() -> int`. That gives operators a
+single stats shape across the admin Configuration card and lets future
+adapters (Redis, file-system, etc.) plug in without rewriting consumers.
+
+Subclasses live both here (`TTLCacheAdapter` — used by the allocation usage
+cache) and in `webapp.caching` (`ChartCache`, `FlaskCacheAdapter`).
+"""
+
+from sam.caching.base import CacheBase, approx_bytes
+from sam.caching.ttl import TTLCacheAdapter
+
+__all__ = ['CacheBase', 'TTLCacheAdapter', 'approx_bytes']

--- a/src/sam/caching/base.py
+++ b/src/sam/caching/base.py
@@ -1,0 +1,73 @@
+"""
+CacheBase: uniform contract for every cache layer.
+"""
+
+import sys
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+def approx_bytes(obj: Any, _seen: set = None) -> int:
+    """Best-effort byte-size approximation for arbitrary cached values.
+
+    Walks one level into list/tuple/dict/set containers and sums
+    `sys.getsizeof` of each leaf. NOT a true deep-size measurement —
+    Python's reference counting and shared-string interning mean the
+    real footprint can be lower; conversely, deeply nested structures
+    will undercount. Treat the result as a useful lower bound for
+    operator dashboards, not a precise number.
+    """
+    if obj is None:
+        return 0
+    if _seen is None:
+        _seen = set()
+    obj_id = id(obj)
+    if obj_id in _seen:
+        return 0
+    _seen.add(obj_id)
+
+    size = sys.getsizeof(obj)
+    if isinstance(obj, (str, bytes, bytearray, int, float, bool)):
+        return size
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            size += approx_bytes(k, _seen) + approx_bytes(v, _seen)
+        return size
+    if isinstance(obj, (list, tuple, set, frozenset)):
+        for v in obj:
+            size += approx_bytes(v, _seen)
+        return size
+    return size
+
+
+class CacheBase(ABC):
+    """Uniform stats/clear contract for any cache layer.
+
+    Subclasses live both in sam (framework-agnostic — TTLCacheAdapter)
+    and in webapp (ChartCache, FlaskCacheAdapter). The `info()` dict has
+    a canonical shape so a single Jinja macro can render any adapter.
+    """
+
+    name: str  # human label for stats display
+
+    @abstractmethod
+    def info(self) -> dict:
+        """Return canonical stats dict.
+
+        Shape:
+            {
+              'name':        str,
+              'enabled':     bool,
+              'currsize':    int | None,    # entry count, None if not introspectable
+              'maxsize':     int | None,    # capacity, None if unbounded
+              'ttl':         float | None,  # seconds; None for non-TTL caches
+              'hits':        int  | None,   # None if backend doesn't track
+              'misses':      int  | None,
+              'bytes_approx': int | None,   # lower-bound (see approx_bytes)
+              'extras':      dict,          # backend-specific (e.g. flask groups)
+            }
+        """
+
+    @abstractmethod
+    def clear(self) -> int:
+        """Invalidate all entries. Return number cleared."""

--- a/src/sam/caching/ttl.py
+++ b/src/sam/caching/ttl.py
@@ -1,0 +1,98 @@
+"""
+TTLCacheAdapter — wraps cachetools.TTLCache to conform to CacheBase.
+"""
+
+import threading
+from typing import Any, Hashable, Optional
+
+from cachetools import TTLCache
+
+from sam.caching.base import CacheBase, approx_bytes
+
+
+class TTLCacheAdapter(CacheBase):
+    """`cachetools.TTLCache` wrapped to match the CacheBase contract.
+
+    Used by `sam.queries.usage_cache` for the allocation summary cache.
+    Provides the standard get/pop/setitem operations the existing
+    consumer expects, plus the `info()`/`clear()` surface every adapter
+    exposes.
+
+    Hits/misses are not tracked — cachetools doesn't expose counters
+    natively and instrumenting that is out of scope. Operators see
+    `hits=None, misses=None` in the admin card.
+    """
+
+    def __init__(self, name: str, *, maxsize: int, ttl: float):
+        self.name = name
+        self._cache: TTLCache = TTLCache(maxsize=maxsize, ttl=ttl)
+        self._lock = threading.RLock()
+
+    # ── thin operations the wrapping query function uses directly ────────
+
+    @property
+    def lock(self) -> threading.RLock:
+        return self._lock
+
+    def __contains__(self, key: Hashable) -> bool:
+        return key in self._cache
+
+    def __getitem__(self, key: Hashable) -> Any:
+        return self._cache[key]
+
+    def __setitem__(self, key: Hashable, value: Any) -> None:
+        self._cache[key] = value
+
+    def pop(self, key: Hashable, default: Any = None) -> Any:
+        return self._cache.pop(key, default)
+
+    @property
+    def maxsize(self) -> int:
+        return self._cache.maxsize
+
+    @property
+    def ttl(self) -> float:
+        return self._cache.ttl
+
+    # ── CacheBase ───────────────────────────────────────────────────────
+
+    def info(self) -> dict:
+        with self._lock:
+            currsize = len(self._cache)
+            # Approximate bytes by walking entries. For the allocation
+            # usage cache the values are list[dict] — approx_bytes
+            # captures container overhead + leaf sizes (lower bound).
+            bytes_approx = approx_bytes(dict(self._cache))
+        return {
+            'name':         self.name,
+            'enabled':      True,
+            'currsize':     currsize,
+            'maxsize':      self._cache.maxsize,
+            'ttl':          self._cache.ttl,
+            'hits':         None,
+            'misses':       None,
+            'bytes_approx': bytes_approx,
+            'extras':       {},
+        }
+
+    def clear(self) -> int:
+        with self._lock:
+            n = len(self._cache)
+            self._cache.clear()
+        return n
+
+
+def disabled_info(name: str, *, maxsize: Optional[int] = None,
+                  ttl: Optional[float] = None) -> dict:
+    """Stats dict for a cache that's been turned off via config (TTL=0 or size=0)."""
+    return {
+        'name':         name,
+        'enabled':      False,
+        'currsize':     0,
+        'maxsize':      maxsize,
+        'ttl':          ttl,
+        'hits':         None,
+        'misses':       None,
+        'bytes_approx': 0,
+        'extras':       {},
+    }

--- a/src/sam/queries/usage_cache.py
+++ b/src/sam/queries/usage_cache.py
@@ -16,8 +16,8 @@ import threading
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from cachetools import TTLCache
-
+from sam.caching import CacheBase, TTLCacheAdapter
+from sam.caching.ttl import disabled_info
 from sam.queries.allocations import get_allocation_summary_with_usage
 
 
@@ -42,21 +42,26 @@ def _normalize(value: Any):
 
 
 # ---------------------------------------------------------------------------
-# Lazy-initialized cache
+# Lazy-initialized adapter
 # ---------------------------------------------------------------------------
 
-_cache: Optional[TTLCache] = None
-_lock = threading.RLock()
+_adapter: Optional[TTLCacheAdapter] = None
+_init_lock = threading.RLock()
 _disabled = False   # set True when TTL or SIZE == 0
 
 
-def _get_cache() -> Optional[TTLCache]:
-    """Return the shared TTLCache, initializing on first call. Returns None if disabled."""
-    global _cache, _disabled
+def get_cache_adapter() -> Optional[TTLCacheAdapter]:
+    """Return the shared CacheBase adapter, initializing on first call.
 
-    with _lock:
-        if _cache is not None or _disabled:
-            return None if _disabled else _cache
+    Returns None when caching is disabled by config (TTL or SIZE == 0).
+    Used by the Caching facade in webapp to surface this cache's stats
+    alongside the webapp-owned chart and Flask caches.
+    """
+    global _adapter, _disabled
+
+    with _init_lock:
+        if _adapter is not None or _disabled:
+            return None if _disabled else _adapter
 
         ttl  = _get_config('ALLOCATION_USAGE_CACHE_TTL',  3600)
         size = _get_config('ALLOCATION_USAGE_CACHE_SIZE', 200)
@@ -65,8 +70,8 @@ def _get_cache() -> Optional[TTLCache]:
             _disabled = True
             return None
 
-        _cache = TTLCache(maxsize=size, ttl=ttl)
-        return _cache
+        _adapter = TTLCacheAdapter(name='allocation_usage', maxsize=size, ttl=ttl)
+        return _adapter
 
 
 # ---------------------------------------------------------------------------
@@ -102,9 +107,9 @@ def cached_allocation_usage(
 
     All other args are forwarded unchanged to get_allocation_summary_with_usage().
     """
-    cache = _get_cache()
+    adapter = get_cache_adapter()
 
-    if cache is None:
+    if adapter is None:
         # Cache disabled — call through directly
         return get_allocation_summary_with_usage(
             session=session,
@@ -130,11 +135,11 @@ def cached_allocation_usage(
         root_only,
     )
 
-    with _lock:
-        if not force_refresh and key in cache:
-            return cache[key]
+    with adapter.lock:
+        if not force_refresh and key in adapter:
+            return adapter[key]
         # Remove stale entry so we can re-insert after the query
-        cache.pop(key, None)
+        adapter.pop(key, None)
 
     result = get_allocation_summary_with_usage(
         session=session,
@@ -149,9 +154,9 @@ def cached_allocation_usage(
         _summary=_summary,
     )
 
-    with _lock:
+    with adapter.lock:
         try:
-            cache[key] = result
+            adapter[key] = result
         except ValueError:
             # Cache full and all entries are unexpired (TTLCache raises ValueError
             # when maxsize is reached and no expired items are available to evict).
@@ -162,31 +167,23 @@ def cached_allocation_usage(
 
 def purge_usage_cache() -> int:
     """Clear all cached usage data. Returns number of entries cleared."""
-    cache = _get_cache()
-    if cache is None:
+    adapter = get_cache_adapter()
+    if adapter is None:
         return 0
-    with _lock:
-        n = len(cache)
-        cache.clear()
-    return n
+    return adapter.clear()
 
 
 def usage_cache_info() -> Dict:
-    """Return cache statistics for monitoring/admin display."""
-    cache = _get_cache()
-    if cache is None:
+    """Return cache statistics for monitoring/admin display.
+
+    Delegates to the adapter's `info()` (canonical CacheBase shape).
+    Backwards-compatible: the legacy keys (`enabled`, `currsize`,
+    `maxsize`, `ttl`) are still present; new fields (`hits`, `misses`,
+    `bytes_approx`, `name`, `extras`) are additive.
+    """
+    adapter = get_cache_adapter()
+    if adapter is None:
         ttl  = _get_config('ALLOCATION_USAGE_CACHE_TTL',  3600)
         size = _get_config('ALLOCATION_USAGE_CACHE_SIZE', 200)
-        return {
-            'enabled': False,
-            'currsize': 0,
-            'maxsize': size,
-            'ttl': ttl,
-        }
-    with _lock:
-        return {
-            'enabled': True,
-            'currsize': len(cache),
-            'maxsize': cache.maxsize,
-            'ttl': cache.ttl,
-        }
+        return disabled_info('allocation_usage', maxsize=size, ttl=ttl)
+    return adapter.info()

--- a/src/webapp/caching/__init__.py
+++ b/src/webapp/caching/__init__.py
@@ -1,0 +1,114 @@
+"""
+Caching facade — the single entry point for every cache layer in the webapp.
+
+Owns the Flask-Caching extension and the chart SVG caches, and proxies the
+sam-package allocation usage cache for unified stats and clear semantics.
+
+Usage
+-----
+
+In the application factory::
+
+    from webapp.caching import caching
+    caching.init_app(app)
+
+Decorating an HTTP route (Flask-Caching pass-through)::
+
+    from webapp.caching import caching
+    @caching.flask.cached(timeout=300, query_string=True)
+    def my_view(): ...
+
+Decorating a chart-generating function::
+
+    @caching.chart_cached(name='usage_timeseries', maxsize=128)
+    def generate_usage_timeseries(daily_charges) -> str: ...
+
+Inspecting all caches (used by the admin Configuration card)::
+
+    caching.stats()            # → dict for the template
+    caching.clear('chart')     # category in {'flask','chart','usage',None}
+"""
+
+from typing import Callable, List, Optional
+
+from sam.caching import CacheBase
+from webapp.caching.chart import ChartCache, chart_cached as _chart_decorator
+from webapp.caching.flask_adapter import FlaskCacheAdapter
+
+
+class Caching:
+    """Single facade for every cache layer the webapp owns or proxies."""
+
+    def __init__(self):
+        from flask_caching import Cache
+        self.flask = Cache()
+        self._flask_adapter = FlaskCacheAdapter(self.flask)
+        self._chart_caches: List[ChartCache] = []
+
+    def init_app(self, app, **flask_config) -> None:
+        self.flask.init_app(app, **flask_config)
+
+    # ── Decorators ──────────────────────────────────────────────────────
+
+    def chart_cached(self, *, name: str, maxsize: int,
+                     key_fn: Optional[Callable] = None):
+        """Decorator factory for matplotlib SVG memoization.
+
+        Each decorated function gets its own bounded LRU. The cache is
+        registered with the facade so it shows up in `stats()` and
+        responds to `clear('chart')`.
+        """
+        cache = ChartCache(name=name, maxsize=maxsize)
+        self._chart_caches.append(cache)
+        return _chart_decorator(cache, key_fn=key_fn)
+
+    # ── Introspection ───────────────────────────────────────────────────
+
+    def adapters(self) -> List[CacheBase]:
+        """All adapters known to the facade, including the proxied usage cache.
+
+        Order: flask first, then chart caches in registration order, then
+        the usage cache (if enabled). Stable across processes since
+        registration order is deterministic.
+        """
+        out: List[CacheBase] = [self._flask_adapter, *self._chart_caches]
+        try:
+            from sam.queries.usage_cache import get_cache_adapter
+            usage = get_cache_adapter()
+        except Exception:
+            usage = None
+        if usage:
+            out.append(usage)
+        return out
+
+    def stats(self) -> dict:
+        """Single dict for the admin card. Stable shape, group-by-category."""
+        from flask import current_app
+        from sam.queries.usage_cache import usage_cache_info
+
+        return {
+            'backend':         current_app.config.get('CACHE_TYPE'),
+            'default_timeout': current_app.config.get('CACHE_DEFAULT_TIMEOUT'),
+            'flask':           self._flask_adapter.info(),
+            'chart':           [c.info() for c in self._chart_caches],
+            'usage':           usage_cache_info(),
+        }
+
+    def clear(self, category: Optional[str] = None) -> dict:
+        """Invalidate caches by category. Returns {category: count_cleared}."""
+        result: dict = {}
+        if category in (None, 'flask'):
+            result['flask'] = self._flask_adapter.clear()
+        if category in (None, 'chart'):
+            result['chart'] = sum(c.clear() for c in self._chart_caches)
+        if category in (None, 'usage'):
+            from sam.queries.usage_cache import purge_usage_cache
+            result['usage'] = purge_usage_cache()
+        return result
+
+
+# Module-level singleton — import this from anywhere in webapp.
+caching = Caching()
+
+
+__all__ = ['Caching', 'caching']

--- a/src/webapp/caching/chart.py
+++ b/src/webapp/caching/chart.py
@@ -1,0 +1,133 @@
+"""
+ChartCache — bounded LRU for matplotlib SVG strings, with native hits/misses.
+
+Lifted from webapp.dashboards.charts._ChartCache (which it now replaces).
+Implements the CacheBase contract so chart caches show up in the unified
+admin Caching card alongside Flask-Cache and the allocation usage cache.
+"""
+
+import hashlib
+import json
+import threading
+from collections import OrderedDict, namedtuple
+from typing import Any, Callable, Optional
+
+from sam.caching import CacheBase
+
+
+_CacheInfo = namedtuple('CacheInfo', ['hits', 'misses', 'maxsize', 'currsize'])
+
+
+def content_hash(data: Any) -> str:
+    """Stable MD5 hex digest of arbitrary JSON-serialisable data.
+
+    O(n) compute, O(1) memory — suitable as a cache key for large inputs
+    where materialising a hashable tuple would be prohibitive.
+    """
+    return hashlib.md5(
+        json.dumps(data, default=str, sort_keys=True).encode(),
+        usedforsecurity=False,
+    ).hexdigest()
+
+
+class ChartCache(CacheBase):
+    """Thread-safe bounded LRU for rendered SVG strings."""
+
+    def __init__(self, name: str, maxsize: int):
+        self.name = name
+        self._data: OrderedDict[str, str] = OrderedDict()
+        self._maxsize = maxsize
+        self._lock = threading.Lock()
+        self._hits = self._misses = 0
+
+    def get(self, key: str) -> Optional[str]:
+        with self._lock:
+            if key in self._data:
+                self._data.move_to_end(key)
+                self._hits += 1
+                return self._data[key]
+            self._misses += 1
+            return None
+
+    def put(self, key: str, value: str) -> None:
+        with self._lock:
+            if key in self._data:
+                self._data.move_to_end(key)
+            else:
+                if len(self._data) >= self._maxsize:
+                    self._data.popitem(last=False)
+                self._data[key] = value
+
+    # ── functools.lru_cache-compatible accessors (existing-caller surface) ──
+
+    def cache_info(self) -> _CacheInfo:
+        with self._lock:
+            return _CacheInfo(
+                hits=self._hits,
+                misses=self._misses,
+                maxsize=self._maxsize,
+                currsize=len(self._data),
+            )
+
+    def cache_clear(self) -> None:
+        self.clear()
+
+    def bytes_used(self) -> int:
+        # SVG values are ASCII-dominant strings — len(str) is the character
+        # count, which for ASCII content matches UTF-8 byte count within ~1%.
+        # Avoids sys.getsizeof's Python-string-overhead noise (49 bytes per).
+        with self._lock:
+            return sum(len(v) for v in self._data.values())
+
+    # ── CacheBase ───────────────────────────────────────────────────────
+
+    def info(self) -> dict:
+        with self._lock:
+            return {
+                'name':         self.name,
+                'enabled':      True,
+                'currsize':     len(self._data),
+                'maxsize':      self._maxsize,
+                'ttl':          None,
+                'hits':         self._hits,
+                'misses':       self._misses,
+                'bytes_approx': sum(len(v) for v in self._data.values()),
+                'extras':       {},
+            }
+
+    def clear(self) -> int:
+        with self._lock:
+            n = len(self._data)
+            self._data.clear()
+            self._hits = self._misses = 0
+            return n
+
+
+def chart_cached(cache: ChartCache, key_fn: Optional[Callable] = None):
+    """Internal decorator factory used by the Caching facade.
+
+    Wraps `fn` so calls hit `cache` first; on miss, computes the SVG and
+    stores it. Exposes `cache_info` / `cache_clear` / `cache_bytes` on
+    the wrapped callable to match the legacy functools.lru_cache surface
+    (some callers and tests probe these attributes directly).
+    """
+    import functools
+
+    _key = key_fn or (lambda *args, **kwargs: content_hash(args[0]))
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            key = _key(*args, **kwargs)
+            result = cache.get(key)
+            if result is None:
+                result = fn(*args, **kwargs)
+                cache.put(key, result)
+            return result
+
+        wrapper.cache_info = cache.cache_info
+        wrapper.cache_clear = cache.cache_clear
+        wrapper.cache_bytes = cache.bytes_used
+        return wrapper
+
+    return decorator

--- a/src/webapp/caching/flask_adapter.py
+++ b/src/webapp/caching/flask_adapter.py
@@ -1,0 +1,117 @@
+"""
+FlaskCacheAdapter — wraps a Flask-Caching instance to conform to CacheBase.
+
+Flask-Caching itself is just an orchestrator for a pluggable backend
+(SimpleCache, Redis, Memcached, …). Stats introspection only works for
+SimpleCache today (in-process backing dict); other backends fall back to a
+"not introspectable" placeholder rather than crashing the admin card.
+"""
+
+from typing import Optional
+
+from sam.caching import CacheBase, approx_bytes
+
+
+# Cache-key prefixes used by the API endpoints we want to break out in the
+# admin card. Flask-Caching with @cache.cached(query_string=True) builds
+# keys from the request path, so a simple prefix bucket gives operators
+# the "where is our memory going" view at a glance.
+_KEY_GROUPS = (
+    'directory_access',
+    'fstree_access',
+    'project_access',
+)
+
+
+class FlaskCacheAdapter(CacheBase):
+    """Best-effort introspection of a Flask-Caching instance."""
+
+    name = 'flask_cache'
+
+    def __init__(self, flask_cache):
+        self._flask = flask_cache
+
+    # ── Try to reach the SimpleCache backing dict ───────────────────────
+
+    def _backing_dict(self) -> Optional[dict]:
+        """Return the SimpleCache backing dict, or None for other backends."""
+        try:
+            backend = self._flask.cache
+        except (AttributeError, RuntimeError):
+            return None
+        # cachelib.simple.SimpleCache stores entries under `_cache` as
+        # {key: (expires_at, value)}. NullCache has no entries.
+        backing = getattr(backend, '_cache', None)
+        if isinstance(backing, dict):
+            return backing
+        return None
+
+    @staticmethod
+    def _bucket_for(key: str) -> str:
+        """Map a flask-cache key to one of the known API groups, else 'other'."""
+        for prefix in _KEY_GROUPS:
+            if prefix in key:
+                return prefix
+        return 'other'
+
+    # ── CacheBase ───────────────────────────────────────────────────────
+
+    def info(self) -> dict:
+        backing = self._backing_dict()
+        if backing is None:
+            # Either NullCache, Redis, Memcached, or no app context.
+            return {
+                'name':         self.name,
+                'enabled':      True,
+                'currsize':     None,
+                'maxsize':      None,
+                'ttl':          None,
+                'hits':         None,
+                'misses':       None,
+                'bytes_approx': None,
+                'extras':       {'message': 'not introspectable for this backend'},
+            }
+
+        # Build a per-group breakdown alongside the totals. Each entry
+        # value is (expires_at, value); we measure the value only.
+        groups: dict[str, dict] = {
+            g: {'entries': 0, 'bytes_approx': 0}
+            for g in (*_KEY_GROUPS, 'other')
+        }
+        total_bytes = 0
+        # Snapshot keys first to avoid issues with concurrent mutation.
+        snapshot = list(backing.items())
+        for key, entry in snapshot:
+            try:
+                _, value = entry
+            except (TypeError, ValueError):
+                value = entry
+            sz = approx_bytes(value)
+            total_bytes += sz
+            bucket = self._bucket_for(key if isinstance(key, str) else str(key))
+            groups[bucket]['entries'] += 1
+            groups[bucket]['bytes_approx'] += sz
+
+        return {
+            'name':         self.name,
+            'enabled':      True,
+            'currsize':     len(snapshot),
+            'maxsize':      None,
+            'ttl':          None,
+            'hits':         None,
+            'misses':       None,
+            'bytes_approx': total_bytes,
+            'extras':       {'groups': groups},
+        }
+
+    def clear(self) -> int:
+        """Wipe the entire flask-cache backend. Returns prior entry count
+        when known, else 0 (some backends don't expose count).
+        """
+        backing = self._backing_dict()
+        prior = len(backing) if backing is not None else 0
+        try:
+            self._flask.clear()
+        except Exception:
+            pass
+        return prior

--- a/src/webapp/dashboards/admin/configuration_routes.py
+++ b/src/webapp/dashboards/admin/configuration_routes.py
@@ -21,7 +21,7 @@ from flask_login import login_required
 
 from webapp.extensions import db
 from webapp.utils.rbac import require_permission, Permission
-from webapp.utils.config_inspect import gather_runtime_state
+from webapp.utils.config_inspect import gather_runtime_state, gather_server_info
 
 from .blueprint import bp
 
@@ -37,4 +37,19 @@ def htmx_configuration_card():
     return render_template(
         'dashboards/admin/fragments/configuration_card.html',
         state=state,
+    )
+
+
+@bp.route('/htmx/server', methods=['GET'])
+@login_required
+@require_permission(Permission.VIEW_SYSTEM_CONFIG)
+def htmx_server_card():
+    """Render just the Server Information card body. Used by the
+    refresh button so admins can re-poll without rebuilding the entire
+    Configuration tab — and, since the LB will likely route the refresh
+    to a different worker, naturally surfaces the per-worker view.
+    """
+    return render_template(
+        'dashboards/admin/fragments/server_card_body.html',
+        server=gather_server_info(),
     )

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -1,8 +1,9 @@
 """
 Chart generation utilities for server-side rendering.
 
-All chart functions are decorated with @_chart_cache, which caches rendered
-SVGs by content hash. The public API is unchanged -- callers pass normal Python
+All chart functions are decorated with `@caching.chart_cached(name=..., maxsize=...)`,
+which caches rendered SVGs by content hash through the unified `Caching` facade
+(see webapp.caching). The public API is unchanged -- callers pass normal Python
 objects; hashing and caching are handled internally.
 
 Cache keys are stable MD5 hex digests of the input data, so key computation is
@@ -10,15 +11,10 @@ O(n) time but O(1) memory regardless of input size. This is safe for large
 inputs (e.g. a year of 5-minute history) where materialising the full data as
 a hashable tuple would allocate several MB per call even on a cache hit.
 
-NOTE: _ChartCache is per-process and thread-safe. It is safe with both gunicorn
+NOTE: ChartCache is per-process and thread-safe. It is safe with both gunicorn
 sync workers (each worker is a forked process) and gthread workers.
 """
 
-import functools
-import hashlib
-import json
-import threading
-from collections import OrderedDict, namedtuple
 from io import StringIO
 from typing import List, Dict
 from datetime import date, datetime, timedelta
@@ -30,6 +26,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from sam import fmt
+from webapp.caching import caching
+from webapp.caching.chart import content_hash as _content_hash  # legacy alias used by _pace_cache_key
 
 
 def _to_display_tz(naive_utc_ts: datetime) -> datetime:
@@ -40,105 +38,11 @@ def _to_display_tz(naive_utc_ts: datetime) -> datetime:
 
 
 # ---------------------------------------------------------------------------
-# Cache infrastructure
-# ---------------------------------------------------------------------------
-
-_CacheInfo = namedtuple('CacheInfo', ['hits', 'misses', 'maxsize', 'currsize'])
-
-
-def _content_hash(data) -> str:
-    """Stable MD5 hex digest of arbitrary JSON-serialisable data.
-
-    O(n) compute, O(1) memory — suitable as a cache key for large inputs
-    where materialising a hashable tuple would be prohibitive.
-    """
-    return hashlib.md5(
-        json.dumps(data, default=str, sort_keys=True).encode(),
-        usedforsecurity=False,
-    ).hexdigest()
-
-
-class _ChartCache:
-    """Thread-safe bounded LRU cache for rendered SVG strings."""
-
-    def __init__(self, maxsize: int):
-        self._data: OrderedDict[str, str] = OrderedDict()
-        self._maxsize = maxsize
-        self._lock = threading.Lock()
-        self._hits = self._misses = 0
-
-    def get(self, key: str):
-        with self._lock:
-            if key in self._data:
-                self._data.move_to_end(key)
-                self._hits += 1
-                return self._data[key]
-            self._misses += 1
-            return None
-
-    def put(self, key: str, value: str) -> None:
-        with self._lock:
-            if key in self._data:
-                self._data.move_to_end(key)
-            else:
-                if len(self._data) >= self._maxsize:
-                    self._data.popitem(last=False)
-                self._data[key] = value
-
-    def cache_info(self) -> _CacheInfo:
-        with self._lock:
-            return _CacheInfo(
-                hits=self._hits,
-                misses=self._misses,
-                maxsize=self._maxsize,
-                currsize=len(self._data),
-            )
-
-    def cache_clear(self) -> None:
-        with self._lock:
-            self._data.clear()
-            self._hits = self._misses = 0
-
-
-def _chart_cache(maxsize: int, key_fn=None):
-    """Decorator factory that caches chart SVG output by content hash.
-
-    Args:
-        maxsize:  Maximum number of SVGs to keep (LRU eviction).
-        key_fn:   Optional callable(*args, **kwargs) -> str that computes the
-                  cache key.  Defaults to _content_hash of the first argument,
-                  which covers every single-argument chart function.  Pass an
-                  explicit key_fn for functions with multiple meaningful args
-                  (e.g. the pace chart).
-
-    The decorated function gains cache_info() and cache_clear() attributes
-    matching the functools.lru_cache interface.
-    """
-    def decorator(fn):
-        cache = _ChartCache(maxsize=maxsize)
-        _key = key_fn or (lambda *args, **kwargs: _content_hash(args[0]))
-
-        @functools.wraps(fn)
-        def wrapper(*args, **kwargs):
-            key = _key(*args, **kwargs)
-            result = cache.get(key)
-            if result is None:
-                result = fn(*args, **kwargs)
-                cache.put(key, result)
-            return result
-
-        wrapper.cache_info = cache.cache_info
-        wrapper.cache_clear = cache.cache_clear
-        return wrapper
-    return decorator
-
-
-# ---------------------------------------------------------------------------
 # 1. Usage timeseries (user dashboard)
 # ---------------------------------------------------------------------------
 
 # One entry per (user, time-range) combination active in the current snapshot window.
-@_chart_cache(maxsize=128)
+@caching.chart_cached(name='usage_timeseries', maxsize=128)
 def generate_usage_timeseries_matplotlib(daily_charges) -> str:
     """
     Generate time-series bar chart using Matplotlib.
@@ -184,7 +88,7 @@ _BYTES_PER_TIB = 1024 ** 4
 _BYTES_PER_PIB = 1024 ** 5
 
 
-@_chart_cache(maxsize=128)
+@caching.chart_cached(name='disk_usage_stacked_area', maxsize=128)
 def generate_disk_usage_stacked_area(timeseries) -> str:
     """Render a stacked-area chart of disk bytes vs time.
 
@@ -267,7 +171,7 @@ def generate_disk_usage_stacked_area(timeseries) -> str:
 # 1c. User / project queue load stacked-area chart (status drill-down)
 # ---------------------------------------------------------------------------
 
-@_chart_cache(maxsize=128)
+@caching.chart_cached(name='user_proj_stacked_area', maxsize=128)
 def generate_user_proj_stacked_area(timeseries) -> str:
     """Render a stacked-area chart of per-user or per-project queue load.
 
@@ -340,7 +244,7 @@ def generate_user_proj_stacked_area(timeseries) -> str:
 # ---------------------------------------------------------------------------
 
 # One entry per node type; can be O(10s) across all machines.
-@_chart_cache(maxsize=64)
+@caching.chart_cached(name='nodetype_history', maxsize=64)
 def generate_nodetype_history_matplotlib(history_data: List[Dict]) -> str:
     """
     Generate node type history chart showing availability and utilization.
@@ -403,7 +307,7 @@ def generate_nodetype_history_matplotlib(history_data: List[Dict]) -> str:
 # ---------------------------------------------------------------------------
 
 # One entry per queue; queue counts can be O(10s) across all resources.
-@_chart_cache(maxsize=64)
+@caching.chart_cached(name='queue_history', maxsize=64)
 def generate_queue_history_matplotlib(history_data: List[Dict]) -> str:
     """
     Generate queue history chart showing job flow and resource demand.
@@ -486,7 +390,7 @@ def _pie_trim(names: list, values: list) -> tuple[list, list]:
 
 
 # One entry per resource filter combination; small number of distinct views.
-@_chart_cache(maxsize=32)
+@caching.chart_cached(name='facility_pie_chart', maxsize=32)
 def generate_facility_pie_chart_matplotlib(facility_data: List[Dict]) -> str:
     """
     Generate pie chart showing distribution by facility. Title is rendered
@@ -536,7 +440,7 @@ def generate_facility_pie_chart_matplotlib(facility_data: List[Dict]) -> str:
 # ---------------------------------------------------------------------------
 
 # One entry per (resource, facility) filter combination.
-@_chart_cache(maxsize=64)
+@caching.chart_cached(name='allocation_type_pie_chart', maxsize=64)
 def generate_allocation_type_pie_chart_matplotlib(type_data: List[Dict]) -> str:
     """
     Generate pie chart showing allocation distribution by type within a facility.
@@ -669,7 +573,7 @@ def _pace_cache_key(allocations, active_at, window_days=180, top_n=15, resource_
 
 
 # One entry per (resource, window_days, top_n) combination across concurrent viewers.
-@_chart_cache(maxsize=64, key_fn=_pace_cache_key)
+@caching.chart_cached(name='pace_chart', maxsize=64, key_fn=_pace_cache_key)
 def generate_pace_chart_matplotlib(
     allocations: List[Dict],
     active_at: datetime,

--- a/src/webapp/extensions.py
+++ b/src/webapp/extensions.py
@@ -6,10 +6,15 @@ Extensions are initialized here but configured in the application factory.
 """
 
 from flask_sqlalchemy import SQLAlchemy
-from flask_caching import Cache
+
+from webapp.caching import caching
 
 db = SQLAlchemy()
-cache = Cache()
+
+# DEPRECATED: prefer `from webapp.caching import caching` and use
+# `caching.flask.cached(...)` / `caching.flask.memoize(...)`. This alias is
+# retained because 40+ existing call sites import `cache` from here.
+cache = caching.flask
 
 
 def user_aware_cache_key() -> str:

--- a/src/webapp/run.py
+++ b/src/webapp/run.py
@@ -10,7 +10,7 @@ from flask_login import LoginManager, current_user
 import sam.session
 import system_status.session
 
-from webapp.extensions import db, cache
+from webapp.extensions import db
 from webapp.admin import admin_bp, init_admin
 from webapp.auth import bp as auth_bp
 from webapp.dashboards.user import bp as user_dashboard_bp
@@ -105,7 +105,8 @@ def create_app(*, config_overrides: dict | None = None):
     app.config.setdefault('CACHE_DEFAULT_TIMEOUT', 300)
     if app.config.get('TESTING') or os.environ.get('FLASK_ENV') == 'testing':
         app.config['CACHE_TYPE'] = 'NullCache'
-    cache.init_app(app)
+    from webapp.caching import caching
+    caching.init_app(app)
 
     # =========================================================================
     # AUDIT LOGGING INITIALIZATION

--- a/src/webapp/templates/dashboards/admin/fragments/configuration_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/configuration_card.html
@@ -55,7 +55,7 @@
 
     <div class="row g-3">
 
-        {# ── Application ──────────────────────────────────────────────── #}
+        {# ── Application (config-shaped facts only) ───────────────────── #}
         <div class="col-12 col-xl-6">
             <div class="card h-100">
                 <div class="card-header py-2">
@@ -69,16 +69,42 @@
                         {{ stat('TESTING',       state.application.testing) }}
                         {{ stat('Python',        state.application.python_version) }}
                         {{ stat('Flask',         state.application.flask_version) }}
-                        {{ stat('Hostname',      state.application.hostname) }}
-                        {{ stat('Started',       state.application.start_time | fmt_date if state.application.start_time else '—') }}
-                        {{ stat('Uptime',        state.application.uptime) }}
                         {{ stat('Display TZ',
                                 (state.application.display_tz ~ '  (' ~ state.application.display_tz_abbr ~ ')')
                                 if state.application.display_tz and state.application.display_tz_abbr
                                 else state.application.display_tz) }}
-                        {{ stat('Build SHA',     state.application.git_sha) }}
-                        {{ stat('Build date',    state.application.build_date) }}
                     </dl>
+                </div>
+            </div>
+        </div>
+
+        {# ── Server Information (worker-scoped runtime facts) ─────────── #}
+        {#  Pod hostname, worker pid/uptime/RSS, cgroup memory + CPU limits,
+            build SHA. The refresh button re-fetches just this card body —
+            the LB will likely route the refresh to a different worker, which
+            is the *point*: it surfaces the per-worker reality (different PID,
+            different RSS each time). #}
+        <div class="col-12 col-xl-6">
+            <div class="card h-100">
+                <div class="card-header py-2 d-flex justify-content-between align-items-center">
+                    <strong><i class="fas fa-server me-1"></i> Server Information</strong>
+                    <button type="button"
+                            class="btn btn-sm btn-outline-secondary py-0 px-2"
+                            hx-get="{{ url_for('admin_dashboard.htmx_server_card') }}"
+                            hx-target="#server-card-body"
+                            hx-swap="innerHTML"
+                            hx-indicator="#server-card-spinner"
+                            title="Re-poll a worker (likely a different one)">
+                        <i class="fas fa-sync-alt"></i>
+                        <span class="d-none d-sm-inline ms-1">Refresh</span>
+                        <span id="server-card-spinner" class="htmx-indicator spinner-border spinner-border-sm ms-1"
+                              role="status" aria-hidden="true"></span>
+                    </button>
+                </div>
+                <div class="card-body" id="server-card-body">
+                    {% with server = state.server %}
+                        {% include 'dashboards/admin/fragments/server_card_body.html' %}
+                    {% endwith %}
                 </div>
             </div>
         </div>

--- a/src/webapp/templates/dashboards/admin/fragments/configuration_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/configuration_card.html
@@ -165,6 +165,35 @@
         </div>
 
         {# ── Caching ──────────────────────────────────────────────────── #}
+        {#  All cache adapters return a uniform info() dict — see CacheBase
+            in src/sam/caching/base.py. The cache_row macro renders any of
+            them: flask, chart, or usage. #}
+        {% macro cache_row(info) %}
+            <dl class="config-stats mb-0 small">
+                {% if info.enabled is not none %}
+                    {{ stat('Enabled', 'Yes' if info.enabled else 'No') }}
+                {% endif %}
+                {% if info.ttl is not none %}
+                    {{ stat('TTL (s)', info.ttl) }}
+                {% endif %}
+                {% if info.currsize is not none %}
+                    {{ stat('Size',
+                            '%d / %s' | format(info.currsize,
+                                                info.maxsize if info.maxsize is not none else '∞')) }}
+                {% endif %}
+                {% if info.hits is not none or info.misses is not none %}
+                    {{ stat('Hits / Misses',
+                            '%d / %d' | format(info.hits or 0, info.misses or 0)) }}
+                {% endif %}
+                {% if info.bytes_approx is not none %}
+                    {{ stat('Memory (approx)', info.bytes_approx | fmt_size) }}
+                {% endif %}
+                {% if info.extras and info.extras.message %}
+                    {{ stat('Note', info.extras.message) }}
+                {% endif %}
+            </dl>
+        {% endmacro %}
+
         <div class="col-12 col-xl-6">
             <div class="card h-100">
                 <div class="card-header py-2">
@@ -176,15 +205,55 @@
                         {{ stat('Default timeout (s)',   state.caching.cache_default_timeout) }}
                     </dl>
 
-                    {% if state.caching.usage_cache %}
+                    {% if state.caching.usage %}
                     <hr class="my-3">
                     <div class="text-muted small mb-2"><strong>Allocation usage cache</strong></div>
+                    {{ cache_row(state.caching.usage) }}
+                    {% endif %}
+
+                    {% if state.caching.flask %}
+                    <hr class="my-3">
+                    <div class="text-muted small mb-2"><strong>Flask-Cache (HTTP-level)</strong></div>
+                    {{ cache_row(state.caching.flask) }}
+                    {% if state.caching.flask.extras and state.caching.flask.extras.groups %}
+                    <details class="mt-2">
+                        <summary class="small text-muted">By API group</summary>
+                        <dl class="config-stats mb-0 small mt-2">
+                            {% for prefix, g in state.caching.flask.extras.groups.items() %}
+                                {% if g.entries %}
+                                {{ stat(prefix,
+                                        '%d entries · %s' | format(g.entries, g.bytes_approx | fmt_size)) }}
+                                {% endif %}
+                            {% endfor %}
+                        </dl>
+                    </details>
+                    {% endif %}
+                    {% endif %}
+
+                    {% if state.caching.chart %}
+                    <hr class="my-3">
+                    <div class="text-muted small mb-2"><strong>Chart SVG caches</strong></div>
+                    {% set chart_total_currsize = state.caching.chart | sum(attribute='currsize') %}
+                    {% set chart_total_maxsize  = state.caching.chart | sum(attribute='maxsize') %}
+                    {% set chart_total_hits     = state.caching.chart | sum(attribute='hits') %}
+                    {% set chart_total_misses   = state.caching.chart | sum(attribute='misses') %}
+                    {% set chart_total_bytes    = state.caching.chart | sum(attribute='bytes_approx') %}
                     <dl class="config-stats mb-0 small">
-                        {{ stat('Enabled', state.caching.usage_cache.enabled) }}
-                        {{ stat('TTL (s)', state.caching.usage_cache.ttl) }}
-                        {{ stat('Size',
-                                '%d / %d' | format(state.caching.usage_cache.currsize, state.caching.usage_cache.maxsize)) }}
+                        {{ stat('Total size',
+                                '%d / %d entries' | format(chart_total_currsize, chart_total_maxsize)) }}
+                        {{ stat('Hits / Misses',
+                                '%d / %d' | format(chart_total_hits, chart_total_misses)) }}
+                        {{ stat('Memory (approx)', chart_total_bytes | fmt_size) }}
                     </dl>
+                    <details class="mt-2">
+                        <summary class="small text-muted">Per-chart breakdown ({{ state.caching.chart | length }})</summary>
+                        <dl class="config-stats mb-0 small mt-2">
+                            {% for c in state.caching.chart %}
+                            {{ stat(c.name,
+                                    '%d/%d · %d hits · %s' | format(c.currsize, c.maxsize, c.hits, c.bytes_approx | fmt_size)) }}
+                            {% endfor %}
+                        </dl>
+                    </details>
                     {% endif %}
                 </div>
             </div>

--- a/src/webapp/templates/dashboards/admin/fragments/server_card_body.html
+++ b/src/webapp/templates/dashboards/admin/fragments/server_card_body.html
@@ -1,0 +1,52 @@
+{#
+  Admin → Configuration → Server Information card BODY (inner content).
+
+  Rendered both inline (from configuration_card.html) and standalone (from
+  the htmx_server_card route, when the user clicks Refresh). Keep this file
+  to JUST the body content — the wrapping <div class="card"> + header +
+  refresh button live in configuration_card.html so they persist across
+  HTMX swaps.
+
+  Uses the same `stat` macro shape as configuration_card.html. Re-declared
+  locally so this fragment is self-contained when served by the refresh
+  endpoint.
+#}
+{% macro stat(label, value, value_class='') %}
+    <dt class="fw-normal text-muted">{{ label }}</dt>
+    <dd class="fw-semibold {{ value_class }}">
+        {{ value if value not in (None, '') else '—' }}
+    </dd>
+{% endmacro %}
+
+<p class="text-muted small mb-3">
+    <i class="fas fa-info-circle"></i>
+    Reflects the worker process that served this request. With multiple
+    gunicorn workers per pod, refreshing may land on a different worker
+    and show different numbers — that's expected.
+    Sampled {{ server.gathered_at.strftime('%H:%M:%S') }}.
+</p>
+
+<dl class="config-stats mb-0 small">
+    {{ stat('Pod hostname',     server.pod_hostname) }}
+    {{ stat('Worker PID',       server.worker_pid) }}
+    {{ stat('Worker started',   server.worker_started | fmt_date if server.worker_started else None) }}
+    {{ stat('Worker uptime',    server.worker_uptime) }}
+    {{ stat('Process RSS',      server.process_rss | fmt_size if server.process_rss is not none else None) }}
+    {% if server.cgroup_mem_limit %}
+        {{ stat('Pod memory',
+                '%s / %s  (%.1f%%)' | format(
+                    (server.cgroup_mem_used or 0) | fmt_size,
+                    server.cgroup_mem_limit | fmt_size,
+                    (server.cgroup_mem_used or 0) / server.cgroup_mem_limit * 100),
+                'text-warning' if server.cgroup_mem_used and server.cgroup_mem_used / server.cgroup_mem_limit > 0.8 else '') }}
+    {% elif server.cgroup_mem_used is not none %}
+        {{ stat('Pod memory', server.cgroup_mem_used | fmt_size) }}
+    {% else %}
+        {{ stat('Pod memory', None) }}
+    {% endif %}
+    {{ stat('Pod CPU limit',
+            ('%g cores' | format(server.cgroup_cpu_limit)) if server.cgroup_cpu_limit else None) }}
+    {{ stat('Gunicorn workers', server.gunicorn_workers) }}
+    {{ stat('Build SHA',        server.git_sha) }}
+    {{ stat('Build date',       server.build_date) }}
+</dl>

--- a/src/webapp/utils/config_inspect.py
+++ b/src/webapp/utils/config_inspect.py
@@ -22,9 +22,16 @@ import platform
 import socket
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import flask
+
+
+# Per-pid cache so a fresh worker doesn't re-parse /proc on every request.
+# Module-level dict survives forks (correctly: each forked worker gets its
+# own copy); keyed by os.getpid() so it's resilient to the master initialising
+# this dict before forking.
+_worker_started_by_pid: Dict[int, datetime] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -130,6 +137,134 @@ def _uptime(start_time: Optional[datetime]) -> Optional[str]:
     return f"{minutes}m"
 
 
+# ---------------------------------------------------------------------------
+# Worker / pod runtime probes
+# ---------------------------------------------------------------------------
+#
+# These read the worker's own /proc + /sys/fs/cgroup files only. No
+# subprocess, no other-pod visibility, no privileged ops. Every probe
+# returns None on macOS dev or any host without the relevant procfs/cgroup
+# entries — so the Flask dev server (`docker compose up webdev`) and a
+# bare-metal host both render the card without raising.
+#
+# cgroup v2 only (single hierarchy at /sys/fs/cgroup/<file>). Modern k8s
+# and Docker Desktop default to v2; v1 hosts will silently report None.
+
+def _worker_start_time() -> datetime:
+    """Best-effort worker process start time, cached per pid.
+
+    Linux: parses ``/proc/self/stat`` field 22 (process start in clock
+    ticks since boot) + ``/proc/stat`` btime. This is the kernel's truth
+    even when ``preload_app=True`` makes module-level timestamps reflect
+    master init time rather than worker fork time.
+
+    macOS / non-procfs: falls back to the time of the first call from
+    this pid (close enough as a lower bound for dev).
+    """
+    pid = os.getpid()
+    cached = _worker_started_by_pid.get(pid)
+    if cached:
+        return cached
+    try:
+        with open(f'/proc/{pid}/stat', 'rb') as f:
+            data = f.read()
+        # comm field is wrapped in parens and may contain spaces or
+        # parens itself — find the LAST ')' before splitting.
+        rparen = data.rindex(b')')
+        rest = data[rparen + 2:].split()
+        # Field 22 (1-indexed) is starttime in clock ticks; index 19
+        # in `rest` because rest starts at field 3 (state).
+        starttime_ticks = int(rest[19])
+        boot = None
+        with open('/proc/stat') as f:
+            for line in f:
+                if line.startswith('btime '):
+                    boot = int(line.split()[1])
+                    break
+        if boot is None:
+            raise ValueError('btime not found')
+        clk_tck = os.sysconf(os.sysconf_names['SC_CLK_TCK'])
+        result = datetime.fromtimestamp(boot + starttime_ticks / clk_tck)
+    except (OSError, ValueError, IndexError, KeyError):
+        result = datetime.now()
+    _worker_started_by_pid[pid] = result
+    return result
+
+
+def _proc_rss_bytes() -> Optional[int]:
+    """RSS of the current process in bytes, or None if /proc unavailable."""
+    try:
+        with open('/proc/self/status') as f:
+            for line in f:
+                if line.startswith('VmRSS:'):
+                    return int(line.split()[1]) * 1024  # kB → bytes
+    except OSError:
+        pass
+    return None
+
+
+def _cgroup_memory() -> Tuple[Optional[int], Optional[int]]:
+    """(used_bytes, limit_bytes) from cgroup v2. (None, None) outside cgroups
+    or when memory is unrestricted."""
+    used: Optional[int] = None
+    limit: Optional[int] = None
+    try:
+        used = int(Path('/sys/fs/cgroup/memory.current').read_text().strip())
+    except (OSError, ValueError):
+        pass
+    try:
+        raw = Path('/sys/fs/cgroup/memory.max').read_text().strip()
+        if raw != 'max':
+            limit = int(raw)
+    except (OSError, ValueError):
+        pass
+    return used, limit
+
+
+def _cgroup_cpu_limit() -> Optional[float]:
+    """Effective CPU limit as a float number of cores. None if unrestricted
+    or cgroup v2 unavailable. The value comes from the same file the
+    gunicorn-worker fix reads (``/sys/fs/cgroup/cpu.max``)."""
+    try:
+        raw = Path('/sys/fs/cgroup/cpu.max').read_text().strip()
+        quota_str, period_str = raw.split()
+        if quota_str == 'max':
+            return None
+        return int(quota_str) / int(period_str)
+    except (OSError, ValueError):
+        return None
+
+
+def gather_server_info() -> Dict[str, Any]:
+    """Worker-scoped runtime snapshot for the Admin → Server Information card.
+
+    Cheap to call (a handful of file reads). Safe to expose without auth
+    headers other than the existing VIEW_SYSTEM_CONFIG gate — there are no
+    secrets here, and every probe is scoped to this worker / this cgroup.
+
+    Returned values reflect *this worker process*. With gunicorn's 33+
+    workers per pod, the same admin user reloading the Configuration tab
+    can land on a different worker each time and see different numbers.
+    The card UI calls this out explicitly.
+    """
+    cg_used, cg_limit = _cgroup_memory()
+    started = _worker_start_time()
+    return {
+        'pod_hostname':      socket.gethostname(),
+        'worker_pid':        os.getpid(),
+        'worker_started':    started,
+        'worker_uptime':     _uptime(started),
+        'process_rss':       _proc_rss_bytes(),
+        'cgroup_mem_used':   cg_used,
+        'cgroup_mem_limit':  cg_limit,
+        'cgroup_cpu_limit':  _cgroup_cpu_limit(),
+        'gunicorn_workers':  os.environ.get('GUNICORN_WORKERS') or None,
+        'git_sha':           os.getenv('GIT_SHA', '') or None,
+        'build_date':        os.getenv('BUILD_DATE', '') or None,
+        'gathered_at':       datetime.now(),
+    }
+
+
 def gather_runtime_state(app, db) -> Dict[str, Any]:
     """Collect runtime state for the Admin Configuration page.
 
@@ -159,7 +294,8 @@ def gather_runtime_state(app, db) -> Dict[str, Any]:
         display_tz_name = None
         display_tz_abbr = None
 
-    # --- Application
+    # --- Application (config-shaped facts; runtime instance facts moved
+    # to the Server Information card below)
     application = {
         'config_class':    config_class_name,
         'flask_config':    os.getenv('FLASK_CONFIG', 'development'),
@@ -167,14 +303,12 @@ def gather_runtime_state(app, db) -> Dict[str, Any]:
         'testing':         bool(cfg.get('TESTING')),
         'python_version':  platform.python_version(),
         'flask_version':   getattr(flask, '__version__', 'unknown'),
-        'hostname':        socket.gethostname(),
-        'start_time':      getattr(app, 'start_time', None),
-        'uptime':          _uptime(getattr(app, 'start_time', None)),
         'display_tz':      display_tz_name,
         'display_tz_abbr': display_tz_abbr,
-        'git_sha':         os.getenv('GIT_SHA', '') or None,
-        'build_date':      os.getenv('BUILD_DATE', '') or None,
     }
+
+    # --- Server Information (worker-scoped runtime facts)
+    server = gather_server_info()
 
     # --- Database (per bind)
     databases = []
@@ -250,6 +384,7 @@ def gather_runtime_state(app, db) -> Dict[str, Any]:
 
     return {
         'application':   application,
+        'server':        server,
         'databases':     databases,
         'auth':          auth,
         'caching':       caching_block,

--- a/src/webapp/utils/config_inspect.py
+++ b/src/webapp/utils/config_inspect.py
@@ -218,20 +218,23 @@ def gather_runtime_state(app, db) -> Dict[str, Any]:
         'oidc_client_secret':  mask_secret(cfg.get('OIDC_CLIENT_SECRET')),
     }
 
-    # --- Caching
+    # --- Caching (unified facade — see webapp.caching)
     try:
-        from sam.queries.usage_cache import usage_cache_info
-        usage_cache = usage_cache_info()
+        from webapp.caching import caching as _caching_facade
+        caching_block = _caching_facade.stats()
+        # Legacy template keys kept alongside the new shape for back-compat.
+        caching_block['flask_cache_backend']   = caching_block.get('backend')
+        caching_block['cache_default_timeout'] = caching_block.get('default_timeout')
+        caching_block['usage_cache']           = caching_block.get('usage')
     except Exception:
-        usage_cache = None
-
-    # Flask-Cache backend type — config key set by run.py at startup.
-    cache_type = cfg.get('CACHE_TYPE', 'unknown')
-    caching = {
-        'flask_cache_backend':    cache_type,
-        'cache_default_timeout':  cfg.get('CACHE_DEFAULT_TIMEOUT'),
-        'usage_cache':            usage_cache,
-    }
+        caching_block = {
+            'flask_cache_backend':   cfg.get('CACHE_TYPE', 'unknown'),
+            'cache_default_timeout': cfg.get('CACHE_DEFAULT_TIMEOUT'),
+            'usage_cache':           None,
+            'flask':                 None,
+            'chart':                 [],
+            'usage':                 None,
+        }
 
     # --- Audit & Logging
     audit_path = cfg.get('AUDIT_LOG_PATH', '')
@@ -249,7 +252,7 @@ def gather_runtime_state(app, db) -> Dict[str, Any]:
         'application':   application,
         'databases':     databases,
         'auth':          auth,
-        'caching':       caching,
+        'caching':       caching_block,
         'audit_logging': audit_logging,
         'audit_tail':    audit_tail,
         'gathered_at':   datetime.now(),

--- a/tests/unit/test_allocations_performance.py
+++ b/tests/unit/test_allocations_performance.py
@@ -660,10 +660,10 @@ def _reset_usage_cache_globals():
     expect the cache to be disabled (TestingConfig sets TTL=0).
     """
     import sam.queries.usage_cache as uc
-    uc._cache = None
+    uc._adapter = None
     uc._disabled = False
     yield
-    uc._cache = None
+    uc._adapter = None
     uc._disabled = False
 
 
@@ -748,18 +748,18 @@ class TestUsageCacheModule:
 
     def test_info_enabled_after_initialization(self):
         import sam.queries.usage_cache as uc
-        uc._get_cache()  # triggers initialization using env-var defaults (TTL=3600)
+        uc.get_cache_adapter()  # triggers initialization using env-var defaults (TTL=3600)
         info = uc.usage_cache_info()
         assert info['enabled'] is True
         assert info['currsize'] == 0
 
-    # --- _get_cache() disabled path ---
+    # --- get_cache_adapter() disabled path ---
 
     def test_get_cache_returns_none_when_ttl_zero(self):
         import sam.queries.usage_cache as uc
         from unittest.mock import patch
         with patch.object(uc, '_get_config', side_effect=lambda k, d: 0):
-            cache = uc._get_cache()
+            cache = uc.get_cache_adapter()
         assert cache is None
         assert uc._disabled is True
 
@@ -767,7 +767,7 @@ class TestUsageCacheModule:
         import sam.queries.usage_cache as uc
         from unittest.mock import patch
         with patch.object(uc, '_get_config', side_effect=lambda k, d: 0):
-            cache = uc._get_cache()
+            cache = uc.get_cache_adapter()
         assert cache is None
 
     # --- purge_usage_cache() ---
@@ -786,20 +786,20 @@ class TestUsageCacheModule:
     def test_purge_clears_all_entries(self, session):
         import sam.queries.usage_cache as uc
         from unittest.mock import patch
-        uc._get_cache()  # initialize
+        uc.get_cache_adapter()  # initialize
         with patch('sam.queries.usage_cache.get_allocation_summary_with_usage', return_value=[]):
             uc.cached_allocation_usage(session=session, resource_name='Derecho')
             uc.cached_allocation_usage(session=session, resource_name='Casper')
         n = uc.purge_usage_cache()
         assert n == 2
-        assert len(uc._cache) == 0
+        assert len(uc._adapter._cache) == 0
 
     # --- cached_allocation_usage() cache hit/miss ---
 
     def test_cache_hit_avoids_second_db_call(self, session):
         import sam.queries.usage_cache as uc
         from unittest.mock import patch
-        uc._get_cache()
+        uc.get_cache_adapter()
         with patch('sam.queries.usage_cache.get_allocation_summary_with_usage') as mock_fn:
             mock_fn.return_value = [{'resource': 'Derecho', 'total_amount': 100}]
             r1 = uc.cached_allocation_usage(session=session, resource_name='Derecho')
@@ -810,7 +810,7 @@ class TestUsageCacheModule:
     def test_different_resources_are_separate_cache_keys(self, session):
         import sam.queries.usage_cache as uc
         from unittest.mock import patch
-        uc._get_cache()
+        uc.get_cache_adapter()
         with patch('sam.queries.usage_cache.get_allocation_summary_with_usage') as mock_fn:
             mock_fn.return_value = []
             uc.cached_allocation_usage(session=session, resource_name='Derecho')
@@ -821,7 +821,7 @@ class TestUsageCacheModule:
         """['Derecho', 'Casper'] and ['Casper', 'Derecho'] must hit the same entry."""
         import sam.queries.usage_cache as uc
         from unittest.mock import patch
-        uc._get_cache()
+        uc.get_cache_adapter()
         with patch('sam.queries.usage_cache.get_allocation_summary_with_usage') as mock_fn:
             mock_fn.return_value = []
             uc.cached_allocation_usage(session=session, resource_name=['Derecho', 'Casper'])
@@ -843,7 +843,7 @@ class TestUsageCacheModule:
     def test_force_refresh_bypasses_cache_hit(self, session):
         import sam.queries.usage_cache as uc
         from unittest.mock import patch
-        uc._get_cache()
+        uc.get_cache_adapter()
         with patch('sam.queries.usage_cache.get_allocation_summary_with_usage') as mock_fn:
             mock_fn.return_value = []
             uc.cached_allocation_usage(session=session, resource_name='Derecho')
@@ -853,7 +853,7 @@ class TestUsageCacheModule:
     def test_force_refresh_updates_cached_value(self, session):
         import sam.queries.usage_cache as uc
         from unittest.mock import patch
-        uc._get_cache()
+        uc.get_cache_adapter()
         first_result  = [{'resource': 'Derecho', 'total_amount': 100}]
         second_result = [{'resource': 'Derecho', 'total_amount': 200}]
         with patch('sam.queries.usage_cache.get_allocation_summary_with_usage') as mock_fn:


### PR DESCRIPTION
## Summary

Originally a refactor that unifies the caching layer behind a single `CacheBase` contract and exposes admin observability. After deploying it caused suspicion of an `/allocations` regression on samuel.k8s.ucar.edu — investigation traced the regression to a separate gunicorn over-provisioning bug (now fixed in #240) and surfaced new findings about how the per-worker cache architecture limits cache effectiveness in production.

This PR is now rebased on top of #240 and additionally includes a new **Server Information** admin card with worker-scoped runtime probes, plus two reference docs capturing the investigation methodology and findings.

## Status — verified end-to-end on samuel.k8s.ucar.edu (sha-f00433b)

| | Pre-fix (sha-fda98ab) | Post-#240 (sha-cb2ef93) | + caching_unified (sha-8008045) | + Server Info (sha-f00433b) |
|---|---|---|---|---|
| OOMKills during 8-load probe | 1 | 0 | 0 | 0 |
| Pod restart count | 1 | 0 | 0 | 0 |
| Memory after 8 loads | OOMKilled at load 2 | ~1.6 GiB | 1.7–1.9 GiB | 1.8–2.0 GiB |
| % of 12 GiB limit | exceeded | ~13% | ~15% | ~17% |

Server Information card on a real k8s pod populates every field correctly:
- Pod hostname: `samuel-f94885dfc-tdfcl`
- Pod CPU limit: `16 cores`
- Gunicorn workers: `33`
- Pod memory: `599 MiB / 11.2 GiB (5.2%)` — exactly tracks `kubectl top pods`
- Worker PID + Process RSS update per refresh

Refresh button rotates across pods AND across workers within a pod — six clicks yielded 4 distinct PIDs spread across both pods. Pod memory column climbed live (639 → 708 MiB on `76j4x` over 5 refreshes), giving operators a direct visual of COW page dirtying — exactly the per-worker reality the SHARED_CACHE_FINDINGS doc describes.

## Changes

### Caching unification (original two commits)
- `src/sam/caching/base.py` — `CacheBase` ABC contract: `info() → dict`, `clear() → int`
- `src/sam/caching/ttl.py` — `TTLCacheAdapter` wrapping `cachetools.TTLCache`
- `src/webapp/caching/__init__.py` — `Caching` facade + module-level singleton
- `src/webapp/caching/chart.py` — `ChartCache` (replaces dashboards/charts._ChartCache)
- `src/webapp/caching/flask_adapter.py` — `FlaskCacheAdapter` for SimpleCache introspection
- `tests/unit/test_usage_cache.py` — updated to poke new adapter internals

### Admin Server Information card (commit f00433b)
- Splits the existing "Application" card into:
  - **Application** — config-shaped facts (Config class, FLASK_CONFIG, DEBUG, Python/Flask versions, Display TZ)
  - **Server Information** — worker-scoped runtime facts (pod hostname, worker PID, started/uptime, process RSS, cgroup memory used/limit, cgroup CPU limit, GUNICORN_WORKERS, build SHA/date)
- HTMX **Refresh** button on the Server card. Because gunicorn rotates requests across 33 workers per pod, refresh routinely lands on a different worker — making the per-worker reality directly visible.
- New helpers in `webapp/utils/config_inspect.py` (parse `/proc/self/stat`, `/proc/self/status`, `/sys/fs/cgroup/memory.*`, `/sys/fs/cgroup/cpu.max`). Worker-scoped only, no subprocess, no cross-pod visibility, graceful fallback to `None` on macOS dev / non-cgroup hosts.
- New route `/admin/htmx/server` for the refresh endpoint, gated on the existing `VIEW_SYSTEM_CONFIG` permission.

### Investigation docs (commit eb3a78c)
- `docs/CIRRUS-k8s-cmds.sh` — kubectl runbook structured by symptom (10 sections: sanity, resource snapshot, deployment introspection, OOMKill detection, in-pod inspection, logs, rollout history, Helm-specific, step-by-step misbehaving-pod checklist). Hardcodes `CTX=nwc1` / `NS=sam-queries` for direct copy-paste.
- `docs/plans/SHARED_CACHE_FINDINGS.md` — writeup of why chart caches don't materially help `/allocations` despite working correctly. Root cause: `preload_app=True` + per-worker `OrderedDict` gives 2 pods × 33 workers = 66 independent caches. Single-user best-case hit rate `~1/33`. Includes three-deploy comparison table, per-worker RSS outlier evidence, and three follow-up paths.

## Commits

- 1ab406c caching: unified CacheBase contract + admin stats surface
- 8008045 tests: update usage_cache poking to new adapter internals
- eb3a78c docs: kubectl runbook + per-worker cache findings from caching_unified probe
- f00433b admin: add Server Information card with worker-scoped runtime probes

## Test plan

- [x] Local pytest passes (no test changes beyond original two commits)
- [x] Configuration card renders in webdev (Flask dev server, Docker Desktop)
- [x] Refresh button HTMX swap works in both webdev and prod
- [x] Graceful-fallback values render as `—` instead of throwing on missing /proc/cgroup paths
- [x] Deployed to samuel.k8s.ucar.edu; Server card shows worker-rotation across refreshes
- [x] `/allocations` probe still OOMKill-free post admin-route changes (8 cold loads, 2 pods, 0 restarts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)