### PR TITLE
Add Peak/Current rank-by selector to user/project queue chart

### DIFF
--- a/src/system_status/queries/user_proj_queues.py
+++ b/src/system_status/queries/user_proj_queues.py
@@ -27,6 +27,8 @@ _VALID_GROUP_BY = ('user', 'project')
 _VALID_STATES = ('running', 'pending', 'held')
 _VALID_METRICS = ('jobs', 'cores', 'gpus', 'nodes')
 
+_VALID_RANK_BY = ('peak', 'current')
+
 # (state, metric) → DB column on UserProjQueueStatus / QueueRollupMetricsMixin.
 # `nodes` is only defined for state='running' (the schema has no
 # nodes_pending / nodes_held columns); other (state, metric) combos
@@ -173,9 +175,9 @@ def get_user_proj_timeseries(
     metric: str,
     group_by: str,
     top_n: int = 15,
+    rank_by: str = 'peak',
 ) -> Dict[str, Any]:
-    """Top-N + Others time series for one queue, or one system, ranked
-    by peak in window.
+    """Top-N + Others time series for one queue, or one system.
 
     Scope is determined by ``queue_name``:
 
@@ -217,12 +219,17 @@ def get_user_proj_timeseries(
 
     Series ordering matches ``get_disk_usage_timeseries_by_user``: Others
     first (so it stacks at the bottom under a neutral colour), then named
-    series smallest-to-largest by peak value over the window so the
-    largest sits on top of the stack.
+    series smallest-to-largest by the rank value so the largest sits on
+    top of the stack.
 
-    Ranking by **MAX over the window** (not latest tick) so a brief spike
-    still earns a slot — important for queue load where short pending/held
-    bursts are exactly what an operator wants to see.
+    ``rank_by`` controls top-N selection:
+
+    - ``'peak'`` (default): rank by **MAX over the window** so a brief
+      spike still earns a slot — useful for catching short pending/held
+      bursts an operator might otherwise miss.
+    - ``'current'``: rank by the value at the **latest timestamp** in the
+      window — answers "who is loading the system right now", at the cost
+      of dropping a label whose run already ended within the window.
     """
     if state not in _VALID_STATES:
         raise ValueError(
@@ -240,6 +247,10 @@ def get_user_proj_timeseries(
     if group_by not in _VALID_GROUP_BY:
         raise ValueError(
             f'group_by must be one of {_VALID_GROUP_BY}, got {group_by!r}'
+        )
+    if rank_by not in _VALID_RANK_BY:
+        raise ValueError(
+            f'rank_by must be one of {_VALID_RANK_BY}, got {rank_by!r}'
         )
 
     column_name = _STATE_METRIC_TO_COLUMN[(state, metric)]
@@ -323,12 +334,14 @@ def get_user_proj_timeseries(
 
     dates = sorted(timestamps)
 
-    # Rank by peak value over the window (catches brief spikes).
-    ranked = sorted(
-        per_label.items(),
-        key=lambda kv: max(kv[1].values()) if kv[1] else 0,
-        reverse=True,
-    )
+    # Two ranking modes — peak catches brief spikes, current answers
+    # "who's hot right now". `dates` is non-empty here (rows guard above).
+    if rank_by == 'current':
+        latest = dates[-1]
+        rank_key = lambda kv: kv[1].get(latest, 0)
+    else:  # 'peak'
+        rank_key = lambda kv: max(kv[1].values()) if kv[1] else 0
+    ranked = sorted(per_label.items(), key=rank_key, reverse=True)
     top = ranked[:top_n]
     rest = ranked[top_n:]
 

--- a/src/webapp/dashboards/status/blueprint.py
+++ b/src/webapp/dashboards/status/blueprint.py
@@ -321,6 +321,7 @@ def _render_user_proj_chart(*, system, queue_name, endpoint_name, endpoint_kwarg
     valid_states = ('running', 'pending', 'held')
     valid_metrics = ('jobs', 'cores', 'gpus', 'nodes')
     valid_groups = ('user', 'project')
+    valid_rank_by = ('peak', 'current')
 
     state = request.args.get('state', 'running')
     if state not in valid_states:
@@ -331,6 +332,9 @@ def _render_user_proj_chart(*, system, queue_name, endpoint_name, endpoint_kwarg
     group_by = request.args.get('group_by', 'user')
     if group_by not in valid_groups:
         group_by = 'user'
+    rank_by = request.args.get('rank_by', 'peak')
+    if rank_by not in valid_rank_by:
+        rank_by = 'peak'
 
     # `nodes` only exists for state='running' (no nodes_pending /
     # nodes_held columns in QueueRollupMetricsMixin). Clamp to cores
@@ -365,6 +369,7 @@ def _render_user_proj_chart(*, system, queue_name, endpoint_name, endpoint_kwarg
         metric=metric,
         group_by=group_by,
         top_n=top_n,
+        rank_by=rank_by,
     )
 
     # Clamp metric=gpus → cores when this scope+window has no GPU
@@ -384,6 +389,7 @@ def _render_user_proj_chart(*, system, queue_name, endpoint_name, endpoint_kwarg
             metric=metric,
             group_by=group_by,
             top_n=top_n,
+            rank_by=rank_by,
         )
 
     chart_svg = generate_user_proj_stacked_area(timeseries)
@@ -407,6 +413,7 @@ def _render_user_proj_chart(*, system, queue_name, endpoint_name, endpoint_kwarg
         metric_label=timeseries.get('metric_label', metric),
         group_by=group_by,
         group_by_label=timeseries.get('group_by_label', group_by),
+        rank_by=rank_by,
         top_n=top_n,
         chart_svg=chart_svg,
         endpoint_name=endpoint_name,

--- a/src/webapp/templates/dashboards/status/partials/user_proj_chart.html
+++ b/src/webapp/templates/dashboards/status/partials/user_proj_chart.html
@@ -1,7 +1,7 @@
 {# Stacked-area chart fragment for the user/project queue load chart.
 
-   Three btn-groups (group_by, state, metric) live INSIDE the swap
-   target so each click re-renders both the buttons (with the new
+   Four btn-groups (group_by, state, metric, rank_by) live INSIDE the
+   swap target so each click re-renders both the buttons (with the new
    active state) and the chart in a single HTMX swap. No JS state to
    keep in sync.
 
@@ -19,7 +19,8 @@
    builds selector URLs against whichever endpoint owns it. `queue_name`
    is None in the system-wide case; the title suffix omits it. #}
 {% set _selector_kwargs = {
-    'group_by': group_by, 'state': state, 'metric': metric, 'hours': hours,
+    'group_by': group_by, 'state': state, 'metric': metric,
+    'hours': hours, 'rank_by': rank_by,
 } %}
 <div id="{{ chart_dom_id }}" data-chart-persist-id="{{ chart_dom_id }}">
     <div class="d-flex flex-wrap gap-3 mb-3 align-items-center">
@@ -79,6 +80,23 @@
                           hx-target="#{{ chart_dom_id }}"
                           hx-swap="outerHTML"
                         {% endif %}>
+                    {{ opt_lbl }}
+                </button>
+                {% endfor %}
+            </div>
+        </div>
+        <div>
+            <label class="form-label small text-muted mb-1 me-2">Select by</label>
+            <div class="btn-group btn-group-sm" role="group" aria-label="Select by">
+                {# Peak: top_n by max over the visible window (catches brief spikes).
+                   Current: top_n by value at the latest tick (who is hot right now). #}
+                {% for opt_val, opt_lbl in [('peak', 'Peak'), ('current', 'Current')] %}
+                <button type="button"
+                        class="btn btn-{% if rank_by == opt_val %}primary{% else %}outline-primary{% endif %}"
+                        hx-get="{{ url_for(endpoint_name,
+                                           **dict(endpoint_kwargs, **dict(_selector_kwargs, rank_by=opt_val))) }}"
+                        hx-target="#{{ chart_dom_id }}"
+                        hx-swap="outerHTML">
                     {{ opt_lbl }}
                 </button>
                 {% endfor %}

--- a/tests/unit/test_user_proj_queues_timeseries.py
+++ b/tests/unit/test_user_proj_queues_timeseries.py
@@ -1,0 +1,108 @@
+"""Unit tests for ``system_status.queries.get_user_proj_timeseries``.
+
+Focused on top-N selection semantics: ``rank_by='peak'`` (default) ranks
+by the maximum value over the window; ``rank_by='current'`` ranks by the
+value at the latest tick.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from system_status import DerechoStatus, UserProjQueueStatus
+from system_status.queries.user_proj_queues import get_user_proj_timeseries
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_derecho(session, ts):
+    parent = DerechoStatus(
+        timestamp=ts,
+        cpu_nodes_total=100, cpu_nodes_available=50, cpu_nodes_down=0,
+        gpu_nodes_total=10, gpu_nodes_available=5, gpu_nodes_down=0,
+        cpu_cores_total=12800, cpu_cores_allocated=6400, cpu_cores_idle=6400,
+        gpu_count_total=40, gpu_count_allocated=20, gpu_count_idle=20,
+        memory_total_gb=10000.0, memory_allocated_gb=5000.0,
+    )
+    session.add(parent)
+    return parent
+
+
+def _make_upq(session, parent, *, queue, user, project, cores):
+    row = UserProjQueueStatus(
+        timestamp=parent.timestamp,
+        system_name='derecho', queue_name=queue,
+        username=user, project_code=project,
+        running_jobs=1 if cores else 0,
+        cores_allocated=cores,
+    )
+    row.derecho_status = parent
+    session.add(row)
+    return row
+
+
+def test_rank_by_peak_vs_current_diverge(status_session):
+    """Two users diverge between peak and latest-tick rankings.
+
+    Window has three ticks. User 'spiker' peaks at t0 (1000) and is gone
+    by t2 (0). User 'steady' rises to 500 at t2 (its latest value, also
+    its peak). Selecting top_n=1:
+
+    - rank_by='peak'    → 'spiker' wins (1000 > 500)
+    - rank_by='current' → 'steady' wins (500 > 0 at t2)
+    """
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    t1 = t0 + timedelta(minutes=5)
+    t2 = t0 + timedelta(minutes=10)
+    p0 = _make_derecho(status_session, t0)
+    p1 = _make_derecho(status_session, t1)
+    p2 = _make_derecho(status_session, t2)
+
+    _make_upq(status_session, p0, queue='main',
+              user='spiker', project='SCSG0001', cores=1000)
+    _make_upq(status_session, p1, queue='main',
+              user='spiker', project='SCSG0001', cores=200)
+    _make_upq(status_session, p1, queue='main',
+              user='steady', project='SCSG0001', cores=300)
+    _make_upq(status_session, p2, queue='main',
+              user='steady', project='SCSG0001', cores=500)
+    status_session.flush()
+
+    common = dict(
+        session=status_session,
+        system='derecho',
+        queue_name='main',
+        start_date=t0,
+        end_date=t2,
+        state='running',
+        metric='cores',
+        group_by='user',
+        top_n=1,
+    )
+
+    peak = get_user_proj_timeseries(**common, rank_by='peak')
+    current = get_user_proj_timeseries(**common, rank_by='current')
+
+    # Series order: 'Others' first, then named series small→large by rank.
+    # With top_n=1 we expect exactly two entries: ['Others', winner].
+    peak_named = [s['label'] for s in peak['series'] if s['label'] != 'Others']
+    current_named = [s['label'] for s in current['series'] if s['label'] != 'Others']
+
+    assert peak_named == ['spiker'], peak['series']
+    assert current_named == ['steady'], current['series']
+
+
+def test_rank_by_invalid_raises(status_session):
+    with pytest.raises(ValueError, match='rank_by'):
+        get_user_proj_timeseries(
+            status_session,
+            system='derecho',
+            queue_name='main',
+            start_date=datetime(2026, 5, 4, 12, 0, 0),
+            end_date=datetime(2026, 5, 4, 13, 0, 0),
+            state='running',
+            metric='cores',
+            group_by='user',
+            rank_by='median',
+        )


### PR DESCRIPTION
Top-N can now be ranked by latest tick ("who's hot right now") in addition to the existing peak-over-window default.