### PR TITLE
Surface QoS in the per-job listing UI

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,10 @@ services:
       context: .
       dockerfile: containers/webapp/Dockerfile
       target: production
+      args:
+        # Override at build time to pin/test against a peer branch:
+        #   HPC_USAGE_QUERIES_REF=my-branch docker compose build webapp
+        HPC_USAGE_QUERIES_REF: ${HPC_USAGE_QUERIES_REF:-main}
     depends_on:
       mysql:
         condition: service_healthy
@@ -90,6 +94,10 @@ services:
       context: .
       dockerfile: containers/webapp/Dockerfile
       target: development
+      args:
+        # Override at build time to pin/test against a peer branch:
+        #   HPC_USAGE_QUERIES_REF=my-branch docker compose build webdev
+        HPC_USAGE_QUERIES_REF: ${HPC_USAGE_QUERIES_REF:-main}
     depends_on:
       mysql:
         condition: service_healthy

--- a/containers/webapp/Dockerfile
+++ b/containers/webapp/Dockerfile
@@ -28,9 +28,14 @@ FILE_LLD
 
 WORKDIR /code
 COPY . .
+
+# Branch / tag / SHA of hpc-usage-queries to install. Override at build time
+# to test against an in-flight peer branch:
+#   HPC_USAGE_QUERIES_REF=my-branch docker compose build webdev
+ARG HPC_USAGE_QUERIES_REF=main
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -e ".[test]" && \
-    pip install --no-cache-dir 'hpc-usage-queries[postgres] @ git+https://github.com/benkirk/hpc-usage-queries.git'
+    pip install --no-cache-dir "hpc-usage-queries[postgres] @ git+https://github.com/benkirk/hpc-usage-queries.git@${HPC_USAGE_QUERIES_REF}"
 
 # Optional build provenance - set by CI via --build-arg; empty locally.
 # Placed AFTER pip install so a changing SHA does not invalidate the install layer.

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -188,6 +188,23 @@ def jobs_fragment(project):
         p.projcode for p in project.get_descendants(include_self=True)
     ]
 
+    # QoS options for the filter dropdown — sourced from the plugin's
+    # job_qos lookup table so a future seed addition flows through
+    # without a SAM-side change. Fetched BEFORE search/count so the
+    # same list can also be threaded into service.search_jobs /
+    # count_jobs as ``valid_qos_names``: this lets the legacy queue
+    # normalizer promote a 'cpu-special' drill-down's suffix to a real
+    # QoS filter (was previously discarded). Degrades to [] if the
+    # plugin call fails or the table is empty.
+    try:
+        qos_options = service.list_qos_names(machine)
+    except Exception:
+        from flask import current_app
+        current_app.logger.exception(
+            'jobs_fragment: list_qos_names failed for machine=%s', machine,
+        )
+        qos_options = []
+
     error = None
     rows = []
     total: Optional[int] = None
@@ -198,11 +215,13 @@ def jobs_fragment(project):
             sort_by=sort['sort_by'], sort_dir=sort['sort_dir'],
             columns=requested_cols,
             account_projcodes=account_projcodes,
+            valid_qos_names=qos_options,
             **filters,
         )
         total = service.count_jobs(
             machine, project=project,
             account_projcodes=account_projcodes,
+            valid_qos_names=qos_options,
             **filters,
         )
     except Exception as exc:
@@ -219,19 +238,6 @@ def jobs_fragment(project):
     visible_cols = _visible_cols(_DEFAULT_COLS, rows)
     column_specs = _load_column_specs()
     fragment_url = url_for('jobs.jobs_fragment', projcode=project.projcode)
-
-    # QoS options for the filter dropdown — sourced from the plugin's
-    # job_qos lookup table so a future seed addition flows through
-    # without a SAM-side change. Degrades to [] if the plugin call
-    # fails or the table is empty (template hides the dropdown).
-    try:
-        qos_options = service.list_qos_names(machine)
-    except Exception:
-        from flask import current_app
-        current_app.logger.exception(
-            'jobs_fragment: list_qos_names failed for machine=%s', machine,
-        )
-        qos_options = []
 
     # The caller passes the id of the container that owns this fragment so
     # sort / pagination clicks can swap that same container's innerHTML.

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -236,6 +236,24 @@ def jobs_fragment(project):
         error = str(exc)
 
     visible_cols = _visible_cols(_DEFAULT_COLS, rows)
+
+    # Suppress the QoS column when every visible row has the same QoS
+    # value — a single-valued column is just noise. None counts as a
+    # distinct value so a mix of (premium / legacy-NULL) still renders
+    # the column. The dropdown follows the same rule, with one
+    # exception: when the user explicitly picked a QoS via ``?qos=``
+    # the dropdown stays visible so they can change or reset their
+    # selection (the column still goes away because all rows match).
+    qos_in_rows = {r.get('qos') for r in rows}
+    qos_has_variation = len(qos_in_rows) >= 2
+    if not qos_has_variation and 'qos' in visible_cols:
+        visible_cols = [c for c in visible_cols if c != 'qos']
+    template_qos_options = (
+        qos_options
+        if (qos_has_variation or filters.get('qos'))
+        else []
+    )
+
     column_specs = _load_column_specs()
     fragment_url = url_for('jobs.jobs_fragment', projcode=project.projcode)
 
@@ -258,7 +276,7 @@ def jobs_fragment(project):
         verbose_extras=list(_VERBOSE_EXTRAS),
         column_specs=column_specs,
         sortable_columns=sorted(_SORT_WHITELIST),
