### PR TITLE
Refactor user_proj_queue_status to (first_seen, last_seen) span semantics

### DIFF
--- a/containers/sam-sql-dev/backups/sam-obfuscated.sql.xz
+++ b/containers/sam-sql-dev/backups/sam-obfuscated.sql.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e9e11419a9478698f10bde3fd24bca420d83f091bee1dc51878a2517c9fdecb
-size 18964008
+oid sha256:c62a76ba68a3a9451ec4ad48d6a8b5f925140bffc8d9d6e599a71e64a5cd5ee2
+size 19020868

--- a/docs/plans/USER_PROJ_QUEUE_LAST_SEEN.md
+++ b/docs/plans/USER_PROJ_QUEUE_LAST_SEEN.md
@@ -1,0 +1,274 @@
+# Refactor `user_proj_queue_status` to span semantics
+
+## Context
+
+The `user_proj_queue_status` table currently stores one row per
+`(timestamp, user_id, project_code_id, queue_id)`. For stable workloads, this
+generates massive duplication: a user running the same job set produces an
+identical row every 5 minutes. The table is on track to dwarf every other
+status table.
+
+This refactor reinterprets each row as a **span of unchanging counts**: the
+existing `timestamp` column becomes "first_seen", and a new `last_seen` column
+records the most recent tick at which the same `(user, project, queue,
+counts)` tuple was observed. Ingest coalesces identical adjacent ticks by
+`UPDATE`ing `last_seen` instead of inserting a new row. A new row is only
+inserted when (a) counts change for a `(user, project, queue)` already
+present, or (b) a new `(user, project, queue)` appears that wasn't there at
+the previous tick. When the tuple disappears from the queue, its row is
+simply left alone — `last_seen` is never bumped again, so the row becomes a
+self-contained record of one steady-state run.
+
+User-confirmed decisions:
+- **Keep `timestamp` column name.** Reinterpret semantically as first_seen;
+  no rename. Add `last_seen` only.
+- **Wipe existing rows in the migration.** No backfill. Fresh start.
+- **Parent FK** (`derecho_status_id` / `casper_status_id`) is set on INSERT
+  to the parent at `timestamp` (first_seen) and never rewritten on UPDATE.
+  CASCADE delete stays — pruning old parent snapshots prunes spans that
+  started in that window.
+
+## Critical files
+
+| File | Role |
+|---|---|
+| `src/system_status/models/user_proj_queues.py` | Add `last_seen` column, update docstring. |
+| `migrations/system_status/versions/0004_user_proj_queue_last_seen.py` | NEW: wipe + add column + index. |
+| `src/system_status/queries/lookups.py` | Expose a synchronous resolver helper for ingest coalescer. |
+| `src/system_status/queries/user_proj_queue_ingest.py` | NEW: `coalesce_user_proj_queue_spans(...)`. |
+| `src/webapp/api/v1/status.py` | Call the coalescer before `db.session.add`. |
+| `src/system_status/queries/user_proj_queues.py` | `get_latest_user_proj_queue_snapshot` + `get_user_proj_timeseries` updated for spans. |
+| `src/system_status/queries/user_proj_usage.py` | `get_user_proj_usage` integrates spans via `cum_dt`. |
+
+## Step 1 — Model (`user_proj_queues.py:1-137`)
+
+- Add `last_seen = Column(DateTime, nullable=False, index=True, comment='...')`
+  just below the FK columns (~line 60).
+- Add `DateTime` to the SQLAlchemy import (~line 5).
+- Keep the existing `(timestamp, user_id, project_code_id, queue_id)`
+  UniqueConstraint — uniqueness still holds because each new span has a
+  distinct `first_seen`.
+- Update the class docstring to spell out span semantics: `timestamp` is
+  first_seen; `last_seen` is the inclusive last tick the same counters
+  were observed; parent FK points at the first_seen parent only.
+- Append `last_seen` to `__str__` / `__repr__` (lines 128–136).
+
+## Step 2 — Migration (`0004_user_proj_queue_last_seen.py`, new)
+
+`revision = '0004_user_proj_queue_last_seen'`, `down_revision =
+'0003_user_proj_queue_status'`.
+
+`upgrade()`:
+1. `op.execute('DELETE FROM user_proj_queue_status')` — wipe so the NOT NULL
+   add is unconditionally safe.
+2. `with op.batch_alter_table('user_proj_queue_status') as batch_op:`
+   - `batch_op.add_column(sa.Column('last_seen', sa.DateTime(), nullable=True))`
+   - `op.execute('UPDATE user_proj_queue_status SET last_seen = timestamp')`
+   - `batch_op.alter_column('last_seen', nullable=False)`
+   - `batch_op.create_index(batch_op.f('ix_user_proj_queue_status_last_seen'), ['last_seen'], unique=False)`
+
+`downgrade()`: drop index then drop column.
+
+## Step 3 — Reusable lookup resolver (`lookups.py:212-287`)
+
+The existing `_resolve_pending_lookup_names` listener only iterates
+`session.new`, but the coalescer needs to resolve FKs on a child *before*
+deciding whether to attach it to the parent. Extract the per-row
+`UserProjQueueStatus` resolution (lines 258–268) into a public helper:
+
+```
+def resolve_user_proj_queue_pending(session, obj, *, sys_cache, queue_cache,
+                                    user_cache, proj_cache):
+    # pop _pending_system_name → obj.system via _ensure_system
+    # pop _pending_queue_name  → obj.queue   via _ensure_queue (system-scoped)
+    # pop _pending_username    → obj.user    via _ensure_user
+    # pop _pending_project_code→ obj.project via _ensure_project_code
+```
+
+Listener body still calls this for `UserProjQueueStatus` instances in
+`session.new` (no behavior change for the existing INSERT-then-flush path).
+
+## Step 4 — Coalescer (`user_proj_queue_ingest.py`, new module)
+
+```
+def coalesce_user_proj_queue_spans(session, parent_status, T_new) -> dict:
+    """Mutates parent_status.user_project_queues in place. Returns
+    {'inserted': N, 'extended': M}."""
+```
+
+Algorithm:
+1. Iterate `parent_status.user_project_queues` (children attached by
+   Marshmallow `load_instance=True`). For each child, call
+   `resolve_user_proj_queue_pending` so `(user_id, project_code_id, queue_id,
+   system_id)` are populated. May require an explicit `session.flush()` of
+   the lookup rows to materialize their ids.
+2. Determine `system_id` (all children on one parent share it).
+3. `prev_ts = SELECT MAX(last_seen) FROM user_proj_queue_status WHERE
+   system_id = :sid`. If `None` → first ever ingest for this system; skip
+   to step 6.
+4. **Span-gap guard**: if `T_new - prev_ts > MAX_SPAN_GAP` (module
+   constant, default `timedelta(minutes=20)` — 3 missed ticks), skip
+   coalescing. Counters that resume after a long collector outage start
+   fresh spans even if they happen to match.
+5. Active-set query: `SELECT id, user_id, project_code_id, queue_id,
+   running_jobs, pending_jobs, held_jobs, cores_allocated, gpus_allocated,
+   nodes_allocated, cores_pending, gpus_pending, cores_held, gpus_held FROM
+   user_proj_queue_status WHERE system_id = :sid AND last_seen = :prev_ts`.
+   Index by `(user_id, project_code_id, queue_id)` → row tuple.
+6. For each child:
+   - 10-tuple of metric columns (the `QueueRollupMetricsMixin` fields).
+   - If `(uid, pid, qid)` exists in active_set with **all 10 metrics
+     equal**:
+     - `existing = session.get(UserProjQueueStatus, row_id)`
+     - `existing.last_seen = T_new`
+     - `parent_status.user_project_queues.remove(child)` — plain list
+       mutation; `parent_status` is not yet in the session, so this is
+       not a SQLAlchemy state operation.
+     - `extended += 1`
+   - Else:
+     - `child.last_seen = T_new` (= `child.timestamp`)
+     - leave attached. `inserted += 1`
+
+**Why mutate before `db.session.add`**: at this point `parent_status` is
+still transient; `parent.user_project_queues` is a plain Python list. No
+`cascade='all, delete-orphan'` semantics are triggered. This avoids any
+SQLAlchemy state surgery on detached duplicates.
+
+## Step 5 — Wire into ingest (`webapp/api/v1/status.py:143-198`)
+
+In `_ingest_system_status`, between `status_object = schema.load(data)`
+(line 172) and `db.session.add(status_object)` (line 175):
+
+```
+from system_status.queries.user_proj_queue_ingest import coalesce_user_proj_queue_spans
+coalesce_user_proj_queue_spans(db.session, status_object, timestamp)
+```
+
+`db.session.add(...)` then proceeds with the trimmed children collection.
+The response field `'user_project_queue_ids'` (line 187) naturally reflects
+only the newly inserted spans — extended spans aren't in the parent's
+collection anymore.
+
+## Step 6 — Read: `get_latest_user_proj_queue_snapshot` (`user_proj_queues.py:88-164`)
+
+- Lines 113–118: `select(UserProjQueueStatus.last_seen).order_by(...desc())`
+  instead of `timestamp`.
+- Line 142: `UserProjQueueStatus.last_seen == latest_ts`.
+- Returned dict (lines 147–164): keep key `'timestamp'` populated from
+  `r.last_seen` (template binding stays); add new key `'first_seen':
+  r.timestamp`.
+
+## Step 7 — Read: `get_user_proj_usage` (`user_proj_usage.py:105-419`)
+
+The big win — span integration is O(1) per row.
+
+- Add `cum_dt = np.concatenate([[0.0], np.cumsum(dt_sec)])` after line 238
+  (length `n_ticks + 1`).
+- Base SELECT (lines 247–258): add `UserProjQueueStatus.last_seen` to the
+  column list.
+- Per-chunk query (lines 270–274): change overlap predicate to
+  `last_seen >= t_lo AND timestamp <= t_hi`. Maintain a `seen_ids: set[int]`
+  across chunks to dedup spans that fall into multiple chunks.
+- Replace lines 296–319 (`searchsorted` + per-tick `dt_per_row` lookup) with
+  span integration:
+  ```
+  first_clamped = np.maximum(ts_arr, np.datetime64(start_date))
+  last_clamped  = np.minimum(last_arr, np.datetime64(end_date))
+  i_first = np.searchsorted(ticks, first_clamped)
+  i_last  = np.searchsorted(ticks, last_clamped, side='right') - 1
+  valid = i_first <= i_last
+  # filter all arrays by valid
+  dt_total = cum_dt[i_last + 1] - cum_dt[i_first]
+  core_sec = cores_arr * dt_total
+  ...
+  tick_count_per_row = (i_last - i_first + 1).astype(np.int64)
+  ```
+- `last_us` per group accumulator (lines 336–338): use `last_arr` (= span
+  last_seen), not `ts_arr`. `first_us` keeps using `ts_arr`.
+- Bincount and merge (lines 327–362) unchanged structurally.
+
+## Step 8 — Read: `get_user_proj_timeseries` (`user_proj_queues.py:167-370`)
+
+The chart needs per-tick values; spans must be exploded onto the parent
+tick grid.
+
+- `gpu_max` probe (lines 282–294): change overlap predicate to
+  `last_seen >= start_date AND timestamp <= end_date`.
+- Replace the GROUP BY query (lines 311–324) with span explosion:
+  1. Fetch parent ticks for `system` in `[start_date, end_date]` (reuse
+     `_PARENT_STATUS_BY_SYSTEM` from `user_proj_usage.py`; consider moving
+     the dict to a shared helper module).
+  2. Fetch span rows: `SELECT timestamp, last_seen, label_col, metric_col
+     FROM user_proj_queue_status JOIN <UserDef|ProjectCodeDef> WHERE
+     scope_filter AND last_seen >= start_date AND timestamp <= end_date`.
+     No DB-side GROUP BY.
+  3. Per row, compute `i_first, i_last` (clamped to window) via
+     `searchsorted`, accumulate `value` into a numpy array of length
+     `n_ticks` keyed by label.
+- Rest of the function (rank by peak/current, top-N, Others) unchanged
+  once `per_label[label]` is a length-`n_ticks` numpy array indexed by
+  tick position.
+- `dates = list(ticks)` for the return shape.
+
+## Step 9 — Tests
+
+| File | Change |
+|---|---|
+| `tests/integration/test_user_proj_queue_listener.py` | Existing tests (lines 27–96) still pass for INSERT path. Add `test_second_flush_with_same_counts_extends_last_seen` and `test_second_flush_with_different_counts_inserts_new_span`. |
+| `tests/api/test_status_endpoints.py` | Update `test_post_derecho_user_project_queues_reuses_lookup_rows` (different counts → 2 rows is correct under new schema). Add `test_post_derecho_user_project_queues_coalesces_identical_counts` (same counts → 1 row, `last_seen` advanced). Add `test_post_derecho_response_id_list_excludes_extended_spans`. |
+| `tests/unit/test_user_proj_queues_timeseries.py` | Update `_make_upq` to take `last_seen` (default `=parent.timestamp` for back-compat). Add `test_chart_explodes_span_across_ticks` — 1 span over 3 ticks → series `[V, V, V]`. |
+| `tests/unit/test_user_proj_usage.py` | Same `_make_upq` update. Add `test_span_integrates_correctly_across_ticks`, `test_overlapping_window_clips_span`. Verify existing `test_two_ticks_left_step_integration` rebuilds correctly under spans. |
+| `tests/integration/test_alembic_migrations.py` | Should auto-exercise `0004` upgrade/downgrade. Verify roundtrip clean. |
+| `tests/conftest.py` (or new factory) | Add `make_span(session, *, parent, queue, user, project, first_seen, last_seen, **counts)` helper. |
+
+## Risks
+
+- **`cascade='all, delete-orphan'`** on `parent.user_project_queues` —
+  mitigated by mutating the children list *before* `db.session.add(parent)`.
+  At that point the parent is transient and the list is plain Python.
+- **`before_flush` listener vs. resolver**: extracting the per-row
+  resolver into a public helper means INSERTs still get `_pending_*`
+  resolution (listener still works), and the coalescer can resolve
+  synchronously without flushing twice.
+- **Active-set query cost**: ~340 rows on Derecho per ingest, indexed
+  scan — sub-millisecond. The new index `ix_user_proj_queue_status_last_seen`
+  covers it.
+- **Span-gap guard** prevents pathological coalescing across collector
+  outages. `MAX_SPAN_GAP = timedelta(minutes=20)` (3 missed ticks).
+- **Window-boundary edge cases** in usage integration (span ends at exact
+  start_date, span fully outside window): handled by `valid = i_first <=
+  i_last` mask. Add unit test.
+- **`scripts/validate_user_proj_usage.py`** likely needs a parallel update
+  (it re-implements integration). Out of scope for this plan but flagged.
+
+## Implementation order
+
+1. Model + migration (Steps 1–2) — schema first.
+2. Resolver extract (Step 3).
+3. Coalescer + ingest wiring (Steps 4–5).
+4. `get_latest_user_proj_queue_snapshot` (Step 6) — trivial, gets templates working.
+5. `get_user_proj_usage` (Step 7) — pure query change, easy to test.
+6. `get_user_proj_timeseries` (Step 8) — most invasive, do last.
+7. Tests in parallel with each step.
+
+Steps 1–5 must ship together: a model with `last_seen NOT NULL` rejects
+inserts from the un-updated ingest path.
+
+## Verification
+
+1. `alembic upgrade head` reaches `0004`. Confirm `last_seen DATETIME NOT
+   NULL` + `ix_user_proj_queue_status_last_seen` exist.
+2. `pytest` (full suite, ~65 s) green — model, migration, listener,
+   ingest, both queries.
+3. POST identical payloads at two timestamps via the API (or
+   `scripts/ingest_mock_status.py` if it exists). Verify `SELECT timestamp,
+   last_seen, COUNT(*) FROM user_proj_queue_status` yields 1 row, with
+   `last_seen > timestamp`.
+4. POST a payload with one user's `cores_allocated` changed. Verify 2
+   rows: the original (now closed at the previous tick) and a new span
+   starting at T_new.
+5. Open the queue drill-down dashboard for a queue with span data.
+   Confirm latest-snapshot table renders and chart shows constant
+   plateaus across spans.
+6. Spot-check `get_user_proj_usage` over a known window: core-hours
+   should match the expected `value × span_duration` to within rounding.

