### PR TITLE
Exempt 'vis' queue from GPU charging

### DIFF
--- a/src/cli/accounting/commands.py
+++ b/src/cli/accounting/commands.py
@@ -156,10 +156,16 @@ def adapt_jobstats_row(row: dict, machine: str) -> Optional[tuple]:
     Raises:
         ValueError: For rows with an unknown machine name.
     """
+    queue = row.get("queue", "Unknown")
     cpu_h = row["cpu_hours"] or 0.0
     gpu_h = row["gpu_hours"] or 0.0
     cpu_c = row["cpu_charges"] or 0.0
     gpu_c = row["gpu_charges"] or 0.0
+
+    # special rules for special queues
+    if queue == "vis":      # vis queue consumes GPUs, but we don't charge for that
+        gpu_h = gpu_c = 0.0 # (so accessible to projects without GPU allocations)
+
     total = cpu_h + gpu_h
 
     if total <= 0.0:
@@ -171,11 +177,9 @@ def adapt_jobstats_row(row: dict, machine: str) -> Optional[tuple]:
         if gpu_h > 0 and gpu_fraction >= GPU_FRACTION_THRESHOLD:
             # Meaningful GPU usage → Derecho GPU resource
             # core_hours = GPU hours (the Derecho GPU billing metric)
-            # TODO: confirm whether charges = gpu_hours or a weighted formula
             return "Derecho GPU", "derecho-gpu", gpu_h, gpu_c
         # Pure CPU job (or anomalous GPU ratio → treat as CPU)
         # core_hours = CPU core-hours (numnodes * 128 * wall_hours)
-        # TODO: confirm charges formula (queue_factor multiplier?)
         return "Derecho", "derecho", cpu_h, cpu_c
 
     elif machine == "casper":
@@ -184,7 +188,6 @@ def adapt_jobstats_row(row: dict, machine: str) -> Optional[tuple]:
             # TODO: confirm Casper GPU resource name and charges formula
             return "Casper GPU", "Casper-gpu", gpu_h, gpu_c
         # Casper CPU resource
-        # TODO: confirm Casper charges formula (cpu_hours + memory_hours?)
         return "Casper", "Casper", cpu_h, cpu_c
 
     else:
@@ -386,6 +389,9 @@ class AccountingAdminCommand(BaseCommand):
                             # Warn on anomalous GPU fraction (proceeded as CPU)
                             cpu_h = row["cpu_hours"] or 0.0
                             gpu_h = row["gpu_hours"] or 0.0
+                            queue = row.get("queue", "Unknown")
+                            if queue == "vis":
+                                gpu_h = 0.0
                             if gpu_h > 0 and resource_name in ("Derecho", "Casper"):
                                 gpu_fraction = gpu_h / (cpu_h + gpu_h)
                                 if self.ctx.verbose:

--- a/tests/unit/test_jobstats_adapter.py
+++ b/tests/unit/test_jobstats_adapter.py
@@ -20,9 +20,11 @@ from cli.accounting.commands import (
 pytestmark = pytest.mark.unit
 
 
-def _row(*, cpu_hours=0.0, gpu_hours=0.0, cpu_charges=0.0, gpu_charges=0.0):
+def _row(*, cpu_hours=0.0, gpu_hours=0.0, cpu_charges=0.0, gpu_charges=0.0,
+         queue="main"):
     """Minimal jobstats row — only the keys adapt_jobstats_row reads."""
     return {
+        "queue": queue,
         "cpu_hours": cpu_hours,
         "gpu_hours": gpu_hours,
         "cpu_charges": cpu_charges,
@@ -104,6 +106,57 @@ class TestAdaptJobstatsRow:
     def test_unknown_machine_raises(self):
         with pytest.raises(ValueError, match="Unknown machine"):
             adapt_jobstats_row(_row(cpu_hours=10.0), "frontier")
+
+
+class TestVisQueueCpuOnly:
+    """The `vis` queue uses GPUs but is intentionally not GPU-billed, so
+    that projects without a GPU allocation can still use it. GPU hours
+    and charges must be dropped before classification, and the row must
+    never land on a *GPU resource regardless of machine or gpu_fraction.
+    """
+
+    def test_vis_derecho_gpu_only_classifies_as_cpu_with_zero_charges(self):
+        """Pure-GPU vis row → after zeroing, total drops to 0 → skipped."""
+        result = adapt_jobstats_row(
+            _row(queue="vis", gpu_hours=100.0, gpu_charges=200.0),
+            "derecho",
+        )
+        assert result is None
+
+    def test_vis_derecho_mixed_charges_only_cpu(self):
+        """Mixed CPU/GPU vis row → Derecho CPU resource, GPU dropped.
+
+        gpu_fraction would be 80/130 ≈ 0.62 — well above the threshold —
+        so without the vis rule this would misroute to Derecho GPU.
+        """
+        result = adapt_jobstats_row(
+            _row(queue="vis", cpu_hours=50.0, gpu_hours=80.0,
+                 cpu_charges=10.0, gpu_charges=40.0),
+            "derecho",
+        )
+        assert result == ("Derecho", "derecho", 50.0, 10.0)
+
+    def test_vis_casper_mixed_charges_only_cpu(self):
+        """Same rule on casper — vis zeroing is machine-agnostic."""
+        result = adapt_jobstats_row(
+            _row(queue="vis", cpu_hours=50.0, gpu_hours=80.0,
+                 cpu_charges=10.0, gpu_charges=40.0),
+            "casper",
+        )
+        assert result == ("Casper", "Casper", 50.0, 10.0)
+
+    def test_non_vis_queue_with_gpu_still_charges_gpu(self):
+        """Negative control: the rule must apply ONLY to queue == 'vis'.
+
+        Identical row body on the main queue must classify as Derecho
+        GPU with GPU hours/charges intact.
+        """
+        result = adapt_jobstats_row(
+            _row(queue="main", cpu_hours=50.0, gpu_hours=80.0,
+                 cpu_charges=10.0, gpu_charges=40.0),
+            "derecho",
+        )
+        assert result == ("Derecho GPU", "derecho-gpu", 80.0, 40.0)
 
 
 class TestNormalizeQueueName:


### PR DESCRIPTION
## Summary
- `adapt_jobstats_row` now zeroes `gpu_hours` / `gpu_charges` when `queue == "vis"`, so visualization jobs land on the CPU resource (Derecho / Casper) with CPU charges only — projects without a GPU allocation can still use the vis queue.
- Same zeroing applied in `_run_comp`'s verbose anomaly-warning branch so the warning doesn't fire on vis rows.
- Adds `TestVisQueueCpuOnly` (4 cases) pinning the intent, incl. a non-vis negative control. Drops three resolved TODOs.

This matches what's already happening in production; the change is to make the rule explicit in code and locked in by tests.

## Test plan
- [x] `pytest tests/unit/test_jobstats_adapter.py -v` — all existing + new cases pass
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)