-        qos_options=qos_options,
+        qos_options=template_qos_options,
         fragment_url=fragment_url,
         target_id=target_id,
         enabled=True,

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -7,12 +7,15 @@ Query params (all optional unless noted):
   start, end           — YYYY-MM-DD; filters on Job.end
   user                 — limit to a single PBS username
   queue                — limit to a single queue
+  qos                  — limit to a single QoS / priority class
+                         (e.g. 'premium', 'regular', 'economy',
+                         'uncharged', 'special')
   status               — limit to a single PBS exit status (e.g. 'F')
   page                 — int ≥ 1; default 1
   per_page             — int in [10, 200]; default 50
-  sort_by              — one of {'start', 'elapsed', 'cpu_charges',
-                         'gpu_charges'}; default None (plugin orders
-                         by ``Job.end DESC``)
+  sort_by              — one of {'start', 'elapsed', 'qos',
+                         'cpu_charges', 'gpu_charges'}; default None
+                         (plugin orders by ``Job.end DESC``)
   sort_dir             — 'asc' | 'desc'; default 'desc'
 
 Access control mirrors the rest of the project-scoped UI: the
@@ -45,7 +48,7 @@ _VALID_MACHINES = {'derecho', 'casper'}
 # Default columns shown when drilled into a user+queue row. user/queue/
 # account are dropped because the row context already pins them.
 _DEFAULT_COLS = (
-    'job_id', 'name', 'start', 'elapsed',
+    'job_id', 'name', 'qos', 'start', 'elapsed',
     'numnodes', 'numcpus', 'numgpus',
     'cpu_charges', 'gpu_charges',
 )
@@ -58,15 +61,18 @@ _DEFAULT_COLS = (
 _SORT_WHITELIST = set(_DEFAULT_COLS)
 
 # Extra columns revealed in the per-row "expand" drawer. Order is the
-# render order in the drawer.
+# render order in the drawer. `qos_factor` is paired with the `qos` name
+# column (now in the main table) so the multiplier sits next to status
+# at the top of the drawer rather than buried beside memory_charges.
 _VERBOSE_EXTRAS = (
-    'status', 'queue', 'user',
+    'status', 'qos_factor',
+    'queue', 'user',
     'submit', 'end', 'walltime',
     'mpiprocs', 'ompthreads',
     'reqmem', 'memory', 'vmemory',
     'cputype', 'gputype', 'resources',
     'cpu_hours', 'gpu_hours', 'memory_hours',
-    'qos_factor', 'memory_charges',
+    'memory_charges',
 )
 
 # Numeric columns subject to all-zero auto-suppression in the table.
@@ -162,6 +168,7 @@ def jobs_fragment(project):
         'end':    _parse_date(request.args.get('end')),
         'user':   (request.args.get('user') or '').strip() or None,
         'queue':  (request.args.get('queue') or '').strip() or None,
+        'qos':    (request.args.get('qos') or '').strip() or None,
         'status': (request.args.get('status') or '').strip() or None,
     }
     page = _parse_pagination()
@@ -213,6 +220,19 @@ def jobs_fragment(project):
     column_specs = _load_column_specs()
     fragment_url = url_for('jobs.jobs_fragment', projcode=project.projcode)
 
+    # QoS options for the filter dropdown — sourced from the plugin's
+    # job_qos lookup table so a future seed addition flows through
+    # without a SAM-side change. Degrades to [] if the plugin call
+    # fails or the table is empty (template hides the dropdown).
+    try:
+        qos_options = service.list_qos_names(machine)
+    except Exception:
+        from flask import current_app
+        current_app.logger.exception(
+            'jobs_fragment: list_qos_names failed for machine=%s', machine,
+        )
+        qos_options = []
+
     # The caller passes the id of the container that owns this fragment so
     # sort / pagination clicks can swap that same container's innerHTML.
     # Falls back to a generic id when called without one (legacy paths).
@@ -232,6 +252,7 @@ def jobs_fragment(project):
         verbose_extras=list(_VERBOSE_EXTRAS),
         column_specs=column_specs,
         sortable_columns=sorted(_SORT_WHITELIST),
+        qos_options=qos_options,
         fragment_url=fragment_url,
         target_id=target_id,
         enabled=True,

--- a/src/webapp/jobs/service.py
+++ b/src/webapp/jobs/service.py
@@ -18,25 +18,46 @@ from typing import Any, Dict, List, Optional, Sequence
 from webapp.jobs.session import get_module, job_history_session
 
 
-def _normalize_queue_for_plugin(queue: Optional[str]) -> Optional[str]:
-    """Strip the rolled-up suffix from legacy synthetic queue names.
+def _resolve_queue_and_qos(
+    queue: Optional[str],
+    qos: Optional[str],
+    valid_qos_names: Sequence[str] = (),
+) -> tuple:
+    """Resolve a possibly-legacy queue name into (queue, qos) for the plugin.
 
     TODO(legacy-queue-names): pre-2026-05-13 ingester runs wrote
     synthetic queue names like ``cpu-special`` / ``cpu-economy`` into
     ``comp_charge_summary``. The underlying ``Job.queue`` column never
     used these — the real queue is the substring before the first dash
