### PR TITLE
Robust docker bootstrap + slim image + lazy session-init + CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,16 +12,32 @@ htmlcov/
 .coverage
 .coverage.*
 *.log
-*.sql
-*.sql.xz
+# Use ** so nested .sql / .sql.xz files (e.g. containers/sam-sql-dev/
+# dump/*.sql) are excluded too. A bare `*.sql` pattern only matches
+# the build-context root, not subdirectories — this is the reason
+# the 223 MB dump dir was previously slipping into the image.
+**/*.sql
+**/*.sql.xz
+**/*.dump
 .git/
 .gitignore
 .DS_Store
 *.swp
 *.swo
 *~
+# emacs lock + autosave files
+.#*
+\#*\#
 
 # Local working data (untracked; not used inside the image)
 data/
 logs/
 collectors/logs/
+
+# DB-image build helpers — not used by the webapp image, and not used
+# by the sam-sql-dev/mysql-test build context either (its Dockerfile
+# only COPYs init-db.sh). Excluding them here drops ~225 MiB from the
+# webapp build context.
+containers/sam-sql-dev/dump/
+containers/sam-sql-dev/__pycache__/
+containers/sam-sql-dev/anonymization_mappings.json

--- a/.env.example
+++ b/.env.example
@@ -23,36 +23,52 @@ PROD_SAM_DB_PASSWORD='your_prod_password'
 # STAGING_SAM_DB_PASSWORD=<from db-creds-staging.sh>
 
 #-------------------------------------------------
-# "proper SAM" is the SAM instance used to feed
-#   our dashboards etc... It may be read-only
-#   depending on credentials.
+# "proper SAM" is the SAM instance used to feed our dashboards etc...
 #
-# To use LOCAL database (default):
-SAM_DB_USERNAME=${LOCAL_SAM_DB_USERNAME}
-SAM_DB_SERVER=${LOCAL_SAM_DB_SERVER}
-SAM_DB_PASSWORD=${LOCAL_SAM_DB_PASSWORD}
-SAM_DB_REQUIRE_SSL=false
+# Pick ONE block below by uncommenting. Leaving ALL of them commented
+# is the default state for `install.sh`-generated `.env`. In that
+# state, `compose.yaml`'s in-stack defaults route the docker stack
+# to the bundled `mysql` service (host `mysql`, root/root). Any
+# out-of-stack tools (sam-search from a conda env, alembic, ...)
+# won't have SAM_DB_SERVER set until you uncomment one block here.
+#
+# IMPORTANT: whatever you uncomment also flows into the in-stack
+# containers via compose `env_file:` (intentional pass-through).
+# So uncommenting LOCAL points the in-stack webapp at 127.0.0.1
+# (loopback inside the container, broken — use only if you are
+# running sam-search out-of-stack and accept that webdev/webapp
+# won't work). Uncommenting PROD points BOTH out-of-stack and
+# in-stack at sam-sql.ucar.edu (useful for prod-data testing).
 
-# To use STAGING database instead, uncomment these and comment out local settings above:
+# Uncomment to use LOCAL (host loopback to docker mysql via 3306):
+#SAM_DB_USERNAME=${LOCAL_SAM_DB_USERNAME}
+#SAM_DB_SERVER=${LOCAL_SAM_DB_SERVER}
+#SAM_DB_PASSWORD=${LOCAL_SAM_DB_PASSWORD}
+#SAM_DB_REQUIRE_SSL=false
+
+# Uncomment to use STAGING:
 #SAM_DB_USERNAME=${STAGING_SAM_DB_USERNAME}
 #SAM_DB_SERVER=${STAGING_SAM_DB_SERVER}
 #SAM_DB_PASSWORD=${STAGING_SAM_DB_PASSWORD}
 #SAM_DB_REQUIRE_SSL=false
 
-# To use PRODUCTION database instead, uncomment these and comment out local settings above:
+# Uncomment to use PRODUCTION:
 #SAM_DB_USERNAME=${PROD_SAM_DB_USERNAME}
 #SAM_DB_SERVER=${PROD_SAM_DB_SERVER}
 #SAM_DB_PASSWORD=${PROD_SAM_DB_PASSWORD}
 #SAM_DB_REQUIRE_SSL=true
 
 #-------------------------------------------------
-# system_status database - used to populate
-# the System Status Dashboard
-# STATUS_DB_DRIVER: "mysql" (default), "postgresql", or "postgres"
+# system_status database - used to populate the System Status
+# Dashboard. STATUS_DB_DRIVER: "mysql" (default), "postgresql",
+# or "postgres". Same pass-through rule as above — leaving the
+# active lines commented lets compose.yaml route in-stack
+# containers to the bundled `mysql` service.
 STATUS_DB_DRIVER=mysql
-STATUS_DB_USERNAME=root
-STATUS_DB_PASSWORD=root
-STATUS_DB_SERVER=127.0.0.1
+# Uncomment for OUT-OF-STACK conda use against the docker mysql:
+#STATUS_DB_USERNAME=root
+#STATUS_DB_PASSWORD=root
+#STATUS_DB_SERVER=127.0.0.1
 
 #-------------------------------------------------
 # Where our data collectors post their results

--- a/.github/scripts/prune_ghcr_packages.py
+++ b/.github/scripts/prune_ghcr_packages.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Prune old container versions from GitHub Container Registry (GHCR).
+
+Used by `.github/workflows/clean-ghcr.yaml` to keep the GHCR namespace
+small. Retention policy (per package):
+
+    * Untagged versions               → DELETE
+    * Tag matches PROTECTED_REGEX     → KEEP (never deleted)
+        (default: ^(latest|main|staging|v[0-9].*)$)
+    * Tag starts with `sha-`          → KEEP the N most-recent, DELETE rest
+        (default N=10)
+    * Anything else                   → KEEP (defensive — leave unknown
+                                       conventions alone)
+
+Owner / repo default to the GitHub Actions context env vars
+(`GITHUB_REPOSITORY_OWNER`, `GITHUB_REPOSITORY`); both can be overridden
+on the command line.
+
+Examples
+--------
+Default (used by the workflow):
+
+    python .github/scripts/prune_ghcr_packages.py
+
+Override packages and retention:
+
+    python .github/scripts/prune_ghcr_packages.py \\
+        --package mysql --package webapp --keep 5
+
+Preview without deleting anything:
+
+    python .github/scripts/prune_ghcr_packages.py --dry-run
+
+Authentication: relies on `gh api`, which reads `GH_TOKEN` from the
+environment. The workflow sets `GH_TOKEN` to a token that has
+`packages: write` scope.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.parse
+
+
+PROTECTED_REGEX = re.compile(r"^(latest|main|staging|v[0-9].*)$")
+
+
+def fetch_versions(pkg_encoded: str, owner: str) -> list[dict]:
+    """Return all versions for a single GHCR package (paginated)."""
+    cmd = [
+        "gh", "api", "--paginate",
+        f"users/{owner}/packages/container/{pkg_encoded}/versions",
+    ]
+    try:
+        res = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as exc:
+        print(f"Error fetching {pkg_encoded}: {exc.stderr}", file=sys.stderr)
+        return []
+
+    if not res.stdout.strip():
+        return []
+    return json.loads(res.stdout.strip())
+
+
+def delete_version(pkg_encoded: str, owner: str, version_id: int,
+                   dry_run: bool = False) -> bool:
+    """Delete a single GHCR package version. Returns True on success."""
+    if dry_run:
+        return True
+    cmd = [
+        "gh", "api", "-X", "DELETE",
+        f"users/{owner}/packages/container/{pkg_encoded}/versions/{version_id}",
+    ]
+    try:
+        subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return True
+    except subprocess.CalledProcessError as exc:
+        print(f"Failed to delete {version_id}: {exc.stderr}", file=sys.stderr)
+        return False
+
+
+def prune_package(pkg: str, owner: str, keep_sha_count: int,
+                  dry_run: bool) -> int:
+    """Apply the retention policy to one package; return delete count."""
+    print("\n" + "=" * 49)
+    print(f"Processing package: {pkg}")
+    pkg_encoded = urllib.parse.quote(pkg, safe="")
+
+    versions = fetch_versions(pkg_encoded, owner)
+    print(f"Found {len(versions)} versions.")
+
+    deleted = 0
+    sha_kept = 0
+    for v in versions:
+        v_id = v["id"]
+        tags = v.get("metadata", {}).get("container", {}).get("tags", [])
+
+        if not tags:
+            print(f"Deleting {v_id} (untagged)")
+            if delete_version(pkg_encoded, owner, v_id, dry_run):
+                deleted += 1
+            continue
+
+        if any(PROTECTED_REGEX.match(t) for t in tags):
+            print(f"Keeping  {v_id} (protected: {tags})")
+            continue
+
+        if any(t.startswith("sha-") for t in tags):
+            if sha_kept < keep_sha_count:
+                print(f"Keeping  {v_id} (recent SHA: {tags})")
+                sha_kept += 1
+            else:
+                print(f"Deleting {v_id} (old SHA: {tags})")
+                if delete_version(pkg_encoded, owner, v_id, dry_run):
+                    deleted += 1
+            continue
+
+        # Defensive default: anything we don't explicitly recognise stays.
+        print(f"Keeping  {v_id} (unknown tags: {tags})")
+
+    return deleted
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="prune_ghcr_packages.py",
+        description="Prune old GHCR package versions per the retention "
+                    "policy documented in this script's docstring.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--owner", default=os.environ.get("GITHUB_REPOSITORY_OWNER"),
+        help="GHCR namespace owner (default: $GITHUB_REPOSITORY_OWNER).",
+    )
+    repo_default = os.environ.get("GITHUB_REPOSITORY", "").split("/")[-1] or None
+    p.add_argument(
+        "--repo", default=repo_default,
+        help="Repository name (default: parsed from $GITHUB_REPOSITORY).",
+    )
+    p.add_argument(
+        "--package", action="append", dest="packages", metavar="NAME",
+        help="Package name relative to --repo (e.g. 'webapp'). Repeat to "
+             "specify multiple. Defaults to: mysql, webapp, collectors.",
+    )
+    p.add_argument(
+        "--keep", type=int, default=10, metavar="N",
+        help="Number of recent sha-* tagged versions to retain per package "
+             "(default: 10).",
+    )
+    p.add_argument(
+        "--dry-run", action="store_true",
+        help="Print what would be deleted without actually deleting.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+
+    if not args.owner:
+        print("--owner not set and $GITHUB_REPOSITORY_OWNER is empty",
+              file=sys.stderr)
+        return 2
+    if not args.repo:
+        print("--repo not set and $GITHUB_REPOSITORY is empty",
+              file=sys.stderr)
+        return 2
+
+    package_names = args.packages or ["mysql", "webapp", "collectors"]
+    packages = [f"{args.repo}/{name}" for name in package_names]
+
+    if args.dry_run:
+        print("[DRY RUN] No deletions will be performed.")
+
+    total = 0
+    for pkg in packages:
+        total += prune_package(pkg, args.owner, args.keep, args.dry_run)
+
+    verb = "would have been deleted" if args.dry_run else "deleted"
+    print(f"\nCleanup complete. Total versions {verb}: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/clean-ghcr.yaml
+++ b/.github/workflows/clean-ghcr.yaml
@@ -14,87 +14,17 @@ jobs:
       packages: write   # Required to delete packages
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Prune Old Package Versions
+        # Retention policy + retries + dry-run support live in
+        # `.github/scripts/prune_ghcr_packages.py` (run with --help to
+        # see flags). Owner / repo come from the standard Actions
+        # context env vars; the script defaults to the three packages
+        # this repo publishes (mysql, webapp, collectors).
         env:
-          # Use personal token if available (for user-owned packages), fallback to standard token
+          # Use personal token if available (for user-owned packages),
+          # fallback to standard token. Either needs `packages: write`.
           GH_TOKEN: ${{ secrets.BENKIRK_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
-          python -c '
-          import os, sys, json, subprocess, re, urllib.parse
-
-          owner = os.environ.get("GITHUB_REPOSITORY_OWNER")
-          repo = os.environ.get("GITHUB_REPOSITORY", "").split("/")[-1]
-
-          if not owner or not repo:
-              print("Missing GITHUB_REPOSITORY_OWNER or GITHUB_REPOSITORY")
-              sys.exit(1)
-
-          # Target packages managed by this repo
-          packages = [f"{repo}/mysql", f"{repo}/webapp", f"{repo}/collectors"]
-
-          # Retention policy
-          keep_sha_count = 10
-          protected_regex = re.compile(r"^(latest|main|staging|v[0-9].*)$")
-
-          def fetch_versions(pkg_encoded):
-              cmd = ["gh", "api", "--paginate", f"users/{owner}/packages/container/{pkg_encoded}/versions"]
-              try:
-                  res = subprocess.run(cmd, capture_output=True, text=True, check=True)
-                  if res.stdout.strip():
-                      return json.loads(res.stdout.strip())
-                  return []
-              except subprocess.CalledProcessError as e:
-                  print(f"Error fetching {pkg_encoded}: {e.stderr}")
-                  return []
-
-          def delete_version(pkg_encoded, version_id):
-              cmd = ["gh", "api", "-X", "DELETE", f"users/{owner}/packages/container/{pkg_encoded}/versions/{version_id}"]
-              try:
-                  subprocess.run(cmd, capture_output=True, text=True, check=True)
-                  return True
-              except subprocess.CalledProcessError as e:
-                  print(f"Failed to delete {version_id}: {e.stderr}")
-                  return False
-
-          total_deleted = 0
-          for pkg in packages:
-              print(f"\n=================================================")
-              print(f"Processing package: {pkg}")
-              pkg_encoded = urllib.parse.quote(pkg, safe="")
-
-              versions = fetch_versions(pkg_encoded)
-              print(f"Found {len(versions)} versions.")
-
-              sha_count = 0
-
-              for v in versions:
-                  v_id = v["id"]
-                  tags = v.get("metadata", {}).get("container", {}).get("tags", [])
-
-                  if not tags:
-                      print(f"Deleting {v_id} (untagged)")
-                      if delete_version(pkg_encoded, v_id):
-                          total_deleted += 1
-                      continue
-
-                  # Keep if it matches protected tags
-                  if any(protected_regex.match(t) for t in tags):
-                      print(f"Keeping {v_id} (protected: {tags})")
-                      continue
-
-                  # Keep up to N recent sha- tags
-                  if any(t.startswith("sha-") for t in tags):
-                      if sha_count < keep_sha_count:
-                          print(f"Keeping {v_id} (recent SHA: {tags})")
-                          sha_count += 1
-                      else:
-                          print(f"Deleting {v_id} (old SHA: {tags})")
-                          if delete_version(pkg_encoded, v_id):
-                              total_deleted += 1
-                      continue
-
-                  # Keep anything else we dont explicitly handle
-                  print(f"Keeping {v_id} (unknown tags: {tags})")
-
-          print(f"\nCleanup complete. Total versions deleted: {total_deleted}")
-          '
+        run: python .github/scripts/prune_ghcr_packages.py

--- a/.github/workflows/sam-ci-conda_make.yaml
+++ b/.github/workflows/sam-ci-conda_make.yaml
@@ -69,12 +69,30 @@ jobs:
         env:
           COMPOSE_SERVICE: mysql
 
+      # The conda-env CLI tools (sam-search, sam-status) run on the
+      # HOST, not inside the docker stack — they reach the docker
+      # mysql/system_status via the host port mapping (127.0.0.1:3306).
+      # Set the SAM_DB_*/STATUS_DB_* env explicitly here. We used to
+      # rely on .env.example having the LOCAL block uncommented, but
+      # that template now defaults to all-commented (so a fresh
+      # `install.sh`-generated .env doesn't leak 127.0.0.1 into
+      # in-stack containers via compose's env_file pass-through).
       - name: Run sam-search CLI tool