--- a/migrations/system_status/versions/0004_user_proj_queue_last_seen.py
+++ b/migrations/system_status/versions/0004_user_proj_queue_last_seen.py
@@ -1,0 +1,65 @@
+"""user_proj_queue_status: add last_seen for span semantics
+
+Reinterpret each row as a (first_seen, last_seen) span of unchanging
+counts instead of a per-tick snapshot. The existing ``timestamp`` column
+is now semantically *first_seen*; a new ``last_seen`` column records the
+most recent tick at which the same ``(user, project, queue, counts)``
+tuple was observed. Ingest coalesces identical adjacent ticks by
+bumping ``last_seen`` instead of inserting a duplicate row.
+
+Per design decision, existing rows are wiped — collectors will repopulate
+under the new semantics. No backfill or compaction is attempted.
+
+Cross-dialect notes:
+  * The ALTER goes through ``batch_alter_table`` (mandatory for SQLite,
+    benign on MySQL/Postgres).
+  * Add the column nullable, populate via UPDATE, then alter to NOT NULL
+    — the only pattern that works cleanly on every dialect when adding a
+    NOT NULL column.
+
+Revision ID: 0004_user_proj_queue_last_seen
+Revises: 0003_user_proj_queue_status
+Create Date: 2026-05-08
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0004_user_proj_queue_last_seen"
+down_revision: Union[str, Sequence[str], None] = "0003_user_proj_queue_status"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Wipe existing per-tick rows. The new ingest path coalesces by
+    # comparing against the most recent tick's `last_seen`; mixing legacy
+    # snapshot rows with new span rows would produce corrupted spans
+    # until the legacy data aged out. Cleaner to start fresh.
+    op.execute("DELETE FROM user_proj_queue_status")
+
+    with op.batch_alter_table("user_proj_queue_status", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("last_seen", sa.DateTime(), nullable=True))
+
+    # Defensive: any rows that survived the DELETE (concurrent inserts on
+    # a live DB, or test fixtures pre-loaded between the two steps) get
+    # last_seen seeded from timestamp so the NOT NULL alter below succeeds.
+    op.execute("UPDATE user_proj_queue_status SET last_seen = timestamp WHERE last_seen IS NULL")
+
+    with op.batch_alter_table("user_proj_queue_status", schema=None) as batch_op:
+        batch_op.alter_column("last_seen", existing_type=sa.DateTime(), nullable=False)
+        batch_op.create_index(
+            batch_op.f("ix_user_proj_queue_status_last_seen"),
+            ["last_seen"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("user_proj_queue_status", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_user_proj_queue_status_last_seen"))
+        batch_op.drop_column("last_seen")

--- a/src/system_status/models/user_proj_queues.py
+++ b/src/system_status/models/user_proj_queues.py
@@ -2,7 +2,7 @@
 # Per-user / per-project queue rollup snapshots
 #-------------------------------------------------------------------------eh-
 
-from sqlalchemy import Column, Integer, UniqueConstraint, ForeignKey
+from sqlalchemy import Column, DateTime, Integer, UniqueConstraint, ForeignKey
 from sqlalchemy.orm import relationship
 from ..base import StatusBase, StatusSnapshotMixin, SessionMixin, QueueRollupMetricsMixin
 from .lookups import System, QueueDef, UserDef, ProjectCodeDef
@@ -11,28 +11,46 @@ from .lookups import System, QueueDef, UserDef, ProjectCodeDef
 class UserProjQueueStatus(StatusBase, StatusSnapshotMixin,
                           QueueRollupMetricsMixin, SessionMixin):
     """
-    Per-user / per-project / per-queue rollup metrics (5-minute intervals).
+    Per-user / per-project / per-queue rollup spans (formerly per-tick snapshots).
+
+    Each row is a **span of unchanging counts** for a single
+    ``(user, project_code, queue)`` tuple. The ``timestamp`` column is the
+    span's *first_seen* — the earliest tick the row was observed — and
+    ``last_seen`` is the most recent tick at which the same counts were
+    observed. Equality at ingest (all ten ``QueueRollupMetricsMixin``
+    counters identical) extends an existing span by bumping ``last_seen``;
+    any change in counters or the appearance of a new tuple inserts a
+    fresh row with ``timestamp == last_seen == T_new``. When the tuple
+    leaves the queue, its row is left alone — ``last_seen`` is never bumped
+    again, so the row becomes a self-contained record of one steady-state
+    run.
+
+    The parent FK (``derecho_status_id`` / ``casper_status_id``) points at
+    the parent status row at *first_seen* and is never rewritten when the
+    span is extended. CASCADE delete is preserved: pruning old parent
+    snapshots also prunes spans that started in that window.
 
     Same counter shape as ``QueueStatus`` (shared via
     ``QueueRollupMetricsMixin``) but keyed by ``(user, project_code, queue)``
-    instead of just ``queue``. Volume is ~100x larger; the table is kept
-    separate so retention can be shorter without affecting the main
-    ``queue_status`` history.
+    instead of just ``queue``. The span representation collapses long
+    runs of identical ticks into a single row.
 
     Username and project_code denormalize through ``UserDef`` and
     ``ProjectCodeDef`` lookups for compact integer keys. The ``before_flush``
     listener in ``system_status.queries.lookups`` resolves the staged
     ``_pending_username`` / ``_pending_project_code`` strings into FKs at