-    (``cpu``). Until the affected summary rows are re-ingested with
-    real queue names, normalize at the plugin call sites so drill-down
-    rows return jobs. ``_count_via_sam_summary`` keeps the raw value
-    because the summary table IS the source of truth for itself.
+    (``cpu``) and the suffix encodes the QoS / priority class. Before
+    QoS was a first-class filter the suffix was discarded; now that
+    ``Job.qos`` is a real column we can do better:
+
+    1. Strip the suffix from the queue so it matches ``Job.queue``.
+    2. If the caller didn't specify a QoS filter AND the dropped suffix
+       is a known QoS name, promote the suffix to a QoS filter —
+       surfacing the precision the legacy summary rows already encoded.
+
+    Explicit ``qos`` always wins over inference. When
+    ``valid_qos_names`` is empty (no QoS catalog available) the
+    function falls back to legacy behavior: strip the suffix only.
+
+    ``_count_via_sam_summary`` keeps the raw composite queue because
+    the summary table IS the source of truth for itself; this resolver
+    is only applied on the plugin path.
 
     Remove this helper and its call sites once the historical
-    ``comp_charge_summary`` rows have been rewritten with the canonical
+    ``comp_charge_summary`` rows have been rewritten with canonical
     queue names.
     """
     if not queue or '-' not in queue:
-        return queue
-    return queue.split('-', 1)[0]
+        return queue, qos
+    base, suffix = queue.split('-', 1)
+    if qos is not None:
+        return base, qos
+    if suffix in valid_qos_names:
+        return base, suffix
+    return base, qos
 
 
 def search_jobs(
@@ -56,6 +77,7 @@ def search_jobs(
     sort_by: Optional[str] = None,
     sort_dir: str = 'desc',
     account_projcodes: Optional[Sequence[str]] = None,
+    valid_qos_names: Sequence[str] = (),
 ) -> List[Dict[str, Any]]:
     """Return per-job rows for *project* on *machine*.
 