+        env:
+          SAM_DB_SERVER: 127.0.0.1
+          SAM_DB_USERNAME: root
+          SAM_DB_PASSWORD: root
+          SAM_DB_REQUIRE_SSL: "false"
         run: |
           sam-search --inactive-projects user benkirk --list-projects --verbose
           sam-search project SCSG0001 --verbose --list-users
 
       - name: Run sam-status CLI tool
+        env:
+          STATUS_DB_DRIVER: mysql
+          STATUS_DB_SERVER: 127.0.0.1
+          STATUS_DB_USERNAME: root
+          STATUS_DB_PASSWORD: root
         run: |
           sam-status derecho
           sam-status casper

--- a/.github/workflows/sam-ci-conda_make.yaml
+++ b/.github/workflows/sam-ci-conda_make.yaml
@@ -27,6 +27,23 @@ jobs:
       && !contains(github.event.pull_request.title, '[no ci]')
     runs-on: ubuntu-latest
 
+    # The host-side CLI tools (sam-search, sam-status) validate BOTH
+    # SAM_DB_* and STATUS_DB_* at startup, regardless of which DB the
+    # specific command actually queries. Set them job-wide so every
+    # `run:` step inherits them. Connection target is the docker mysql
+    # exposed on host port 3306 (sam-ci-docker uses the same compose
+    # stack), so 127.0.0.1/root/root is the right wiring for ALL the
+    # CLI steps below.
+    env:
+      SAM_DB_SERVER: 127.0.0.1
+      SAM_DB_USERNAME: root
+      SAM_DB_PASSWORD: root
+      SAM_DB_REQUIRE_SSL: "false"
+      STATUS_DB_DRIVER: mysql
+      STATUS_DB_SERVER: 127.0.0.1
+      STATUS_DB_USERNAME: root
+      STATUS_DB_PASSWORD: root
+
     steps:
       - name: Install MySQL Client
         run: |
@@ -69,30 +86,16 @@ jobs:
         env:
           COMPOSE_SERVICE: mysql
 
-      # The conda-env CLI tools (sam-search, sam-status) run on the
-      # HOST, not inside the docker stack — they reach the docker
-      # mysql/system_status via the host port mapping (127.0.0.1:3306).
-      # Set the SAM_DB_*/STATUS_DB_* env explicitly here. We used to
-      # rely on .env.example having the LOCAL block uncommented, but
-      # that template now defaults to all-commented (so a fresh
-      # `install.sh`-generated .env doesn't leak 127.0.0.1 into
-      # in-stack containers via compose's env_file pass-through).
+      # SAM_DB_* / STATUS_DB_* come from the job-level `env:` block
+      # at the top of this file. Both CLIs validate BOTH var sets at
+      # startup, so they must be set together — see the rationale on
+      # the job env: block.
       - name: Run sam-search CLI tool
-        env:
-          SAM_DB_SERVER: 127.0.0.1
-          SAM_DB_USERNAME: root
-          SAM_DB_PASSWORD: root
-          SAM_DB_REQUIRE_SSL: "false"
         run: |
           sam-search --inactive-projects user benkirk --list-projects --verbose
           sam-search project SCSG0001 --verbose --list-users
 
       - name: Run sam-status CLI tool
-        env:
-          STATUS_DB_DRIVER: mysql
-          STATUS_DB_SERVER: 127.0.0.1
-          STATUS_DB_USERNAME: root
-          STATUS_DB_PASSWORD: root
         run: |
           sam-status derecho
           sam-status casper

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -26,9 +26,6 @@ jobs:
       && !contains(github.event.pull_request.title, '[no ci]')
     runs-on: ubuntu-latest
     steps:
-      - name: Install MySQL Client
-        run: sudo apt-get install -y mysql-client
-
       - name: Setup Environment
         run: echo "INSTALL_DIR=${{ runner.temp }}/test-install-target" >> ${GITHUB_ENV}
 
@@ -37,134 +34,174 @@ jobs:
         with:
           lfs: true
 
-      # Ensure latest Docker for compatibility
+      # Latest docker for compatibility with --wait, COPY --exclude, etc.
       - name: Install latest Docker
         uses: docker/setup-docker-action@v4
         with:
           docker-ce-version: latest
 
-      - name: Test "curl | bash" style installation
+      # ----------------------------------------------------------------
+      # 1. Argument parsing canary — cheap, exits before any clone
+      # ----------------------------------------------------------------
+      - name: install.sh --help
+        run: bash install.sh --help
+
+      # ----------------------------------------------------------------
+      # 2. The recommended `curl | bash` shape (clone path)
+      # ----------------------------------------------------------------
+      - name: install.sh — first run (clones into a fresh dir)
         run: |
-          # ---------------------------------------------------------
-          # Determine Repo and Branch to test
-          # ---------------------------------------------------------
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # For PRs, use the head repo url (handles forks)
             TARGET_REPO="${{ github.event.pull_request.head.repo.clone_url }}"
             TARGET_BRANCH="${{ github.head_ref }}"
           else
-            # For pushes, use the current repository
             TARGET_REPO="${{ github.server_url }}/${{ github.repository }}"
             TARGET_BRANCH="${{ github.ref_name }}"
           fi
-
           echo "Testing install logic with:"
           echo "  Repo:   ${TARGET_REPO}"
           echo "  Branch: ${TARGET_BRANCH}"
 
-          # ---------------------------------------------------------
-          # Execute Install Script
-          # ---------------------------------------------------------
-          # Simulate remote execution by piping the local script file.
-          # We pass arguments to verify the script correctly handles them
-          # and to point it to the code version corresponding to this CI run.
+          # Pipe so the script enters its non-TTY branch (set -eo pipefail
+          # without set -u) — same path users hit via `curl | bash`.
           cat install.sh | bash -s -- \
             --dir "${INSTALL_DIR}" \
             --repo "${TARGET_REPO}" \
             --branch "${TARGET_BRANCH}"
 
-          # ---------------------------------------------------------
-          # Verify Results
-          # ---------------------------------------------------------
-          echo "--- Verifying Installation ---"
-          if [[ ! -d "${INSTALL_DIR}" ]]; then
-             echo "::error::Installation directory was not created."
-             exit 1
+      - name: Verify install dir contents
+        run: |
+          echo "--- Verifying installation outputs ---"
+          test -d "${INSTALL_DIR}"              || { echo "::error::install dir not created"; exit 1; }
+          test -d "${INSTALL_DIR}/.git"         || { echo "::error::no .git in install dir"; exit 1; }
+          test -f "${INSTALL_DIR}/compose.yaml" || { echo "::error::compose.yaml missing"; exit 1; }
+          test -f "${INSTALL_DIR}/Makefile"     || { echo "::error::Makefile missing"; exit 1; }
+          test -f "${INSTALL_DIR}/.env"         || { echo "::error::.env not created (setup step failed)"; exit 1; }
+          echo "✅ Install dir contents look right"
+
+      # ----------------------------------------------------------------
+      # 3. Re-run install.sh against the same dir — exercises the
+      #    "fetch + checkout + pull --ff-only" branch in the script,
+      #    which the first run never touches.
+      # ----------------------------------------------------------------
+      - name: install.sh — second run (update path, idempotent)
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            TARGET_REPO="${{ github.event.pull_request.head.repo.clone_url }}"
+            TARGET_BRANCH="${{ github.head_ref }}"
+          else
+            TARGET_REPO="${{ github.server_url }}/${{ github.repository }}"
+            TARGET_BRANCH="${{ github.ref_name }}"
           fi
