### PR TITLE
Accounting: COMP_CHARGING_EPOCH + --epoch override; --notify progress bar

### DIFF
--- a/src/cli/accounting/commands.py
+++ b/src/cli/accounting/commands.py
@@ -37,6 +37,7 @@ from sam.plugins import HPC_USAGE_QUERIES
 from sam.summaries.disk_summaries import (
     DISK_CHARGING_TIB_EPOCH, mark_disk_snapshot_current, tib_years,
 )
+from sam.summaries.comp_summaries import COMP_CHARGING_EPOCH
 
 
 # Reconcile tolerance: allocations within this fraction of quota truth are
@@ -222,6 +223,8 @@ class AccountingAdminCommand(BaseCommand):
         reconcile_quota_gap: bool = False,
         gap_tolerance_bytes: int = 1024 ** 3,    # 1 GiB
         gap_tolerance_frac: float = 0.01,        # 1%
+        # --comp/--disk epoch override (default: hard-coded constant per mode)
+        epoch: Optional[date] = None,
     ) -> int:
         if reconcile_quotas is not None:
             return self._run_reconcile_quotas(
@@ -241,6 +244,7 @@ class AccountingAdminCommand(BaseCommand):
                 create_queues=create_queues,
                 chunk_size=chunk_size,
                 include_deleted_accounts=include_deleted_accounts,
+                epoch=epoch,
             )
         if disk:
             return self._run_disk(
@@ -258,6 +262,7 @@ class AccountingAdminCommand(BaseCommand):
                 skip_errors=skip_errors,
                 chunk_size=chunk_size,
                 include_deleted_accounts=include_deleted_accounts,
+                epoch=epoch,
             )
         if archive:
             self.console.print("[yellow]--archive: not yet implemented[/yellow]")
@@ -270,6 +275,22 @@ class AccountingAdminCommand(BaseCommand):
 
     def _run_comp(self, machine: str, start_date: date, end_date: date, **kwargs) -> int:
         """Query hpc-usage-queries and post results to comp_charge_summary."""
+        # --- 0. Cutover-epoch enforcement (refuse pre-epoch writes) ----
+        # Check before plugin load so operators see a clean epoch error
+        # even when hpc-usage-queries isn't installed.
+        effective_epoch = kwargs.get("epoch") or COMP_CHARGING_EPOCH
+        if start_date < effective_epoch:
+            self.console.print(
+                f"Error: start_date {start_date} is before the "
+                f"COMP_CHARGING_EPOCH ({effective_epoch}). "
+                "This command only writes post-epoch comp_charge_summary "
+                "rows; pre-epoch historical data is not rewritten. "
+                "Pass --epoch YYYY-MM-DD to override for a known-safe "
+                "backfill.",
+                style="bold red",
+            )
+            return 2
+
         # --- 1. Load job_history plugin (graceful error if not installed) ---
         mod = self.require_plugin(HPC_USAGE_QUERIES)
         if mod is None:
@@ -417,6 +438,7 @@ class AccountingAdminCommand(BaseCommand):
         skip_errors: bool,
         chunk_size: int,
         include_deleted_accounts: bool,
