### PR TITLE
UX polish: trim chrome, align modals with Unity theme

### DIFF
--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -332,6 +332,8 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     --bs-btn-border-width: 3px;
     --bs-btn-border-radius: 0;
     --bs-btn-box-shadow: none;
+    text-transform: uppercase;
+    letter-spacing: 0.05rem;
 }
 
 .btn-primary {

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -591,34 +591,64 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
    ALERTS
    ========================================================================= */
 
+/* Unity flat-fill treatment (source/scss/components/_alerts.scss): solid
+   color fill, no border, no left accent, 0 radius. Color carries the
+   semantic; text auto-picks for legibility. Info kept as NCAR blue rather
+   than Unity's literal yellow — most users expect info=blue, yellow reads
+   as warning. */
 .alert {
-    border-radius: var(--radius-lg);
-    border: none;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    color: var(--ncar-space-blue);
+    padding: 0.875rem 1rem;
+}
+
+.alert a,
+.alert button {
+    color: var(--ncar-space-blue);
+    text-decoration: underline;
+    font-weight: var(--font-weight-semi-bold);
+}
+
+.alert a:hover,
+.alert button:hover {
+    color: var(--ncar-navy);
 }
 
 .alert-info {
-    background-color: rgba(var(--ncar-teal-rgb), 0.1);
-    color: var(--ncar-navy);
-    border-left: 4px solid var(--ncar-blue);
+    background-color: var(--ncar-blue);
+    color: #fff;
 }
 
-.alert-danger {
-    background-color: rgba(220, 38, 38, 0.1);
-    color: #991b1b;
-    border-left: 4px solid var(--danger-color);
+.alert-info a,
+.alert-info button {
+    color: #fff;
 }
 
 .alert-warning {
-    background-color: rgba(245, 158, 11, 0.1);
-    color: #92400e;
-    border-left: 4px solid var(--warning-color);
+    background-color: var(--ncar-orange);
+    color: var(--ncar-space-blue);
+}
+
+.alert-danger {
+    background-color: var(--ncar-vermilion);
+    color: #fff;
+}
+
+.alert-danger a,
+.alert-danger button {
+    color: #fff;
 }
 
 .alert-success {
-    background-color: rgba(16, 185, 129, 0.1);
-    color: #065f46;
-    border-left: 4px solid var(--success-color);
+    background-color: #10b981;
+    color: #fff;
+}
+
+.alert-success a,
+.alert-success button {
+    color: #fff;
 }
 
 /* ============================================================================

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -803,15 +803,27 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     margin-bottom: 24px;
 }
 
+/* Project-card headers follow the same invert pattern as .nav-tabs and
+   .btn-group toggles: collapsed (inactive) = solid NCAR blue + white text,
+   expanded (active) = white + blue text. Matches Unity's tab/accordion
+   convention. Badge children keep their own subtle palette — only the
+   title text, icons, and chevron flip with the header state. */
 .project-card .card-header {
     cursor: pointer;
     user-select: none;
     padding: 8px 16px;
-    /* Thin gray hairline divider matching Unity's panel separators
-       (overrides the heavier 2px blue from the global .card > .card-header rule) */
-    border-bottom: 1px solid var(--ncar-gray-light);
-    color: var(--ncar-blue);
+    background-color: var(--ncar-blue);
+    color: #fff;
+    border-bottom: 1px solid var(--ncar-blue);
     transition: background-color var(--transition-base), color var(--transition-base);
+}
+
+/* Force the title's folder icon (.text-primary overrides default inheritance)
+   and the chevron to flip with the header. !important needed to win against
+   the .text-primary utility class on the icon. */
+.project-card .card-header h5 i,
+.project-card .card-header .accordion-chevron {
+    color: #fff !important;
 }
 
 /* Match Unity's .accordion-button: fixed 1rem font, semi-bold, single weight
@@ -828,18 +840,24 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
 }
 
 .project-card .card-header:hover {
-    background-color: rgba(var(--ncar-blue-rgb), 0.06);
+    background-color: var(--ncar-navy);
 }
 
-/* Expanded state: NCAR blue bg + white text, matching Unity's active accordion */
+/* Expanded (active) state: white surface with blue text — the "settled" look
+   matching .nav-tabs.active and .btn-group .btn-secondary.active. */
 .project-card .card-header[aria-expanded="true"] {
-    background-color: var(--ncar-blue);
-    color: #fff;
-    border-bottom-color: var(--ncar-blue);
+    background-color: #fff;
+    color: var(--ncar-blue);
+    border-bottom-color: var(--ncar-gray-light);
 }
 
-.project-card .card-header[aria-expanded="true"] * {
-    color: #fff;
+.project-card .card-header[aria-expanded="true"] h5 i,
+.project-card .card-header[aria-expanded="true"] .accordion-chevron {
+    color: var(--ncar-blue) !important;
+}
+
+.project-card .card-header[aria-expanded="true"]:hover {
+    background-color: rgba(var(--ncar-teal-rgb), 0.08);
 }
 
 /* Accordion chevron — reusable affordance for any collapsible header.

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -381,6 +381,45 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
    positive actions and btn-outline-primary for destructive/informational
    actions instead. */
 
+/* Toggle button groups (.btn-group with .btn-secondary / .btn-outline-secondary
+   pair, used by time_range_picker, date_range_picker, system_user_proj_chart_card,
+   and other quick-select preset rows). Match the Unity .nav-tabs invert pattern:
+   inactive = solid NCAR-blue, active = white with blue text. Scoped to .btn-group
+   so non-group .btn-secondary uses (modal Cancel, queue_history Back) keep their
+   existing treatments. */
+.btn-group .btn-outline-secondary {
+    --bs-btn-bg: var(--ncar-blue);
+    --bs-btn-border-color: var(--ncar-blue);
+    --bs-btn-color: #fff;
+    --bs-btn-hover-bg: var(--ncar-navy);
+    --bs-btn-hover-border-color: var(--ncar-navy);
+    --bs-btn-hover-color: #fff;
+}
+
+.btn-group .btn-secondary,
+.btn-group .btn-secondary.active,
+.btn-group .btn-secondary:active {
+    --bs-btn-bg: #fff;
+    --bs-btn-border-color: var(--ncar-blue);
+    --bs-btn-color: var(--ncar-blue);
+    --bs-btn-hover-bg: rgba(var(--ncar-teal-rgb), 0.08);
+    --bs-btn-hover-border-color: var(--ncar-blue);
+    --bs-btn-hover-color: var(--ncar-blue);
+    --bs-btn-active-bg: #fff;
+    --bs-btn-active-border-color: var(--ncar-blue);
+    --bs-btn-active-color: var(--ncar-blue);
+}
+
+/* Unity-style focus ring on interactive button-like elements — upstream
+   uses box-shadow 0 0 0 .2rem rgba(ncar-blue, .2) across .btn and .nav-link.
+   Replaces Bootstrap's default outline so the ring matches palette. */
+.btn:focus,
+.btn:focus-visible,
+.nav-tabs .nav-link:focus-visible {
+    box-shadow: 0 0 0 0.2rem rgba(0, 87, 194, 0.2);
+    outline: none;
+}
+
 /* ============================================================================
    FOOTER
    ========================================================================= */

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -503,29 +503,10 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     letter-spacing: 0.3px;
 }
 
-.badge-success {
-    background-color: var(--success-color);
-}
-
-.badge-primary {
-    background-color: var(--ncar-blue);
-}
-
-.badge-warning {
-    background-color: var(--warning-color);
-}
-
-.badge-danger {
-    background-color: var(--danger-color);
-}
-
-.badge-secondary {
-    background-color: #6c757d;
-}
-
-.badge-info {
-    background-color: var(--info-color);
-}
+/* Note: the hyphenated `.badge-success` / `.badge-primary` / etc. variants
+   were intentionally removed — no template uses them (every callsite uses
+   the Bootstrap `.badge.bg-X` utility form). The live badge palette is the
+   subtle Bootstrap 5.3 .bg-X-bg-subtle override applied lower in this file. */
 
 /* ============================================================================
    LOADING SPINNER

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -211,7 +211,10 @@ body {
 
 .main-content {
     padding: 0.5rem 0;
-    min-height: calc(100vh - 200px);
+    /* Reserve viewport space for header (136px) + footer margin (50px) + footer
+       (~99px) = 285px. Previously 200px, which left ~85px of always-on overflow
+       and a noisy scrollbar on otherwise-fitting pages like /admin/. */
+    min-height: calc(100vh - 285px);
 }
 
 @media (min-width: 64rem) {
@@ -586,9 +589,14 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
 
 .nav-tabs {
     border-bottom: 0;
-    /* Never wrap to a second row — horizontal scroll if necessary. */
+    /* Never wrap to a second row — horizontal scroll if necessary. Explicitly
+       clamp overflow-y to hidden: setting only overflow-x:auto causes the
+       browser to also force overflow-y:auto (CSS spec quirk — the orthogonal
+       axis can't stay `visible` when one axis is scrollable), which produces
+       a stray 1px vertical scrollbar from sub-pixel layout rounding. */
     flex-wrap: nowrap;
     overflow-x: auto;
+    overflow-y: hidden;
 }
 
 .nav-tabs .nav-item {
@@ -608,6 +616,7 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     background-color: #fff;
     border: none;
     border-radius: 0;
+    padding: 0.375rem 1rem;
     transition: background-color var(--transition-base), color var(--transition-base);
 }
 
@@ -632,7 +641,7 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
    Unity's seamless tab→panel transition. No borders — content just flows. */
 .tab-content {
     background-color: #fff;
-    padding: 1.875rem;
+    padding: 1.25rem;
 }
 
 /* ============================================================================

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -268,9 +268,9 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     --bs-accordion-color: var(--ncar-space-blue);
     --bs-accordion-btn-color: var(--ncar-space-blue);
     --bs-accordion-active-color: #fff;
-    --bs-accordion-active-bg: rgba(0, 87, 194, 0.1);
+    --bs-accordion-active-bg: rgba(var(--ncar-blue-rgb), 0.1);
     --bs-accordion-btn-focus-border-color: var(--ncar-blue);
-    --bs-accordion-btn-focus-box-shadow: 0 0 0 0.25rem rgba(0, 87, 194, 0.25);
+    --bs-accordion-btn-focus-box-shadow: 0 0 0 0.25rem rgba(var(--ncar-blue-rgb), 0.25);
     /* Chevron icon filled with space-blue for collapsed state */
     --bs-accordion-btn-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23011837'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
     /* Chevron icon filled with white for expanded state */
@@ -435,7 +435,7 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
 .btn:focus,
 .btn:focus-visible,
 .nav-tabs .nav-link:focus-visible {
-    box-shadow: 0 0 0 0.2rem rgba(0, 87, 194, 0.2);
+    box-shadow: 0 0 0 0.2rem rgba(var(--ncar-blue-rgb), 0.2);
     outline: none;
 }
 
@@ -828,7 +828,7 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
 }
 
 .project-card .card-header:hover {
-    background-color: rgba(0, 87, 194, 0.06);
+    background-color: rgba(var(--ncar-blue-rgb), 0.06);
 }
 
 /* Expanded state: NCAR blue bg + white text, matching Unity's active accordion */

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -738,6 +738,18 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
    Mirrors Unity's cascade: base color set first, :not(.active) overrides inactive.
    ========================================================================= */
 
+/* Pills — recolor to NCAR blue without changing the visual treatment.
+   Used for sub-navigation inside accordions and chart-selection rows where the
+   bolder .nav-tabs invert pattern would be too aggressive. Bootstrap 5
+   implements .nav-pills via CSS custom properties, so the four overrides
+   below are sufficient — no per-state selectors needed. */
+.nav-pills {
+    --bs-nav-link-color: var(--ncar-blue);
+    --bs-nav-link-hover-color: var(--ncar-navy);
+    --bs-nav-pills-link-active-color: #fff;
+    --bs-nav-pills-link-active-bg: var(--ncar-blue);
+}
+
 .nav-tabs {
     border-bottom: 0;
     /* Never wrap to a second row — horizontal scroll if necessary. Explicitly

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -583,6 +583,88 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
 }
 
 /* ============================================================================
+   MODALS — Unity NCAR style. The HTMX modal system (modal_scaffold +
+   htmx_form macros) predates the Unity restyle, so templates still emit
+   Bootstrap utility classes (bg-success/warning/danger/primary/secondary on
+   .modal-header, .btn-secondary on Cancel). The rules below repaint those
+   to NCAR palette tokens, flatten the surface, and scope a Cancel-button
+   restyle to .modal-footer so toggle groups using .btn-secondary elsewhere
+   stay untouched. CSS-only — no template edits needed.
+   ========================================================================= */
+
+.modal-content {
+    border-radius: 0;
+    border: 1px solid var(--ncar-gray-light);
+    box-shadow: var(--shadow-md);
+}
+
+/* Create variant + hand-coded bg-primary (e.g. user/allocation_modals.html). */
+.modal-header.bg-success,
+.modal-header.bg-primary {
+    background-color: var(--ncar-blue) !important;
+    color: #fff;
+    border-bottom: none;
+}
+
+/* Edit variant — darker palette blue, subtle UX cue for modifying existing data. */
+.modal-header.bg-warning {
+    background-color: var(--ncar-navy) !important;
+    color: #fff;
+    border-bottom: none;
+}
+
+/* Destructive confirmation (samConfirmModal, outage delete). */
+.modal-header.bg-danger {
+    background-color: var(--ncar-vermilion) !important;
+    color: #fff;
+    border-bottom: none;
+}
+
+/* Neutral variant (one outage_modals case). */
+.modal-header.bg-secondary {
+    background-color: var(--ncar-gray) !important;
+    color: #fff;
+    border-bottom: none;
+}
+
+/* bg-success/danger/primary already get .btn-close-white from the template;
+   bg-warning + bg-secondary headers don't, so invert the close button on those
+   two so it's legible against the dark fill. */
+.modal-header.bg-warning .btn-close,
+.modal-header.bg-secondary .btn-close {
+    filter: invert(1) grayscale(100%) brightness(200%);
+}
+
+.modal-title {
+    font-size: 1.125rem;
+    font-weight: var(--font-weight-semi-bold);
+    letter-spacing: 0.02em;
+}
+
+.modal-header {
+    padding: 0.875rem 1.25rem;
+}
+
+.modal-footer {
+    border-top: 1px solid var(--ncar-gray-light);
+    padding: 0.875rem 1.25rem;
+}
+
+/* Cancel button — scoped to .modal-footer so .btn-secondary used as a toggle
+   active-state in time-range / date-range pickers stays Bootstrap-stock. */
+.modal-footer .btn-secondary {
+    --bs-btn-bg: transparent;
+    --bs-btn-border-color: var(--ncar-gray-light);
+    --bs-btn-color: var(--ncar-navy);
+    --bs-btn-hover-bg: var(--ncar-navy);
+    --bs-btn-hover-border-color: var(--ncar-navy);
+    --bs-btn-hover-color: #fff;
+    --bs-btn-active-bg: var(--ncar-navy);
+    --bs-btn-active-border-color: var(--ncar-navy);
+    --bs-btn-active-color: #fff;
+}
+
+/* ============================================================================
    TABS — Unity NCAR style: inactive = solid blue, active = white with blue text
    Mirrors Unity's cascade: base color set first, :not(.active) overrides inactive.
    ========================================================================= */

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -367,6 +367,23 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     --bs-btn-hover-color: #fff;
 }
 
+/* Unity-style :disabled — transparent fill, transparent 3px border (keeps
+   the button's footprint so layout doesn't shift / nothing visually
+   disappears), gray text. opacity:1 overrides Bootstrap's default .65 fade.
+   Mirrors source/scss/_theme-colors.scss .ncar .btn-primary:disabled but
+   keeps the border slot so it reads as "available shape, just inert". */
+.btn-primary:disabled,
+.btn-primary[disabled],
+.btn-outline-primary:disabled,
+.btn-outline-primary[disabled],
+.btn-outline-secondary:disabled,
+.btn-outline-secondary[disabled] {
+    background-color: transparent !important;
+    border-color: transparent !important;
+    color: var(--ncar-gray) !important;
+    opacity: 1;
+}
+
 .btn-link {
     --bs-btn-color: var(--ncar-blue);
     --bs-btn-hover-color: var(--ncar-sky);

--- a/src/webapp/static/css/variables.css
+++ b/src/webapp/static/css/variables.css
@@ -40,6 +40,7 @@
     --ncar-gray-light: #bbbcbc;   /* Unity grays.light — nav item dividers */
     --ncar-navy:       #00357a;   /* NSF NCAR brand navy */
     --ncar-blue:       #0057c2;   /* NSF NCAR brand blue */
+    --ncar-blue-rgb:   0, 87, 194; /* for rgba(var(--ncar-blue-rgb), <a>) callsites */
     --ncar-light-blue: #00A2B4;   /* NSF NCAR teal light */
     --ncar-cyan:       #34e1f4;   /* NSF NCAR sky blue */
     --ncar-teal:       #00818F;   /* NSF NCAR teal dark */

--- a/src/webapp/static/css/variables.css
+++ b/src/webapp/static/css/variables.css
@@ -45,6 +45,7 @@
     --ncar-teal:       #00818F;   /* NSF NCAR teal dark */
     --ncar-sky:        #42C0FF;   /* NSF NCAR sky light */
     --ncar-vermilion:  #ff1f1f;   /* NSF NCAR defining accent */
+    --ncar-orange:     #faa119;   /* Unity secondary-colors.orange (warning fill) */
     --ncar-gold:       #fdd509;   /* Unity yellow — bright gold accent (e.g. dark-panel headings) */
     --ncar-gray:       #97999b;
     --ncar-navy-mid:   #003579;   /* gradient midpoint (navy → blue) */

--- a/src/webapp/templates/dashboards/admin/dashboard.html
+++ b/src/webapp/templates/dashboards/admin/dashboard.html
@@ -98,7 +98,7 @@
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <h5 class="mb-0"><i class="fas fa-search"></i> Search Projects</h5>
                         {% if has_permission_any_facility(Permission.CREATE_PROJECTS) %}
-                        <button type="button" class="btn btn-sm btn-primary"
+                        <button type="button" class="btn btn-sm btn-outline-success"
                                 data-bs-toggle="modal"
                                 data-bs-target="#createProjectModal"
                                 hx-get="{{ url_for('admin_dashboard.htmx_project_create_form') }}"


### PR DESCRIPTION
## Summary

A polish pass on top of PR #269 (Unity NCAR integration), spanning layout fixes, missing component coverage, color/typography alignment, and cleanup. All edits are CSS + a couple template tweaks — no app logic, no schema changes, no test updates.

### Layout / chrome
- **`e5f4c4a` Trim dashboard chrome to eliminate noise scrollbars** — fixed an off-by-85px `min-height` formula on `.main-content` (`calc(100vh - 200px)` → `calc(100vh - 285px)`), added explicit `overflow-y: hidden` on `.nav-tabs` (the implicit-auto from `overflow-x: auto` was rendering stray 1px scrollbars), tightened `.nav-tabs .nav-link` + `.tab-content` padding so admin/user dashboards stop just-barely overflowing the viewport.

### Component coverage Unity missed
- **`089c762` Bring HTMX modals into closer alignment with the Unity theme** — HTMX modals predated the Unity restyle, so headers were stock Bootstrap green/yellow/red. Repaint to NCAR palette (create=blue, edit=navy, danger=vermilion), flatten the surface (0 radius, hairline border), scoped Cancel-button restyle to `.modal-footer` so toggle-group `.btn-secondary` usages elsewhere stay untouched.
- **`f017770` Retune `.alert` rules to Unity's flat-fill treatment** — replace soft-fill + left-accent + dark-colored-text with Unity's solid-fill + no-border treatment from `source/scss/components/_alerts.scss`. info=NCAR blue (pragmatic; Unity literal info=yellow felt wrong), warning=NCAR orange (`#faa119`, new token), danger=NCAR vermilion.
- **`d4499d2` Match Create Project button style to other admin Create buttons** — `btn-primary` → `btn-outline-success` so it matches the green-outlined convention used by every other "Create X" button in admin.

### Unity invert pattern, unified
Unity uses an "inactive = filled blue, active = white-with-blue-text" convention on tabs. Applied that same convention everywhere it was missing:
- **`df2681b` Adopt Unity invert pattern on toggle button groups + add focus rings** — `.btn-group` toggles (time-range / chart-customization pickers) had `.btn-secondary.active` (Bootstrap gray) as the selected state, opposite of how tabs read. Scoped to `.btn-group` so standalone `.btn-secondary` uses (modal Cancel, queue_history Back) keep their existing treatments. Also added Unity-style `:focus` rings on `.btn` / `.nav-link`.
- **`15af6dc` Invert project-card header convention to match Unity tab/toggle pattern** — `/user/` My Accounts project cards now read: collapsed (inactive) = solid NCAR blue header, expanded (active) = white surface with blue text. Scoped color override so badge children keep their subtle palette in both states.
- **`6386825` Recolor `.nav-pills` to NCAR blue** — `/admin/` Project Expirations sub-tabs and `/allocations/` chart-selection sub-tabs inherited Bootstrap's default `#0d6efd` instead of NCAR `#0057c2`. Kept the subtle pill look (didn't escalate to `.nav-tabs` invert), just recolored via four Bootstrap CSS variables.

### Typography & polish
- **`1d453d9` Adopt Unity uppercase + letter-spacing on `.btn`** — `text-transform: uppercase; letter-spacing: 0.05rem` on the `.btn` base rule. Single biggest "feels-like-Unity" lever in the audit. Doesn't affect tabs/nav-links/body text — only `.btn`.
- **`20b839c` Add Unity-style `:disabled` treatment to `.btn-primary` / outline variants** — replace Bootstrap's `.65` opacity fade with a hybrid ghost: transparent fill + transparent 3px border + gray text, `opacity: 1`. Keeps the button's footprint (no layout shift) but reads as clearly inert.

### Cleanup
- **`e8d8911` Remove dead `.badge-*` rules** — `.badge-success`, `.badge-primary`, etc. (hyphenated form) had zero template hits, verified by grep. ~23 lines deleted. Zero visual delta.
- **`59f13d1` Template `--ncar-blue-rgb`** — refactor 4 literal `rgba(0, 87, 194, X)` callsites in `dashboard.css` to use a paired `--ncar-blue-rgb: 0, 87, 194` token in `variables.css`. Pure refactor; if `--ncar-blue` ever shifts, the four call sites no longer drift.

## Test plan
- [x] `/admin/`, `/user/`, `/allocations/` — chrome scrollbars gone at typical resolutions; tab chrome tighter; all buttons render UPPERCASE.
- [x] Create Project, Edit Project Directory, samConfirmModal — headers in NCAR blue / navy / vermilion respectively; flat corners; Cancel button outlined gray/navy; submit button blue.
- [x] `/status/queue-history/derecho/cpu` — preset time-range buttons now invert: inactive = solid NCAR blue, selected = white with blue text.
- [x] `/user/` My Accounts — project-card headers: collapsed = blue, expanded = white, badge children legible in both states.
- [x] `/admin/` Project Expirations + `/allocations/` chart pills — render in NCAR blue (`#0057c2`), not Bootstrap blue (`#0d6efd`).
- [x] Trigger a disabled button (HTMX form submission) — ghosted gray text in footprint, no fill.
- [x] Verify alerts on any page that surfaces a flash — solid NCAR blue / orange / vermilion / emerald bars, no left accent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)