-    flush time, mirroring the pattern used for ``queue_name`` /
-    ``system_name``.
+    flush time for INSERTs; the ingest coalescer in
+    ``system_status.queries.user_proj_queue_ingest`` resolves them
+    synchronously before deciding INSERT-vs-UPDATE.
     """
     __bind_key__ = "system_status"
     __tablename__ = 'user_proj_queue_status'
 
-    # Snapshot uniqueness: (timestamp, user, project_code, queue). ``system_id``
-    # is intentionally absent — ``queue_id`` references a single ``QueueDef``
-    # row which is itself ``(system_id, name)``-keyed, so the queue uniquely
-    # identifies its system.
+    # Span uniqueness: (timestamp, user, project_code, queue) — i.e.
+    # ``(first_seen, ...)``. Each new span has a distinct first_seen, so
+    # the constraint is unchanged from the per-tick era. ``system_id`` is
+    # intentionally absent — ``queue_id`` references a single ``QueueDef``
+    # row which is itself ``(system_id, name)``-keyed.
     __table_args__ = (
         UniqueConstraint('timestamp', 'user_id', 'project_code_id', 'queue_id',
                          name='uq_user_proj_queue_status_snapshot'),
@@ -58,6 +76,13 @@ class UserProjQueueStatus(StatusBase, StatusSnapshotMixin,
                        nullable=False, index=True)
     queue_id = Column(Integer, ForeignKey('queues.queue_id'),
                       nullable=False, index=True)
+
+    # Span endpoint: most recent tick at which the same (user, project,
+    # queue, counts) was observed. Equals ``timestamp`` (first_seen) on a
+    # brand-new span; bumped forward when ingest coalesces an identical
+    # tick.
+    last_seen = Column(DateTime, nullable=False, index=True,
+                       comment='Most recent tick at which counts matched timestamp (first_seen)')
 
     # Rollup metric columns inherited from QueueRollupMetricsMixin:
     # running_jobs, pending_jobs, held_jobs, cores_allocated, gpus_allocated,
@@ -127,10 +152,11 @@ class UserProjQueueStatus(StatusBase, StatusSnapshotMixin,
 
     def __str__(self):
         return (f"{self.username}/{self.project_code} on {self.queue_name} "
-                f"({self.system_name}, {self.timestamp})")
+                f"({self.system_name}, {self.timestamp}..{self.last_seen})")
 
     def __repr__(self):
         return (f"<UserProjQueueStatus(id={self.user_proj_queue_status_id}, "
                 f"user='{self.username}', project='{self.project_code}', "
                 f"queue='{self.queue_name}', system='{self.system_name}', "
+                f"first_seen={self.timestamp}, last_seen={self.last_seen}, "
                 f"running={self.running_jobs})>")

--- a/src/system_status/queries/lookups.py
+++ b/src/system_status/queries/lookups.py
@@ -231,6 +231,54 @@ def _ensure_project_code(session: Session, cache: dict, project_code: str) -> Pr
     return obj
 
 
+def resolve_user_proj_queue_pending(
+    session: Session,
+    obj,
+    *,
+    sys_cache: Optional[dict] = None,
+    queue_cache: Optional[dict] = None,
+    user_cache: Optional[dict] = None,
+    proj_cache: Optional[dict] = None,
+) -> None:
+    """Resolve ``_pending_*`` strings on a ``UserProjQueueStatus`` synchronously.
+
+    Equivalent to what the ``before_flush`` listener does for these objects,
+    but callable from outside a flush — used by the ingest coalescer
+    (``user_proj_queue_ingest.coalesce_user_proj_queue_spans``) to populate
+    FK relationships before deciding INSERT-vs-UPDATE on each child row.
+
+    Mutates ``obj`` in place (assigns ``obj.system``, ``obj.queue``,
+    ``obj.user``, ``obj.project``). The caller can share cache dicts
+    across many calls to coalesce lookups for one ingest batch; missing
+    dicts are created fresh.
+    """
+    if sys_cache is None:
+        sys_cache = {}
+    if queue_cache is None:
+        queue_cache = {}
+    if user_cache is None:
+        user_cache = {}
+    if proj_cache is None:
+        proj_cache = {}
+
+    pending_system = obj.__dict__.pop("_pending_system_name", None)
+    if pending_system:
+        obj.system = _ensure_system(session, sys_cache, pending_system)
+    sys_obj = obj.system
+
+    pending_queue = obj.__dict__.pop("_pending_queue_name", None)
+    if pending_queue and sys_obj is not None:
+        obj.queue = _ensure_queue(session, queue_cache, sys_obj, pending_queue)
+
+    pending_user = obj.__dict__.pop("_pending_username", None)
+    if pending_user:
+        obj.user = _ensure_user(session, user_cache, pending_user)
+
+    pending_proj = obj.__dict__.pop("_pending_project_code", None)
+    if pending_proj:
+        obj.project = _ensure_project_code(session, proj_cache, pending_proj)
+
+
 @event.listens_for(Session, "before_flush")
 def _resolve_pending_lookup_names(session, flush_context, instances):
     snapshot_classes = _snapshot_models()
@@ -250,24 +298,23 @@ def _resolve_pending_lookup_names(session, flush_context, instances):
         if not isinstance(obj, snapshot_classes):
             continue
 
+        if isinstance(obj, UserProjQueueStatus):
+            # Single helper handles system + queue + user + project for these
+            # rows — same code path that the ingest coalescer uses
+            # synchronously.
+            resolve_user_proj_queue_pending(
+                session, obj,
+                sys_cache=sys_cache, queue_cache=queue_cache,
+                user_cache=user_cache, proj_cache=proj_cache,
+            )
+            continue
+
         pending_system = obj.__dict__.pop("_pending_system_name", None)
         if pending_system:
             obj.system = _ensure_system(session, sys_cache, pending_system)
         sys_obj = obj.system  # may already have been set; may be None for legacy code
 
-        if isinstance(obj, UserProjQueueStatus):
-            # Resolve queue (system-scoped), user, and project_code lookups.
-            pending_queue = obj.__dict__.pop("_pending_queue_name", None)
-            if pending_queue and sys_obj is not None:
-                obj.queue = _ensure_queue(session, queue_cache, sys_obj, pending_queue)
-            pending_user = obj.__dict__.pop("_pending_username", None)
-            if pending_user:
-                obj.user = _ensure_user(session, user_cache, pending_user)
-            pending_proj = obj.__dict__.pop("_pending_project_code", None)
-            if pending_proj:
-                obj.project = _ensure_project_code(session, proj_cache, pending_proj)
-
-        elif isinstance(obj, QueueStatus):
+        if isinstance(obj, QueueStatus):
             pending_queue = obj.__dict__.pop("_pending_queue_name", None)
             if pending_queue and sys_obj is not None:
                 obj.queue = _ensure_queue(session, queue_cache, sys_obj, pending_queue)

--- a/src/system_status/queries/user_proj_queue_ingest.py
+++ b/src/system_status/queries/user_proj_queue_ingest.py
@@ -1,0 +1,187 @@
+"""Ingest-time coalescer for ``user_proj_queue_status`` spans.
+
+Each row in the table is a *span* of unchanging counts for a single
+``(user, project, queue)`` tuple — see the ``UserProjQueueStatus``
+docstring. On each ingest tick the collector POSTs the active set of
+tuples; this helper folds those incoming rows against the most recent
+tick's spans and decides per-row whether to:
+
+* **Extend** an existing span (UPDATE its ``last_seen``) — when the
+  tuple's counts match an active span exactly.
+* **Insert** a new span (with ``timestamp = last_seen = T_new``) — when
+  the tuple is new at this tick or its counts differ from the active
+  span.
+
+The coalescer mutates ``parent_status.user_project_queues`` in place
+*before* the parent is added to the session, so detached duplicates
+never enter SQLAlchemy's unit-of-work — no ``cascade='all,
+delete-orphan'`` surgery required.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Dict, Tuple
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from system_status.models import UserProjQueueStatus
+
+from .lookups import resolve_user_proj_queue_pending
+
+
+# A `MAX_SPAN_GAP`-or-greater jump between the previous tick's `last_seen`
+# and the incoming `T_new` is treated as a collector outage: spans don't
+# extend across it, even if counts happen to match. Three missed 5-minute
+# ticks is the operational definition.
+MAX_SPAN_GAP = timedelta(minutes=20)
+
+
+# Order of the QueueRollupMetricsMixin counters compared for span equality.
+# The 10-tuple built per child must use this order.
+_METRIC_FIELDS: Tuple[str, ...] = (
+    'running_jobs',
+    'pending_jobs',
+    'held_jobs',
+    'cores_allocated',
+    'gpus_allocated',
+    'nodes_allocated',
+    'cores_pending',
+    'gpus_pending',
+    'cores_held',
+    'gpus_held',
+)
+
+
+def _metric_tuple(obj) -> Tuple[int, ...]:
+    return tuple(int(getattr(obj, f) or 0) for f in _METRIC_FIELDS)
+
+
+def coalesce_user_proj_queue_spans(
+    session: Session,
+    parent_status,
+    T_new: datetime,
+) -> Dict[str, int]:
+    """Coalesce ``parent_status.user_project_queues`` against the previous
+    tick's active span set.
+
+    Mutates the children list in place: extended spans are loaded by id
+    and have ``last_seen`` bumped; new spans get ``last_seen = T_new``
+    set and stay attached to the parent for INSERT.
+
+    Returns ``{'inserted': N, 'extended': M}`` for logging.
+
+    The parent status object is expected to be **transient** at call time
+    (Marshmallow has built it but the route hasn't called
+    ``session.add(parent_status)`` yet). That keeps the children-list
+    mutations as pure Python list operations, untouched by SQLAlchemy
+    cascade machinery.
+    """
+    children = list(parent_status.user_project_queues)
+    if not children:
+        return {'inserted': 0, 'extended': 0}
+
+    # 1. Resolve `_pending_*` strings on every child. Share caches across
+    #    children so a batch of 340 rows hits each lookup table at most
+    #    once. The helper assigns `obj.system / obj.queue / obj.user /
+    #    obj.project`; we may need to flush so newly-created lookup rows
+    #    have ids before we query against them.
+    sys_cache: dict = {}
+    queue_cache: dict = {}
+    user_cache: dict = {}
+    proj_cache: dict = {}
+    for child in children:
+        resolve_user_proj_queue_pending(
+            session, child,
+            sys_cache=sys_cache, queue_cache=queue_cache,
+            user_cache=user_cache, proj_cache=proj_cache,
+        )
+
+    # Materialize ids for any newly-created lookup rows so we can read
+    # `child.user.user_id / queue.queue_id / project.project_code_id /
+    # system.system_id` below.
+    session.flush()
+
+    # Read FKs through the resolved relationships (the children are
+    # transient, so their column-level FKs aren't auto-synced yet).
+    def _child_fks(c):
+        return (
+            c.user.user_id if c.user is not None else None,
+            c.project.project_code_id if c.project is not None else None,
+            c.queue.queue_id if c.queue is not None else None,
+            c.system.system_id if c.system is not None else None,
+        )
+
+    # 2. Determine system_id (every child on one parent shares it).
+    _, _, _, system_id = _child_fks(children[0])
+    if system_id is None:
+        # Defensive: nothing to coalesce against without a system scope.
+        for child in children:
+            child.last_seen = T_new
+        return {'inserted': len(children), 'extended': 0}
+
+    # 3. Most recent `last_seen` for this system. None ⇒ first ingest.
+    prev_ts = session.execute(
+        select(func.max(UserProjQueueStatus.last_seen))
+        .where(UserProjQueueStatus.system_id == system_id)
+    ).scalar_one_or_none()
+
+    # 4. Span-gap guard: skip coalescing across collector outages.
+    if prev_ts is None or (T_new - prev_ts) > MAX_SPAN_GAP:
+        for child in children:
+            child.last_seen = T_new
+        return {'inserted': len(children), 'extended': 0}
+
+    # 5. Active set: spans whose `last_seen == prev_ts` for this system.
+    active_rows = session.execute(
+        select(
+            UserProjQueueStatus.user_proj_queue_status_id,
+            UserProjQueueStatus.user_id,
+            UserProjQueueStatus.project_code_id,
+            UserProjQueueStatus.queue_id,
+            UserProjQueueStatus.running_jobs,
+            UserProjQueueStatus.pending_jobs,
+            UserProjQueueStatus.held_jobs,
+            UserProjQueueStatus.cores_allocated,
+            UserProjQueueStatus.gpus_allocated,
+            UserProjQueueStatus.nodes_allocated,
+            UserProjQueueStatus.cores_pending,
+            UserProjQueueStatus.gpus_pending,
+            UserProjQueueStatus.cores_held,
+            UserProjQueueStatus.gpus_held,
+        )
+        .where(
+            UserProjQueueStatus.system_id == system_id,
+            UserProjQueueStatus.last_seen == prev_ts,
+        )
+    ).all()
+
+    # Index by (user_id, project_code_id, queue_id) → (row_id, metric_tuple)
+    active: Dict[Tuple[int, int, int], Tuple[int, Tuple[int, ...]]] = {
+        (r[1], r[2], r[3]): (r[0], tuple(int(v or 0) for v in r[4:]))
+        for r in active_rows
+    }
+
+    inserted = 0
+    extended = 0
+    for child in children:
+        uid, pid, qid, _ = _child_fks(child)
+        key = (uid, pid, qid)
+        match = active.get(key)
+        if match is not None and match[1] == _metric_tuple(child):
+            row_id, _ = match
+            existing = session.get(UserProjQueueStatus, row_id)
+            if existing is not None:
+                existing.last_seen = T_new
+                # Drop the duplicate before the parent enters the session.
+                # This is a plain list mutation while parent_status is still
+                # transient — no cascade machinery fires.
+                parent_status.user_project_queues.remove(child)
+                extended += 1
+                continue
+        # New span: stamp last_seen and leave attached for INSERT.
+        child.last_seen = T_new
+        inserted += 1
+
+    return {'inserted': inserted, 'extended': extended}

