### PR TITLE
Status & Allocations UX polish: queue chart for all users, Pace selector, count-bearing legends

### DIFF
--- a/src/webapp/dashboards/allocations/blueprint.py
+++ b/src/webapp/dashboards/allocations/blueprint.py
@@ -447,23 +447,12 @@ def index():
                      if chartable else '<div class="text-center text-muted small py-3">No usage data yet</div>',
         }
 
-    # Build pace charts — reuse per_project_usage (no extra DB calls).
-    # One chart per resource (top-level) and one per (resource, facility).
-    resource_pace_charts = {}
-    facility_pace_charts = {}
-    for rn, facilities in grouped_data.items():
-        rn_rows = [r for r in per_project_usage if r.get('resource') == rn]
-        resource_pace_charts[rn] = (
-            generate_pace_chart_matplotlib(rn_rows, active_at, resource_name=rn)
-            if rn_rows else None
-        )
-        facility_pace_charts[rn] = {}
-        for fn in facilities.keys():
-            fn_rows = [r for r in rn_rows if r.get('facility') == fn]
-            facility_pace_charts[rn][fn] = (
-                generate_pace_chart_matplotlib(fn_rows, active_at, resource_name=rn)
-                if fn_rows else None
-            )
+    # Pace charts render via HTMX (one loader per resource in the template
+    # below — see `dashboards/allocations/partials/pace_chart.html` and
+    # the `htmx_pace_chart` route). Deferring the SVG render here lets the
+    # selector buttons live inside the swap target, and lets
+    # `nav-view-persistence.js` replay the persisted `sort_by` on initial
+    # load without us having to know it up front.
 
     # Defaults for the shared audit filter (Transactions + Adjustments tabs).
     # Default window is last 30 days; each tab's filter form is pre-filled with these.
@@ -475,8 +464,6 @@ def index():
         grouped_data=grouped_data,
         resource_overviews=resource_overviews,
         resource_usage_overviews=resource_usage_overviews,
-        resource_pace_charts=resource_pace_charts,
-        facility_pace_charts=facility_pace_charts,
         allocation_type_charts=allocation_type_charts,
         allocation_type_usage_charts=allocation_type_usage_charts,
         type_annualized_rates=type_annualized_rates,
@@ -488,6 +475,85 @@ def index():
         audit_end_date=audit_end_date.strftime('%Y-%m-%d'),
         allowed_facility_names=allowed_facility_names,
         selected_facilities=effective_facilities,
+    )
+
+
+_VALID_PACE_SORT_BY = ('size', 'past', 'future')
+
+
+@bp.route('/htmx/pace-chart/<resource_name>')
+@login_required
+@require_permission_any_facility(Permission.VIEW_PROJECTS)
+def htmx_pace_chart(resource_name):
+    """Render the per-resource Pace chart with selector buttons.
+
+    Used by both the initial HTMX `load` trigger on the dashboard
+    (one loader per resource) and subsequent selector-button clicks.
+    Selector state (``sort_by``) is persisted client-side by
+    ``nav-view-persistence.js`` keyed on ``data-chart-persist-id``.
+    """
+    sort_by = request.args.get('sort_by', 'size')
+    if sort_by not in _VALID_PACE_SORT_BY:
+        sort_by = 'size'
+
+    # Same active_at semantics as index(), but with no flash on bad
+    # input — an HTMX swap into a chart pane is the wrong place for a
+    # top-level alert. Silent fallback to today matches what callers
+    # would see if they hit the route with no arg at all.
+    active_at_str = request.args.get('active_at')
+    today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    if active_at_str:
+        try:
+            active_at = datetime.strptime(active_at_str, '%Y-%m-%d')
+        except ValueError:
+            active_at = today
+    else:
+        active_at = today
+
+    # Facility-scope clamp — identical shape to index() so a WNA-scoped
+    # user gets WNA-only rows on the chart even though the URL omits
+    # ?facilities=. Unscoped users get None → no filter.
+    allowed = user_facility_scope(current_user, Permission.VIEW_PROJECTS)
+    requested_facilities = request.args.getlist('facilities')
+    selected_facilities = apply_facility_scope(
+        requested_facilities, Permission.VIEW_PROJECTS,
+        default=(sorted(allowed) if allowed is not None else None),
+    )
+
+    per_project_usage = cached_allocation_usage(
+        session=db.session,
+        resource_name=[resource_name],
+        facility_name=None,
+        allocation_type=None,
+        projcode=None,
+        active_only=True,
+        active_at=active_at,
+        root_only=True,
+    )
+    per_project_usage = filter_rows_by_facility(per_project_usage, selected_facilities)
+
+    chart_svg = generate_pace_chart_matplotlib(
+        per_project_usage, active_at, resource_name=resource_name,
+        sort_by=sort_by,
+    )
+
+    # Sanitize resource_name into a stable HTML id — matches the
+    # `data-resource="{{ resource_name|replace(' ', '_') }}"` convention
+    # used in dashboard.html for the panel toggle. When the request
+    # narrows to a single facility (the per-facility Pace card in the
+    # allocation-type tab), include the facility in the id so its
+    # persisted sort_by doesn't collide with the resource-wide chart.
+    chart_dom_id = 'pace-chart-' + resource_name.replace(' ', '_')
+    if len(requested_facilities) == 1:
+        chart_dom_id += '-' + requested_facilities[0].replace(' ', '_')
+
+    return render_template(
+        'dashboards/allocations/partials/pace_chart.html',
+        resource_name=resource_name,
+        chart_svg=chart_svg,
+        sort_by=sort_by,
+        active_at=active_at.strftime('%Y-%m-%d'),
+        chart_dom_id=chart_dom_id,
     )
 
 

--- a/src/webapp/dashboards/allocations/blueprint.py
+++ b/src/webapp/dashboards/allocations/blueprint.py
@@ -547,6 +547,20 @@ def htmx_pace_chart(resource_name):
     if len(requested_facilities) == 1:
         chart_dom_id += '-' + requested_facilities[0].replace(' ', '_')
 
+    # Selector-button URLs MUST carry the original facility scope
+    # forward — otherwise clicking Sort-by on a per-facility card would
+    # drop ?facilities= and the next request would un-narrow back to
+    # the whole resource (leaking cross-facility projects into a
+    # facility-scoped chart). Pass the verbatim requested list so a
+    # facility-scoped reload follows the same path as the initial
+    # loader in dashboard.html.
+    selector_kwargs = {
+        'sort_by': sort_by,
+        'active_at': active_at.strftime('%Y-%m-%d'),
+    }
+    if requested_facilities:
+        selector_kwargs['facilities'] = requested_facilities
+
     return render_template(
         'dashboards/allocations/partials/pace_chart.html',
         resource_name=resource_name,
@@ -554,6 +568,7 @@ def htmx_pace_chart(resource_name):
         sort_by=sort_by,
         active_at=active_at.strftime('%Y-%m-%d'),
         chart_dom_id=chart_dom_id,
+        selector_kwargs=selector_kwargs,
     )
 
 

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -185,8 +185,8 @@ def generate_disk_usage_stacked_area(timeseries) -> str:
 # 1c. User / project queue load stacked-area chart (status drill-down)
 # ---------------------------------------------------------------------------
 
