### PR TITLE
Fix mark_disk_snapshot_current: per-date validity, not single-pointer

### DIFF
--- a/src/cli/accounting/commands.py
+++ b/src/cli/accounting/commands.py
@@ -291,6 +291,23 @@ class AccountingAdminCommand(BaseCommand):
             )
             return 2
 
+        # NOTE: unlike _run_disk, we intentionally do NOT write to
+        # `comp_charge_summary_status`. The asymmetry is deliberate:
+        # legacy migration V13 reshaped that table from a (activity_date,
+        # current) per-date marker into an in-flight aggregation lock
+        # keyed by (command_id, charge_summary_id). It's not a
+        # "this date is posted" checkpoint — it's a transient lock that
+        # legacy's Quartz watchdog cleaned up on command completion.
+        # Prod state (queried 2026-05-13) shows that lock pipeline is
+        # dormant since 2024-11 (438 stale rows from one abandoned
+        # command_id, no new activity since), and no legacy report
+        # joins the status table to filter comp_charge_summary. Our
+        # writes are therefore visible to legacy reports as-is, and
+        # populating the lock table would only add coordination cost
+        # for the deprecated Java path. See
+        # `~/.claude/plans/consider-git-grep-epoch-vivid-hartmanis.md`
+        # for the full investigation.
+
         # --- 1. Load job_history plugin (graceful error if not installed) ---
         mod = self.require_plugin(HPC_USAGE_QUERIES)
         if mod is None:

--- a/src/sam/summaries/disk_summaries.py
+++ b/src/sam/summaries/disk_summaries.py
@@ -78,12 +78,21 @@ class DiskChargeSummary(Base):
 
 #----------------------------------------------------------------------------
 class DiskChargeSummaryStatus(Base):
-    """Tracks which disk charge summary date is the current snapshot.
+    """Per-date validity flag for the disk charge summary.
 
-    The row whose ``current = True`` marks the latest fully-imported
-    snapshot. Used by ``Account.current_disk_usage()`` /
-    ``Project.current_disk_usage()`` to answer "how full is this project
-    *right now*?" without summing across snapshots.
+    Legacy SAM semantics (confirmed against prod ``sam-sql.ucar.edu`` on
+    2026-05-13: 883 imported dates, all ``current=TRUE``):
+
+    - One row per successfully imported ``activity_date``.
+    - ``current = TRUE`` → that date's summary is valid / posted.
+    - ``current = FALSE`` → that date has been invalidated and needs
+      recalculation (legacy named query
+      ``findInvalidDiskChargeSummaryDates``).
+    - Multiple ``current = TRUE`` rows are normal — readers pick
+      ``MAX(activity_date) WHERE current = TRUE`` for "right now"
+      queries (``Account.current_disk_usage()`` /
+      ``Project.current_disk_usage()`` /
+      ``bulk_current_disk_usage()``).
 
     Maintained by ``mark_disk_snapshot_current()``.
     """
@@ -104,16 +113,18 @@ class DiskChargeSummaryStatus(Base):
 # ============================================================================
 
 def mark_disk_snapshot_current(session, activity_date) -> None:
-    """Mark ``activity_date`` as the current disk snapshot.
+    """Mark ``activity_date`` as a valid disk snapshot (``current=TRUE``).
 
-    Clears ``current=True`` from any prior row, then upserts
-    ``(activity_date, current=True)`` for the given date. Does NOT
-    commit — caller wraps in ``management_transaction``.
+    Upserts only the given date. Does NOT touch any other row's
+    ``current`` flag — that flag is per-date in the legacy schema, not
+    a single-row pointer. Flipping prior rows to ``current=FALSE``
+    would tell legacy reports that every historical date needs
+    recalculation
+    (cf. ``findInvalidDiskChargeSummaryDates``); see
+    ``DiskChargeSummaryStatus`` docstring for the full semantics.
+
+    Does NOT commit — caller wraps in ``management_transaction``.
     """
-    session.query(DiskChargeSummaryStatus).filter(
-        DiskChargeSummaryStatus.current == True  # noqa: E712 — SQL boolean
-    ).update({DiskChargeSummaryStatus.current: False}, synchronize_session=False)
-
     existing = session.get(DiskChargeSummaryStatus, activity_date)
     if existing is None:
         session.add(DiskChargeSummaryStatus(activity_date=activity_date, current=True))