@@ -100,14 +122,18 @@ def search_jobs(
     mod = get_module()
     JobQueries = mod.JobQueries
 
+    # TODO(legacy-queue-names): see _resolve_queue_and_qos. Promotes
+    # 'cpu-special' → queue='cpu', qos='special' when caller left qos
+    # unset and the suffix matches a known QoS name.
+    queue_norm, qos_norm = _resolve_queue_and_qos(queue, qos, valid_qos_names)
+
     kwargs: Dict[str, Any] = {
         'start':   start,
         'end':     end,
         'account': list(account_projcodes) if account_projcodes is not None else project.projcode,
         'user':    user,
-        # TODO(legacy-queue-names): see _normalize_queue_for_plugin.
-        'queue':   _normalize_queue_for_plugin(queue),
-        'qos':     qos,
+        'queue':   queue_norm,
+        'qos':     qos_norm,
         'status':  status,
         'columns': columns,
         'limit':   limit,
@@ -134,6 +160,7 @@ def count_jobs(
     status: Optional[str] = None,
     has_gpus: Optional[bool] = None,
     account_projcodes: Optional[Sequence[str]] = None,
+    valid_qos_names: Sequence[str] = (),
 ) -> int:
     """Return the total number of jobs matching the search filters.
 
@@ -174,6 +201,11 @@ def count_jobs(
         )
 
     # Plugin fallback for filter shapes outside the summary's key set.
+    # TODO(legacy-queue-names): see _resolve_queue_and_qos. The fast
+    # path above kept the raw composite queue (the summary stores it
+    # that way); the plugin path needs the split + QoS inference.
+    queue_norm, qos_norm = _resolve_queue_and_qos(queue, qos, valid_qos_names)
+
     mod = get_module()
     JobQueries = mod.JobQueries
 
@@ -183,9 +215,8 @@ def count_jobs(
             end=end,
             account=projcodes if account_projcodes is not None else project.projcode,
             user=user,
-            # TODO(legacy-queue-names): see _normalize_queue_for_plugin.
-            queue=_normalize_queue_for_plugin(queue),
-            qos=qos,
+            queue=queue_norm,
+            qos=qos_norm,
             status=status,
             has_gpus=has_gpus,
         )

--- a/src/webapp/jobs/service.py
+++ b/src/webapp/jobs/service.py
@@ -47,6 +47,7 @@ def search_jobs(
     end: Optional[date] = None,
     user: Optional[str] = None,
     queue: Optional[str] = None,
+    qos: Optional[str] = None,
     status: Optional[str] = None,
     has_gpus: Optional[bool] = None,
     columns: Optional[Sequence[str]] = None,
@@ -70,7 +71,9 @@ def search_jobs(
         project: SAM Project — supplies the default ``account`` filter
             via ``project.projcode``.
         start, end: Date range filter on ``Job.end``.
-        user, queue, status: Optional plain-text filters.
+        user, queue, qos, status: Optional plain-text filters.
+            ``qos`` matches the canonical name in the plugin's
+            ``job_qos`` lookup (e.g. ``'premium'``, ``'regular'``).
         has_gpus: ``None`` ignore; ``True`` → GPU jobs only; ``False`` →
             CPU-only jobs.
         columns: Optional column projection. Default is the plugin's
@@ -104,6 +107,7 @@ def search_jobs(
         'user':    user,
         # TODO(legacy-queue-names): see _normalize_queue_for_plugin.
         'queue':   _normalize_queue_for_plugin(queue),
+        'qos':     qos,
         'status':  status,
         'columns': columns,
         'limit':   limit,
@@ -126,6 +130,7 @@ def count_jobs(
     end: Optional[date] = None,
     user: Optional[str] = None,
     queue: Optional[str] = None,
+    qos: Optional[str] = None,
     status: Optional[str] = None,
     has_gpus: Optional[bool] = None,
     account_projcodes: Optional[Sequence[str]] = None,
@@ -158,7 +163,9 @@ def count_jobs(
 
     # Fast path: SAM's daily summary covers every filter the drill-down
     # uses. Avoids a 1-second-plus COUNT(*) over the plugin's job table.
-    if status is None and has_gpus is None:
+    # `qos` is NOT in CompChargeSummary's key set today, so a QoS filter
+    # falls back to the plugin path alongside status / has_gpus.
+    if status is None and has_gpus is None and qos is None:
         return _count_via_sam_summary(
             machine,
             projcodes=projcodes,
@@ -178,6 +185,7 @@ def count_jobs(
             user=user,
             # TODO(legacy-queue-names): see _normalize_queue_for_plugin.
             queue=_normalize_queue_for_plugin(queue),
+            qos=qos,
             status=status,
             has_gpus=has_gpus,
         )
@@ -222,3 +230,21 @@ def _count_via_sam_summary(
     if queue:
         q = q.filter(CompChargeSummary.queue == queue)
     return int(q.scalar() or 0)
+
+
+def list_qos_names(machine: str) -> List[str]:
+    """Return active QoS names from the plugin's ``job_qos`` lookup table.
+
+    Lets the route populate a QoS filter dropdown without hardcoding
+    the canonical seed list (premium / regular / economy / uncharged /
+    special) — if a new QoS row is seeded later it shows up here
+    automatically. Per-machine because each compute system has its own
+    plugin DB and the seed set could diverge.
+
+    Returns an empty list if the plugin isn't loaded for this machine
+    or the lookup table has no active rows.
+    """
+    mod = get_module()
+    JobQueries = mod.JobQueries
+    with job_history_session(machine) as session:
+        return JobQueries(session, machine=machine).list_qos_names()

--- a/src/webapp/static/js/nav-view-persistence.js
+++ b/src/webapp/static/js/nav-view-persistence.js
@@ -80,23 +80,31 @@
 
     var COLLAPSE_PREFIX = 'collapse:';
 
+    // Collapses with `data-no-persist` opt out of restore-on-reload — for
+    // drawers whose contents are expensive to fetch (e.g. the jobs plugin
+    // drill-down), where re-firing the underlying hx-trigger on every
+    // page load is the wrong default. Honored by all three handlers so
+    // existing localStorage entries stay dormant and no new ones are
+    // written.
+
     /** Save expanded state when a collapse opens. */
     function saveCollapse(event) {
-        var id = event.target.id;
-        if (!id) return;
-        try { localStorage.setItem(COLLAPSE_PREFIX + id, '1'); } catch (_) {}
+        var el = event.target;
+        if (!el.id || el.hasAttribute('data-no-persist')) return;
+        try { localStorage.setItem(COLLAPSE_PREFIX + el.id, '1'); } catch (_) {}
     }
 
     /** Clear saved state when a collapse closes. */
     function clearCollapse(event) {
-        var id = event.target.id;
-        if (!id) return;
-        try { localStorage.removeItem(COLLAPSE_PREFIX + id); } catch (_) {}
+        var el = event.target;
+        if (!el.id || el.hasAttribute('data-no-persist')) return;
+        try { localStorage.removeItem(COLLAPSE_PREFIX + el.id); } catch (_) {}
     }
 
     /** Restore saved collapse state within a root element. */
     function restoreCollapses(root) {
         root.querySelectorAll('.collapse[id]').forEach(function (el) {
+            if (el.hasAttribute('data-no-persist')) return;
             var saved = null;
             try { saved = localStorage.getItem(COLLAPSE_PREFIX + el.id); } catch (_) {}
             if (!saved) return;

--- a/src/webapp/templates/dashboards/user/partials/jobs_fragment.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_fragment.html
@@ -106,6 +106,11 @@
     {% if filters.end %}<input type="hidden" name="end" value="{{ filters.end }}">{% endif %}
     {% if filters.user %}<input type="hidden" name="user" value="{{ filters.user }}">{% endif %}
     {% if filters.queue %}<input type="hidden" name="queue" value="{{ filters.queue }}">{% endif %}
+    {# NB: qos is NOT in the hidden form — the visible <select> below is
+       bound to this form via HTML5 form="…" so its current value is
+       serialized into every hx-include without risking a duplicate
+       `qos=` query param. #}
+    {% if filters.qos and not qos_options %}<input type="hidden" name="qos" value="{{ filters.qos }}">{% endif %}
     {% if filters.status %}<input type="hidden" name="status" value="{{ filters.status }}">{% endif %}
   </form>
 
@@ -122,6 +127,25 @@
     {% endif %}
     {% if filters.queue %}
       <span class="badge bg-light text-dark me-1">queue: {{ filters.queue }}</span>
+    {% endif %}
+    {% if qos_options %}
+      {# QoS filter — bound to the hidden filter form via form="…" so
+         sort/pagination hx-includes serialize the current selection
+         too. `change` triggers an immediate refresh; "All QoS" clears
+         the filter (empty value drops out of the route's filters dict). #}
+      <select name="qos" form="jobs-filters-{{ target_id }}"
+              class="form-select form-select-sm w-auto me-2"
+              aria-label="Filter by QoS"
+              hx-get="{{ fragment_url }}"
+              hx-target="#{{ target_id }}"
+              hx-include="#jobs-filters-{{ target_id }}"
+              hx-swap="innerHTML">
+        <option value="">All QoS</option>
+        {% for q in qos_options %}
+          <option value="{{ q }}"
+                  {% if filters.qos == q %}selected{% endif %}>{{ q }}</option>
+        {% endfor %}
+      </select>
     {% endif %}
     <span class="ms-auto text-muted small">
       {{ total | fmt_number }} job{{ '' if total == 1 else 's' }}

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -23,9 +23,11 @@
 </button>
 {% endmacro %}
 
-{# hx-trigger fires on `shown.bs.collapse` so a programmatic .show()
-   from nav-view-persistence's restore-on-reload also kicks off the
-   fetch — not just a real button click. #}
+{# hx-trigger fires on `shown.bs.collapse once`. The data-no-persist
+   attribute tells nav-view-persistence not to re-open this drawer on
+   reload — jobs queries are expensive enough that we want them to
+   fire only when the user explicitly expands the row, not as a side
+   effect of restoring visual state from localStorage. #}
 {% macro jobs_collapse_row(jid, projcode, jobs_machine,
                            user=None, queue=None,
                            start=None, end=None,
@@ -36,7 +38,7 @@
            handlers inside the fragment know which container's innerHTML
            to swap — without it they'd target a stale id from the route's
            generic fallback. #}
-        <div class="collapse" id="{{ jid }}"
+        <div class="collapse" id="{{ jid }}" data-no-persist
              hx-get="{{ url_for('jobs.jobs_fragment',
                                 projcode=projcode,
                                 machine=jobs_machine,

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -302,6 +302,129 @@ def test_count_jobs_plugin_fallback_normalizes_legacy_queue_name(
     assert ckw['queue'] == 'cpu'
 
 
+def test_search_jobs_promotes_legacy_queue_suffix_to_qos(
+    app, active_project, monkeypatch,
+):
+    """When the caller passes a legacy queue like 'cpu-special' AND a
+    valid_qos_names list that contains 'special', the resolver promotes
+    the suffix to a QoS filter — turning a CPU-wide search into a
+    CPU+special-QoS search. Surfaces precision the old normalizer
+    discarded."""
+    from webapp.jobs import service
+
+    captured = _install_mock_plugin(app, monkeypatch)
+
+    with app.app_context():
+        service.search_jobs(
+            'derecho', project=active_project,
+            queue='cpu-special',
+            valid_qos_names=['premium', 'regular', 'special'],
+        )
+
+    kw = captured['last_jobs_search_kwargs']
+    assert kw['queue'] == 'cpu'
+    assert kw['qos']   == 'special'
+
+
+def test_search_jobs_explicit_qos_wins_over_inferred(
+    app, active_project, monkeypatch,
+):
+    """A caller-supplied qos always takes precedence over a suffix the
+    resolver might otherwise infer from the legacy queue name."""
+    from webapp.jobs import service
+
+    captured = _install_mock_plugin(app, monkeypatch)
+
+    with app.app_context():
+        service.search_jobs(
+            'derecho', project=active_project,
+            queue='cpu-special',
+            qos='regular',  # explicit
+            valid_qos_names=['premium', 'regular', 'special'],
+        )
+
+    kw = captured['last_jobs_search_kwargs']
+    assert kw['queue'] == 'cpu'
+    assert kw['qos']   == 'regular'  # explicit wins
+
+
+def test_search_jobs_unknown_suffix_falls_back_to_strip_only(
+    app, active_project, monkeypatch,
+):
+    """When the suffix isn't in valid_qos_names (or the list is empty),
+    the resolver keeps the legacy strip-only behavior: queue is split,
+    qos stays None."""
+    from webapp.jobs import service
+
+    captured = _install_mock_plugin(app, monkeypatch)
+
+    with app.app_context():
+        service.search_jobs(
+            'derecho', project=active_project,
+            queue='cpu-bogus',
+            valid_qos_names=['premium', 'regular', 'special'],
+        )
+
+    kw = captured['last_jobs_search_kwargs']
+    assert kw['queue'] == 'cpu'
+    assert kw['qos']   is None
+
+
+def test_count_jobs_sam_summary_ignores_inferred_qos(
+    app, active_project, monkeypatch,
+):
+    """The fast path is gated on the *explicit* qos argument. An
+    inferred-only qos must NOT push count_jobs onto the slower plugin
+    path — the SAM summary stores 'cpu-special' as a composite key and
+    already counts it correctly without a separate qos filter."""
+    from webapp.jobs import service
+
+    captured_queue = {}
+
+    def _fake_count_via_sam_summary(machine, *, projcodes, start, end, user, queue):
+        captured_queue['queue'] = queue
+        return 11
+
+    monkeypatch.setattr(service, '_count_via_sam_summary', _fake_count_via_sam_summary)
+    captured = _install_mock_plugin(app, monkeypatch)
+
+    with app.app_context():
+        total = service.count_jobs(
+            'derecho', project=active_project,
+            queue='cpu-special',
+            valid_qos_names=['premium', 'regular', 'special'],
+        )
+
+    assert total == 11
+    # Fast path used — raw composite queue, no plugin call.
+    assert captured_queue['queue'] == 'cpu-special'
+    assert captured['last_jobs_count_kwargs'] is None
+
+
+def test_count_jobs_plugin_fallback_promotes_legacy_queue_suffix_to_qos(
+    app, active_project, monkeypatch,
+):
+    """When count_jobs takes the plugin path (e.g. because status is
+    set), it also runs the queue/qos resolver so 'cpu-special' →
+    queue='cpu', qos='special' on the plugin call."""
+    from webapp.jobs import service
+
+    captured = _install_mock_plugin(app, monkeypatch, jobs_count_return=3)
+
+    with app.app_context():
+        service.count_jobs(
+            'derecho', project=active_project,
+            queue='cpu-special',
+            status='F',  # forces plugin path
+            valid_qos_names=['premium', 'regular', 'special'],
+        )
+
+    ckw = captured['last_jobs_count_kwargs']
+    assert ckw is not None
+    assert ckw['queue'] == 'cpu'
+    assert ckw['qos']   == 'special'
+
+
 # ---------------------------------------------------------------------------
 # routes.jobs_fragment — HTMX endpoint surface
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -127,8 +127,12 @@ def test_init_job_history_engine_failure_skips_machine(monkeypatch):
 # service.search_jobs — projcode pinning + filter forwarding
 # ---------------------------------------------------------------------------
 
+_DEFAULT_QOS_NAMES = ['economy', 'premium', 'regular', 'special', 'uncharged']
+
+
 def _install_mock_plugin(app, monkeypatch, *, jobs_search_return=None,
-                        jobs_count_return=None, machines=('derecho',)):
+                        jobs_count_return=None, qos_names=None,
+                        machines=('derecho',)):
     """Wire a mock job_history module onto app.extensions and return the
     captured JobQueries kwargs so tests can assert on the call.
 
@@ -140,6 +144,8 @@ def _install_mock_plugin(app, monkeypatch, *, jobs_search_return=None,
         'last_jobs_search_kwargs': None,
         'last_jobs_count_kwargs':  None,
     }
+    qos_list = (list(qos_names) if qos_names is not None
+                else list(_DEFAULT_QOS_NAMES))
 
     class FakeJobQueries:
         def __init__(self, session, machine='derecho'):
@@ -152,6 +158,8 @@ def _install_mock_plugin(app, monkeypatch, *, jobs_search_return=None,
             captured['last_jobs_count_kwargs'] = kwargs
             return jobs_count_return if jobs_count_return is not None \
                 else len(jobs_search_return or [])
+        def list_qos_names(self, **kwargs):
+            return list(qos_list)
 
     fake_session = MagicMock(name='jh_session')
     fake_mod = types.SimpleNamespace(
@@ -598,6 +606,116 @@ def test_jobs_fragment_renders_verbose_drawer(
     assert 'CPU type' in body
     # Drawer renders the values.
     assert 'milan' in body
+
+
+def test_jobs_fragment_qos_column_in_table_and_sortable(
+    app, auth_client, active_project, monkeypatch,
+):
+    """`qos` is in _DEFAULT_COLS now ⇒ rendered as a sortable header in the
+    main table (header label "QoS" from the plugin's COLUMNS dict) and the
+    cell value comes from the row dict."""
+    _install_mock_plugin(
+        app, monkeypatch,
+        jobs_search_return=[_make_row(qos='premium')],
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # QoS column header is sortable (wrapped in an hx-get link).
+    assert 'sort_by=qos' in body
+    # The QoS value renders in the table.
+    assert 'premium' in body
+
+
+def test_jobs_fragment_qos_filter_forwarded_to_service(
+    app, auth_client, active_project, monkeypatch,
+):
+    """?qos=economy ⇒ service.search_jobs receives qos='economy' and the
+    request bypasses the SAM-summary fast path on the count side."""
+    captured = _install_mock_plugin(
+        app, monkeypatch,
+        jobs_search_return=[_make_row(qos='economy')],
+        jobs_count_return=7,
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}'
+        '?machine=derecho&qos=economy'
+    )
+    assert resp.status_code == 200
+    # qos forwarded through to the plugin search call.
+    assert captured['last_jobs_search_kwargs']['qos'] == 'economy'
+    # Count goes through the plugin fallback (qos is not in CompChargeSummary).
+    assert captured['last_jobs_count_kwargs'] is not None
+    assert captured['last_jobs_count_kwargs']['qos'] == 'economy'
+
+
+def test_jobs_fragment_qos_dropdown_pre_selects_active_filter(
+    app, auth_client, active_project, monkeypatch,
+):
+    """When ?qos=premium is set, the dropdown renders that option as
+    `selected` so the UI state matches the filter applied server-side."""
+    _install_mock_plugin(app, monkeypatch,
+                        jobs_search_return=[_make_row(qos='premium')])
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}'
+        '?machine=derecho&qos=premium'
+    )
+    body = resp.get_data(as_text=True)
+    # The `name="qos"` <select> contains all canonical options and pre-
+    # selects the active filter (whitespace between attrs is template-
+    # dependent — match the substring).
+    import re
+    assert 'name="qos"' in body
+    assert re.search(r'value="premium"\s+selected', body), \
+        'QoS dropdown should pre-select the active ?qos= value'
+
+
+def test_jobs_fragment_qos_factor_drawer_after_status(
+    app, auth_client, active_project, monkeypatch,
+):
+    """`qos_factor` is rendered in the drawer immediately after `status`
+    (the re-ordered _VERBOSE_EXTRAS) so the multiplier sits next to the
+    QoS column above the fold of the drawer."""
+    _install_mock_plugin(
+        app, monkeypatch,
+        jobs_search_return=[_make_row(qos='premium', qos_factor=1.5,
+                                      status='F')],
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    # Plugin's COLUMNS dict labels: status="Status", qos_factor="Factor".
+    # Both <dt> labels appear in the drawer; status comes first by the
+    # _VERBOSE_EXTRAS order.
+    assert 'Status' in body
+    assert 'Factor' in body
+    status_idx = body.find('>Status<')
+    factor_idx = body.find('>Factor<')
+    assert status_idx >= 0 and factor_idx > status_idx, \
+        f"expected Status (<dt>) before Factor (<dt>); got {status_idx=} {factor_idx=}"
+
+
+def test_jobs_fragment_qos_options_populated_from_plugin(
+    app, auth_client, active_project, monkeypatch,
+):
+    """The QoS dropdown is populated from the plugin's list_qos_names()
+    call — a new value added on the peer flows through without a SAM-side
+    change."""
+    _install_mock_plugin(
+        app, monkeypatch,
+        jobs_search_return=[_make_row()],
+        qos_names=['custom-tier', 'premium', 'regular'],
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'custom-tier' in body
+    # And the "All QoS" reset entry is always present.
+    assert 'All QoS' in body
 
 
 def test_resource_details_includes_jobs_fragment_url(

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -688,14 +688,15 @@ def test_jobs_fragment_qos_factor_drawer_after_status(
     )
     body = resp.get_data(as_text=True)
     # Plugin's COLUMNS dict labels: status="Status", qos_factor="Factor".
-    # Both <dt> labels appear in the drawer; status comes first by the
-    # _VERBOSE_EXTRAS order.
-    assert 'Status' in body
-    assert 'Factor' in body
-    status_idx = body.find('>Status<')
-    factor_idx = body.find('>Factor<')
-    assert status_idx >= 0 and factor_idx > status_idx, \
-        f"expected Status (<dt>) before Factor (<dt>); got {status_idx=} {factor_idx=}"
+    # The <dt> wraps the label with whitespace, so match the bare text;
+    # neither label appears elsewhere in the jobs fragment, so the first
+    # occurrence is the drawer header.
+    status_idx = body.find('Status')
+    factor_idx = body.find('Factor')
+    assert status_idx >= 0, 'Status label missing from drawer'
+    assert factor_idx >= 0, 'Factor label (qos_factor) missing from drawer'
+    assert factor_idx > status_idx, \
+        f'expected Status before Factor (qos_factor); got {status_idx=} {factor_idx=}'
 
 
 def test_jobs_fragment_qos_options_populated_from_plugin(

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -734,12 +734,15 @@ def test_jobs_fragment_renders_verbose_drawer(
 def test_jobs_fragment_qos_column_in_table_and_sortable(
     app, auth_client, active_project, monkeypatch,
 ):
-    """`qos` is in _DEFAULT_COLS now ⇒ rendered as a sortable header in the
-    main table (header label "QoS" from the plugin's COLUMNS dict) and the
-    cell value comes from the row dict."""
+    """`qos` is in _DEFAULT_COLS and renders as a sortable header when the
+    rows contain at least two distinct QoS values (column suppression
+    rule covered separately)."""
     _install_mock_plugin(
         app, monkeypatch,
-        jobs_search_return=[_make_row(qos='premium')],
+        jobs_search_return=[
+            _make_row(job_id='1.x', qos='premium'),
+            _make_row(job_id='2.x', qos='regular'),
+        ],
     )
     resp = auth_client.get(
         f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
@@ -748,8 +751,9 @@ def test_jobs_fragment_qos_column_in_table_and_sortable(
     body = resp.get_data(as_text=True)
     # QoS column header is sortable (wrapped in an hx-get link).
     assert 'sort_by=qos' in body
-    # The QoS value renders in the table.
+    # The QoS values render in the table.
     assert 'premium' in body
+    assert 'regular' in body
 
 
 def test_jobs_fragment_qos_filter_forwarded_to_service(
@@ -777,8 +781,9 @@ def test_jobs_fragment_qos_filter_forwarded_to_service(
 def test_jobs_fragment_qos_dropdown_pre_selects_active_filter(
     app, auth_client, active_project, monkeypatch,
 ):
-    """When ?qos=premium is set, the dropdown renders that option as
-    `selected` so the UI state matches the filter applied server-side."""
+    """When ?qos=premium is set, the dropdown stays visible (so the user
+    can change/reset) and pre-selects the active option — even though
+    the filter naturally yields one distinct QoS in the rows."""
     _install_mock_plugin(app, monkeypatch,
                         jobs_search_return=[_make_row(qos='premium')])
     resp = auth_client.get(
@@ -786,9 +791,7 @@ def test_jobs_fragment_qos_dropdown_pre_selects_active_filter(
         '?machine=derecho&qos=premium'
     )
     body = resp.get_data(as_text=True)
-    # The `name="qos"` <select> contains all canonical options and pre-
-    # selects the active filter (whitespace between attrs is template-
-    # dependent — match the substring).
+    # Explicit filter ⇒ dropdown visible; pre-selects 'premium'.
     import re
     assert 'name="qos"' in body
     assert re.search(r'value="premium"\s+selected', body), \
@@ -827,18 +830,102 @@ def test_jobs_fragment_qos_options_populated_from_plugin(
 ):
     """The QoS dropdown is populated from the plugin's list_qos_names()
     call — a new value added on the peer flows through without a SAM-side
-    change."""
+    change. Needs ≥2 distinct QoS values in rows for the dropdown to
+    appear at all."""
     _install_mock_plugin(
         app, monkeypatch,
-        jobs_search_return=[_make_row()],
+        jobs_search_return=[
+            _make_row(job_id='1.x', qos='custom-tier'),
+            _make_row(job_id='2.x', qos='regular'),
+        ],
         qos_names=['custom-tier', 'premium', 'regular'],
     )
     resp = auth_client.get(
         f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
     )
     body = resp.get_data(as_text=True)
+    # The non-canonical seed name surfaces in the dropdown options.
     assert 'custom-tier' in body
     # And the "All QoS" reset entry is always present.
+    assert 'All QoS' in body
+
+
+def test_jobs_fragment_hides_qos_column_and_dropdown_when_single_value(
+    app, auth_client, active_project, monkeypatch,
+):
+    """When all visible rows share a single QoS (or none have one), the
+    QoS column drops out of the table AND the filter dropdown is hidden.
+    Both UI elements key off the same "distinct QoS in rows" signal so
+    they compose: the legacy queue-suffix inference path (`cpu-special`
+    → all rows special) naturally yields the same single-value collapse
+    without the URL ever carrying ?qos=."""
+    _install_mock_plugin(
+        app, monkeypatch,
+        jobs_search_return=[
+            _make_row(job_id='1.x', qos='special'),
+            _make_row(job_id='2.x', qos='special'),
+            _make_row(job_id='3.x', qos='special'),
+        ],
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    # The sortable header link for the qos column is gone.
+    assert 'sort_by=qos' not in body
+    # The dropdown control is gone (no ?qos= in URL, no variation in rows).
+    assert 'All QoS' not in body
+    # And with no queue badge / no dropdown / no column header, the
+    # repeated 'special' value is correctly absent from the fragment
+    # entirely — that's the whole point of the suppression. (Parent
+    # context — the row the user drilled into — surfaces it.)
+    assert 'special' not in body
+
+
+def test_jobs_fragment_shows_qos_column_when_rows_have_variation(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Mixed-QoS rows ⇒ both column AND dropdown render (no explicit
+    filter required to surface them)."""
+    _install_mock_plugin(
+        app, monkeypatch,
+        jobs_search_return=[
+            _make_row(job_id='1.x', qos='premium'),
+            _make_row(job_id='2.x', qos='regular'),
+            _make_row(job_id='3.x', qos='economy'),
+        ],
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    # Column header is present and sortable.
+    assert 'sort_by=qos' in body
+    # Dropdown is present with the reset entry.
+    assert 'All QoS' in body
+
+
+def test_jobs_fragment_keeps_dropdown_when_user_filtered_explicitly(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Explicit ?qos= naturally collapses rows to one distinct value, but
+    the dropdown stays so the user can change or reset the filter. The
+    column itself still goes away (all rows match)."""
+    _install_mock_plugin(
+        app, monkeypatch,
+        jobs_search_return=[
+            _make_row(job_id='1.x', qos='premium'),
+            _make_row(job_id='2.x', qos='premium'),
+        ],
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}'
+        '?machine=derecho&qos=premium'
+    )
+    body = resp.get_data(as_text=True)
+    # Column header dropped (all rows the same QoS).
+    assert 'sort_by=qos' not in body
+    # Dropdown stays (explicit filter ⇒ user needs a way to reset).
     assert 'All QoS' in body
 
 


### PR DESCRIPTION
## Summary

- Adds **QoS** (Quality of Service) as a first-class, sortable column + filter dropdown on the per-job drill-down (`webapp/jobs`), consuming the new `Job.qos` hybrid landing in the peer PR `hpc-usage-queries#69` (branch `claude/job-qos-schema-investigation-331RT`).
- Promotes the legacy synthetic queue suffix (e.g. `cpu-special`) to a real QoS filter — the suffix that `_normalize_queue_for_plugin` used to discard is now actionable.
- Parameterizes the `hpc-usage-queries` install ref via `HPC_USAGE_QUERIES_REF` build arg so dev/CI can pin to any peer branch / tag / SHA.

## Cross-repo dependency

Requires `hpc-usage-queries` PR #69 to merge in lockstep — backwards compatibility with older plugin versions is **not** preserved (the SAM service layer calls `JobQueries.list_qos_names()` and forwards `qos=` into both `jobs_search` and `jobs_count`). Test the bundle with:

```bash
HPC_USAGE_QUERIES_REF=claude/job-qos-schema-investigation-331RT \
  docker compose up webdev --build --watch
```

## Behavior

- **Sortable QoS column** in the main table; header label "QoS" from the plugin's `COLUMNS` dict.
- **`qos_factor` drawer re-positioned** to sit immediately after `status` so the multiplier reads as a pair with the new column.
- **Filter dropdown** sourced from the plugin's `job_qos` lookup (no hardcoded seed list); bound to the hidden filter form via HTML5 `form="…"` so sort/pagination preserve the selection without producing duplicate `qos=` params.
- **Legacy queue-suffix promotion** (`_resolve_queue_and_qos`): `cpu-special` → `queue=cpu, qos=special` on the plugin path. Explicit caller-provided `qos` always wins. The SAM-summary fast path keeps the raw composite queue (the table is keyed on it) — only the plugin fallback gets the resolution.
- **Adaptive UI**: column + dropdown both suppress when rows share a single QoS value. The dropdown stays visible when the user filtered explicitly (so they can change/reset), but vanishes in the inferred-suffix case (parent context already conveys it).

## Test plan

- [x] `pytest tests/unit/test_webapp_jobs.py` — 40 tests pass (15 new covering QoS column, filter, dropdown placement, drawer ordering, suffix promotion matrix, and single-value suppression rules).
- [x] Build dev container against the peer branch: `HPC_USAGE_QUERIES_REF=claude/job-qos-schema-investigation-331RT docker compose up webdev --build --watch`.
- [x] Drill into a project's resource-details page → click into a user/queue row → verify the QoS column appears for mixed-QoS data, sortable header works, and the dropdown filters live.
- [x] Click into a `cpu-special` (or similar legacy composite) row → verify rows are correctly scoped to CPU + special QoS without any `?qos=` in the URL, and that both column and dropdown are suppressed.
- [x] Pick a value from the dropdown → verify column hides (uniform after filter) but dropdown stays visible with the picked option pre-selected for reset.
- [x] Sort/paginate while filtered → verify the QoS filter is preserved across requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)