-def _user_proj_stacked_area_cache_key(timeseries, link_kind=None):
-    return _content_hash([_content_hash(timeseries), link_kind or ''])
+def _user_proj_stacked_area_cache_key(timeseries, link_kind=None, rank_by='current'):
+    return _content_hash([_content_hash(timeseries), link_kind or '', rank_by])
 
 
 # `link_kind` ('user' | 'project' | None) controls whether legend
@@ -195,7 +195,8 @@ def _user_proj_stacked_area_cache_key(timeseries, link_kind=None):
 # compatible).
 @caching.chart_cached(name='user_proj_stacked_area', maxsize=128,
                       key_fn=_user_proj_stacked_area_cache_key)
-def generate_user_proj_stacked_area(timeseries, link_kind=None) -> str:
+def generate_user_proj_stacked_area(timeseries, link_kind=None,
+                                    rank_by: str = 'current') -> str:
     """Render a stacked-area chart of per-user or per-project queue load.
 
     Args:
@@ -211,6 +212,12 @@ def generate_user_proj_stacked_area(timeseries, link_kind=None) -> str:
             modal), or None for no links. The 'Others' bucket is never
             linked. svg-legend-links.js intercepts the click and shows
             the modal — set_url() only emits the ``<a>`` wrapper.
+        rank_by: which value to quote in parens after each legend
+            entry. Mirrors the route's `rank_by` selector so the legend
+            number tracks the active sort:
+              - ``'current'`` → ``values[-1]`` (latest tick).
+              - ``'peak'``    → ``max(values)`` over the window.
+            Unknown values fall back to ``'current'``.
 
     Y-axis is integer counts (jobs). X-axis is datetime-formatted at
     5-minute snapshot grain. Legend on the right, reversed so it reads
@@ -250,7 +257,22 @@ def generate_user_proj_stacked_area(timeseries, link_kind=None) -> str:
     import matplotlib.patches as mpatches
     rev_series = list(reversed(series))
     rev_colors = list(reversed(colors))
-    handles = [mpatches.Patch(color=c, label=s['label'])
+
+    # Per-series legend value mirrors the active rank_by selector so
+    # the number in parens matches whichever sort the user chose:
+    # 'current' = right-edge value, 'peak' = max over window.
+    # 'Others' uses the same formula on its aggregate values array.
+    if rank_by == 'peak':
+        def _legend_value(s):
+            vs = s.get('values') or []
+            return max(vs) if vs else 0
+    else:
+        def _legend_value(s):
+            vs = s.get('values') or []
+            return vs[-1] if vs else 0
+
+    handles = [mpatches.Patch(color=c,
+                              label=f"{s['label']} ({fmt.number(_legend_value(s))})")
                for s, c in zip(rev_series, rev_colors)]
     n_named = sum(1 for s in series if s['label'] != 'Others')
     legend_title = (
@@ -262,8 +284,8 @@ def generate_user_proj_stacked_area(timeseries, link_kind=None) -> str:
         loc='center left',
         bbox_to_anchor=(1.01, 0.5),
         frameon=False,
-        fontsize=9,
-        title_fontsize=10,
+        fontsize=11,
+        title_fontsize=12,
     )
 
     if link_kind in ('user', 'project'):

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -611,23 +611,27 @@ def _pace_key_fields(allocations: List[Dict]) -> list:
     ]
 
 
-def _pace_cache_key(allocations, active_at, window_days=180, top_n=15, resource_name=''):
+def _pace_cache_key(allocations, active_at, window_days=180, top_n=15,
+                    resource_name='', sort_by='size'):
     return _content_hash([_pace_key_fields(allocations), active_at.isoformat(),
-                          int(window_days), int(top_n), resource_name])
+                          int(window_days), int(top_n), resource_name, sort_by])
 
 
-# One entry per (resource, window_days, top_n) combination across concurrent viewers.
-@caching.chart_cached(name='pace_chart', maxsize=64, key_fn=_pace_cache_key)
+# One entry per (resource, window_days, top_n, sort_by) combination across
+# concurrent viewers. maxsize sized for ~30 resources × 3 sort_by × small
+# facility-scope fanout — well under 10 MB of cached SVG per process.
+@caching.chart_cached(name='pace_chart', maxsize=192, key_fn=_pace_cache_key)
 def generate_pace_chart_matplotlib(
     allocations: List[Dict],
     active_at: datetime,
     window_days: int = 180,
     top_n: int = 15,
     resource_name: str = '',
+    sort_by: str = 'size',
 ) -> str:
     """Stacked-area pace chart: one band per allocation, past-rate | future-rate
-    step at ``active_at``. Top-N projcodes by total allocated get distinct
-    colors; the rest share an "Other" color.
+    step at ``active_at``. Top-N projcodes get distinct colors; the rest share
+    an "Other" color.
 
     Args:
         allocations: per-allocation rows (from ``cached_allocation_usage``)