--- a/tests/unit/test_current_disk_usage.py
+++ b/tests/unit/test_current_disk_usage.py
@@ -51,13 +51,12 @@ def _seed_summary(session, account, user, *, activity_date, bytes_, ty=1.0, file
 
 
 def _mark_current(session, activity_date):
-    """Test-only narrow alternative to mark_disk_snapshot_current.
+    """Test helper kept for symmetry with `mark_disk_snapshot_current`.
 
-    The prod helper does a bulk UPDATE on every row where current=true, which
-    deadlocks under xdist when two workers run it concurrently. These read-path
-    tests only need *their* row marked current; per-test SAVEPOINT rollback
-    means we don't need to clear others. Use the real helper only in tests
-    that are testing it (TestMarkSnapshotCurrent).
+    Functionally equivalent to the prod helper after we corrected the
+    semantics in 2026-05 (upsert single row, do not touch others). Used
+    by read-path tests to seed an explicit current=True row without
+    importing the prod helper directly.
     """
     row = session.get(DiskChargeSummaryStatus, activity_date)
     if row is None:
@@ -79,21 +78,33 @@ class TestMarkSnapshotCurrent:
         assert len(rows) == 1
         assert rows[0].activity_date == d
 
-    def test_subsequent_call_clears_prior(self, session):
+    def test_does_not_clobber_prior_current_rows(self, session):
+        """Calling mark_disk_snapshot_current(d2) must NOT flip d1 to False.
+
+        Legacy semantics (and prod state on sam-sql.ucar.edu) keep every
+        successfully imported date at current=True; the flag is per-date,
+        not a single-pointer. The earlier "clear all, set one" behavior
+        would mass-invalidate historical disk summaries on first prod run
+        and break legacy reports that key off current=False for recalc.
+        """
         d1 = next_date("disk_snap")
         d2 = d1 + timedelta(days=7)
         mark_disk_snapshot_current(session, d1)
         mark_disk_snapshot_current(session, d2)
-        # Only the new date should be current — among rows for these
-        # specific dates (other workers may have their own current rows).
-        currents = session.query(DiskChargeSummaryStatus).filter(
-            DiskChargeSummaryStatus.activity_date.in_((d1, d2)),
-            DiskChargeSummaryStatus.current == True  # noqa: E712
-        ).all()
-        assert [r.activity_date for r in currents] == [d2]
-        # The prior row exists but is False.
-        prior = session.get(DiskChargeSummaryStatus, d1)
-        assert prior is not None and prior.current is False
+        rows = session.query(DiskChargeSummaryStatus).filter(
+            DiskChargeSummaryStatus.activity_date.in_((d1, d2))
+        ).order_by(DiskChargeSummaryStatus.activity_date).all()
+        assert [(r.activity_date, r.current) for r in rows] == [(d1, True), (d2, True)]
+
+    def test_revalidates_invalidated_date(self, session):
+        """A pre-existing current=False row (legacy invalidation) flips to
+        current=True when re-imported."""
+        d = next_date("disk_snap")
+        session.add(DiskChargeSummaryStatus(activity_date=d, current=False))
+        session.flush()
+        mark_disk_snapshot_current(session, d)
+        row = session.get(DiskChargeSummaryStatus, d)
+        assert row is not None and row.current is True
 
 
 class TestAccountCurrentDiskUsage:


### PR DESCRIPTION
## Summary

Investigation of how legacy SAM uses the `*_charge_summary_status` companion tables turned up a real prod-cutover bug on the disk side. The old `mark_disk_snapshot_current` did a bulk
`UPDATE ... SET current=False WHERE current=True` before stamping the new date `current=True`. Legacy semantics — and prod state on `sam-sql.ucar.edu` (883 rows, all `current=True`) — keep `current=True` on every successfully imported date and reserve `current=False` for dates legacy explicitly invalidates for recalc (`findInvalidDiskChargeSummaryDates`). Running our `--disk` against prod under the old behavior would have flipped 882 historical dates to `current=False`, signalling "everything needs recalc" to legacy reports.

The fix is small: `mark_disk_snapshot_current` now upserts only the given date and leaves every other row untouched. Readers (`Account.current_disk_usage()` / `bulk_current_disk_usage()`) already pick `MAX(activity_date) WHERE current=True`, so they're compatible with multiple `current=True` rows.

Also rewrote the `DiskChargeSummaryStatus` docstring to capture the correct semantics, and added a comment block in `_run_comp` explaining why the comp side is deliberately asymmetric: legacy migration V13 reshaped `comp_charge_summary_status` into an in-flight aggregation lock keyed by `(command_id, charge_summary_id)`. Prod shows that lock pipeline is dormant since 2024-11 (438 stale rows from one abandoned `command_id`); no legacy report joins it. Populating it from our path would add coordination cost for the deprecated Java pipeline.

## Test Results

Replaced the obsolete `test_subsequent_call_clears_prior` (which codified the bug) with two new cases in
`tests/unit/test_current_disk_usage.py`:
- `test_does_not_clobber_prior_current_rows`
- `test_revalidates_invalidated_date`

Updated the stale rationale on the `_mark_current` test helper (the xdist-deadlock concern no longer applies). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)