+          cat install.sh | bash -s -- \
+            --dir "${INSTALL_DIR}" \
+            --repo "${TARGET_REPO}" \
+            --branch "${TARGET_BRANCH}"
 
-          if [[ ! -d "${INSTALL_DIR}/.git" ]]; then
-             echo "::error::Git repository not initialized in target."
-             exit 1
-          fi
-
-          if [[ ! -f "${INSTALL_DIR}/compose.yaml" ]]; then
-             echo "::error::compose.yaml missing in install dir."
-             exit 1
-          fi
-
-          if [[ ! -f "${INSTALL_DIR}/.env" ]]; then
-             echo "::error::.env file was not created (setup step failed)."
-             exit 1
-          fi
-
-          echo "✅ Installation verified successfully at ${INSTALL_DIR}"
-
-      - name: Verify backup file
+      # ----------------------------------------------------------------
+      # 4. LFS recovery — if the bundled backup is still a pointer file,
+      #    pull the real bytes (init-db.sh detects this and warns, but
+      #    the test would then run against an empty schema).
+      # ----------------------------------------------------------------
+      - name: Verify backup file (LFS recovery if needed)
         run: |
           cd "${INSTALL_DIR}"
           BACKUP_FILE="containers/sam-sql-dev/backups/sam-obfuscated.sql.xz"
-          
-          echo "=== Verifying backup file ==="
-          ls -lh "${BACKUP_FILE}" || echo "Backup file not found"
-          
-          FILE_SIZE=$(stat -c%s "${BACKUP_FILE}" 2>/dev/null || stat -f%z "${BACKUP_FILE}" 2>/dev/null || echo "0")
-          echo "File size: ${FILE_SIZE} bytes"
-          
+          ls -lh "${BACKUP_FILE}" || true
+          FILE_SIZE=$(stat -c%s "${BACKUP_FILE}" 2>/dev/null || stat -f%z "${BACKUP_FILE}" 2>/dev/null || echo 0)
           if [ "${FILE_SIZE}" -lt 1000 ]; then
-            echo "⚠️ File appears to be LFS pointer, pulling..."
+            echo "⚠️ Backup looks like an LFS pointer (${FILE_SIZE}B) — pulling..."
             git lfs pull
             ls -lh "${BACKUP_FILE}"
           fi
 
-      - name: Start Services
+      # ----------------------------------------------------------------
+      # 5. `make help` smoke — proves the Makefile in the cloned tree
+      #    surfaces the targets install.sh's banner tells users to run.
+      # ----------------------------------------------------------------
+      - name: make help advertises the rules install.sh recommends
         run: |
           cd "${INSTALL_DIR}"
-          echo "Starting services in ${INSTALL_DIR}..."
-          docker compose build
-          docker compose up -d
-          
-          echo "=== Initial container status ==="
-          docker compose ps -a
-          sleep 5
-          docker compose ps -a
+          out=$(make help)
+          echo "${out}"
+          echo "${out}" | grep -qE 'docker-up '      || { echo "::error::make help missing docker-up";      exit 1; }
+          echo "${out}" | grep -qE 'docker-down '    || { echo "::error::make help missing docker-down";    exit 1; }
+          echo "${out}" | grep -qE 'docker-pytest '  || { echo "::error::make help missing docker-pytest";  exit 1; }
+          echo "${out}" | grep -qE 'docker-watch '   || { echo "::error::make help missing docker-watch";   exit 1; }
 
-      - name: Wait for MySQL
+      # ----------------------------------------------------------------
+      # 6. The recommended next step from install.sh's banner.
+      #    `make docker-up` is `docker compose up -d --wait`, which gates
+      #    on every healthcheck — so a passing exit means MySQL finished
+      #    its restore (sam + system_status both queryable) AND the
+      #    webapp's /health/ready endpoint reports both binds healthy.
+      #    No separate wait-for-mysql / poll loop is needed.
+      # ----------------------------------------------------------------
+      - name: make docker-up (gates on every healthcheck via --wait)
         run: |
           cd "${INSTALL_DIR}"
-          "${GITHUB_WORKSPACE}/scripts/ci/wait-for-mysql.sh"
-        env:
-          COMPOSE_SERVICE: mysql
+          make docker-up
 
-      - name: Wait for webapp to be ready
+      - name: Show container status
+        if: always()
         run: |
-          cd "${INSTALL_DIR}"
-          timeout 60 bash -c 'until docker compose exec -T webapp python -c "import sam; import sys; sys.exit(0)" 2>/dev/null; do sleep 2; done'
-          echo "✅ Webapp is ready"
+          if [ -d "${INSTALL_DIR}" ]; then
+            cd "${INSTALL_DIR}"
+            docker compose ps
+          fi
 
-      - name: Show running containers
-        run: |
-          cd "${INSTALL_DIR}"
-          docker compose ps
-
-      # This workflow verifies install.sh produced a working install. It
-      # does NOT re-run the full test suite — that's sam-ci-docker.yaml's
-      # job. A smoke check against the installed CLI + health endpoint is
-      # enough to prove the install path is healthy end-to-end.
-      - name: Install smoke — sam-search CLI
+      # ----------------------------------------------------------------
+      # 7. Smoke checks against the now-healthy stack. The full pytest
+      #    suite is intentionally NOT run here — that's sam-ci-docker's
+      #    job; this workflow only proves the install path is healthy
+      #    end-to-end.
+      # ----------------------------------------------------------------
+      - name: Smoke — sam-search CLI inside webapp
         run: |
           cd "${INSTALL_DIR}"
           docker compose exec -T webapp sam-search user csgteam
 
-      - name: Install smoke — webapp /health/live
+      - name: Smoke — webapp /health/live (port 7050; gunicorn / prod target)
         run: |
           curl -fsS http://localhost:7050/api/v1/health/live | grep -q '"status": "alive"'
 
+      - name: Smoke — webdev /health/ready (port 5050; verifies BOTH DB binds)
+        run: |
+          # /health/ready pings every configured SQLAlchemy bind. The new
+          # compose healthcheck already exercises this internally, but
+          # asserting it from outside the network proves the user-visible
+          # endpoint matches what `--wait` saw.
+          curl -fsS http://localhost:5050/api/v1/health/ready | tee /tmp/ready.json
+          jq -e '.checks.sam.status == "healthy"'           /tmp/ready.json >/dev/null \
+            || { echo "::error::sam bind not healthy in /health/ready";           exit 1; }
+          jq -e '.checks.system_status.status == "healthy"' /tmp/ready.json >/dev/null \
+            || { echo "::error::system_status bind not healthy in /health/ready"; exit 1; }
+
+      # ----------------------------------------------------------------
+      # 8. Tear down via the make rule users will reach for, and
+      #    verify the stack actually goes away.
+      # ----------------------------------------------------------------
+      - name: make docker-down
+        run: |
+          cd "${INSTALL_DIR}"
+          make docker-down
+          remaining=$(docker compose ps -q)
+          if [ -n "${remaining}" ]; then
+            echo "::error::containers still running after make docker-down"
+            docker compose ps
+            exit 1
+          fi
+          echo "✅ stack torn down cleanly"
+
+      # ----------------------------------------------------------------
+      # Diagnostics + cleanup
+      # ----------------------------------------------------------------
       - name: Show container logs (on failure)
         if: failure()
         run: |
           if [ -d "${INSTALL_DIR}" ]; then
             cd "${INSTALL_DIR}"
-            docker compose logs --tail=300
+            docker compose logs --tail=400 || true
           fi
 
       - name: Cleanup
@@ -172,6 +209,5 @@ jobs:
         run: |
           if [ -d "${INSTALL_DIR}" ]; then
             cd "${INSTALL_DIR}"
-            docker compose logs --tail=300
-            docker compose down -v
+            docker compose down -v 2>&1 || true
           fi

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CONDA_ROOT := $(shell conda info --base)
 # Common way to initialize environment across various types of systems
 config_env := module load conda >/dev/null 2>&1 || true && . $(CONDA_ROOT)/etc/profile.d/conda.sh
 
-.PHONY: help clean clobber distclean fixperms check perf check-db-vs-orms docker-build docker-up docker-down docker-restart \
+.PHONY: help clean clobber distclean fixperms check perf check-db-vs-orms docker-build docker-up docker-down docker-restart docker-watch docker-pytest \
         migrate-status-current migrate-status-up migrate-status-down migrate-status-history migrate-status-revision migrate-status-stamp-head
 
 # -------------------------------------------------------------------
@@ -95,19 +95,44 @@ validate_user_proj_usage: ## Reconcile + benchmark get_user_proj_usage against l
 docker-build: ## Build docker containers
 	@docker compose build
 
-docker-up: ## Start docker containers
-	@docker compose up --detach
-	@echo "Waiting for healthy status..."
-	@timeout 300 bash -c 'until docker compose ps | grep -q "healthy"; do sleep 5; done'
+docker-up: ## Start docker containers (waits until every service reports healthy)
+	@# `--wait` blocks until every service with a healthcheck is healthy and
+	@# exits non-zero if any becomes unhealthy. Replaces the older
+	@# `grep -q healthy` loop, which returned as soon as the first container
+	@# (usually cache, in 5s) reported healthy — well before mysql had
+	@# finished restoring the backup.
+	@docker compose up --detach --wait
 	@echo "✅ Containers ready!"
 
 docker-down: ## Stop docker containers
 	docker compose down
 
-docker-restart: ## Restart docker containers
+docker-restart: ## Rebuild and restart docker containers
 	@$(MAKE) docker-down
 	@$(MAKE) docker-build
 	@$(MAKE) docker-up
+
+docker-watch: ## Live-sync host → /code in webdev (foreground; Ctrl-C to stop)
+	@# Runs `docker compose watch` against an already-up stack so the syncer
+	@# stays in the foreground without blocking other rules. `docker-up`
+	@# brings the stack up first if it isn't already, and `--wait` ensures
+	@# we don't start syncing into containers that are still booting.
+	@$(MAKE) docker-up
+	@echo "👀 Watching for source changes — Ctrl-C to stop"
+	@docker compose watch
+
+docker-pytest: ## Run pytest with coverage inside the webapp container against mysql-test (parity with CI)
+	@# Brings up the `test` profile, which adds the isolated `mysql-test`
+	@# service on its own volume + port (see compose.yaml). `--wait` gates on
+	@# every service being healthy — including mysql-test verifying both
+	@# `sam` and `system_status` are queryable — so pytest never starts
+	@# against a half-restored DB. Mirrors `.github/workflows/sam-ci-docker.yaml`.
+	@docker compose --profile test up --detach --wait
+	@docker compose exec -T \
+	    -e SAM_TEST_DB_URL='mysql+pymysql://root:root@mysql-test:3306/sam' \
+	    webapp bash -c "cd /code && pytest --cov=src --cov-report=term-missing --cov-report=html"
+	@docker compose cp webapp:/code/htmlcov ./htmlcov >/dev/null 2>&1 || echo "⚠️  No coverage report copied"
+	@echo "📊 HTML coverage report: ./htmlcov/index.html"
 
 # -------------------------------------------------------------------
 # Alembic — system_status database (per-bind env)