+        epoch: Optional[date] = None,
     ) -> int:
         """Import a per-user-per-project disk usage snapshot into ``disk_charge_summary``.
 
@@ -512,12 +534,19 @@ class AccountingAdminCommand(BaseCommand):
                 return 2
 
         # ---- 4. Cutover-epoch enforcement ------------------------------
-        if snap_date < DISK_CHARGING_TIB_EPOCH:
+        # `epoch` (from --epoch) overrides the hard-coded constant for
+        # known-safe backfills; the error message still names
+        # DISK_CHARGING_TIB_EPOCH so operators know which constant the
+        # override is replacing.
+        effective_epoch = epoch or DISK_CHARGING_TIB_EPOCH
+        if snap_date < effective_epoch:
             self.console.print(
                 f"Error: snapshot date {snap_date} is before the "
-                f"DISK_CHARGING_TIB_EPOCH ({DISK_CHARGING_TIB_EPOCH}). "
+                f"DISK_CHARGING_TIB_EPOCH ({effective_epoch}). "
                 "This command only writes post-epoch TiB-year rows; "
-                "pre-epoch legacy rows are not rewritten.",
+                "pre-epoch legacy rows are not rewritten. "
+                "Pass --epoch YYYY-MM-DD to override for a known-safe "
+                "backfill.",
                 style="bold red",
             )
             return 2

--- a/src/cli/cmds/admin.py
+++ b/src/cli/cmds/admin.py
@@ -215,6 +215,11 @@ def project(ctx: Context, projcode, validate, reconcile, upcoming_expirations, r
               help='[disk] Minimum absolute gap in bytes before emitting a synthetic row (default 1 GiB)')
 @click.option('--gap-tolerance-frac', 'gap_tolerance_frac', type=float, default=0.01, show_default=True,
               help='[disk] Minimum gap as a fraction of FILESET usage (default 1%)')
+# --- Comp/Disk shared epoch override ---------------------------------------
+@click.option('--epoch', 'epoch_str', type=str, default=None, metavar='YYYY-MM-DD',
+              help='[comp/disk] Override the hard-coded charging epoch. '
+                   'Default: COMP_CHARGING_EPOCH for --comp, '
+                   'DISK_CHARGING_TIB_EPOCH for --disk.')
 # --- Reconcile (--reconcile-quotas) ----------------------------------------
 @click.option('--update-accounting-system', 'update_accounting_system', is_flag=True,
               help='[reconcile] Apply mismatched amount updates (default: report-only)')
@@ -234,6 +239,7 @@ def accounting(ctx: Context, comp, disk, archive, reconcile_quotas, resource,
                user_usage_path, quotas_path, reporting_interval,
                unidentified_label, reconcile_quota_gap,
                gap_tolerance_bytes, gap_tolerance_frac,
+               epoch_str,
                start, end, date_str, today_flag, last,
                dry_run, update_accounting_system, deactivate_orphaned,
                force, verify_paths, verify_host,
@@ -316,6 +322,26 @@ def accounting(ctx: Context, comp, disk, archive, reconcile_quotas, resource,
             style="bold red",
         )
         sys.exit(1)
+
+    # --- --epoch parse + scope check --------------------------------------
+    # --epoch only applies to --comp / --disk. Reject early elsewhere so
+    # operators don't get a silent no-op under --reconcile-quotas/--archive.
+    epoch_date = None
+    if epoch_str:
+        if not (comp or disk):
+            ctx.console.print(
+                "Error: --epoch only applies to --comp or --disk",
+                style="bold red",
+            )
+            sys.exit(1)
+        try:
+            epoch_date = datetime.strptime(epoch_str, '%Y-%m-%d').date()
+        except ValueError:
+            ctx.console.print(
+                "Error: --epoch must be in YYYY-MM-DD format",
+                style="bold red",
+            )
+            sys.exit(1)
 
     if reconcile_mode:
         if not resource:
@@ -420,6 +446,7 @@ def accounting(ctx: Context, comp, disk, archive, reconcile_quotas, resource,
             skip_errors=skip_errors,
             chunk_size=chunk_size,
             include_deleted_accounts=include_deleted_accounts,
+            epoch=epoch_date,
         )
         sys.exit(exit_code)
 
@@ -445,6 +472,7 @@ def accounting(ctx: Context, comp, disk, archive, reconcile_quotas, resource,
         create_queues=create_queues,
         chunk_size=chunk_size,
         include_deleted_accounts=include_deleted_accounts,
+        epoch=epoch_date,
     )
     sys.exit(exit_code)
 

--- a/src/cli/notifications/email.py
+++ b/src/cli/notifications/email.py
@@ -7,6 +7,9 @@ from pathlib import Path
 from typing import Tuple, Optional, List, Dict
 from jinja2 import Environment, FileSystemLoader
 import jinja2
+from rich.progress import (
+    Progress, BarColumn, TextColumn, TimeElapsedColumn, MofNCompleteColumn,
+)
 
 
 class EmailNotificationService:
@@ -178,28 +181,42 @@ class EmailNotificationService:
         if dry_run:
             results['preview_samples'] = []
 
-        for i, notification in enumerate(notifications):
-            if dry_run:
-                # Dry-run: render email but don't send
-                try:
-                    rendered = self._render_email_preview(notification)
-                    results['success'].append(notification)
+        description = (
+            "Rendering email previews..." if dry_run
+            else "Sending expiration notifications..."
+        )
+        with Progress(
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+            console=self.ctx.console,
+            transient=False,
+        ) as progress:
+            task = progress.add_task(description, total=len(notifications))
+            for i, notification in enumerate(notifications):
+                if dry_run:
+                    # Dry-run: render email but don't send
+                    try:
+                        rendered = self._render_email_preview(notification)
+                        results['success'].append(notification)
 
-                    # Collect first 2 emails as samples
-                    if i < 2:
-                        results['preview_samples'].append(rendered)
-                except Exception as e:
-                    notification['error'] = str(e)
-                    results['failed'].append(notification)
-            else:
-                # Normal mode: actually send email
-                success, error = self.send_expiration_notification(notification)
-
-                if success:
-                    results['success'].append(notification)
+                        # Collect first 2 emails as samples
+                        if i < 2:
+                            results['preview_samples'].append(rendered)
+                    except Exception as e:
+                        notification['error'] = str(e)
+                        results['failed'].append(notification)
                 else:
-                    notification['error'] = error
-                    results['failed'].append(notification)
+                    # Normal mode: actually send email
+                    success, error = self.send_expiration_notification(notification)
+
+                    if success:
+                        results['success'].append(notification)
+                    else:
+                        notification['error'] = error
+                        results['failed'].append(notification)
+                progress.advance(task)
 
         return results
 

--- a/src/sam/summaries/comp_summaries.py
+++ b/src/sam/summaries/comp_summaries.py
@@ -1,7 +1,25 @@
 #-------------------------------------------------------------------------bh-
 # Common Imports:
 from ..base import *
+from datetime import date as _stdlib_date
 #-------------------------------------------------------------------------eh-
+
+
+# ============================================================================
+# Comp-charging cutover constant
+# ============================================================================
+
+# Cutover epoch: the earliest activity_date that `sam-admin accounting --comp`
+# is allowed to write into `comp_charge_summary`. Runs whose `start_date` is
+# before this date are refused with a clear error pointing at this constant,
+# protecting the post-epoch regime (validated hpc-usage-queries feed +
+# current charging formulas) from accidental backfill against pre-epoch
+# historical data.
+#
+# Treated as immutable. Overridable per-invocation via `sam-admin accounting
+# --epoch YYYY-MM-DD` for one-off backfills the operator knows are safe.
+# Analogous to `disk_summaries.DISK_CHARGING_TIB_EPOCH`.
+COMP_CHARGING_EPOCH = _stdlib_date(1970, 1, 1)
 
 
 #-------------------------------------------------------------------------bm-

--- a/tests/unit/test_comp_epoch_enforcement.py
+++ b/tests/unit/test_comp_epoch_enforcement.py
@@ -1,0 +1,65 @@
+"""Tests for cutover-epoch enforcement on `sam-admin accounting --comp`.
+
+The CLI must refuse to write rows whose ``start_date`` is before
+``COMP_CHARGING_EPOCH`` — pre-epoch historical data is not rewritten by
+this tool. ``--epoch YYYY-MM-DD`` overrides the hard-coded constant.
+"""
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from cli.cmds.admin import cli
+from sam.summaries.comp_summaries import COMP_CHARGING_EPOCH
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestCompEpochEnforcement:
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_db_session(self, session):
+        """Hand the admin CLI our SAVEPOINT'd session."""
+        with patch('sam.session.create_sam_engine') as mock_engine, \
+             patch('cli.cmds.admin.Session') as mock_session_cls:
+            mock_engine.return_value = (MagicMock(), None)
+            mock_session_cls.return_value = session
+            yield session
+
+    def test_pre_epoch_date_refused(self, runner, mock_db_session):
+        pre = COMP_CHARGING_EPOCH - timedelta(days=1)
+        result = runner.invoke(cli, [
+            'accounting', '--comp',
+            '--machine', 'derecho',
+            '--date', pre.isoformat(),
+        ])
+        assert result.exit_code == 2
+        assert "COMP_CHARGING_EPOCH" in result.output
+
+    def test_at_epoch_date_allowed(self, runner, mock_db_session):
+        # At-epoch should NOT emit the epoch-error string. The run may
+        # then fail later (plugin missing / no data) — that's fine; we
+        # only assert the epoch gate didn't fire.
+        result = runner.invoke(cli, [
+            'accounting', '--comp',
+            '--machine', 'derecho',
+            '--date', COMP_CHARGING_EPOCH.isoformat(),
+        ])
+        assert "COMP_CHARGING_EPOCH" not in result.output
+
+    def test_pre_epoch_date_allowed_with_override(self, runner, mock_db_session):
+        pre = COMP_CHARGING_EPOCH - timedelta(days=30)
+        result = runner.invoke(cli, [
+            'accounting', '--comp',
+            '--machine', 'derecho',
+            '--date', pre.isoformat(),
+            '--epoch', pre.isoformat(),
+        ])
+        assert "COMP_CHARGING_EPOCH" not in result.output