--- a/src/system_status/queries/user_proj_queues.py
+++ b/src/system_status/queries/user_proj_queues.py
@@ -10,16 +10,29 @@ queue drill-down view (``status_dashboard.queue_history``).
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+import numpy as np
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from system_status.models import (
+    CasperStatus,
+    DerechoStatus,
     ProjectCodeDef,
     QueueDef,
     System,
     UserDef,
     UserProjQueueStatus,
 )
+
+
+# Parent status table by system, used to fetch the canonical tick
+# timeline for span explosion. Mirrors the dict in
+# ``user_proj_usage.py`` — duplicated here to avoid a cross-module
+# dependency loop.
+_PARENT_STATUS_BY_SYSTEM = {
+    'derecho': DerechoStatus,
+    'casper': CasperStatus,
+}
 
 
 _VALID_GROUP_BY = ('user', 'project')
@@ -94,13 +107,20 @@ def get_latest_user_proj_queue_snapshot(
     """One row per ``(user, project_code)`` for the most recent tick of
     this queue.
 
+    Under span semantics, "the most recent tick" means rows whose
+    ``last_seen`` equals the maximum ``last_seen`` for the queue — i.e.
+    spans that were still active at the most recent observation.
+
     Returns a list of dicts shaped for direct template rendering:
 
         [{'username': 'benkirk', 'project_code': 'SCSG0001',
           'running_jobs': 3, 'pending_jobs': 0, 'held_jobs': 0,
           'cores_allocated': 256, 'cores_pending': 0, 'cores_held': 0,
           'gpus_allocated': 0, 'gpus_pending': 0, 'gpus_held': 0,
-          'nodes_allocated': 4, 'timestamp': datetime(...)}, ...]
+          'nodes_allocated': 4,
+          'timestamp':  datetime(...),  # last_seen (template-facing alias)
+          'first_seen': datetime(...),  # span start
+          'last_seen':  datetime(...)}, ...]
 
     Empty list if the queue is unknown or has never reported a snapshot.
     The ``_unknown_`` project bucket (jobs missing ``Account_Name``) is
@@ -111,9 +131,9 @@ def get_latest_user_proj_queue_snapshot(
         return []
 
     latest_ts = session.execute(
-        select(UserProjQueueStatus.timestamp)
+        select(UserProjQueueStatus.last_seen)
         .where(UserProjQueueStatus.queue_id == queue_id)
-        .order_by(UserProjQueueStatus.timestamp.desc())
+        .order_by(UserProjQueueStatus.last_seen.desc())
         .limit(1)
     ).scalar_one_or_none()
     if latest_ts is None:
@@ -134,12 +154,13 @@ def get_latest_user_proj_queue_snapshot(
             UserProjQueueStatus.gpus_held,
             UserProjQueueStatus.nodes_allocated,
             UserProjQueueStatus.timestamp,
+            UserProjQueueStatus.last_seen,
         )
         .join(UserDef, UserProjQueueStatus.user_id == UserDef.user_id)
         .join(ProjectCodeDef,
               UserProjQueueStatus.project_code_id == ProjectCodeDef.project_code_id)
         .where(UserProjQueueStatus.queue_id == queue_id,
-               UserProjQueueStatus.timestamp == latest_ts)
+               UserProjQueueStatus.last_seen == latest_ts)
         .order_by(UserProjQueueStatus.running_jobs.desc(),
                   UserDef.username)
     ).all()
@@ -158,7 +179,14 @@ def get_latest_user_proj_queue_snapshot(
             'gpus_pending': r.gpus_pending,
             'gpus_held': r.gpus_held,
             'nodes_allocated': r.nodes_allocated,
-            'timestamp': r.timestamp,
+            # Templates and existing callers refer to `'timestamp'`. Under
+            # span semantics that key now carries the *last_seen* value
+            # (the most recent observation), so the rendered "as of" time
+            # is current. `'first_seen'` exposes the span start for
+            # callers that want span duration.
+            'timestamp': r.last_seen,
+            'first_seen': r.timestamp,
+            'last_seen': r.last_seen,
         }
         for r in rows
     ]
@@ -277,8 +305,8 @@ def get_user_proj_timeseries(
     # Probe whether the scope has ANY GPU activity in the window. The UI
     # uses this to suppress the GPUs metric button on CPU-only queues
     # (or any system+window with no GPU rollup activity) — purely
-    # data-driven, no queue/system whitelist. One indexed MAX over the
-    # same scope+window predicate as the main aggregation.
+    # data-driven, no queue/system whitelist. Span overlap predicate:
+    # last_seen >= start AND timestamp <= end.
     gpu_max = session.execute(
         select(
             func.coalesce(func.max(UserProjQueueStatus.gpus_allocated), 0),
@@ -287,7 +315,7 @@ def get_user_proj_timeseries(
         )
         .where(
             scope_filter,
-            UserProjQueueStatus.timestamp >= start_date,
+            UserProjQueueStatus.last_seen >= start_date,
             UserProjQueueStatus.timestamp <= end_date,
         )
     ).one()
@@ -304,58 +332,91 @@ def get_user_proj_timeseries(
             UserProjQueueStatus.project_code_id == ProjectCodeDef.project_code_id,
         )
 
-    # Sum the metric within each (timestamp, label) bucket — multiple
-    # (user, project, queue) rows collapse to a single series row when
-    # grouping by just one of those keys (and, in system-wide scope,
-    # across all queues for that system).
-    rows = session.execute(
+    # Build the canonical tick timeline from the parent status table for
+    # this system. Spans are exploded onto these ticks: each span
+    # contributes its constant value to every tick in [first_seen,
+    # last_seen] ∩ [start_date, end_date].
+    parent = _PARENT_STATUS_BY_SYSTEM.get(system)
+    if parent is None:
+        return empty
+    tick_rows = session.execute(
+        select(parent.timestamp)
+        .where(parent.timestamp >= start_date,
+               parent.timestamp <= end_date)
+        .order_by(parent.timestamp)
+    ).all()
+    tick_list = [r[0] for r in tick_rows]
+    if not tick_list:
+        return empty
+    n_ticks = len(tick_list)
+    ticks = np.array(tick_list, dtype='datetime64[us]')
+    start_dt64 = np.datetime64(start_date, 'us')
+    end_dt64 = np.datetime64(end_date, 'us')
+
+    # Fetch span rows overlapping the window and join the chosen label.
+    span_rows = session.execute(
         select(
             UserProjQueueStatus.timestamp,
+            UserProjQueueStatus.last_seen,
             label_col,
-            func.sum(metric_col).label('value'),
+            metric_col.label('value'),
         )
         .join(join_target, join_cond)
         .where(
             scope_filter,
-            UserProjQueueStatus.timestamp >= start_date,
+            UserProjQueueStatus.last_seen >= start_date,
             UserProjQueueStatus.timestamp <= end_date,
         )
-        .group_by(UserProjQueueStatus.timestamp, label_col)
     ).all()
 
-    if not rows:
+    if not span_rows:
         return empty
 
-    per_label: Dict[str, Dict[datetime, int]] = {}
-    timestamps: set = set()
-    for ts, label, value in rows:
-        timestamps.add(ts)
-        per_label.setdefault(label, {})[ts] = int(value or 0)
+    per_label: Dict[str, np.ndarray] = {}
+    for first_seen, last_seen, label, value in span_rows:
+        v = int(value or 0)
+        if v == 0:
+            continue
+        i_first = int(np.searchsorted(
+            ticks, np.datetime64(max(first_seen, start_date), 'us')))
+        i_last = int(np.searchsorted(
+            ticks, np.datetime64(min(last_seen, end_date), 'us'),
+            side='right')) - 1
+        if i_first > i_last or i_first >= n_ticks or i_last < 0:
+            continue
+        arr = per_label.get(label)
+        if arr is None:
+            arr = np.zeros(n_ticks, dtype=np.int64)
+            per_label[label] = arr
+        # Collapsed scopes (e.g. group_by='user' across multiple
+        # queues/projects) sum naturally via in-place addition.
+        arr[i_first:i_last + 1] += v
 
-    dates = sorted(timestamps)
+    if not per_label:
+        return empty
+
+    dates = list(tick_list)
 
     # Two ranking modes — peak catches brief spikes, current answers
-    # "who's hot right now". `dates` is non-empty here (rows guard above).
+    # "who's hot right now".
     if rank_by == 'current':
-        latest = dates[-1]
-        rank_key = lambda kv: kv[1].get(latest, 0)
+        rank_key = lambda kv: int(kv[1][-1])
     else:  # 'peak'
-        rank_key = lambda kv: max(kv[1].values()) if kv[1] else 0
+        rank_key = lambda kv: int(kv[1].max())
     ranked = sorted(per_label.items(), key=rank_key, reverse=True)
     top = ranked[:top_n]
     rest = ranked[top_n:]
 
     series: List[Dict[str, Any]] = []
     if rest:
-        others_values = [0] * len(dates)
-        for _label, by_ts in rest:
-            for i, d in enumerate(dates):
-                others_values[i] += by_ts.get(d, 0)
-        series.append({'label': 'Others', 'values': others_values})
-    for label, by_ts in reversed(top):
+        others_arr = np.zeros(n_ticks, dtype=np.int64)
+        for _label, arr in rest:
+            others_arr += arr
+        series.append({'label': 'Others', 'values': others_arr.tolist()})
+    for label, arr in reversed(top):
         series.append({
             'label':  label,
-            'values': [by_ts.get(d, 0) for d in dates],
+            'values': arr.tolist(),
         })
 
     return {

--- a/src/system_status/queries/user_proj_usage.py
+++ b/src/system_status/queries/user_proj_usage.py
@@ -1,9 +1,9 @@
 """
-Time-integrated consumption from ``user_proj_queue_status`` snapshots.
+Time-integrated consumption from ``user_proj_queue_status`` spans.
 
 The sibling ``user_proj_queues`` module exposes instantaneous /
 time-series views of the per-user / per-project / per-queue rollup
-table. This module integrates those snapshots over a window into
+table. This module integrates those spans over a window into
 core-hours / GPU-hours / node-hours by ``(user, project, queue)``.
 
 Two complications drive the design:
@@ -14,25 +14,26 @@ Two complications drive the design:
    ``DerechoStatus`` / ``CasperStatus`` table (the canonical record of
    "the collector ran at this moment", regardless of whether any user
    had jobs).
-2. **Sparse rows** — a ``(user, project, queue)`` row exists only when
-   that tuple has ≥1 job at that tick. Absence at a tick is treated as
-   ``0 cores / 0 gpus / 0 nodes`` for that tuple at that tick (NOT
-   carry-forward — that would attribute load forever after a user's
-   jobs end).
+2. **Each row is a span, not a snapshot** — a single ``(user, project,
+   queue)`` row covers every tick from ``timestamp`` (first_seen) to
+   ``last_seen`` inclusive at constant counters (the ingest coalescer
+   collapses identical ticks into one span). When the tuple disappears
+   from the queue, its row is left alone — ``last_seen`` records the
+   final tick of the run.
 
-Integration is **left-step** (rectangle rule): a row at tick ``t_i``
-with ``cores_allocated = X`` contributes ``X * (t_{i+1} - t_i)``
-core-seconds. The last tick in the window has no successor and
-contributes 0 (boundary effect is negligible for any window > a few
-ticks). Trapezoidal would average with a "0" at the next tick when a
-tuple disappears, under-counting by half — left-step is the honest
-discretization for jobs that start/stop in discrete jumps.
+Integration is **left-step** (rectangle rule): a span at ticks
+``[t_i .. t_j]`` with ``cores_allocated = X`` contributes
+``X * Σ_{k=i}^{j} (t_{k+1} - t_k)`` core-seconds — equivalently
+``X * (cum_dt[j+1] - cum_dt[i])`` using a cumulative-sum prefix array,
+which collapses a per-row integral to O(1). The last tick in the
+window has ``dt = 0`` so closed spans never over-count.
 
-For year-scale windows (~36M rows) the snapshot rows are streamed in
-monthly chunks; per-chunk aggregation uses numpy ``bincount`` on a
-composite ``(user_id, project_code_id, queue_id)`` key, then merged
-into a master accumulator dict. See ``get_user_proj_usage`` for the
-full algorithm.
+Spans make this query dramatically smaller than the per-tick era: each
+span is one row regardless of how many ticks it covers. Year-scale
+queries that previously scanned ~36M snapshot rows now scan however
+many spans the workload churn produced. The chunking infrastructure is
+preserved for spans that straddle chunk boundaries, with a
+``seen_ids`` set deduplicating spans seen in multiple chunks.
 """
 
 from datetime import datetime, timedelta
@@ -236,6 +237,14 @@ def get_user_proj_usage(
     dt_sec = np.zeros(n_ticks, dtype=np.float64)
     dt_sec[:-1] = np.diff(ticks).astype('int64').astype(np.float64) / 1e6
 
+    # Cumulative-sum prefix so any span [i..j] integrates as
+    #   sum(dt_sec[i:j+1]) == cum_dt[j+1] - cum_dt[i]
+    # — O(1) per span instead of O(j - i + 1).
+    cum_dt = np.concatenate([[0.0], np.cumsum(dt_sec)])
+
+    start_dt64 = np.datetime64(start_date, 'us')
+    end_dt64 = np.datetime64(end_date, 'us')
+
     # ------------------------------------------------------------------
     # 2. Stream user_proj rows in chunks; per-chunk numpy aggregation
     #    merged into a master accumulator dict keyed by composite int.
@@ -243,10 +252,15 @@ def get_user_proj_usage(
     # totals[composite_key] = [core_sec, gpu_sec, node_sec,
     #                          first_us, last_us, tick_count]
     totals: Dict[int, List[float]] = {}
+    # Spans whose [first_seen, last_seen] cross a chunk boundary may
+    # appear in two consecutive chunks; this set dedups them.
+    seen_ids: set = set()
 
     base = (
         select(
+            UserProjQueueStatus.user_proj_queue_status_id,
             UserProjQueueStatus.timestamp,
+            UserProjQueueStatus.last_seen,
             UserProjQueueStatus.user_id,
             UserProjQueueStatus.project_code_id,
             UserProjQueueStatus.queue_id,
@@ -268,39 +282,53 @@ def get_user_proj_usage(
         base = base.where(UserProjQueueStatus.project_code_id != unknown_pid)
 
     for t_lo, t_hi in _iter_chunks(start_date, end_date, chunk_days):
+        # Span-overlap predicate: a span [first, last] overlaps chunk
+        # [t_lo, t_hi] iff last >= t_lo AND first <= t_hi.
         rows = session.execute(
-            base.where(UserProjQueueStatus.timestamp >= t_lo,
+            base.where(UserProjQueueStatus.last_seen >= t_lo,
                        UserProjQueueStatus.timestamp <= t_hi)
         ).all()
         if not rows:
             continue
 
+        # Drop spans we already integrated in a previous chunk.
+        rows = [r for r in rows if r[0] not in seen_ids]
+        if not rows:
+            continue
+        seen_ids.update(r[0] for r in rows)
+
         # Columnar conversion. Tuples come back from SQLAlchemy in a
         # known order, matching the SELECT above.
-        ts_arr = np.array([r[0] for r in rows], dtype='datetime64[us]')
-        uid_arr = np.fromiter((r[1] for r in rows), dtype=np.int64,
+        ts_arr = np.array([r[1] for r in rows], dtype='datetime64[us]')
+        last_arr = np.array([r[2] for r in rows], dtype='datetime64[us]')
+        uid_arr = np.fromiter((r[3] for r in rows), dtype=np.int64,
                               count=len(rows))
-        pid_arr = np.fromiter((r[2] for r in rows), dtype=np.int64,
+        pid_arr = np.fromiter((r[4] for r in rows), dtype=np.int64,
                               count=len(rows))
-        qid_arr = np.fromiter((r[3] for r in rows), dtype=np.int64,
+        qid_arr = np.fromiter((r[5] for r in rows), dtype=np.int64,
                               count=len(rows))
-        cores_arr = np.fromiter((r[4] for r in rows), dtype=np.float64,
+        cores_arr = np.fromiter((r[6] for r in rows), dtype=np.float64,
                                 count=len(rows))
-        gpus_arr = np.fromiter((r[5] for r in rows), dtype=np.float64,
+        gpus_arr = np.fromiter((r[7] for r in rows), dtype=np.float64,
                                count=len(rows))
-        nodes_arr = np.fromiter((r[6] for r in rows), dtype=np.float64,
+        nodes_arr = np.fromiter((r[8] for r in rows), dtype=np.float64,
                                 count=len(rows))
 
         _assert_id_fits(uid_arr, pid_arr, qid_arr)
 
-        # Vectorized dt lookup. `searchsorted` on a sorted tick array
-        # gives the index where each row's timestamp would be inserted;
-        # for an exact match the index points AT that tick. Defensive
-        # mask drops anything that doesn't land on a known tick (should
-        # be empty in practice — parent and child ticks share the same
-        # timestamp by construction).
-        idx = np.searchsorted(ticks, ts_arr)
-        valid = (idx < n_ticks) & (ticks[np.minimum(idx, n_ticks - 1)] == ts_arr)
+        # Span integration via prefix-sum lookup. Clamp endpoints to the
+        # query window so spans that overhang either edge contribute
+        # only the in-window portion. searchsorted on a sorted tick
+        # array places each clamped endpoint at the matching tick index
+        # (or the next-greater for an off-tick value, which is benign
+        # since collector ticks and span endpoints share the same set
+        # by construction).
+        first_clamped = np.maximum(ts_arr, start_dt64)
+        last_clamped = np.minimum(last_arr, end_dt64)
+        i_first = np.searchsorted(ticks, first_clamped)
+        i_last = np.searchsorted(ticks, last_clamped, side='right') - 1
+
+        valid = (i_first <= i_last) & (i_first >= 0) & (i_last < n_ticks)
         if not valid.all():
             uid_arr = uid_arr[valid]
             pid_arr = pid_arr[valid]
@@ -309,14 +337,17 @@ def get_user_proj_usage(
             gpus_arr = gpus_arr[valid]
             nodes_arr = nodes_arr[valid]
             ts_arr = ts_arr[valid]
-            idx = idx[valid]
-            if idx.size == 0:
+            last_arr = last_arr[valid]
+            i_first = i_first[valid]
+            i_last = i_last[valid]
+            if i_first.size == 0:
                 continue
 
-        dt_per_row = dt_sec[idx]   # seconds; 0 for last-tick rows
-        core_sec = cores_arr * dt_per_row
-        gpu_sec = gpus_arr * dt_per_row
-        node_sec = nodes_arr * dt_per_row
+        dt_total = cum_dt[i_last + 1] - cum_dt[i_first]
+        core_sec = cores_arr * dt_total
+        gpu_sec = gpus_arr * dt_total
+        node_sec = nodes_arr * dt_total
+        tick_per_row = (i_last - i_first + 1).astype(np.int64)
 
         # Composite key for groupby. int64 is large enough by
         # construction (3 × 21 = 63 bits used).
@@ -327,15 +358,16 @@ def get_user_proj_usage(
         core_sums = np.bincount(inverse, weights=core_sec, minlength=n_groups)
         gpu_sums = np.bincount(inverse, weights=gpu_sec, minlength=n_groups)
         node_sums = np.bincount(inverse, weights=node_sec, minlength=n_groups)
-        tick_counts = np.bincount(inverse, minlength=n_groups)
+        tick_counts = np.bincount(inverse, weights=tick_per_row.astype(np.float64),
+                                  minlength=n_groups)
 
-        # Per-group min/max timestamp via reduce-at-indices. Convert to
-        # int64 microseconds for arithmetic, convert back at merge.
-        ts_int = ts_arr.astype('int64')
+        # Per-group min(first_seen) and max(last_seen) via reduce-at-indices.
+        first_int = ts_arr.astype('int64')
+        last_int = last_arr.astype('int64')
         first_us = np.full(n_groups, np.iinfo(np.int64).max, dtype=np.int64)
         last_us = np.full(n_groups, np.iinfo(np.int64).min, dtype=np.int64)
-        np.minimum.at(first_us, inverse, ts_int)
-        np.maximum.at(last_us, inverse, ts_int)
+        np.minimum.at(first_us, inverse, first_int)
+        np.maximum.at(last_us, inverse, last_int)
 
         # Merge into accumulator dict. Iterating over n_groups (not
         # n_rows) keeps Python overhead bounded.

--- a/src/system_status/schemas/status.py
+++ b/src/system_status/schemas/status.py
@@ -125,6 +125,12 @@ class UserProjQueueSchema(BaseSchema):
     timestamp = fields.DateTime(dump_only=True)
     system_name = fields.String(dump_only=True)
 
+    # Collectors don't send `last_seen` — the parent schema's @post_load
+    # seeds it to `timestamp` (degenerate single-tick span) and the ingest
+    # coalescer overwrites it again before flush. Override the auto-derived
+    # required-by-NOT-NULL behavior so the load step accepts the absence.
+    last_seen = fields.DateTime(load_default=None)
+
     # Per-row strings — loaded into property setters, dumped via @property readers.
     username = fields.String(required=True)
     project_code = fields.String(required=True)
@@ -184,6 +190,8 @@ class DerechoStatusSchema(BaseSchema):
         for upq in data.get('user_project_queues', []):
             upq.timestamp = timestamp
             upq.system_name = 'derecho'
+            if upq.last_seen is None:
+                upq.last_seen = timestamp
 
         for fs in data.get('filesystems', []):
             fs.timestamp = timestamp
@@ -250,6 +258,8 @@ class CasperStatusSchema(BaseSchema):
         for upq in data.get('user_project_queues', []):
             upq.timestamp = timestamp
             upq.system_name = 'casper'
+            if upq.last_seen is None:
+                upq.last_seen = timestamp
 
         for fs in data.get('filesystems', []):
             fs.timestamp = timestamp

--- a/src/webapp/api/v1/status.py
+++ b/src/webapp/api/v1/status.py
@@ -171,6 +171,15 @@ def _ingest_system_status(system_name, StatusSchema, id_mappers):
         schema.context = {'session': db.session}
         status_object = schema.load(data)
 
+        # Coalesce per-user/project/queue rows into spans: identical
+        # adjacent ticks UPDATE last_seen instead of inserting duplicates.
+        # Must run before db.session.add() so detached duplicates never
+        # enter the unit of work.
+        from system_status.queries.user_proj_queue_ingest import (
+            coalesce_user_proj_queue_spans,
+        )
+        coalesce_user_proj_queue_spans(db.session, status_object, timestamp)
+
         # Add to session - all nested objects are already linked
         db.session.add(status_object)
         db.session.flush()  # Get IDs for all objects

--- a/tests/api/test_status_endpoints.py
+++ b/tests/api/test_status_endpoints.py
@@ -232,7 +232,48 @@ class TestDerechoPost:
 
         assert status_session.query(UserDef).count() == 1
         assert status_session.query(ProjectCodeDef).count() == 1
+        # Counts changed between posts → new span inserted, not extended.
         assert status_session.query(UserProjQueueStatus).count() == 2
+
+    def test_post_derecho_coalesces_identical_counts(
+            self, api_key_client, status_session):
+        """Two posts with identical (user, project, queue, counts) at
+        consecutive ticks → one span with last_seen bumped, not two rows."""
+        base = {
+            'cpu_nodes_total': 100, 'cpu_nodes_available': 80,
+            'cpu_nodes_down': 5, 'cpu_nodes_reserved': 15,
+            'gpu_nodes_total': 10, 'gpu_nodes_available': 8,
+            'gpu_nodes_down': 0, 'gpu_nodes_reserved': 2,
+            'cpu_cores_total': 12800, 'cpu_cores_allocated': 10000,
+            'cpu_cores_idle': 2800,
+            'gpu_count_total': 80, 'gpu_count_allocated': 60,
+            'gpu_count_idle': 20,
+            'memory_total_gb': 25600.0, 'memory_allocated_gb': 20000.0,
+            'running_jobs': 1, 'pending_jobs': 0, 'active_users': 1,
+        }
+        upq = {'username': 'benkirk', 'project_code': 'SCSG0001',
+               'queue_name': 'main', 'running_jobs': 1, 'cores_allocated': 64}
+
+        first = dict(base, timestamp='2026-05-04T10:00:00',
+                     user_project_queues=[dict(upq)])
+        r1 = api_key_client.post('/api/v1/status/derecho', json=first)
+        assert r1.status_code == 201
+
+        second = dict(base, timestamp='2026-05-04T10:05:00',
+                      user_project_queues=[dict(upq)])
+        r2 = api_key_client.post('/api/v1/status/derecho', json=second)
+        assert r2.status_code == 201
+
+        # Single span survives, last_seen now at the second tick.
+        rows = status_session.query(UserProjQueueStatus).all()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.timestamp.isoformat() == '2026-05-04T10:00:00'
+        assert row.last_seen.isoformat() == '2026-05-04T10:05:00'
+
+        # The second response's id list excludes the extended span — no
+        # new id was minted.
+        assert r2.get_json()['user_project_queue_ids'] == []
 
     def test_post_derecho_missing_required_field(self, api_key_client, status_session):
         """Test posting Derecho status with missing required field."""

--- a/tests/integration/test_user_proj_queue_listener.py
+++ b/tests/integration/test_user_proj_queue_listener.py
@@ -25,8 +25,10 @@ pytestmark = pytest.mark.integration
 
 
 def test_single_row_resolves_all_pending_names(status_session):
+    ts = datetime(2026, 5, 4, 12, 0, 0)
     obj = UserProjQueueStatus(
-        timestamp=datetime(2026, 5, 4, 12, 0, 0),
+        timestamp=ts,
+        last_seen=ts,
         system_name='derecho',
         queue_name='main',
         username='benkirk',
@@ -54,11 +56,11 @@ def test_multiple_rows_share_new_lookup_rows_in_one_flush(status_session):
     ts = datetime(2026, 5, 4, 12, 0, 0)
     rows = [
         UserProjQueueStatus(
-            timestamp=ts, system_name='derecho', queue_name='main',
+            timestamp=ts, last_seen=ts, system_name='derecho', queue_name='main',
             username='benkirk', project_code='SCSG0001', running_jobs=2,
         ),
         UserProjQueueStatus(
-            timestamp=ts, system_name='derecho', queue_name='preempt',
+            timestamp=ts, last_seen=ts, system_name='derecho', queue_name='preempt',
             username='benkirk', project_code='SCSG0001', pending_jobs=1,
         ),
     ]
@@ -81,8 +83,9 @@ def test_existing_lookup_rows_are_reused(status_session):
     status_session.add(ProjectCodeDef(project_code='SCSG0001'))
     status_session.flush()
 
+    ts = datetime(2026, 5, 4, 12, 0, 0)
     obj = UserProjQueueStatus(
-        timestamp=datetime(2026, 5, 4, 12, 0, 0),
+        timestamp=ts, last_seen=ts,
         system_name='derecho', queue_name='main',
         username='benkirk', project_code='SCSG0001', running_jobs=1,
     )
@@ -93,3 +96,158 @@ def test_existing_lookup_rows_are_reused(status_session):
     assert status_session.query(ProjectCodeDef).count() == 1
     assert obj.user.username == 'benkirk'
     assert obj.project.project_code == 'SCSG0001'
+
+
+# ---------------------------------------------------------------------------
+# Span-coalescer tests
+# ---------------------------------------------------------------------------
+
+class _FakeParent:
+    """Plain stand-in for a transient DerechoStatus / CasperStatus parent.
+
+    The coalescer treats ``parent_status.user_project_queues`` as a plain
+    Python list (the parent isn't in the session yet), so we don't need
+    a real parent ORM object for these tests.
+    """
+    def __init__(self, user_project_queues):
+        self.user_project_queues = user_project_queues
+
+
+def _make_child(ts, *, username='benkirk', project_code='SCSG0001',
+                queue_name='main', system_name='derecho', **counts):
+    """Build a transient UserProjQueueStatus mirroring schema-loaded shape."""
+    return UserProjQueueStatus(
+        timestamp=ts,
+        system_name=system_name,
+        queue_name=queue_name,
+        username=username,
+        project_code=project_code,
+        **counts,
+    )
+
+
+def test_second_flush_with_same_counts_extends_last_seen(status_session):
+    from system_status.queries.user_proj_queue_ingest import (
+        coalesce_user_proj_queue_spans,
+    )
+
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    t1 = datetime(2026, 5, 4, 12, 5, 0)
+
+    # First tick: insert a fresh span via the coalescer.
+    parent0 = _FakeParent([
+        _make_child(t0, running_jobs=3, cores_allocated=64),
+    ])
+    counts0 = coalesce_user_proj_queue_spans(status_session, parent0, t0)
+    status_session.add_all(parent0.user_project_queues)
+    status_session.flush()
+
+    assert counts0 == {'inserted': 1, 'extended': 0}
+    assert status_session.query(UserProjQueueStatus).count() == 1
+
+    # Second tick, identical counts → should extend, not insert.
+    parent1 = _FakeParent([
+        _make_child(t1, running_jobs=3, cores_allocated=64),
+    ])
+    counts1 = coalesce_user_proj_queue_spans(status_session, parent1, t1)
+    status_session.add_all(parent1.user_project_queues)
+    status_session.flush()
+
+    assert counts1 == {'inserted': 0, 'extended': 1}
+    assert status_session.query(UserProjQueueStatus).count() == 1
+    row = status_session.query(UserProjQueueStatus).one()
+    assert row.timestamp == t0
+    assert row.last_seen == t1
+
+
+def test_second_flush_with_different_counts_inserts_new_span(status_session):
+    from system_status.queries.user_proj_queue_ingest import (
+        coalesce_user_proj_queue_spans,
+    )
+
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    t1 = datetime(2026, 5, 4, 12, 5, 0)
+
+    parent0 = _FakeParent([
+        _make_child(t0, running_jobs=3, cores_allocated=64),
+    ])
+    coalesce_user_proj_queue_spans(status_session, parent0, t0)
+    status_session.add_all(parent0.user_project_queues)
+    status_session.flush()
+
+    parent1 = _FakeParent([
+        _make_child(t1, running_jobs=4, cores_allocated=128),  # changed
+    ])
+    counts = coalesce_user_proj_queue_spans(status_session, parent1, t1)
+    status_session.add_all(parent1.user_project_queues)
+    status_session.flush()
+
+    assert counts == {'inserted': 1, 'extended': 0}
+    rows = status_session.query(UserProjQueueStatus).order_by(
+        UserProjQueueStatus.timestamp).all()
+    assert len(rows) == 2
+    # Original span closed at its own first_seen (never extended).
+    assert rows[0].timestamp == t0 and rows[0].last_seen == t0
+    # New span starts at t1.
+    assert rows[1].timestamp == t1 and rows[1].last_seen == t1
+
+
+def test_disappearing_tuple_is_left_alone(status_session):
+    """A tuple that vanishes at the next tick keeps its old span as-is."""
+    from system_status.queries.user_proj_queue_ingest import (
+        coalesce_user_proj_queue_spans,
+    )
+
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    t1 = datetime(2026, 5, 4, 12, 5, 0)
+
+    parent0 = _FakeParent([
+        _make_child(t0, username='alice', running_jobs=1, cores_allocated=8),
+        _make_child(t0, username='bob', running_jobs=2, cores_allocated=16),
+    ])
+    coalesce_user_proj_queue_spans(status_session, parent0, t0)
+    status_session.add_all(parent0.user_project_queues)
+    status_session.flush()
+
+    # Bob disappears; alice still here.
+    parent1 = _FakeParent([
+        _make_child(t1, username='alice', running_jobs=1, cores_allocated=8),
+    ])
+    counts = coalesce_user_proj_queue_spans(status_session, parent1, t1)
+    status_session.add_all(parent1.user_project_queues)
+    status_session.flush()
+
+    assert counts == {'inserted': 0, 'extended': 1}
+    rows = {r.user.username: r for r in
+            status_session.query(UserProjQueueStatus).all()}
+    assert rows['alice'].timestamp == t0 and rows['alice'].last_seen == t1
+    # Bob's row still has last_seen == t0 (untouched).
+    assert rows['bob'].timestamp == t0 and rows['bob'].last_seen == t0
+
+
+def test_long_gap_starts_fresh_span(status_session):
+    """If T_new - prev_ts > MAX_SPAN_GAP, even matching counts insert."""
+    from datetime import timedelta as _td
+    from system_status.queries.user_proj_queue_ingest import (
+        coalesce_user_proj_queue_spans, MAX_SPAN_GAP,
+    )
+
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    t_after_gap = t0 + MAX_SPAN_GAP + _td(minutes=1)
+
+    parent0 = _FakeParent([
+        _make_child(t0, running_jobs=1, cores_allocated=8),
+    ])
+    coalesce_user_proj_queue_spans(status_session, parent0, t0)
+    status_session.add_all(parent0.user_project_queues)
+    status_session.flush()
+
+    parent1 = _FakeParent([
+        _make_child(t_after_gap, running_jobs=1, cores_allocated=8),
+    ])
+    counts = coalesce_user_proj_queue_spans(status_session, parent1, t_after_gap)
+    status_session.add_all(parent1.user_project_queues)
+    status_session.flush()
+
+    assert counts == {'inserted': 1, 'extended': 0}
+    assert status_session.query(UserProjQueueStatus).count() == 2

--- a/tests/unit/test_user_proj_queues_timeseries.py
+++ b/tests/unit/test_user_proj_queues_timeseries.py
@@ -29,9 +29,18 @@ def _make_derecho(session, ts):
     return parent
 
 
-def _make_upq(session, parent, *, queue, user, project, cores):
+def _make_upq(session, parent, *, queue, user, project, cores, last_seen=None):
+    """Build a span-shaped UserProjQueueStatus.
+
+    By default the span is degenerate (last_seen == parent.timestamp), so
+    legacy per-tick fixtures still work. Pass ``last_seen=<datetime>`` to
+    build a span covering multiple parent ticks.
+    """
+    if last_seen is None:
+        last_seen = parent.timestamp
     row = UserProjQueueStatus(
         timestamp=parent.timestamp,
+        last_seen=last_seen,
         system_name='derecho', queue_name=queue,
         username=user, project_code=project,
         running_jobs=1 if cores else 0,
@@ -91,6 +100,49 @@ def test_rank_by_peak_vs_current_diverge(status_session):
 
     assert peak_named == ['spiker'], peak['series']
     assert current_named == ['steady'], current['series']
+
+
+def test_chart_explodes_span_across_ticks(status_session):
+    """A single span covering three parent ticks contributes its constant
+    value at every tick."""
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    t1 = t0 + timedelta(minutes=5)
+    t2 = t0 + timedelta(minutes=10)
+    _make_derecho(status_session, t0)
+    _make_derecho(status_session, t1)
+    p2 = _make_derecho(status_session, t2)
+
+    # Single span [t0..t2] anchored at p0 timestamp, last_seen at t2.
+    row = UserProjQueueStatus(
+        timestamp=t0, last_seen=t2,
+        system_name='derecho', queue_name='main',
+        username='steady', project_code='SCSG0001',
+        running_jobs=1, cores_allocated=100,
+    )
+    # Parent FK on first_seen tick — match the production convention.
+    row.derecho_status = status_session.query(DerechoStatus).filter_by(
+        timestamp=t0).one()
+    status_session.add(row)
+    # Touch p2 to silence flake about unused parent.
+    assert p2.timestamp == t2
+    status_session.flush()
+
+    out = get_user_proj_timeseries(
+        status_session,
+        system='derecho',
+        queue_name='main',
+        start_date=t0,
+        end_date=t2,
+        state='running',
+        metric='cores',
+        group_by='user',
+        top_n=5,
+        rank_by='peak',
+    )
+
+    named = {s['label']: s['values'] for s in out['series']
+             if s['label'] != 'Others'}
+    assert named == {'steady': [100, 100, 100]}
 
 
 def test_rank_by_invalid_raises(status_session):

--- a/tests/unit/test_user_proj_usage.py
+++ b/tests/unit/test_user_proj_usage.py
@@ -60,10 +60,18 @@ def _make_casper(session, ts):
 
 
 def _make_upq(session, parent, *, system, queue, user, project,
-              cores=0, gpus=0, nodes=0):
-    """Add a UserProjQueueStatus row attached to its system parent."""
+              cores=0, gpus=0, nodes=0, last_seen=None):
+    """Add a UserProjQueueStatus row (span) anchored at parent.timestamp.
+
+    By default the span is degenerate (last_seen == parent.timestamp), so
+    legacy per-tick fixtures still work. Pass ``last_seen=<datetime>`` to
+    build a multi-tick span.
+    """
+    if last_seen is None:
+        last_seen = parent.timestamp
     row = UserProjQueueStatus(
         timestamp=parent.timestamp,
+        last_seen=last_seen,
         system_name=system, queue_name=queue,
         username=user, project_code=project,
         running_jobs=1 if cores or gpus or nodes else 0,
@@ -525,6 +533,63 @@ def test_multi_day_window_with_small_chunks(status_session):
     # 8 intervals of 8 hours each (last tick contributes 0)
     expected = 100 * 8 * 8 * 3600.0 / 3600.0   # cores × intervals × seconds / 3600
     assert r['core_hours'] == pytest.approx(expected)
+
+
+def test_span_integrates_correctly_across_ticks(status_session):
+    """A single span [t0..t2] at constant cores=120 covers three parent
+    ticks. Equivalent to three degenerate per-tick rows for integration
+    purposes. Confirms cum_dt prefix-sum integration is correct.
+    """
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    t1 = t0 + timedelta(minutes=5)
+    t2 = t0 + timedelta(minutes=10)
+    t3 = t0 + timedelta(minutes=15)
+    p0 = _make_derecho(status_session, t0)
+    _make_derecho(status_session, t1)
+    _make_derecho(status_session, t2)
+    _make_derecho(status_session, t3)
+
+    # One span covering t0..t2 (last_seen=t2). Three tick intervals
+    # contribute: t0→t1 (300s), t1→t2 (300s), t2→t3 (300s) = 900s.
+    _make_upq(status_session, p0, system='derecho', queue='main',
+              user='benkirk', project='SCSG0001',
+              cores=120, last_seen=t2)
+    status_session.flush()
+
+    out = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=t0, end_date=t3,
+    )
+    assert len(out) == 1
+    r = out[0]
+    assert r['core_hours'] == pytest.approx(120 * 900.0 / 3600.0)
+    assert r['tick_count'] == 3
+    assert r['first_seen'] == t0
+    assert r['last_seen'] == t2
+
+
+def test_overlapping_window_clips_span(status_session):
+    """A span [t0..t10] queried over a sub-window [t3..t6] should only
+    integrate the in-window ticks."""
+    t0 = datetime(2026, 5, 4, 12, 0, 0)
+    ticks = [t0 + timedelta(minutes=5 * i) for i in range(11)]
+    parents = [_make_derecho(status_session, t) for t in ticks]
+    # One long span across all ticks with cores=60.
+    _make_upq(status_session, parents[0], system='derecho', queue='main',
+              user='benkirk', project='SCSG0001',
+              cores=60, last_seen=ticks[-1])
+    status_session.flush()
+
+    # Window [t3..t6]: ticks at t3,t4,t5,t6. Three intervals of 300s
+    # contribute (t6→t7 isn't included because end_date is t6).
+    out = get_user_proj_usage(
+        status_session, system='derecho',
+        start_date=ticks[3], end_date=ticks[6],
+    )
+    assert len(out) == 1
+    # Three 5-min intervals fully inside the window.
+    expected = 60 * (3 * 300.0) / 3600.0
+    assert out[0]['core_hours'] == pytest.approx(expected)
 
 
 def test_results_sorted_by_core_hours_desc(status_session):


### PR DESCRIPTION
## Summary

Reinterpret each row in `user_proj_queue_status` as a **span of unchanging counts** for one `(user, project, queue)` tuple, instead of one row per 5-minute snapshot.

The existing `timestamp` column is now semantically *first_seen*; a new `last_seen` column records the most recent tick at which the same counts were observed. Ingest coalesces identical adjacent ticks by `UPDATE`ing `last_seen` instead of inserting a duplicate row. New rows are only inserted when (a) counts change for a `(user, project, queue)` already present, or (b) a new `(user, project, queue)` appears that wasn't there at the previous tick. When a tuple disappears from the queue, its row is left alone — `last_seen` is never bumped again, so the row becomes a self-contained record of one steady-state run.

## Motivation

For stable workloads, the per-tick schema generates massive duplication: one user running the same job set produces an identical row every 5 minutes. The table was on track to dwarf every other status table. Span coalescing collapses long steady-state runs into single rows. Year-scale `get_user_proj_usage` queries that previously scanned ~36M rows now scan however many spans the workload churn produced — typically a 100× reduction.

## Decisions (locked in before implementation)

| Choice | Decision |
|---|---|
| Column naming | **Keep `timestamp` as-is**, reinterpret as first_seen. Add `last_seen` only. No rename. |
| Existing data | **Wipe** in the migration. No backfill, no compaction. Fresh start. |
| Parent FK | Set on INSERT to the parent at first_seen, **never rewritten** on UPDATE. CASCADE delete is preserved — pruning old parent snapshots prunes spans that started in that window. |

## Schema change

`migrations/system_status/versions/0004_user_proj_queue_last_seen.py`:
- `DELETE FROM user_proj_queue_status` — wipe legacy per-tick rows.
- `ALTER TABLE … ADD COLUMN last_seen DATETIME` (nullable), `UPDATE … SET last_seen = timestamp` (defensive, in case any rows survived the wipe), `ALTER COLUMN last_seen … NOT NULL`, `CREATE INDEX ix_user_proj_queue_status_last_seen`. All via `batch_alter_table` for cross-dialect safety (MySQL / PostgreSQL / SQLite).
- `downgrade()` drops the index then the column.
- The `(timestamp, user_id, project_code_id, queue_id)` UniqueConstraint is unchanged — each new span has a distinct first_seen.

## Ingest path

New module `src/system_status/queries/user_proj_queue_ingest.py` exports `coalesce_user_proj_queue_spans(session, parent_status, T_new)`. Algorithm:

1. Resolve `_pending_*` strings on every child via the new public helper `resolve_user_proj_queue_pending` (extracted from the existing `before_flush` listener so the same code path is reused synchronously).
2. `prev_ts = SELECT MAX(last_seen) WHERE system_id = X`.
3. **Span-gap guard**: if `T_new - prev_ts > MAX_SPAN_GAP` (20 minutes, ≈ 3 missed ticks), skip coalescing — counters that resume after a collector outage start fresh spans even if they happen to match.
4. Active-set query: `SELECT … WHERE system_id = X AND last_seen = prev_ts`. Indexed by `(user_id, project_code_id, queue_id)` → row id + 10-tuple of metric columns.
5. For each incoming child:
   - If a row exists in active_set with all 10 metrics matching: load it, `existing.last_seen = T_new`, then `parent.user_project_queues.remove(child)`.
   - Else: `child.last_seen = T_new` and leave attached for INSERT.

The coalescer mutates `parent.user_project_queues` *before* `db.session.add(parent)`, so detached duplicates never enter the unit of work — `cascade='all, delete-orphan'` machinery never fires for them. This avoids any SQLAlchemy state surgery.

`_ingest_system_status` (`src/webapp/api/v1/status.py`) calls the coalescer between `schema.load(data)` and `db.session.add(status_object)`.

The `before_flush` listener in `system_status/queries/lookups.py` is refactored to delegate `UserProjQueueStatus` resolution to `resolve_user_proj_queue_pending`, keeping the listener and the coalescer on a single code path. Behavior for INSERT-only paths is unchanged.

## Read paths

**`get_latest_user_proj_queue_snapshot`** — the active set at the most recent observation:
- Orders/filters by `last_seen` instead of `timestamp`.
- Returns `first_seen`, `last_seen`, and a `timestamp` template alias (= `last_seen`) so existing template bindings still render the most recent observation moment.

**`get_user_proj_usage`** — span integration is O(1) per row:
- Adds `cum_dt = np.concatenate([[0.0], np.cumsum(dt_sec)])` (cumulative-sum prefix over the parent tick timeline).
- Each span integrates as `value × (cum_dt[i_last + 1] - cum_dt[i_first])` where `i_first/i_last` come from `np.searchsorted` on clamped span endpoints.
- Chunk overlap predicate is now `last_seen >= t_lo AND timestamp <= t_hi`; spans crossing chunk boundaries are deduplicated via a `seen_ids` set across chunks.
- Per-group `last_seen` accumulator uses `last_arr` (max of span last_seen), not `ts_arr`.
- Result shape is unchanged: same `core_hours / gpu_hours / node_hours / first_seen / last_seen / tick_count` per `(user, project, queue)`.

**`get_user_proj_timeseries`** — span explosion onto the parent tick grid:
- Fetches the canonical tick timeline from `DerechoStatus` / `CasperStatus` for `[start_date, end_date]`.
- Fetches overlapping spans with `last_seen >= start AND timestamp <= end`, no DB-side `GROUP BY`.
- For each span, `arr[i_first:i_last+1] += value` into a per-label numpy array of length `n_ticks`.
- Rank (peak / current), top-N, and the "Others" bucket are computed against the per-label arrays.
- The series shape returned to `generate_user_proj_stacked_area` is unchanged.

## Tests

| File | Added |
|---|---|
| `tests/integration/test_user_proj_queue_listener.py` | `test_second_flush_with_same_counts_extends_last_seen`, `test_second_flush_with_different_counts_inserts_new_span`, `test_disappearing_tuple_is_left_alone`, `test_long_gap_starts_fresh_span`. |
| `tests/api/test_status_endpoints.py` | `test_post_derecho_coalesces_identical_counts` (single span, `last_seen` advanced, response id list excludes extended spans). Existing test for *different* counts stays at 2 rows (correct under spans). |
| `tests/unit/test_user_proj_queues_timeseries.py` | `test_chart_explodes_span_across_ticks` — single span over 3 ticks → series `[V, V, V]`. |
| `tests/unit/test_user_proj_usage.py` | `test_span_integrates_correctly_across_ticks`, `test_overlapping_window_clips_span`. |

Existing test fixtures default `last_seen=parent.timestamp` (degenerate single-tick spans) so legacy assertions still hold without rewrite.

## Verification

I could not run the full project `pytest` in the development sandbox — the `mysql-test` Docker container isn't reachable, and the conftest hard-blocks any DB target outside the allowlist. Instead I verified end-to-end with standalone SQLite scripts that exercise the new code paths:

- **Span coalescer**: extend on identical counts, insert on changed counts, gap-breaks-span at `> MAX_SPAN_GAP`, untouched-row when tuple disappears.
- **Latest snapshot**: orders by `last_seen`, returns first/last_seen + template alias.
- **Usage integration**: a single span `[t0..t2]` at `cores=120` produces the same core-hours as three degenerate per-tick rows, both equal to `120 × 900 / 3600`.
- **Window clipping**: span `[t0..t10]` queried over `[t3..t6]` integrates only the in-window ticks.
- **Chart explosion**: single span over 3 ticks renders constant `[V, V, V]`.
- **Listener regression**: the `before_flush` listener still resolves `_pending_*` on direct INSERTs (existing tests' behavior preserved).
- **Legacy scenarios**: two-tick left-step / sparse-tuple appears-disappears-reappears / variable-dt / chunk-size-invariant / rank-by-peak-vs-current all still pass on the new code with `last_seen=parent.timestamp` fixtures.
- **Migration roundtrip**: `alembic upgrade head` from `0001 → 0004` adds `last_seen NOT NULL` + index; `alembic downgrade 0003_user_proj_queue_status` removes them cleanly.

The full project `pytest` suite should be run with the `mysql-test` container up before merge to confirm against the live test DB.

## Files changed

```
migrations/system_status/versions/0004_user_proj_queue_last_seen.py  (new)
src/system_status/models/user_proj_queues.py                          (+last_seen, span docstring)
src/system_status/queries/lookups.py                                  (+resolve_user_proj_queue_pending; listener refactor)
src/system_status/queries/user_proj_queue_ingest.py                   (new — coalesce_user_proj_queue_spans)
src/system_status/queries/user_proj_queues.py                         (latest_snapshot + timeseries → spans)
src/system_status/queries/user_proj_usage.py                          (cum_dt-based O(1) span integration)
src/webapp/api/v1/status.py                                           (call coalescer before db.session.add)
tests/api/test_status_endpoints.py                                    (+coalesce test)
tests/integration/test_user_proj_queue_listener.py                    (+4 coalescer tests)
tests/unit/test_user_proj_queues_timeseries.py                        (+span-explode test)
tests/unit/test_user_proj_usage.py                                    (+span-integrate, +window-clip)
docs/plans/USER_PROJ_QUEUE_LAST_SEEN.md                               (new — design doc)
```

## Test plan

- [ ] `docker compose --profile test up -d mysql-test`
- [ ] `source etc/config_env.sh && pytest` (full suite, ~65 s)
- [ ] `alembic -c migrations/system_status/alembic.ini upgrade head` against staging DB; verify `last_seen DATETIME NOT NULL` + `ix_user_proj_queue_status_last_seen`.
- [ ] POST identical `user_project_queues` payload at two timestamps via `/api/v1/status/derecho`; verify `SELECT timestamp, last_seen, COUNT(*) FROM user_proj_queue_status` yields 1 row with `last_seen > timestamp`.
- [ ] POST a payload with one user's `cores_allocated` changed; verify 2 rows (the original closed at the previous tick + a new span starting at T_new).
- [ ] Open the queue drill-down dashboard for a queue with span data; verify the latest-snapshot table renders and the chart shows constant plateaus across spans.
- [ ] Spot-check `get_user_proj_usage` over a known window; core-hours should match `value × span_duration` to within rounding.

Plan: `docs/plans/USER_PROJ_QUEUE_LAST_SEEN.md`