--- a/README.md
+++ b/README.md
@@ -99,27 +99,48 @@ and any `*_RUNBOOK.md` siblings of the corresponding revision file.
 
 ## Quick Start
 
-```bash
-# make sure you have git-lfs so the mock database can be cloned:
-git lfs --version
+The bundled obfuscated MySQL backup (`containers/sam-sql-dev/backups/sam-obfuscated.sql.xz`,
+~18 MiB) is stored in **Git LFS**. Without LFS the file checked out into your
+working tree is a tiny pointer file, the database container has no real data
+to restore, and the webapp comes up against an empty schema. Make sure LFS is
+both installed *and* activated for your account before cloning:
 
-# clone the repo
+```bash
+# 1. Verify Git LFS is installed AND active for your user. The first
+#    command checks the binary exists; the second registers the LFS
+#    smudge/clean filter in ~/.gitconfig (a one-time per-user step,
+#    harmless to re-run).
+git lfs --version
+git lfs install
+
+# 2. Clone — LFS files are pulled automatically when the filter is active.
 git clone https://github.com/benkirk/sam-queries.git
 cd sam-queries
 
-# build & launch the containers
+# 3. Sanity check: the backup file should be ~18 MiB, not ~130 bytes.
+ls -lh containers/sam-sql-dev/backups/sam-obfuscated.sql.xz
+# If it is tiny / shows "version https://git-lfs.github.com/...", run:
+#   git lfs pull
+
+# 4. Build & launch the containers. First run is slow: Compose builds
+#    the images (~2–3 min) and then MySQL restores the obfuscated
+#    backup (~30 s) before the healthchecks unlock the webapp.
 make docker-up
 
-# you should now be able to see
-# 'webdev' - http://127.0.0.1:5050
-# 'webapp' - http://127.0.0.1:7050
+# 5. You should now be able to see
+#      'webdev' - http://127.0.0.1:5050
+#      'webapp' - http://127.0.0.1:7050
 
-# run the test suite inside docker
+# 6. Run the test suite inside docker
 make docker-pytest
 ```
+
 See also `make help` for other targets.
 
-For interactive development you can run `make docker-watch`.  This will block the current shell with an interactive process synchronzing the local source tree to the container, so local changes are immediately served.
+For interactive development you can run `make docker-watch`. This will block
+the current shell with an interactive process synchronizing the local source
+tree into the `webdev` container, so local edits are picked up immediately
+by Flask's auto-reloader.
 
 
 ## Local Development

--- a/README.md
+++ b/README.md
@@ -98,9 +98,29 @@ and any `*_RUNBOOK.md` siblings of the corresponding revision file.
 ---
 
 ## Quick Start
-```bash
 
+```bash
+# make sure you have git-lfs so the mock database can be cloned:
+git lfs --version
+
+# clone the repo
+git clone https://github.com/benkirk/sam-queries.git
+cd sam-queries
+
+# build & launch the containers
+make docker-up
+
+# you should now be able to see
+# 'webdev' - http://127.0.0.1:5050
+# 'webapp' - http://127.0.0.1:7050
+
+# run the test suite inside docker
+make docker-pytest
 ```
+See also `make help` for other targets.
+
+For interactive development you can run `make docker-watch`.  This will block the current shell with an interactive process synchronzing the local source tree to the container, so local changes are immediately served.
+
 
 ## Local Development
 ### Option 1: Local Development (Recommended)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,11 @@ and any `*_RUNBOOK.md` siblings of the corresponding revision file.
 ---
 
 ## Quick Start
+```bash
 
+```
+
+## Local Development
 ### Option 1: Local Development (Recommended)
 
 For local development with Docker database:
