### PR TITLE
Add workflow to sync staging to main after PR merge

### DIFF
--- a/.github/workflows/sync-staging-to-main.yaml
+++ b/.github/workflows/sync-staging-to-main.yaml
@@ -1,0 +1,53 @@
+name: Sync staging to main
+
+# When a PR from `staging` into `main` is merged, `main` advances (merge
+# commit / squash / rebase) and its history diverges from `staging`. This
+# workflow force-resets `staging` back to the post-merge tip of `main` so the
+# two branches are byte-for-byte in sync again, ready for the next round of
+# staging work.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-staging-to-main
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Reset staging to main
+    # Only act on a *merged* PR whose head was `staging` and base was `main`.
+    # (workflow_dispatch carries no pull_request payload, so allow it through.)
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (github.event.pull_request.merged == true
+          && github.event.pull_request.head.ref == 'staging'
+          && github.event.pull_request.base.ref == 'main')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main (post-merge tip)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Force-reset staging to main
+        run: |
+          set -euo pipefail
+          MAIN_SHA="$(git rev-parse HEAD)"
+          echo "Resetting staging -> ${MAIN_SHA}"
+          git push --force origin "HEAD:refs/heads/staging"
+
+          {
+            echo "## Staging synced to main"
+            echo ""
+            echo "- **staging** now points at \`${MAIN_SHA}\` (current tip of \`main\`)"
+            echo "- Triggered by: \`${{ github.event_name }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/sync-staging-to-main.yaml`, which force-resets the
`staging` branch back to the post-merge tip of `main` whenever a PR from
`staging` -> `main` is merged. This keeps the two branches in sync after a
merge commit / squash / rebase causes their histories to diverge.

- Triggers on `pull_request: [closed]` against `main`, gated on the PR being
  merged with head `staging` and base `main`
- Also supports manual `workflow_dispatch`
- Uses `GITHUB_TOKEN` with `contents: write` to `git push --force` main's tip
  onto `staging`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>