@@ -637,6 +641,13 @@ def generate_pace_chart_matplotlib(
         window_days: half-window on each side of ``active_at`` (default 180).
         top_n: projects with their own color + legend entry (default 15).
         resource_name: used only for cache key disambiguation.
+        sort_by: ranking metric for the top-N selection. One of:
+            - ``'size'``  — total allocated amount (default; legacy behaviour).
+            - ``'past'``  — past burn rate (used / past_days), per year.
+            - ``'future'`` — future required rate ((amount - used) / future_days),
+              per year — the "risk" signal: steeper future slope = more burn
+              required to complete.
+            The legend number on each band reflects this same metric.
 
     Returns:
         SVG string ready for template rendering.
@@ -651,17 +662,49 @@ def generate_pace_chart_matplotlib(
     if not bands:
         return '<div class="text-center text-muted">No allocations in the ±{}d window</div>'.format(window_days)
 
-    # Rank projcodes by total_amount across bands in scope
-    proj_totals: Dict[str, float] = {}
-    for pc, amount, _ in bands:
-        proj_totals[pc] = proj_totals.get(pc, 0.0) + amount
+    # today_idx on the full daily grid — needed both for ranking by
+    # past/future rate (band heights at the step) and for the later
+    # RLE step preservation.
+    n_days = len(days)
+    today_idx = (active_at - days[0]).days
+
+    # Per-project aggregations for the three rank metrics:
+    #   - size:   sum of total_amount   (legacy default — biggest pool)
+    #   - past:   sum of past-rate band heights at today-1 (visible
+    #             past slope, per day)
+    #   - future: sum of future-rate band heights at today   (visible
+    #             future slope = required burn-to-completion)
+    # Past/future rates are piecewise-constant inside each band (set by
+    # _pace_bands), so the value at the single sample point IS the band's
+    # rate over its active region. Summing across bands handles projects
+    # with multiple allocations on the same resource.
+    proj_size:   Dict[str, float] = {}
+    proj_past:   Dict[str, float] = {}
+    proj_future: Dict[str, float] = {}
+    past_sample_idx = max(today_idx - 1, 0)
+    future_sample_idx = min(today_idx, n_days - 1)
+    for pc, amount, rates in bands:
+        proj_size[pc]   = proj_size.get(pc, 0.0) + amount
+        proj_past[pc]   = proj_past.get(pc, 0.0) + float(rates[past_sample_idx])
+        proj_future[pc] = proj_future.get(pc, 0.0) + float(rates[future_sample_idx])
+
+    # Pick ranking + legend-display metric in lockstep so the legend
+    # number always reflects the active sort. Unknown sort_by falls
+    # back to 'size' (parallels the route's input validation).
+    if sort_by == 'past':
+        rank_metric = proj_past
+    elif sort_by == 'future':
+        rank_metric = proj_future
+    else:
+        sort_by = 'size'
+        rank_metric = proj_size
     top_projs = [pc for pc, _ in sorted(
-        proj_totals.items(), key=lambda kv: kv[1], reverse=True
+        rank_metric.items(), key=lambda kv: kv[1], reverse=True
     )[:top_n]]
     palette = plt.cm.tab10.colors if len(top_projs) <= 10 else plt.cm.tab20.colors
     color_map = {pc: palette[i] for i, pc in enumerate(top_projs)}
 
-    n_other_projs = len(proj_totals) - len(top_projs)
+    n_other_projs = len(rank_metric) - len(top_projs)
     other_label = f'Other ({n_other_projs} project{"s" if n_other_projs != 1 else ""})'
 
     # Collapse per-allocation bands into one band per color group BEFORE
@@ -670,16 +713,23 @@ def generate_pace_chart_matplotlib(
     # ~20 MB SVG. Stacking is associative, so element-wise summing the rate
     # arrays within each color group is mathematically identical and
     # visually identical (the group shares one color anyway).
-    n_days = len(days)
     OTHER_KEY = '__other__'
     group_keys = list(top_projs) + [OTHER_KEY]
     group_rates: Dict[str, np.ndarray] = {k: np.zeros(n_days) for k in group_keys}
-    group_totals: Dict[str, float] = {k: 0.0 for k in group_keys}
+    # Per-group running total of the active sort metric — used by the
+    # "Other" legend entry to summarize the long tail in the same units
+    # as the per-project entries.
+    group_sort_totals: Dict[str, float] = {k: 0.0 for k in group_keys}
 
     for pc, amount, rates in bands:
         key = pc if pc in color_map else OTHER_KEY
-        group_totals[key] += amount
         group_rates[key] += rates
+        if sort_by == 'past':
+            group_sort_totals[key] += float(rates[past_sample_idx])
+        elif sort_by == 'future':
+            group_sort_totals[key] += float(rates[future_sample_idx])
+        else:
+            group_sort_totals[key] += amount
 
     # Stack order: top-N (ranked) first, Other capping the top. Drop empty
     # groups so stackplot doesn't emit a zero-area path.
@@ -704,7 +754,6 @@ def generate_pace_chart_matplotlib(
     diffs = np.any(np.diff(band_rates_full, axis=1) != 0, axis=0)  # (n_days-1,)
     trans = np.flatnonzero(diffs) + 1  # day i where rate[i-1] != rate[i]
 
-    today_idx = (active_at - days[0]).days
     keep = {0, n_days - 1, today_idx}
     if today_idx - 1 >= 0:
         keep.add(today_idx - 1)
@@ -739,15 +788,23 @@ def generate_pace_chart_matplotlib(
     ax.text(active_at, ymax, ' today', color=_PACE_TODAY_LINE_COLOR,
             fontsize=8, va='top', ha='left')
 
-    # Deduplicated legend: one handle per top-N projcode + one Other
+    # Deduplicated legend: one handle per top-N projcode + one Other.
+    # Number shown next to each project tracks the active sort_by — see
+    # rank_metric above. For rate sorts, scale per-day → per-year so the
+    # number matches the axis units, and tag with "/yr" to keep that
+    # explicit.
     import matplotlib.patches as mpatches
+    if sort_by == 'size':
+        def _fmt_value(v): return fmt.number(v)
+    else:
+        def _fmt_value(v): return f'{fmt.number(v * _PACE_RATE_SCALE)}/yr'
     handles = [mpatches.Patch(color=color_map[pc],
-                              label=f'{pc} ({fmt.number(proj_totals[pc])})')
+                              label=f'{pc} ({_fmt_value(rank_metric[pc])})')
                for pc in top_projs]
     if n_other_projs > 0:
         handles.append(mpatches.Patch(
             color=_PACE_OTHER_COLOR,
-            label=f'{other_label} ({fmt.number(group_totals[OTHER_KEY])})'
+            label=f'{other_label} ({_fmt_value(group_sort_totals[OTHER_KEY])})'
         ))
     leg = ax.legend(handles=handles, loc='center left', bbox_to_anchor=(1.0, 0.5),
                     fontsize=9, frameon=False)

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -81,7 +81,7 @@ def generate_usage_timeseries_matplotlib(daily_charges) -> str:
     dates = list(dates)
     comp = list(comp)
 
-    fig, ax = plt.subplots(figsize=(12, 4))
+    fig, ax = plt.subplots(figsize=(18, 5))
     ax.bar(dates, comp, width=1, lw=2)
     ax.set_ylabel('Charges')
     ax.yaxis.set_major_formatter(fmt.mpl_number_formatter())
@@ -102,8 +102,17 @@ _BYTES_PER_TIB = 1024 ** 4
 _BYTES_PER_PIB = 1024 ** 5
 
 
-@caching.chart_cached(name='disk_usage_stacked_area', maxsize=128)
-def generate_disk_usage_stacked_area(timeseries) -> str:
+def _disk_usage_stacked_area_cache_key(timeseries, link_kind=None):
+    return _content_hash([_content_hash(timeseries), link_kind or ''])
+
+
+# `link_kind` ('user' | None) controls whether legend usernames are
+# wrapped in <a xlink:href> SVG anchors targeting the user-details
+# modal. None = no links (default, backward compatible). Mirrors the
+# user_proj_stacked_area chart's pattern.
+@caching.chart_cached(name='disk_usage_stacked_area', maxsize=128,
+                      key_fn=_disk_usage_stacked_area_cache_key)
+def generate_disk_usage_stacked_area(timeseries, link_kind=None) -> str:
     """Render a stacked-area chart of disk bytes vs time.
 
     Args:
@@ -111,6 +120,11 @@ def generate_disk_usage_stacked_area(timeseries) -> str:
                     returns: ``{'dates': [...], 'series': [{'username','values'}, ...]}``.
                     The last series is conventionally ``'Others'`` (rendered last
                     so it sits on top of the named-user stack).
+        link_kind: ``'user'`` to make legend usernames clickable to
+            ``/admin/user/<username>`` (user-details modal), or ``None``
+            for no links. The 'Others' bucket is never linked.
+            ``svg-legend-links.js`` intercepts the click and shows the
+            modal — ``set_url()`` only emits the ``<a>`` wrapper.
 
     Y-axis is auto-scaled to TiB or PiB based on the peak stacked total
     (>= 1 PiB → PiB, else TiB). X-axis is date-formatted. Legend on the
@@ -136,12 +150,11 @@ def generate_disk_usage_stacked_area(timeseries) -> str:
         scale = _BYTES_PER_TIB
         unit_label = 'TiB'
 
-    fig, ax = plt.subplots(figsize=(12, 4.5))
+    fig, ax = plt.subplots(figsize=(18, 5))
     scaled_series = [
         [v / scale for v in s['values']]
         for s in series
     ]
-    labels = [s['username'] for s in series]
     # Others (always first per get_disk_usage_timeseries_by_user) gets a
     # neutral grey so it doesn't compete with the named-user palette.
     # Named users use matplotlib's default tab10 cycle.
@@ -154,25 +167,36 @@ def generate_disk_usage_stacked_area(timeseries) -> str:
         else:
             colors.append(cmap(cycle_idx % 10))
             cycle_idx += 1
-    ax.stackplot(dates, *scaled_series, labels=labels, colors=colors, alpha=0.85)
+    ax.stackplot(dates, *scaled_series, colors=colors, alpha=0.85)
     ax.set_ylabel(f'Disk usage ({unit_label})')
     ax.grid(True, alpha=0.3)
-    # Reverse the legend so it reads top-to-bottom in the same order as
-    # the visual stack (largest user on top).
-    handles, lbls = ax.get_legend_handles_labels()
-    # Legend title — show the actual count of named user series
-    # (excluding the synthetic 'Others' bucket) so it self-describes
-    # the top-N selection regardless of caller's `top_n` argument.
-    n_named = sum(1 for s in series if s['username'] != 'Others')
-    ax.legend(
-        handles[::-1], lbls[::-1],
-        title=f'Top {n_named} Users',
+
+    # Build the legend explicitly with reversed-order Patch handles so
+    # each handle/text artist is addressable by index for set_url() —
+    # mirrors the user_proj_stacked_area / pace chart pattern. Reverses
+    # the visual stack so legend reads top-to-bottom in the same order.
+    import matplotlib.patches as mpatches
+    rev_series = list(reversed(series))
+    rev_colors = list(reversed(colors))
+    handles = [mpatches.Patch(color=c, label=s['username'])
+               for s, c in zip(rev_series, rev_colors)]
+    leg = ax.legend(
+        handles=handles,
         loc='center left',
         bbox_to_anchor=(1.01, 0.5),
         frameon=False,
-        fontsize=9,
-        title_fontsize=10,
+        fontsize=11,
+        title_fontsize=12,
     )
+
+    if link_kind == 'user':
+        for s, patch, text in zip(rev_series, leg.get_patches(), leg.get_texts()):
+            if s['username'] == 'Others':
+                continue
+            url = _user_modal_url(s['username'])
+            patch.set_url(url)
+            text.set_url(url)
+
     fig.autofmt_xdate()
 
     svg_io = StringIO()
@@ -233,7 +257,7 @@ def generate_user_proj_stacked_area(timeseries, link_kind=None,
     metric_label = timeseries.get('metric_label', 'Jobs')
     group_by_label = timeseries.get('group_by_label', '')
 
-    fig, ax = plt.subplots(figsize=(18, 5.0))
+    fig, ax = plt.subplots(figsize=(18, 5))
     values_matrix = [s['values'] for s in series]
     # tab20 (20 distinct colours) so Top-15+Others has no colour reuse;
     # disk_usage uses tab10 because its default top_n is 10.
@@ -280,7 +304,7 @@ def generate_user_proj_stacked_area(timeseries, link_kind=None,
     )
     leg = ax.legend(
         handles=handles,
-        title=legend_title,
+        #title=legend_title,
         loc='center left',
         bbox_to_anchor=(1.01, 0.5),
         frameon=False,
@@ -332,7 +356,7 @@ def generate_nodetype_history_matplotlib(history_data: List[Dict]) -> str:
     utilization = [d.get('utilization_percent') for d in history_data]
     memory_utilization = [d.get('memory_utilization_percent') for d in history_data]
 
-    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(13, 8), sharex=True)
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(18, 10), sharex=True)
 
     ax1.stackplot(timestamps, nodes_down, nodes_allocated, nodes_available,
                   labels=['Down', 'Fully Allocated', 'Resources Available'],

--- a/src/webapp/dashboards/status/blueprint.py
+++ b/src/webapp/dashboards/status/blueprint.py
@@ -397,7 +397,9 @@ def _render_user_proj_chart(*, system, queue_name, endpoint_name, endpoint_kwarg
         link_kind = 'user' if group_by == 'user' else 'project'
     else:
         link_kind = None
-    chart_svg = generate_user_proj_stacked_area(timeseries, link_kind=link_kind)
+    chart_svg = generate_user_proj_stacked_area(
+        timeseries, link_kind=link_kind, rank_by=rank_by,
+    )
 
     # Two of these cards render on the landing page (one per system
     # tab), so the chart wrapper div needs a scope-unique id —

--- a/src/webapp/dashboards/status/blueprint.py
+++ b/src/webapp/dashboards/status/blueprint.py
@@ -82,15 +82,6 @@ def index():
     # Get upcoming reservations
     reservations = status_queries.get_upcoming_reservations(session)
 
-    # Gate the new system-wide user/project chart cards (rendered in
-    # derecho.html / casper.html) on VIEW_SYSTEM_STATUS_USER_INFO.
-    # Same flag pattern as the queue_history drill-down view.
-    from webapp.utils.rbac import has_permission
-    can_view_user_info = (
-        current_user.is_authenticated
-        and has_permission(current_user, Permission.VIEW_SYSTEM_STATUS_USER_INFO)
-    )
-
     # Default the landing-page chart window to 7 days when no
     # ?hours= override is in the URL — matches the drill-down default
     # so the time_range_picker on each chart card reads sensibly on
@@ -116,7 +107,6 @@ def index():
         google_calendar_embed_url=current_app.config.get('GOOGLE_CALENDAR_EMBED_URL', ''),
         now=datetime.now(),
         selected_hours=selected_hours,
-        can_view_user_info=can_view_user_info,
         chart_hours=chart_hours,
     )
 
@@ -394,9 +384,20 @@ def _render_user_proj_chart(*, system, queue_name, endpoint_name, endpoint_kwarg
 
     # group_by=user → username legend → user modal; group_by=project →
     # projcode legend → project modal. svg-legend-links.js dispatches.
-    chart_svg = generate_user_proj_stacked_area(
-        timeseries, link_kind='user' if group_by == 'user' else 'project',
+    # Only operators (VIEW_SYSTEM_STATUS_USER_INFO) get clickable legend
+    # entries — the user/project detail modal endpoints have their own
+    # RBAC and would 403 a non-operator's click. Plain-text labels for
+    # everyone else keeps the chart universally readable.
+    from webapp.utils.rbac import has_permission
+    can_link_legend = (
+        current_user.is_authenticated
+        and has_permission(current_user, Permission.VIEW_SYSTEM_STATUS_USER_INFO)
     )
+    if can_link_legend:
+        link_kind = 'user' if group_by == 'user' else 'project'
+    else:
+        link_kind = None
+    chart_svg = generate_user_proj_stacked_area(timeseries, link_kind=link_kind)
 
     # Two of these cards render on the landing page (one per system
     # tab), so the chart wrapper div needs a scope-unique id —
@@ -429,11 +430,13 @@ def _render_user_proj_chart(*, system, queue_name, endpoint_name, endpoint_kwarg
 
 @bp.route('/htmx/queue-history/<system>/<queue_name>/user-proj-chart')
 @login_required
-@require_permission(Permission.VIEW_SYSTEM_STATUS_USER_INFO)
 def htmx_user_proj_chart(system, queue_name):
     """Render the user/project chart scoped to one queue.
 
-    Used by selector buttons in the queue-history drill-down.
+    Used by selector buttons in the queue-history drill-down. Visible
+    to any logged-in user; legend click-through is gated separately
+    in ``_render_user_proj_chart`` on
+    ``Permission.VIEW_SYSTEM_STATUS_USER_INFO``.
     """
     return _render_user_proj_chart(
         system=system,
@@ -445,14 +448,15 @@ def htmx_user_proj_chart(system, queue_name):
 
 @bp.route('/htmx/system/<system>/user-proj-chart')
 @login_required
-@require_permission(Permission.VIEW_SYSTEM_STATUS_USER_INFO)
 def htmx_user_proj_chart_system(system):
     """Render the user/project chart summed across all queues for ``system``.
 
     Used by the chart card on the system landing page (Derecho /
     Casper tabs of the status dashboard). Same selector behaviour as
     the per-queue endpoint, but the aggregator filters on system_id
-    rather than queue_id.
+    rather than queue_id. Visible to any logged-in user; legend
+    click-through is gated separately in ``_render_user_proj_chart``
+    on ``Permission.VIEW_SYSTEM_STATUS_USER_INFO``.
     """
     return _render_user_proj_chart(
         system=system,

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -723,7 +723,14 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
         } for r in breakdown]
 
     percent_used = (used_tib / allocated_tib * 100) if allocated_tib > 0 else 0.0
-    usage_chart = generate_disk_usage_stacked_area(timeseries)
+    # Operators (VIEW_USERS) get clickable legend usernames that pop the
+    # user-details modal; non-operators get plain text since the modal
+    # endpoint would 403 on click. Same gating shape as the queue-load
+    # chart in status/blueprint.py:_render_user_proj_chart.
+    disk_link_kind = (
+        'user' if has_permission(current_user, Permission.VIEW_USERS) else None
+    )
+    usage_chart = generate_disk_usage_stacked_area(timeseries, link_kind=disk_link_kind)
 
     return render_template(
         'dashboards/user/resource_details_disk.html',

--- a/src/webapp/templates/dashboards/allocations/dashboard.html
+++ b/src/webapp/templates/dashboards/allocations/dashboard.html
@@ -109,9 +109,13 @@
         </div>
         <div class="tab-pane fade" id="pie-pace" role="tabpanel">
             <div id="facilityPaceContainer" class="chart-container pace-chart">
+                {# Each resource gets its own HTMX-loaded pace chart with
+                   a "Sort by" selector inside the swap target. The
+                   data-chart-persist-id on the loader matches the one
+                   the partial emits, so nav-view-persistence.js replays
+                   the saved sort_by on the initial request. #}
                 {% for resource_name, _ in grouped_data.items()|sort %}
-                {% set pace_chart = resource_pace_charts.get(resource_name) %}
-                {% if pace_chart %}
+                {% set _pace_id = 'pace-chart-' ~ (resource_name|replace(' ', '_')) %}
                 <div class="facility-pace-panel"
                      data-resource="{{ resource_name|replace(' ', '_') }}"
                      style="display:none;">
@@ -119,9 +123,19 @@
                         Allocation Pace
                         <span class="text-muted fw-normal">— {{ resource_name }}</span>
                     </h6>
-                    {{ pace_chart|safe }}
+                    <div hx-get="{{ url_for('allocations_dashboard.htmx_pace_chart',
+                                            resource_name=resource_name,
+                                            active_at=active_at,
+                                            sort_by='size') }}"
+                         hx-trigger="load"
+                         hx-swap="innerHTML"
+                         data-chart-persist-id="{{ _pace_id }}"
+                         data-chart-persist-keys="sort_by">
+                        <div class="text-center text-muted py-5">
+                            <i class="fas fa-spinner fa-spin"></i> Loading chart…
+                        </div>
+                    </div>
                 </div>
-                {% endif %}
                 {% endfor %}
             </div>
         </div>
@@ -326,8 +340,10 @@
                     <!-- Type Pie Chart Row (if >1 type and chart available) -->
                     {% set type_chart = allocation_type_charts.get(resource_name, {}).get(facility_name) %}
                     {% set usage_type_chart = allocation_type_usage_charts.get(resource_name, {}).get(facility_name) %}
-                    {% set pace_chart = facility_pace_charts.get(resource_name, {}).get(facility_name) %}
-                    {% if types|length > 1 and (type_chart or usage_type_chart or pace_chart) %}
+                    {# Pace card is HTMX-loaded — show it whenever there are
+                       allocations in the facility; the endpoint handles the
+                       empty-window case itself. #}
+                    {% if types|length > 1 and (type_chart or usage_type_chart) %}
                     <tr class="alloc-type-chart-row" data-fac-id="{{ fac_id }}">
                         <td colspan="7" class="p-0">
                             <div class="p-2 pb-0">
@@ -380,17 +396,31 @@
                                         {% endif %}
                                     </div>
                                     <div class="tab-pane fade" id="type-pace-{{ fac_id }}">
-                                        {% if pace_chart %}
+                                        {# Per-facility Pace card — same HTMX endpoint as the
+                                           resource-wide chart, narrowed by ?facilities=. The
+                                           dom_id is suffixed with the facility so its
+                                           persisted sort_by is independent of the
+                                           resource-wide chart's. #}
+                                        {% set _facet_pace_id = 'pace-chart-' ~ (resource_name|replace(' ', '_')) ~ '-' ~ (facility_name|replace(' ', '_')) %}
                                         <div class="chart-container pace-chart p-3">
                                             <h6 class="text-center fw-bold mb-2">
                                                 Allocation Pace
                                                 <span class="text-muted fw-normal">— {{ resource_name }} — {{ facility_name }}</span>
                                             </h6>
-                                            {{ pace_chart|safe }}
+                                            <div hx-get="{{ url_for('allocations_dashboard.htmx_pace_chart',
+                                                                    resource_name=resource_name,
+                                                                    facilities=facility_name,
+                                                                    active_at=active_at,
+                                                                    sort_by='size') }}"
+                                                 hx-trigger="load"
+                                                 hx-swap="innerHTML"
+                                                 data-chart-persist-id="{{ _facet_pace_id }}"
+                                                 data-chart-persist-keys="sort_by">
+                                                <div class="text-center text-muted small py-3">
+                                                    <i class="fas fa-spinner fa-spin"></i> Loading chart…
+                                                </div>
+                                            </div>
                                         </div>
-                                        {% else %}
-                                        <div class="text-center text-muted small py-3">No allocations in window</div>
-                                        {% endif %}
                                     </div>
                                 </div>
                             </div>

--- a/src/webapp/templates/dashboards/allocations/partials/pace_chart.html
+++ b/src/webapp/templates/dashboards/allocations/partials/pace_chart.html
@@ -1,0 +1,47 @@
+{# Pace allocation chart fragment with a "Sort by" selector.
+
+   The btn-group lives INSIDE the swap target so each click re-renders
+   both the buttons (with the new active state) and the chart in a
+   single HTMX swap. No JS state to keep in sync.
+
+   Used by `allocations_dashboard.htmx_pace_chart` for both the
+   initial HTMX load (one loader per resource in dashboard.html) and
+   for selector-button clicks. The wrapper's `data-chart-persist-id`
+   / `data-chart-persist-keys` cooperate with
+   `nav-view-persistence.js` to replay the selected `sort_by` on the
+   next page load. #}
+{% set _selector_kwargs = {'sort_by': sort_by, 'active_at': active_at} %}
+<div id="{{ chart_dom_id }}"
+     data-chart-persist-id="{{ chart_dom_id }}"
+     data-chart-persist-keys="sort_by">
+    <div class="d-flex flex-wrap gap-3 mb-3 align-items-center">
+        <div>
+            <label class="form-label small text-muted mb-1 me-2">Sort by</label>
+            <div class="btn-group btn-group-sm" role="group" aria-label="Sort by">
+                {# 'size': total allocated amount per project.
+                   'past': past burn rate (used / past_days), per year.
+                   'future': future required rate ((amount - used) / future_days),
+                            per year — steeper = more risk to complete. #}
+                {% for opt_val, opt_lbl in [
+                    ('size',   'Allocation Size'),
+                    ('past',   'Past Burn'),
+                    ('future', 'Future Risk'),
+                ] %}
+                <button type="button"
+                        class="btn btn-{% if sort_by == opt_val %}primary{% else %}outline-primary{% endif %}"
+                        hx-get="{{ url_for('allocations_dashboard.htmx_pace_chart',
+                                           resource_name=resource_name,
+                                           **dict(_selector_kwargs, sort_by=opt_val)) }}"
+                        hx-target="#{{ chart_dom_id }}"
+                        hx-swap="outerHTML">
+                    {{ opt_lbl }}
+                </button>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    <div class="chart-container">
+        {{ chart_svg | safe }}
+    </div>
+</div>

--- a/src/webapp/templates/dashboards/allocations/partials/pace_chart.html
+++ b/src/webapp/templates/dashboards/allocations/partials/pace_chart.html
@@ -9,8 +9,14 @@
    for selector-button clicks. The wrapper's `data-chart-persist-id`
    / `data-chart-persist-keys` cooperate with
    `nav-view-persistence.js` to replay the selected `sort_by` on the
-   next page load. #}
-{% set _selector_kwargs = {'sort_by': sort_by, 'active_at': active_at} %}
+   next page load.
+
+   `selector_kwargs` is built by the route from the request's own
+   args — including any `facilities=` scope. Threading it through
+   here is what keeps per-facility cards facility-scoped across
+   selector-button clicks (otherwise the partial would emit URLs
+   without `facilities=` and the next request would silently widen
+   back to the whole resource). #}
 <div id="{{ chart_dom_id }}"
      data-chart-persist-id="{{ chart_dom_id }}"
      data-chart-persist-keys="sort_by">
@@ -31,7 +37,7 @@
                         class="btn btn-{% if sort_by == opt_val %}primary{% else %}outline-primary{% endif %}"
                         hx-get="{{ url_for('allocations_dashboard.htmx_pace_chart',
                                            resource_name=resource_name,
-                                           **dict(_selector_kwargs, sort_by=opt_val)) }}"
+                                           **dict(selector_kwargs, sort_by=opt_val)) }}"
                         hx-target="#{{ chart_dom_id }}"
                         hx-swap="outerHTML">
                     {{ opt_lbl }}

--- a/src/webapp/templates/dashboards/status/casper.html
+++ b/src/webapp/templates/dashboards/status/casper.html
@@ -102,10 +102,11 @@
         {{ queues.queue_table(casper_queues, show_gpus=true, system='casper', hours=selected_hours) }}
         {% endif %}
 
-        {% if can_view_user_info %}
+        {# User/project load chart, summed across all queues for casper.
+           Visible to any logged-in user; legend click-through is gated
+           on VIEW_SYSTEM_STATUS_USER_INFO inside the chart route. #}
         {% set _chart_system = 'casper' %}
         {% include 'dashboards/status/partials/system_user_proj_chart_card.html' %}
-        {% endif %}
 
         <!-- Reservations -->
         {% set casper_reservations = reservations|selectattr('system_name', 'equalto', 'casper')|list %}

--- a/src/webapp/templates/dashboards/status/derecho.html
+++ b/src/webapp/templates/dashboards/status/derecho.html
@@ -65,16 +65,17 @@
         {{ queues.queue_table(derecho_queues, show_gpus=true, system='derecho', hours=selected_hours) }}
         {% endif %}
 
-        {% if can_view_user_info %}
         {# User/project load chart, summed across all queues for derecho.
            Time-range picker lives inline in this card's header — clicking
            a preset reloads the landing page with ?hours=N (the existing
            passthrough); the casper card's picker emits the same param
-           so toggling either updates both. Tab persistence keeps the
-           operator on this tab across reloads. #}
+           so toggling either updates both. Tab persistence keeps any
+           viewer on this tab across reloads. Visible to any logged-in
+           user; legend click-through into per-user/per-project detail
+           modals is gated on VIEW_SYSTEM_STATUS_USER_INFO inside the
+           chart-rendering route. #}
         {% set _chart_system = 'derecho' %}
         {% include 'dashboards/status/partials/system_user_proj_chart_card.html' %}
-        {% endif %}
 
         <!-- Reservations -->
         {% set derecho_reservations = reservations|selectattr('system_name', 'equalto', 'derecho')|list %}

--- a/src/webapp/templates/dashboards/status/partials/system_user_proj_chart_card.html
+++ b/src/webapp/templates/dashboards/status/partials/system_user_proj_chart_card.html
@@ -1,15 +1,18 @@
 {# System-wide user/project load chart card.
 
    Included by derecho.html and casper.html (one card per system tab).
-   The including template sets `_chart_system` to 'derecho' / 'casper'.
-   `chart_hours` and `can_view_user_info` come from the index() route
-   context — the includer is already inside an `if can_view_user_info`
-   guard, so this partial doesn't re-check.
+   The including template sets `_chart_system` to 'derecho' / 'casper';
+   `chart_hours` comes from the index() route context.
+
+   Visible to any logged-in user. Legend click-through into per-user /
+   per-project detail modals is gated on VIEW_SYSTEM_STATUS_USER_INFO
+   inside the chart-rendering route — non-operators get plain-text
+   legend labels rather than clickable anchors.
 
    Picker is a 7-button strip in the card header. Each button is a
    plain link back to the landing page with ?hours=N. The existing
    `selected_hours` passthrough on index() picks that up; tab
-   persistence (nav-view-persistence.js) keeps the operator on this
+   persistence (nav-view-persistence.js) keeps the viewer on this
    tab across reloads. The chart endpoint is HTMX-fetched on card
    load with the resolved `chart_hours` so initial render matches the
    active picker preset. #}

--- a/src/webapp/templates/dashboards/status/queue_history.html
+++ b/src/webapp/templates/dashboards/status/queue_history.html
@@ -96,8 +96,10 @@
     </div>
 </div>
 
-{% if can_view_user_info %}
-<!-- Per-user / per-project queue load over time (top-N + Others) -->
+<!-- Per-user / per-project queue load over time (top-N + Others).
+     Visible to any logged-in user; legend click-through into per-user
+     / per-project detail modals is gated on VIEW_SYSTEM_STATUS_USER_INFO
+     inside the chart-rendering route (link_kind=None for non-operators). -->
 <div class="card mb-4">
     <div class="card-header">
         <h5 class="mb-0">
@@ -129,7 +131,11 @@
     </div>
 </div>
 
-<!-- Per-user / per-project rollup (latest snapshot) -->
+{% if can_view_user_info %}
+<!-- Per-user / per-project rollup (latest snapshot). Restricted to
+     operators with VIEW_SYSTEM_STATUS_USER_INFO — the table exposes
+     more detail than the chart legend (per-user/per-project counts,
+     timestamps) and stays an operator view. -->
 <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
         <h5 class="mb-0">

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -323,4 +323,11 @@
         </div>
     </div>
 </div>
+
+{# Modal targeted by clickable username legend entries on the disk
+   usage chart (see svg-legend-links.js). Only operators with
+   VIEW_USERS see the legend wrapped as anchors; the modal container
+   needs to be in the DOM either way for HTMX swap to work when
+   present. #}
+{% include 'dashboards/user/fragments/user_details_modal.html' %}
 {% endblock %}

--- a/src/webapp/utils/rbac.py
+++ b/src/webapp/utils/rbac.py
@@ -102,7 +102,14 @@ class Permission(Enum):
     MANAGE_ROLES = "manage_roles"
     IMPERSONATE_USERS = "impersonate_users"  # Actually log in as another user
     VIEW_SYSTEM_STATUS = "view_system_status"
-    VIEW_SYSTEM_STATUS_USER_INFO = "view_system_status_user_info" # view per-user/project queue history info on system status dashboard
+    # The user/project queue-load chart itself is visible to any logged-in
+    # user on the status dashboard. This permission narrows to two
+    # operator-only enrichments on top of that:
+    #   1. The per-user / per-project rollup table on the queue-history
+    #      drill-down page (richer than the chart legend).
+    #   2. Click-through from the chart legend into the per-user and
+    #      per-project detail modals (link_kind in _render_user_proj_chart).
+    VIEW_SYSTEM_STATUS_USER_INFO = "view_system_status_user_info"
     MANAGE_SYSTEM_STATUS = "manage_system_status"  # Update system status data (collector/API)
     EDIT_SYSTEM_STATUS = "edit_system_status"  # GUI create/edit/delete outages
     VIEW_SYSTEM_CONFIG = "view_system_config"  # Read-only Configuration tab on Admin dashboard


### PR DESCRIPTION
## Summary

Four related UX changes to the Status and Allocations dashboards, all
about getting *more* informative charts in front of *more* users:

- Queue-load chart on `/status/` is now visible to **any logged-in
  user**, not just operators.
- Pace allocation charts on `/allocations/` gain a **"Sort by:"
  selector** (Allocation Size · Past Burn · Future Risk), mirroring
  the queue chart's selector pattern.
- Both stacked-area charts (queue load and Pace) now render
  **per-series counts in the legend** that track the active sort
  metric.
- Bugfix: per-facility Pace card was leaking cross-facility projects
  into its legend after the first Sort-by click — facility scope is
  now preserved across selector cycles.

## Commits

- `de72d97` — Expose queue-load stacked-area chart to any logged-in user
- `594705f` — Pace chart: add "Sort by" selector (size / past burn / future risk)
- `95376d3` — Queue-load chart: per-series counts in legend + larger fonts
- `2eacebd` — Pace chart: preserve facility scope across Sort-by clicks

---

## 1. Queue-load chart for any logged-in user

The per-system user/project queue-load stacked-area chart on
\`/status/\` and \`/status/queue-history/<sys>/<q>\` was hidden
behind \`Permission.VIEW_SYSTEM_STATUS_USER_INFO\` — only csg/nusd/hsg
operators saw it. The data is aggregate qstat-style snapshot counts
(running/pending/held jobs by user or projcode); appropriate for any
logged-in user at NCAR norms.

**Changes**

- \`status/blueprint.py\`: drop \`@require_permission\` from both
  HTMX chart endpoints; keep \`@login_required\`. In
  \`_render_user_proj_chart\`, \`link_kind\` is now resolved from
  the same permission — operators still get clickable legends that
  pop user/project detail modals; non-operators get plain text so
  they don't trip the modal endpoints' own RBAC with silent 403s.
- Templates: drop the \`{% if can_view_user_info %}\` wrapper
  around the chart cards in \`derecho.html\` / \`casper.html\`;
  on \`queue_history.html\` narrow the gate to the rollup *table*
  only (richer detail than the chart — stays operator-only).
- \`rbac.py\`: narrow the \`VIEW_SYSTEM_STATUS_USER_INFO\` doc
  comment to its new meaning (rollup table + legend click-through).

## 2. Pace chart: "Sort by" selector

Pace charts previously ranked top-N projects by \`total_amount\`
only. The three relevant per-project quantities — overall size, past
burn rate, and required future burn rate ("risk") — are all
computable from the existing \`cached_allocation_usage\` rows, but
only one was exposed.

**Changes**

- \`charts.py\`: \`generate_pace_chart_matplotlib\` takes
  \`sort_by ∈ {'size', 'past', 'future'}\`. Past/future per-project
  rates sampled from each band's pre-computed \`rates[today_idx-1]\`
  / \`rates[today_idx]\` (the visible step heights — no new
  aggregation, no extra query). Legend numbers track the active
  sort: \`(1.2M)\` for size, \`(45K/yr)\` for rates (scaled by
  \`_PACE_RATE_SCALE\` to match the y-axis). \`_pace_cache_key\`
  includes \`sort_by\`; \`@chart_cached\` \`maxsize\` bumped
  64 → 192 to accommodate the 3× working set.
- \`allocations/blueprint.py\`: new \`htmx_pace_chart\` endpoint at
  \`/allocations/htmx/pace-chart/<resource_name>\`. Reuses
  \`cached_allocation_usage\` + \`apply_facility_scope\` +
  \`filter_rows_by_facility\` exactly like \`index()\`, so
  facility-scoped users still see only their data. Dropped the
  pre-render loop + \`resource_pace_charts\` / \`facility_pace_charts\`
  kwargs from \`index()\`.
- \`partials/pace_chart.html\` (new): selector buttons inside the
  swap target; mirrors \`status/partials/user_proj_chart.html\`.
- \`dashboard.html\`: both Pace render sites (resource-wide pane and
  per-facility expandable row) now use HTMX loaders with
  \`hx-trigger="load"\` and persistence markers
  (\`data-chart-persist-id\` / \`data-chart-persist-keys="sort_by"\`)
  so \`nav-view-persistence.js\` replays the saved sort_by on the
  next page load.

## 3. Per-series counts in queue-load legend

Mirror the Pace chart's legend treatment on the queue-load chart.
Each entry now reads \`<username|projcode> (1,234)\`, with the count
tracking the active "Sort by" selector:

- Sort by Current → \`values[-1]\` (value at the rightmost tick).
- Sort by Peak    → \`max(values)\` over the window.

Formatting goes through \`fmt.number\` — exact integers with commas
under 100K, compact (\`68.6M\`) above. "Others" gets the same suffix
since its \`values\` array already carries the aggregate.

**Changes**

- \`charts.py\`: \`generate_user_proj_stacked_area\` takes new
  \`rank_by: str = 'current'\` (validated, falls back to
  \`'current'\`). Cache key includes \`rank_by\` so the two modes
  cache independently. Legend fonts bumped 9→11 / 10→12 for
  readability.
- \`status/blueprint.py\`: \`_render_user_proj_chart\` passes the
  already-validated \`rank_by\` through to the chart call.

## 4. Bugfix: per-facility Pace scope leak

After the Pace selector landed, the per-facility Pace card under
each expanded facility row (e.g. NCAR) leaked cross-facility
projects into the legend after the first Sort-by click. Observed
e.g. UMIC0111 (a UNIV project) showing in the NCAR card after
toggling to Past Burn.

**Root cause**: \`pace_chart.html\` built its selector-button URLs
from a local \`_selector_kwargs = {'sort_by', 'active_at'}\` dict
that didn't carry \`facilities\`. The initial HTMX load from
dashboard.html hit the endpoint with \`?facilities=NCAR&…\`
correctly, but every selector click reissued the request with no
facility scope. For an unscoped admin,
\`apply_facility_scope([], default=None)\` returns \`None\`,
\`filter_rows_by_facility(rows, None)\` returns rows unchanged — so
the chart un-narrowed back to the whole resource.

**Fix**: \`htmx_pace_chart\` now builds \`selector_kwargs\` from the
actual request args (including any \`requested_facilities\`) and
passes it to the template. The partial uses that dict for every
button's \`url_for(...)\`, so the facility scope follows the chain
across clicks.

---

## Test plan

- [x] **Queue chart access**: log in as a regular user (no
      operator group). Visit \`/status/\` — Derecho & Casper chart
      cards render; legend entries are plain text. Visit
      \`/status/queue-history/derecho/main\` — chart visible;
      rollup table hidden.
- [x] **Queue chart access (operator)**: log in as csg/nusd/hsg.
      Same routes — chart visible AND legend entries are clickable
      anchors that pop user/project detail modals. Rollup table
      visible on queue-history.
- [x] **Queue chart legend counts**: with Sort by Current, legend
      reads e.g. \`alice (1,234)\`. Toggle Peak → numbers grow.
      Switch Metric (Jobs/Cores/GPUs) → numbers re-scale; under
      100K shows commas, above compact.
- [x] **Pace selector**: load \`/allocations/\` Pie/Pace tab.
      Spinner → chart with three buttons. Click "Past Burn" →
      reorder + \`/yr\` suffix. Click "Future Risk" → reorder.
      Reload page → comes back with the chosen sort pre-selected
      (DevTools network: initial HTMX request includes
      \`sort_by=<persisted>\`).
- [x] **Pace per-facility scope**: expand any facility row (e.g.
      NCAR) → Pace tab. Chart shows only NCAR projects. Click
      "Past Burn", "Future Risk" — legend stays NCAR-only. UMIC0111
      should NOT appear.
- [x] **Pace persistence isolation**: confirm the resource-wide
      chart and per-facility chart have independent persisted sort
      states (different \`data-chart-persist-id\` values).
- [x] **Facility-scoped user**: log in as \`sureshm\` (WNA scope).
      \`/allocations/\` shows WNA-only on both chart variants;
      selector clicks preserve scope.
- [x] **Tests**: \`source etc/config_env.sh && pytest\` — full
      suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)