@@ -449,65 +453,7 @@ For detailed Web UI documentation, see **[src/webapp/README.md](src/webapp/READM
 
 ### REST API
 
-Programmatic access via JSON REST API:
-
-```bash
-# Authenticate and save session cookie
-curl -c cookies.txt -X POST http://localhost:5050/auth/login \
-  -d "username=your_username&password=your_password"
-
-# Get user details
-curl -b cookies.txt http://localhost:5050/api/v1/users/benkirk
-
-# Get user's projects
-curl -b cookies.txt http://localhost:5050/api/v1/users/benkirk/projects
-
-# Get project details
-curl -b cookies.txt http://localhost:5050/api/v1/projects/SCSG0001
-
-# Get project allocations with real-time usage
-curl -b cookies.txt http://localhost:5050/api/v1/projects/SCSG0001/allocations
-
-# Get projects expiring in next 90 days
-curl -b cookies.txt "http://localhost:5050/api/v1/projects/expiring?days=90&facility_names=UNIV"
-
-# Get recently expired projects (90-365 days ago)
-curl -b cookies.txt "http://localhost:5050/api/v1/projects/recently_expired?min_days=90&max_days=365"
-
-# Get account balance
-curl -b cookies.txt http://localhost:5050/api/v1/accounts/12345/balance
-
-# Systems integration APIs (LDAP provisioning, PBS fairshare)
-curl -b cookies.txt http://localhost:5050/api/v1/directory_access/hpc
-curl -b cookies.txt http://localhost:5050/api/v1/project_access/hpc
-curl -b cookies.txt http://localhost:5050/api/v1/fstree_access/Derecho
-```
-
 See **[docs/apis/SYSTEMS_INTEGRATION_APIs.md](docs/apis/SYSTEMS_INTEGRATION_APIs.md)** for full schema documentation on the directory access, project access, and fairshare tree APIs.
-
-**Example Response:**
-
-```json
-{
-  "allocation_id": 12345,
-  "allocated": 1000000.0,
-  "used": 456789.12,
-  "remaining": 543210.88,
-  "percent_used": 45.68,
-  "start_date": "2024-01-01T00:00:00",
-  "end_date": "2024-12-31T23:59:59",
-  "charges_by_type": {
-    "comp": 345678.90,
-    "dav": 111110.22,
-    "disk": 0.0,
-    "archive": 0.0
-  },
-  "resource": {
-    "resource_id": 42,
-    "name": "Derecho"
-  }
-}
-```
 
 For complete API documentation, see **[src/webapp/README.md](src/webapp/README.md#rest-api)**.
 
@@ -922,23 +868,6 @@ For additional troubleshooting, see **[CONTRIBUTING.md](CONTRIBUTING.md#troubles
 - **Click** - CLI framework for sam-search command
 - **Docker Compose** - Containerized development environment
 - **Conda** - Isolated environment management
-
----
-
-## Key Contacts & Context
-
-- **Organization:** NCAR CISL (Computational & Information Systems Laboratory)
-- **Section:** USS (University Services Section)
-- **Primary Resources:** Derecho (HPC), Casper (HPC), Gust (analysis), Stratus (storage), Campaign Store (storage)
-- **Facilities:** UNIV (University), WNA (Wyoming-NCAR Alliance)
-
-For access to SAM database credentials or production systems, contact CISL staff.
-
----
-
-## License
-
-Copyright (c) 2025 NCAR CISL
 
 ---
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,27 +19,51 @@ services:
       - sam-network
     volumes:
       - ./logs/prod:/var/log/sam
+    # Pass the host's `.env` through as a Docker env_file. Every key the
+    # user maintains there (MAIL_*, SAM_LEGACY_*, STATUS_API_*, etc.)
+    # reaches the container without having to be enumerated below.
+    # `required: false` so a fresh clone without `.env` doesn't error.
+    # `environment:` below takes precedence over env_file and provides
+    # defaults for the empty-`.env` case + forces compose-network-only
+    # addresses.
+    env_file:
+      - path: .env
+        required: false
     environment:
       # Each entry is YAML-quoted so future values containing `:`, `#`, `&`,
       # etc. can't surprise the parser. Compose's ${VAR:-default} substitution
       # happens INSIDE these strings — do NOT wrap the default in quotes
       # (those would become literal characters in the value).
-      - "DISABLE_AUTH=0"         # Explicitly disabled — must remain 0 in production
-      - "FLASK_DEBUG=0"
-      - "GUNICORN_WORKERS=${GUNICORN_WORKERS:-4}"   # Pin small default; gunicorn_config.py would otherwise spawn 2·host_cpus+1
-      - "AUDIT_ENABLED=1"
-      - "AUDIT_LOG_PATH=/var/log/sam/model_audit.log"
-      - "JUPYTERHUB_API_URL=https://jupyterhub.hpc.ucar.edu"
-      - "JUPYTERHUB_INSTANCE=stable"
-      - "JUPYTERHUB_API_TOKEN=${JUPYTERHUB_API_TOKEN:-}"
-      - "JUPYTERHUB_CACHE_TTL=300"
+      #
+      # ── DB routing — substituted from .env if user set a value, else
+      #    fall back to compose service-name defaults. If the user
+      #    uncomments PROD in .env, that flows through to in-stack
+      #    containers (intentional pass-through).
+      - "SAM_DB_SERVER=${SAM_DB_SERVER:-mysql}"
+      - "SAM_DB_USERNAME=${SAM_DB_USERNAME:-root}"
+      - "SAM_DB_PASSWORD=${SAM_DB_PASSWORD:-root}"
+      - "SAM_DB_REQUIRE_SSL=${SAM_DB_REQUIRE_SSL:-false}"
       - "STATUS_DB_DRIVER=${STATUS_DB_DRIVER:-mysql}"
       - "STATUS_DB_SERVER=${STATUS_DB_SERVER:-mysql}"
       - "STATUS_DB_USERNAME=${STATUS_DB_USERNAME:-root}"
       - "STATUS_DB_PASSWORD=${STATUS_DB_PASSWORD:-root}"
+      # ── FORCED in-stack — host `.env` localhost variants would point
+      #    out of the docker network. No interpolation here on purpose.
+      - "CACHE_REDIS_URL=redis://cache:6379/0"
+      - "RATELIMIT_STORAGE_URI=redis://cache:6379/1"
+      # ── Per-service application policy
+      - "DISABLE_AUTH=0"         # Explicitly disabled — must remain 0 in production
+      - "FLASK_DEBUG=0"
+      - "AUDIT_ENABLED=1"
+      - "AUDIT_LOG_PATH=/var/log/sam/model_audit.log"
+      # ── Sensible defaults — overridable via .env
+      - "FLASK_SECRET_KEY=${FLASK_SECRET_KEY:-dev-only-insecure-key-change-for-production}"
+      - "GUNICORN_WORKERS=${GUNICORN_WORKERS:-4}"   # Pin small default; gunicorn_config.py would otherwise spawn 2·host_cpus+1
+      - "JUPYTERHUB_API_URL=${JUPYTERHUB_API_URL:-https://jupyterhub.hpc.ucar.edu}"
+      - "JUPYTERHUB_INSTANCE=${JUPYTERHUB_INSTANCE:-stable}"
+      - "JUPYTERHUB_API_TOKEN=${JUPYTERHUB_API_TOKEN:-}"
+      - "JUPYTERHUB_CACHE_TTL=${JUPYTERHUB_CACHE_TTL:-300}"
       - "GOOGLE_CALENDAR_EMBED_URL=${GOOGLE_CALENDAR_EMBED_URL:-https://calendar.google.com/calendar/embed?src=ucar.edu_o09r1n89tid1b8jkrvurc8qio4%40group.calendar.google.com&ctz=America%2FDenver}"
-      - "CACHE_REDIS_URL=${CACHE_REDIS_URL:-redis://cache:6379/0}"
-      - "RATELIMIT_STORAGE_URI=${RATELIMIT_STORAGE_URI:-redis://cache:6379/1}"
 
     healthcheck:
       # Probe the app's own readiness endpoint, which pings every configured
@@ -70,27 +94,39 @@ services:
       - sam-network
     volumes:
       - ./logs/dev:/var/log/sam
+    # See the `webapp` service for the env_file / environment rationale.
+    env_file:
+      - path: .env
+        required: false
     # Development: Disable Python bytecode caching to avoid stale .pyc issues
     # when adding new files/functions. Remove for production deployment.
     environment:
-      # See the `webapp` service for the YAML-quoting rationale and the
-      # warning about not wrapping ${VAR:-default} values in literal quotes.
+      # ── DB routing (see `webapp` for the pass-through reasoning)
+      - "SAM_DB_SERVER=${SAM_DB_SERVER:-mysql}"
+      - "SAM_DB_USERNAME=${SAM_DB_USERNAME:-root}"
+      - "SAM_DB_PASSWORD=${SAM_DB_PASSWORD:-root}"
+      - "SAM_DB_REQUIRE_SSL=${SAM_DB_REQUIRE_SSL:-false}"
+      - "STATUS_DB_DRIVER=${STATUS_DB_DRIVER:-mysql}"
+      - "STATUS_DB_SERVER=${STATUS_DB_SERVER:-mysql}"
+      - "STATUS_DB_USERNAME=${STATUS_DB_USERNAME:-root}"
+      - "STATUS_DB_PASSWORD=${STATUS_DB_PASSWORD:-root}"
+      # ── FORCED in-stack
+      - "CACHE_REDIS_URL=redis://cache:6379/0"
+      - "RATELIMIT_STORAGE_URI=redis://cache:6379/1"
+      # ── Webdev-specific application policy (no DISABLE_AUTH — keep
+      #    click-login stub default; user picks RBAC tier via UI)
       - "PYTHONDONTWRITEBYTECODE=1"
       - "PYTHONUNBUFFERED=1"
       - "FLASK_DEBUG=1"
       - "AUDIT_ENABLED=1"
       - "AUDIT_LOG_PATH=/var/log/sam/model_audit.log"
-      - "JUPYTERHUB_API_URL=https://jupyterhub.hpc.ucar.edu"
-      - "JUPYTERHUB_INSTANCE=stable"
+      # ── Sensible defaults — overridable via .env
+      - "FLASK_SECRET_KEY=${FLASK_SECRET_KEY:-dev-only-insecure-key-change-for-production}"
+      - "JUPYTERHUB_API_URL=${JUPYTERHUB_API_URL:-https://jupyterhub.hpc.ucar.edu}"
+      - "JUPYTERHUB_INSTANCE=${JUPYTERHUB_INSTANCE:-stable}"
       - "JUPYTERHUB_API_TOKEN=${JUPYTERHUB_API_TOKEN:-}"
-      - "JUPYTERHUB_CACHE_TTL=300"
-      - "STATUS_DB_DRIVER=${STATUS_DB_DRIVER:-mysql}"
-      - "STATUS_DB_SERVER=${STATUS_DB_SERVER:-mysql}"
-      - "STATUS_DB_USERNAME=${STATUS_DB_USERNAME:-root}"
-      - "STATUS_DB_PASSWORD=${STATUS_DB_PASSWORD:-root}"
+      - "JUPYTERHUB_CACHE_TTL=${JUPYTERHUB_CACHE_TTL:-300}"
       - "GOOGLE_CALENDAR_EMBED_URL=${GOOGLE_CALENDAR_EMBED_URL:-https://calendar.google.com/calendar/embed?src=ucar.edu_o09r1n89tid1b8jkrvurc8qio4%40group.calendar.google.com&ctz=America%2FDenver}"
-      - "CACHE_REDIS_URL=${CACHE_REDIS_URL:-redis://cache:6379/0}"
-      - "RATELIMIT_STORAGE_URI=${RATELIMIT_STORAGE_URI:-redis://cache:6379/1}"
 
     # Important: watch the current directory, re-syncing as needed based on source changes
     develop:
@@ -107,6 +143,8 @@ services:
             - "*.pyc"
             - .git/
             - "*~"
+            - .env       # don't ferry the host .env into /code; env_file
+                         # already passes its values to the container
     healthcheck:
       # Probe the app's own readiness endpoint, which pings every configured
       # DB bind (sam + system_status). Returns 503 if any bind is unreachable,

--- a/compose.yaml
+++ b/compose.yaml
@@ -20,27 +20,32 @@ services:
     volumes:
       - ./logs/prod:/var/log/sam
     environment:
-      - DISABLE_AUTH=0         # Explicitly disabled — must remain 0 in production
-      - FLASK_DEBUG=0
-      - GUNICORN_WORKERS=${GUNICORN_WORKERS:-4}   # Pin small default; gunicorn_config.py would otherwise spawn 2·host_cpus+1
-      - AUDIT_ENABLED=1
-      - AUDIT_LOG_PATH=/var/log/sam/model_audit.log
-      - JUPYTERHUB_API_URL=https://jupyterhub.hpc.ucar.edu
-      - JUPYTERHUB_INSTANCE=stable
-      - JUPYTERHUB_API_TOKEN=${JUPYTERHUB_API_TOKEN:-}
-      - JUPYTERHUB_CACHE_TTL=300
-      - STATUS_DB_DRIVER=${STATUS_DB_DRIVER:-mysql}
-      - STATUS_DB_SERVER=${STATUS_DB_SERVER:-mysql}
-      - STATUS_DB_USERNAME=${STATUS_DB_USERNAME:-root}
-      - STATUS_DB_PASSWORD=${STATUS_DB_PASSWORD:-root}
-      - GOOGLE_CALENDAR_EMBED_URL=${GOOGLE_CALENDAR_EMBED_URL:-'https://calendar.google.com/calendar/embed?src=ucar.edu_o09r1n89tid1b8jkrvurc8qio4%40group.calendar.google.com&ctz=America%2FDenver'}
-      - CACHE_REDIS_URL=${CACHE_REDIS_URL:-redis://cache:6379/0}
-      - RATELIMIT_STORAGE_URI=${RATELIMIT_STORAGE_URI:-redis://cache:6379/1}
+      # Each entry is YAML-quoted so future values containing `:`, `#`, `&`,
+      # etc. can't surprise the parser. Compose's ${VAR:-default} substitution
+      # happens INSIDE these strings — do NOT wrap the default in quotes
+      # (those would become literal characters in the value).
+      - "DISABLE_AUTH=0"         # Explicitly disabled — must remain 0 in production
+      - "FLASK_DEBUG=0"
+      - "GUNICORN_WORKERS=${GUNICORN_WORKERS:-4}"   # Pin small default; gunicorn_config.py would otherwise spawn 2·host_cpus+1
+      - "AUDIT_ENABLED=1"
+      - "AUDIT_LOG_PATH=/var/log/sam/model_audit.log"
+      - "JUPYTERHUB_API_URL=https://jupyterhub.hpc.ucar.edu"
+      - "JUPYTERHUB_INSTANCE=stable"
+      - "JUPYTERHUB_API_TOKEN=${JUPYTERHUB_API_TOKEN:-}"
+      - "JUPYTERHUB_CACHE_TTL=300"
+      - "STATUS_DB_DRIVER=${STATUS_DB_DRIVER:-mysql}"
+      - "STATUS_DB_SERVER=${STATUS_DB_SERVER:-mysql}"
+      - "STATUS_DB_USERNAME=${STATUS_DB_USERNAME:-root}"
+      - "STATUS_DB_PASSWORD=${STATUS_DB_PASSWORD:-root}"
+      - "GOOGLE_CALENDAR_EMBED_URL=${GOOGLE_CALENDAR_EMBED_URL:-https://calendar.google.com/calendar/embed?src=ucar.edu_o09r1n89tid1b8jkrvurc8qio4%40group.calendar.google.com&ctz=America%2FDenver}"
+      - "CACHE_REDIS_URL=${CACHE_REDIS_URL:-redis://cache:6379/0}"
+      - "RATELIMIT_STORAGE_URI=${RATELIMIT_STORAGE_URI:-redis://cache:6379/1}"
 
     healthcheck:
-      test: |
-        python -c "import sam; import sys; sys.exit(0)"
-        sam-search user csgteam
+      # Probe the app's own readiness endpoint, which pings every configured
+      # DB bind (sam + system_status). Returns 503 if any bind is unreachable,
+      # so the webapp is only marked healthy once both databases are queryable.
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; urllib.request.urlopen('http://127.0.0.1:5050/api/v1/health/ready', timeout=3).read()\""]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -68,22 +73,24 @@ services:
     # Development: Disable Python bytecode caching to avoid stale .pyc issues
     # when adding new files/functions. Remove for production deployment.
     environment:
-      - PYTHONDONTWRITEBYTECODE=1
-      - PYTHONUNBUFFERED=1
-      - FLASK_DEBUG=1
-      - AUDIT_ENABLED=1
-      - AUDIT_LOG_PATH=/var/log/sam/model_audit.log
-      - JUPYTERHUB_API_URL=https://jupyterhub.hpc.ucar.edu
-      - JUPYTERHUB_INSTANCE=stable
-      - JUPYTERHUB_API_TOKEN=${JUPYTERHUB_API_TOKEN:-}
-      - JUPYTERHUB_CACHE_TTL=300
-      - STATUS_DB_DRIVER=${STATUS_DB_DRIVER:-mysql}
-      - STATUS_DB_SERVER=${STATUS_DB_SERVER:-mysql}
-      - STATUS_DB_USERNAME=${STATUS_DB_USERNAME:-root}
-      - STATUS_DB_PASSWORD=${STATUS_DB_PASSWORD:-root}
-      - GOOGLE_CALENDAR_EMBED_URL=${GOOGLE_CALENDAR_EMBED_URL:-'https://calendar.google.com/calendar/embed?src=ucar.edu_o09r1n89tid1b8jkrvurc8qio4%40group.calendar.google.com&ctz=America%2FDenver'}
-      - CACHE_REDIS_URL=${CACHE_REDIS_URL:-redis://cache:6379/0}
-      - RATELIMIT_STORAGE_URI=${RATELIMIT_STORAGE_URI:-redis://cache:6379/1}
+      # See the `webapp` service for the YAML-quoting rationale and the
+      # warning about not wrapping ${VAR:-default} values in literal quotes.
+      - "PYTHONDONTWRITEBYTECODE=1"
+      - "PYTHONUNBUFFERED=1"
+      - "FLASK_DEBUG=1"
+      - "AUDIT_ENABLED=1"
+      - "AUDIT_LOG_PATH=/var/log/sam/model_audit.log"
+      - "JUPYTERHUB_API_URL=https://jupyterhub.hpc.ucar.edu"
+      - "JUPYTERHUB_INSTANCE=stable"
+      - "JUPYTERHUB_API_TOKEN=${JUPYTERHUB_API_TOKEN:-}"
+      - "JUPYTERHUB_CACHE_TTL=300"
+      - "STATUS_DB_DRIVER=${STATUS_DB_DRIVER:-mysql}"
+      - "STATUS_DB_SERVER=${STATUS_DB_SERVER:-mysql}"
+      - "STATUS_DB_USERNAME=${STATUS_DB_USERNAME:-root}"
+      - "STATUS_DB_PASSWORD=${STATUS_DB_PASSWORD:-root}"
+      - "GOOGLE_CALENDAR_EMBED_URL=${GOOGLE_CALENDAR_EMBED_URL:-https://calendar.google.com/calendar/embed?src=ucar.edu_o09r1n89tid1b8jkrvurc8qio4%40group.calendar.google.com&ctz=America%2FDenver}"
+      - "CACHE_REDIS_URL=${CACHE_REDIS_URL:-redis://cache:6379/0}"
+      - "RATELIMIT_STORAGE_URI=${RATELIMIT_STORAGE_URI:-redis://cache:6379/1}"
 
     # Important: watch the current directory, re-syncing as needed based on source changes
     develop:
@@ -95,14 +102,16 @@ services:
             - containers/
             - logs/
             - collectors/logs/
+            - conda-env/
             - __pycache__/
             - "*.pyc"
             - .git/
             - "*~"
     healthcheck:
-      test: |
-        python -c "import sam; import sys; sys.exit(0)"
-        sam-search user csgteam
+      # Probe the app's own readiness endpoint, which pings every configured
+      # DB bind (sam + system_status). Returns 503 if any bind is unreachable,
+      # so the webdev is only marked healthy once both databases are queryable.
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; urllib.request.urlopen('http://127.0.0.1:5050/api/v1/health/ready', timeout=3).read()\""]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -133,15 +142,21 @@ services:
       context: containers/sam-sql-dev
       dockerfile: Dockerfile
     environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: sam
+      MYSQL_ROOT_PASSWORD: "root"
+      MYSQL_DATABASE: "sam"
     volumes:
       - samuel-mysql-data:/var/lib/mysql
       - ./containers/sam-sql-dev/backups/sam-obfuscated.sql.xz:/backup.sql.xz:ro
     healthcheck:
-      # Verify MySQL is up AND the sam database is queryable.
-      # This prevents the webapp from starting before the restore completes.
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -proot && mysql -h localhost -u root -proot sam -e 'SELECT 1'"]
+      # Use 127.0.0.1 (TCP) — NOT localhost (which would use the Unix socket).
+      # During first-run init, MySQL serves init scripts (incl. the backup
+      # restore) on a socket-only instance with --skip-networking, so a
+      # socket-based ping can give a false positive long before the restore
+      # is finished. TCP only opens after init completes and the real mysqld
+      # restarts. Verifying both `sam` and `system_status` ensures the webapp
+      # never starts before the system_status schema is in place — see
+      # scripts/ci/wait-for-mysql.sh for the same approach in CI.
+      test: ["CMD-SHELL", "mysql -h 127.0.0.1 -P 3306 -u root -proot -e 'SELECT 1' && mysql -h 127.0.0.1 -P 3306 -u root -proot sam -e 'SELECT 1' && mysql -h 127.0.0.1 -P 3306 -u root -proot system_status -e 'SELECT 1'"]
       interval: 10s
       timeout: 5s
       retries: 30
@@ -173,13 +188,15 @@ services:
       context: containers/sam-sql-dev
       dockerfile: Dockerfile
     environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: sam
+      MYSQL_ROOT_PASSWORD: "root"
+      MYSQL_DATABASE: "sam"
     volumes:
       - samuel-mysql-test-data:/var/lib/mysql
       - ./containers/sam-sql-dev/backups/sam-obfuscated.sql.xz:/backup.sql.xz:ro
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -proot && mysql -h localhost -u root -proot sam -e 'SELECT 1'"]
+      # See the `mysql` service above for the rationale on TCP vs socket and
+      # on verifying both `sam` and `system_status` databases.
+      test: ["CMD-SHELL", "mysql -h 127.0.0.1 -P 3306 -u root -proot -e 'SELECT 1' && mysql -h 127.0.0.1 -P 3306 -u root -proot sam -e 'SELECT 1' && mysql -h 127.0.0.1 -P 3306 -u root -proot system_status -e 'SELECT 1'"]
       interval: 10s
       timeout: 5s
       retries: 30

--- a/containers/webapp/Dockerfile
+++ b/containers/webapp/Dockerfile
@@ -2,38 +2,9 @@ FROM python:3 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Bake an image-default /.env so the runtime's `load_dotenv()` (in
-# sam.session, system_status.session, src/config.py) has a sane fallback
-# for in-stack DB connection settings (hostname `mysql`, root/root) and
-# the dev FLASK_SECRET_KEY. compose.yaml's environment block injects the
-# user-tunable knobs (JUPYTERHUB_*, GOOGLE_CALENDAR_*, etc.) — those
-# take precedence because python-dotenv defaults to override=False.
-# Also bake a small in-image debug helper for ad-hoc image-size
-# investigations from inside a running container (not called by code).
-RUN <<'FILE_ENV' cat > /.env
-#-------------------------
-# local container instance
-LOCAL_SAM_DB_SERVER=mysql
-LOCAL_SAM_DB_USERNAME=root
-LOCAL_SAM_DB_PASSWORD=root
-SAM_DB_SERVER=${LOCAL_SAM_DB_SERVER}
-SAM_DB_USERNAME=${LOCAL_SAM_DB_USERNAME}
-SAM_DB_PASSWORD=${LOCAL_SAM_DB_PASSWORD}
-SAM_DB_REQUIRE_SSL=false
-
-#-------------------------
-# system status database
-STATUS_DB_DRIVER=mysql
-STATUS_DB_SERVER=mysql
-STATUS_DB_USERNAME=root
-STATUS_DB_PASSWORD=root
-
-#-------------------------
-# Flask application security
-# WARNING: dev-only key - change for production
-FLASK_SECRET_KEY=dev-only-insecure-key-change-for-production
-FILE_ENV
-
+# In-image debug helper for investigating image bloat / unexpected
+# on-disk state from inside a running container. Invoked manually via
+# `docker compose exec`; not called by repo code.
 RUN <<'FILE_LLD' cat > /usr/bin/list-large-directories && \
     chmod a+rx /usr/bin/list-large-directories
 #!/bin/bash

--- a/containers/webapp/Dockerfile
+++ b/containers/webapp/Dockerfile
@@ -1,17 +1,16 @@
 FROM python:3 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-    && apt-get install -y \
-               rsync git git-lfs \
-    && pip install --upgrade pip \
-    && rm -rf /var/lib/apt/lists/*
 
-RUN echo "Creating default .env" && \
-    <<'FILE1' cat > /.env && \
-    <<'FILE2' cat > /usr/bin/list-large-directories && \
-    chmod a+rx /usr/bin/list-large-directories && \
-    echo "Done"
+# Bake an image-default /.env so the runtime's `load_dotenv()` (in
+# sam.session, system_status.session, src/config.py) has a sane fallback
+# for in-stack DB connection settings (hostname `mysql`, root/root) and
+# the dev FLASK_SECRET_KEY. compose.yaml's environment block injects the
+# user-tunable knobs (JUPYTERHUB_*, GOOGLE_CALENDAR_*, etc.) — those
+# take precedence because python-dotenv defaults to override=False.
+# Also bake a small in-image debug helper for ad-hoc image-size
+# investigations from inside a running container (not called by code).
+RUN <<'FILE_ENV' cat > /.env
 #-------------------------
 # local container instance
 LOCAL_SAM_DB_SERVER=mysql
@@ -33,7 +32,10 @@ STATUS_DB_PASSWORD=root
 # Flask application security
 # WARNING: dev-only key - change for production
 FLASK_SECRET_KEY=dev-only-insecure-key-change-for-production
-FILE1
+FILE_ENV
+
+RUN <<'FILE_LLD' cat > /usr/bin/list-large-directories && \
+    chmod a+rx /usr/bin/list-large-directories
 #!/bin/bash
 
 dirs="/home /mnt /tmp /opt /usr /var /container"
@@ -51,11 +53,12 @@ for dir in ${dirs}; do
         du 2>/dev/null --block-size=1MiB --threshold=${THRESHOLD_SIZE_MB}MiB --separate-dirs ${dir} | sort -n
     fi
 done
-FILE2
+FILE_LLD
 
 WORKDIR /code
 COPY . .
-RUN pip install -e ".[test]"
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -e ".[test]"
 
 # Optional build provenance - set by CI via --build-arg; empty locally.
 # Placed AFTER pip install so a changing SHA does not invalidate the install layer.

--- a/etc/config_env.sh
+++ b/etc/config_env.sh
@@ -69,6 +69,3 @@ if [[ -f "${ROOT_DIR}/collectors/.env" ]]; then
     set +a
     echo "Loaded .env from ${ROOT_DIR}/collectors"
 fi
-
-# prevent leakage
-unset SAM_DB_PASSWORD TEST_SAM_DB_PASSWORD LOCAL_SAM_DB_PASSWORD

--- a/install.sh
+++ b/install.sh
@@ -24,18 +24,24 @@ TARGET_DIR="${SAMQ_HOME:-${HOME}/codes/project_samuel/${REPO_BRANCH}}"
 # --------------------------------------------
 # Command-line arguments
 # --------------------------------------------
+EXPLICIT_DIR=""
+EXPLICIT_REPO=""
+EXPLICIT_BRANCH=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -r|--repo)
             REPO_URL="$2"
+            EXPLICIT_REPO=1
             shift 2
             ;;
         -b|--branch)
             REPO_BRANCH="$2"
+            EXPLICIT_BRANCH=1
             shift 2
             ;;
         -d|--dir)
             TARGET_DIR="$2"
+            EXPLICIT_DIR=1
             shift 2
             ;;
         -h|--help)
@@ -47,6 +53,15 @@ Options:
   -b, --branch <branch>     Specify the git branch to clone (default: ${REPO_BRANCH})
   -d, --dir <directory>     Specify the installation directory (default: ${TARGET_DIR})
   -h, --help                Show this help message
+
+Run modes:
+  curl … | bash             Clones to <default-dir>; ideal for one-shot install.
+  ./install.sh              When invoked from a valid checkout (compose.yaml,
+                            .env.example, .git/ all present alongside this
+                            script), and no -d/-r/-b is given, the script
+                            installs IN-PLACE — it does not re-clone or change
+                            the branch. Pass any flag to force the legacy
+                            clone-to-target behaviour.
 EOF
             exit 0
             ;;
@@ -56,6 +71,36 @@ EOF
             ;;
     esac
 done
+
+# --------------------------------------------
+# In-place detection — running from a checkout?
+# --------------------------------------------
+# When invoked as `./install.sh` from inside a tree that already
+# looks like sam-queries, treat that tree as the install dir and
+# skip the clone/fetch/checkout/pull dance. `curl … | bash` falls
+# through to the legacy clone path because BASH_SOURCE[0] in piped
+# mode points at /dev/fd/* or is empty — `[[ -f … ]]` rejects it.
+# Any explicit -d/-r/-b also disables in-place detection (the user
+# has signalled they want a specific clone target).
+IN_PLACE=""
+if [[ -z "${EXPLICIT_DIR}" && -z "${EXPLICIT_REPO}" && -z "${EXPLICIT_BRANCH}" ]]; then
+    SCRIPT_PATH="${BASH_SOURCE[0]:-}"
+    if [[ -n "${SCRIPT_PATH}" && -f "${SCRIPT_PATH}" ]]; then
+        SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_PATH}")" >/dev/null 2>&1 && pwd)"
+        # `.git` may be a directory (normal clone), a file (worktree, where
+        # it points at the real gitdir), or absent. `git rev-parse
+        # --is-inside-work-tree` is the canonical "is this a git working
+        # tree?" check and handles all three cases. Marker files
+        # (compose.yaml, .env.example) make sure it's THIS project, not
+        # some unrelated repo that happens to wrap us.
+        if [[ -f "${SCRIPT_DIR}/compose.yaml" \
+           && -f "${SCRIPT_DIR}/.env.example" ]] \
+           && git -C "${SCRIPT_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            TARGET_DIR="${SCRIPT_DIR}"
+            IN_PLACE=1
+        fi
+    fi
+fi
 
 # --------------------------------------------
 # Helpers
@@ -128,19 +173,23 @@ check_docker_compose_version
 # --------------------------------------------
 # Clone or update repo
 # --------------------------------------------
-step "Preparing repository at ${TARGET_DIR}"
-
-if [[ -d "${TARGET_DIR}/.git" ]]; then
+if [[ -n "${IN_PLACE}" ]]; then
+    step "Using existing checkout at ${TARGET_DIR} (in-place mode)"
+    echo "  Detected sam-queries tree alongside this script — skipping clone."
+    echo "  Branch and remote are left as-is; run 'git pull' yourself if needed."
+elif [[ -d "${TARGET_DIR}/.git" ]]; then
+    step "Preparing repository at ${TARGET_DIR}"
     echo "Repository already exists. Updating..."
     git -C "${TARGET_DIR}" fetch --all --quiet
     git -C "${TARGET_DIR}" checkout "${REPO_BRANCH}" --quiet
     git -C "${TARGET_DIR}" pull --ff-only --quiet
 else
+    step "Preparing repository at ${TARGET_DIR}"
     echo "Cloning branch '${REPO_BRANCH}' from ${REPO_URL} ..."
     git clone --branch "${REPO_BRANCH}" "${REPO_URL}" "${TARGET_DIR}"
 fi
 
-# Ensure git-lfs files are fetched
+# Ensure git-lfs files are fetched (cheap no-op if already present)
 git -C "${TARGET_DIR}" lfs pull
 
 # --------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -60,13 +60,43 @@ done
 # --------------------------------------------
 # Helpers
 # --------------------------------------------
+
+# Colour helpers — only emit ANSI escapes when stdout is a TTY and `tput`
+# is available with a colour-capable terminfo entry. Falls back to empty
+# strings otherwise, so `curl … | bash`, log redirects, and dumb terminals
+# all see plain ASCII. Wrapped in a parameter-expansion guard so this is
+# safe under both `set -u` (interactive) and the relaxed piped mode above.
+if [[ -t 1 ]] && command -v tput >/dev/null 2>&1 && [[ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]]; then
+    C_RESET=$(tput sgr0)
+    C_BOLD=$(tput bold)
+    C_DIM=$(tput dim)
+    C_RED=$(tput setaf 1)
+    C_GREEN=$(tput setaf 2)
+    C_YELLOW=$(tput setaf 3)
+    C_BLUE=$(tput setaf 4)
+    C_CYAN=$(tput setaf 6)
+else
+    C_RESET=""
+    C_BOLD=""
+    C_DIM=""
+    C_RED=""
+    C_GREEN=""
+    C_YELLOW=""
+    C_BLUE=""
+    C_CYAN=""
+fi
+
 abort() {
-    echo "ERROR: ${*}" >&2
+    echo "${C_RED}${C_BOLD}ERROR:${C_RESET} ${*}" >&2
     exit 1
 }
 
 need_cmd() {
     command -v "${1}" >/dev/null 2>&1 || abort "Required command '${1}' not found."
+}
+
+step() {
+    echo "${C_BOLD}${C_CYAN}==>${C_RESET} ${C_BOLD}${*}${C_RESET}"
 }
 
 check_docker_compose_version() {
@@ -88,7 +118,7 @@ check_docker_compose_version() {
 # --------------------------------------------
 # Checks
 # --------------------------------------------
-echo "--- Checking requirements ---"
+step "Checking requirements"
 need_cmd git
 need_cmd git-lfs
 need_cmd docker
@@ -98,7 +128,7 @@ check_docker_compose_version
 # --------------------------------------------
 # Clone or update repo
 # --------------------------------------------
-echo "--- Preparing repository at ${TARGET_DIR} ---"
+step "Preparing repository at ${TARGET_DIR}"
 
 if [[ -d "${TARGET_DIR}/.git" ]]; then
     echo "Repository already exists. Updating..."
@@ -117,7 +147,7 @@ git -C "${TARGET_DIR}" lfs pull
 # Install / Setup step
 # You can customize this section
 # --------------------------------------------
-echo "--- Running setup ---"
+step "Running setup"
 
 # Example: create env file if not present
 if [[ ! -f "${TARGET_DIR}/.env" ]]; then
@@ -125,11 +155,38 @@ if [[ ! -f "${TARGET_DIR}/.env" ]]; then
     cp "${TARGET_DIR}/.env.example" "${TARGET_DIR}/.env" 2>/dev/null || true
 fi
 
-cat <<EOF
-Install complete.
-To start services"
-  cd \"${TARGET_DIR}\""
-  docker compose --profile test up --build --watch
+# --------------------------------------------
+# Final summary
+# --------------------------------------------
+# Build a fixed-width ASCII banner. Width is hard-coded so the box stays
+# aligned regardless of terminal capabilities — `tput cols` would give a
+# nicer fit on wide terminals but breaks under `curl … | bash` (no TTY)
+# and on systems without ncurses installed.
+RULE="------------------------------------------------------------"
 
-Once all services are up, connect to http://127.0.0.1:5050/user/
-EOF
+echo
+echo "${C_GREEN}${C_BOLD}${RULE}${C_RESET}"
+echo "${C_GREEN}${C_BOLD}  ✓ Install complete${C_RESET}"
+echo "${C_GREEN}${C_BOLD}${RULE}${C_RESET}"
+echo
+echo "${C_BOLD}Next steps:${C_RESET}"
+echo
+echo "  ${C_DIM}# 1. Move into the source tree${C_RESET}"
+echo "  ${C_CYAN}cd${C_RESET} ${C_YELLOW}\"${TARGET_DIR}\"${C_RESET}"
+echo
+echo "  ${C_DIM}# 2. Build & launch the stack (waits until every service is healthy)${C_RESET}"
+echo "  ${C_DIM}#    First run is slow: image build (~2-3 min) + MySQL backup restore (~30 s).${C_RESET}"
+echo "  ${C_CYAN}make${C_RESET} docker-up"
+echo
+echo "  ${C_DIM}# 3. (optional) Run the test suite + coverage inside docker${C_RESET}"
+echo "  ${C_CYAN}make${C_RESET} docker-pytest"
+echo
+echo "  ${C_DIM}# 4. (optional) Live-sync source changes into the running webdev${C_RESET}"
+echo "  ${C_CYAN}make${C_RESET} docker-watch"
+echo
+echo "${C_BOLD}Once 'make docker-up' reports healthy, open:${C_RESET}"
+echo "  ${C_BLUE}http://127.0.0.1:5050/${C_RESET}   ${C_DIM}# webdev (Flask debug, hot-reload)${C_RESET}"
+echo "  ${C_BLUE}http://127.0.0.1:7050/${C_RESET}   ${C_DIM}# webapp (gunicorn, prod-like)${C_RESET}"
+echo
+echo "${C_DIM}See \`make help\` from inside the source tree for other targets.${C_RESET}"
+echo

--- a/src/sam/session/__init__.py
+++ b/src/sam/session/__init__.py
@@ -10,14 +10,29 @@ from contextlib import contextmanager
 connection_string = None
 
 def init_sam_db_defaults():
+    """Build the module-level `connection_string` from SAM_DB_* env vars.
+
+    Tolerant of missing env at import time: if any of the three required
+    vars (USERNAME, PASSWORD, SERVER) is unset/empty, leave
+    `connection_string = None` and return silently. Callers that need a
+    connection (`create_sam_engine()`, webapp boot) raise a clear error
+    when they actually need it. This lets pytest import `sam.session`
+    without `SAM_DB_*` set in shell — `conftest.py` overrides
+    `SQLALCHEMY_DATABASE_URI` via `config_overrides=` from
+    `SAM_TEST_DB_URL`, so it never reads `connection_string`.
+    """
     from dotenv import load_dotenv, find_dotenv
     import os
 
     load_dotenv(find_dotenv())
 
-    username = os.environ['SAM_DB_USERNAME']
-    password = os.environ['SAM_DB_PASSWORD']
-    server = os.environ['SAM_DB_SERVER']
+    username = os.environ.get('SAM_DB_USERNAME')
+    password = os.environ.get('SAM_DB_PASSWORD')
+    server = os.environ.get('SAM_DB_SERVER')
+
+    if not (username and password and server):
+        return
+
     database = os.getenv('SAM_DB_NAME', 'sam')
 
     import logging as _logging
@@ -35,7 +50,6 @@ def init_sam_db_defaults():
         host=server,
         database=database,
     )
-    #print(connection_string)
 
 # run on import
 init_sam_db_defaults()
@@ -57,6 +71,15 @@ def create_sam_engine(input_connection_string: str = None):
 
     if input_connection_string is None:
         input_connection_string = connection_string
+
+    if input_connection_string is None:
+        raise RuntimeError(
+            "SAM database connection is not configured. Set the SAM_DB_USERNAME, "
+            "SAM_DB_PASSWORD, and SAM_DB_SERVER environment variables (see "
+            "`.env.example` for a template) and call `sam.session.init_sam_db_defaults()` "
+            "again, or pass an explicit `input_connection_string` to "
+            "`create_sam_engine()`."
+        )
 
     # Check if SSL is required (for remote servers)
     require_ssl = os.getenv('SAM_DB_REQUIRE_SSL', 'false').lower() in ('true', '1', 'yes')

--- a/src/system_status/session/__init__.py
+++ b/src/system_status/session/__init__.py
@@ -10,14 +10,25 @@ from contextlib import contextmanager
 connection_string = None
 
 def init_status_db_defaults():
+    """Build the module-level `connection_string` from STATUS_DB_* env vars.
+
+    Tolerant of missing env at import time: if any of USERNAME/PASSWORD/
+    SERVER is unset/empty, leave `connection_string = None` and return
+    silently. Callers raise a clear error when they actually need it.
+    See `sam.session.init_sam_db_defaults` for the full rationale.
+    """
     from dotenv import load_dotenv, find_dotenv
     import os
 
     load_dotenv(find_dotenv())
 
-    username = os.environ['STATUS_DB_USERNAME']
-    password = os.environ['STATUS_DB_PASSWORD']
-    server = os.environ['STATUS_DB_SERVER']
+    username = os.environ.get('STATUS_DB_USERNAME')
+    password = os.environ.get('STATUS_DB_PASSWORD')
+    server = os.environ.get('STATUS_DB_SERVER')
+
+    if not (username and password and server):
+        return
+
     database = os.getenv('STATUS_DB_NAME', 'system_status')
 
     print(f'{username}:$STATUS_DB_PASSWORD@{server}/{database}')
@@ -61,6 +72,16 @@ def create_status_engine(input_connection_string: str = None):
 
     if input_connection_string is None:
         input_connection_string = connection_string
+
+    if input_connection_string is None:
+        raise RuntimeError(
+            "system_status database connection is not configured. Set the "
+            "STATUS_DB_USERNAME, STATUS_DB_PASSWORD, and STATUS_DB_SERVER "
+            "environment variables (see `.env.example` for a template) and "
+            "call `system_status.session.init_status_db_defaults()` again, "
+            "or pass an explicit `input_connection_string` to "
+            "`create_status_engine()`."
+        )
 
     # Check if SSL is required (for remote servers)
     require_ssl = os.getenv('STATUS_DB_REQUIRE_SSL', 'false').lower() in ('true', '1', 'yes')

--- a/src/webapp/run.py
+++ b/src/webapp/run.py
@@ -47,9 +47,15 @@ def create_app(*, config_overrides: dict | None = None):
     """
     import os
 
-    # Load and validate environment-based configuration
+    # Load environment-based configuration. Validation is skipped when the
+    # caller passes `config_overrides=` (the test harness does this to
+    # point Flask-SQLAlchemy at the mysql-test container via SAM_TEST_DB_URL,
+    # and conftest.py never reads `SAM_DB_USERNAME` etc.). Production
+    # callers pass no overrides and see the original validate-on-startup
+    # behaviour — fail fast if the runtime env is missing required vars.
     cfg = get_webapp_config()
-    cfg.validate()
+    if config_overrides is None:
+        cfg.validate()
 
     app = Flask(__name__)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,22 @@ def pytest_configure(config):
     os.environ.setdefault("FLASK_CONFIG", "testing")
     os.environ.setdefault("FLASK_SECRET_KEY", "test-secret-key")
 
+    # Test-only placeholder values for SAM_DB_*/STATUS_DB_*. The test
+    # suite never reads these — sessions are routed through SAM_TEST_DB_URL
+    # (mysql-test) via `create_app(config_overrides=…)`, and CLI tests
+    # patch `cli.cmds.search.Session`. They exist purely to satisfy the
+    # fail-fast `SAMConfig.validate()` calls in webapp.run.create_app and
+    # the click CLI entry points, which would otherwise throw
+    # `EnvironmentError` during test collection on hosts whose `.env`
+    # has the SAM_DB_* / STATUS_DB_* blocks commented out (the new
+    # `.env.example` default state).
+    os.environ.setdefault("SAM_DB_USERNAME",    "test-placeholder-user")
+    os.environ.setdefault("SAM_DB_PASSWORD",    "test-placeholder-pass")
+    os.environ.setdefault("SAM_DB_SERVER",      "test-placeholder-host")
+    os.environ.setdefault("STATUS_DB_USERNAME", "test-placeholder-user")
+    os.environ.setdefault("STATUS_DB_PASSWORD", "test-placeholder-pass")
+    os.environ.setdefault("STATUS_DB_SERVER",   "test-placeholder-host")
+
     url = os.environ.get("SAM_TEST_DB_URL")
     if not url:
         pytest.exit(


### PR DESCRIPTION
## Summary

What started as "tighten the compose health gating so a fresh
`docker compose up --build` can't fool itself" pulled three more
threads with it: a slim webapp image, a clean separation between
the host-side conda workflow and the in-stack docker workflow, and
a code-level fix so `pytest` from a host without `SAM_DB_*` no
longer crashes at import. End state: every supported workflow
(local docker, host pytest, host CLI, CI, k8s prod) works without
needing the user to toggle `.env` between sessions.

**Deployed and verified live on CIRRUS** at sha `9193e80`:
`/api/v1/health/ready` returns 200, both `sam` and `system_status`
binds healthy, zero tracebacks since rollout, restartCount=0.

## Changes by file

### Compose health + env wiring

- **`compose.yaml`**:
  - `mysql` / `mysql-test` healthchecks switched from
    `localhost`-via-socket to `127.0.0.1` (TCP) — the MySQL Docker
    entrypoint runs init scripts (incl. our backup restore) on a
    socket-only `--skip-networking` mysqld, so socket-based pings
    gave false positives. Same approach as `scripts/ci/wait-for-mysql.sh`.
    Healthcheck now also verifies both `sam` AND `system_status`
    are queryable, not just `sam`.
  - `webapp` / `webdev` healthchecks moved to a `/api/v1/health/ready`
    probe that pings every configured SQLAlchemy bind (returns 503
    on any failure).
  - `env_file: [{ path: .env, required: false }]` flows the host's
    `.env` into the container — every key the user maintains
    (`MAIL_*`, `SAM_LEGACY_*`, `STATUS_API_*`, `JUPYTERHUB_API_TOKEN`, …)
    reaches the in-stack containers without enumeration.
  - `environment:` block reshaped: `${VAR:-default}` interpolation
    for tunable knobs + DB routing (so user can flip
    `SAM_DB_SERVER` to a `PROD_*` alias and have it reach the
    in-stack webapp), forced compose-network addresses for
    `CACHE_REDIS_URL` / `RATELIMIT_STORAGE_URI`.
  - Defensive YAML quoting on every list entry; bare strings in
    map-form mysql env quoted; literal `'…'` removed from
    `GOOGLE_CALENDAR_EMBED_URL` default (was being passed
    verbatim into the iframe URL).
  - `conda-env/` and `.env` added to `develop.watch.sync.ignore`.

- **`.env.example`**: active `SAM_DB_*` / `STATUS_DB_*` lines
  commented out by default. `install.sh`-generated `.env` no
  longer ships with `127.0.0.1` values that would leak into
  in-stack containers via `env_file:`. Header documents the
  uncomment-one-block UX and the pass-through behaviour.

- **`containers/webapp/Dockerfile`**: dropped the `/.env` heredoc
  (production never relied on it; helm sets every var). Dropped
  `apt-get install rsync git git-lfs` — zero callers, zero
  build-time need (`pyproject.toml` deps are all wheels). Added
  `pip install --no-cache-dir`. Kept `/usr/bin/list-large-directories`
  per prior feedback (in-image debug helper).

- **`.dockerignore`**: replaced root-only `*.sql` / `*.sql.xz` with
  recursive `**/*.sql` / `**/*.sql.xz`. Explicit deny entries for
  `containers/sam-sql-dev/dump/` (~223 MiB of per-table SQL dumps
  from the anonymization workflow that were silently slipping into
  the build context). Added `**/*.dump`, emacs lock/autosave globs.

  **Net image-size delta: 2.6 GB → 2.06 GB (-540 MiB). Build
  context: 288 MiB → 10 MiB.**

### Source — defer config-required errors from import to use

- **`src/sam/session/__init__.py`** /
  **`src/system_status/session/__init__.py`**:
  `init_*_db_defaults()` now uses `os.environ.get()` and returns
  silently if any of USERNAME/PASSWORD/SERVER is missing —
  `connection_string` stays `None`. `create_*_engine()` raises a
  clear `RuntimeError` pointing at the env vars / `.env.example`
  if called when no connection_string was configured. Production
  webapp container has all env vars set (helm), so the normal path
  runs unchanged. Test harness can now import these modules
  without env, and `conftest.py` overrides `SQLALCHEMY_DATABASE_URI`
  via `create_app(config_overrides=…)` from `SAM_TEST_DB_URL`.

- **`src/webapp/run.py`**: `cfg.validate()` skipped when
  `config_overrides=` is passed. Production callers pass no
  overrides — fail-fast on missing env preserved. Test harness
  passes overrides — bypasses the validate gate.

### Makefile / build automation

- **`Makefile`**: `docker-up` now uses `docker compose up --detach
  --wait` (gates on every healthcheck; the old `grep -q healthy`
  loop matched the first container — usually cache at 5s — and
  exited while mysql was still mid-restore). New `docker-watch`
  (foreground `compose watch`) and `docker-pytest` (full pytest +
  coverage inside `webapp` against `mysql-test`, mirroring
  `sam-ci-docker.yaml`).

- **`install.sh`**: closing banner recommends `make docker-up` /
  `make docker-pytest` / `make docker-watch` instead of
  `docker compose --profile test up --build --watch` (the old form
  spun up the test profile for a normal dev run AND blocked the
  shell on `--watch`). Stray-quote bug in the heredoc fixed.
  Portable color helper gated on `[[ -t 1 ]] && tput`, so
  `curl | bash` and log redirects see plain ASCII.

- **`README.md`**: rewritten Quick Start covers the `make docker-up`
  flow with explicit Git LFS prerequisites (`git lfs --version`
  AND `git lfs install`), backup-file sanity check, first-run
  timing expectations.

### CI

- **`.github/workflows/test-install.yaml`** rewritten to walk the
  recommended user flow:
  - `bash install.sh --help` (arg-parse canary)
  - `install.sh` second run against same dir (exercises the
    `git fetch + checkout + pull --ff-only` update branch)
  - `make help` asserts `docker-up`/`docker-down`/`docker-pytest`/`docker-watch` advertised
  - `make docker-up` replaces the hand-rolled `wait-for-mysql` +
    `import sam` polling loop (`--wait` makes it redundant)
  - `/health/ready` smoke parsed with `jq`, asserts both binds
    healthy from outside the network
  - `make docker-down` + verify stack actually goes away

- **`.github/workflows/sam-ci-conda_make.yaml`**: SAM_DB_* /
  STATUS_DB_* lifted to job-level `env:` (sam-search and
  sam-status both validate both var sets at startup), since
  `.env.example` no longer has them active by default.

- **`tests/conftest.py`**: `pytest_configure` sets
  `os.environ.setdefault()` placeholder values for SAM_DB_* /
  STATUS_DB_* — the test suite never reads them (sessions route
  through `SAM_TEST_DB_URL`, CLI tests patch `Session`), but they
  satisfy the fail-fast `SAMConfig.validate()` gate on hosts
  whose `.env` has those blocks commented.

## Verification

End-to-end across every supported scenario:

- **Local fresh clone, no `.env`** (`env -i` clean shell, `install.sh -d /tmp/test-install`):
  `make docker-up` exits 0, both `/health/ready` endpoints 200,
  `/status/` renders, `sam-search user csgteam` works.
- **`make docker-pytest`** in the slim image: 2042 passed, 24
  skipped, 1 xfailed in 82.39s, coverage 80.12%.
- **Host pytest** (`source etc/config_env.sh && pytest -v -n auto`)
  with `.env` having SAM_DB_* commented out: 2043 passed in
  82.39s.
- **PROD pass-through**: uncommenting the PROD block in `.env`
  flows `sam-sql.ucar.edu` into the in-stack webapp container
  (verified via `docker compose exec webapp env | grep SAM_DB_SERVER`).
- **CI**: `test-install`, `sam-ci-conda_make` (Run Test Suite —
  Docker), `sam-ci-docker` (Test Suite), Helm Chart Render, Lint,
  Secret Scan, Terraform Validation all green on the head commit.
- **Production deploy on CIRRUS**: image `sha-9193e80` rolled out,
  both pods healthy, `/api/v1/health/ready` returns 200 with
  `sam` (113ms over WAN to `sam-sql.ucar.edu`) and `system_status`
  (32ms in-cluster postgres) both healthy. `/.env` confirmed
  absent inside the running pod, all env vars resolved from
  helm-injected Secrets/values, gunicorn workers = 33 (formula
  `2·cpu_limit + 1` honours cgroup), zero tracebacks since rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)