--- a/tests/unit/test_disk_epoch_enforcement.py
+++ b/tests/unit/test_disk_epoch_enforcement.py
@@ -71,3 +71,20 @@ class TestEpochEnforcement:
         # outcomes: 0 (clean), or 2 if user resolution fails — either way
         # the EPOCH error must NOT appear.
         assert "DISK_CHARGING_TIB_EPOCH" not in result.output
+
+    def test_pre_epoch_date_allowed_with_override(self, runner, mock_db_session, tmp_path):
+        pre = DISK_CHARGING_TIB_EPOCH - timedelta(days=1)
+        f = _make_acct_glade(tmp_path, pre)
+        result = runner.invoke(cli, [
+            'accounting', '--disk',
+            '--resource', 'Campaign_Store',
+            '--user-usage', str(f),
+            '--date', pre.isoformat(),
+            '--epoch', pre.isoformat(),
+            '--dry-run',
+            '--skip-errors',
+        ])
+        # With the override, the epoch gate should not fire. Like the
+        # at-epoch case, the run may still fail later (resource lookup,
+        # entity resolution) — only the epoch-error string is asserted.
+        assert "DISK_CHARGING_TIB_EPOCH" not in result.output


### PR DESCRIPTION
## Summary

Two small, independent improvements to `sam-admin`:

- **`COMP_CHARGING_EPOCH` + `--epoch` override** — mirrors the existing
  disk-side guard (`DISK_CHARGING_TIB_EPOCH`). `sam-admin accounting
  --comp` now refuses to write `comp_charge_summary` rows whose
  `start_date` is before the constant. The hard-coded value lives in
  `sam.summaries.comp_summaries` (currently `1970-01-01`, effectively
  open until we ratchet it forward). A new `--epoch YYYY-MM-DD` CLI
  option overrides the constant for one-off backfills and applies to
  both `--comp` and `--disk` (rejected elsewhere). The comp check runs
  *before* plugin load so the error surfaces cleanly even when
  `hpc-usage-queries` isn't installed.

- **Progress bar on `--notify` send loop** — a `sam-admin project
  --notify --upcoming-expirations` run can fan out to 300+ recipient
  emails. The loop in `EmailNotificationService.send_batch_notifications`
  is now wrapped in a rich `Progress` bar (`description / bar / M-of-N
  / elapsed`), same column set used by the accounting chunked-post
  loops. Active for real sends and `--dry-run` (rendering 300+ Jinja
  templates also takes time), with the description switching between
  "Sending expiration notifications..." and "Rendering email
  previews...".

## Test plan

- [ ] `pytest tests/unit/test_comp_epoch_enforcement.py tests/unit/test_disk_epoch_enforcement.py -v`
  — new comp test (pre/at/with-override) + new disk override case all
  pass.
- [ ] `pytest` full suite — no regressions in the existing
  accounting / disk admin tests.
- [ ] Manual: `sam-admin accounting --comp --machine derecho --date
  1969-12-31` → expect epoch refusal naming `COMP_CHARGING_EPOCH`.
- [ ] Manual: `sam-admin accounting --disk ... --epoch <pre-date>
  --dry-run` → epoch gate skipped.
- [ ] Manual: `docker exec samuel-webdev sam-admin project --notify
  --upcoming-expirations --dry-run` → progress bar advances per
  recipient; final summary unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)