### PR TITLE
Lock cirrus branch: push it as a dedicated GitHub App

### DIFF
--- a/.github/workflows/build-images-cirrus-deploy.yaml
+++ b/.github/workflows/build-images-cirrus-deploy.yaml
@@ -270,16 +270,33 @@ jobs:
     if: needs.setup.outputs.webapp_built == 'true'
     runs-on: ubuntu-latest
 
+    # Serialize cirrus force-pushes so two concurrent deploys can't race the
+    # branch (it is reset + force-pushed on every run).
+    concurrency:
+      group: cirrus-branch-push
+      cancel-in-progress: false
+
     permissions:
-      contents: write   # required to push the cirrus branch
+      contents: read   # push to cirrus uses the App token below, not GITHUB_TOKEN
 
     steps:
+      # The cirrus branch is locked by a repository ruleset whose only bypass
+      # actor is this GitHub App, so the push below MUST authenticate as the App.
+      - name: Mint GitHub App token (cirrus deploy identity)
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CIRRUS_DEPLOY_APP_ID }}
+          private-key: ${{ secrets.CIRRUS_DEPLOY_APP_PRIVATE_KEY }}
+
       - name: Checkout triggering ref
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: 1
-          # persist-credentials: true (default) wires GITHUB_TOKEN into git remote
+          # persist-credentials (default true) wires this App token into the git
+          # remote so the force-push step below pushes as the App.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Patch helm/values.yaml with SHA image tag
         run: |
@@ -293,8 +310,8 @@ jobs:
 
       - name: Commit and force-push cirrus branch
         run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name  "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           git checkout -B cirrus
           git add helm/values.yaml
           git commit -m "ci: pin webapp image to sha-${GITHUB_SHA:0:7} ($(date -u '+%Y-%m-%d %H:%M UTC')) [skip ci]"


### PR DESCRIPTION
## Summary

Makes the `cirrus` deploy branch updatable **only** by the
`build-images-cirrus-deploy` workflow. Today nothing protects `cirrus` — any
write-access user or other workflow could push to it and silently change what
production runs.

This PR is the **workflow-side half** (code). It changes only the `update-helm`
job in `.github/workflows/build-images-cirrus-deploy.yaml`:

- Mints a short-lived **GitHub App token** (`actions/create-github-app-token`)
  and uses it for the `git push origin cirrus --force`, instead of the default
  `GITHUB_TOKEN`.
- Sets the cirrus commit author/committer to the App bot.
- Adds a `concurrency` guard so two deploys can't race the force-push.
- Drops the now-unneeded default-token `contents: write` (push uses the App token).

**Triggering is unchanged** — automatic on push to `main` / `v*` tags, and
manual `workflow_dispatch` from the UI both still work. The ruleset (your part)
only governs the *push to cirrus*, not who can *run* the workflow.

---

## ⚠️ Required admin setup (your part) — do BEFORE this reaches `main`

I cannot do these (no admin/UI/API access). The new workflow references two
secrets and assumes a ruleset exists; without them the deploy will fail or be
blocked. Please complete steps 1–2 before this lands on `main`, and step 3 as
this lands on `main`.

### 1. Create the GitHub App
Settings → Developer settings → GitHub Apps → New GitHub App
- Repository permissions: **Contents: Read & write** and **Workflows: Read &
  write** (the force-pushed `cirrus` branch carries the `.github/workflows/`
  tree from `main`; without Workflows:write the App push can hit "refusing to
  update workflow file").
- No webhook needed. **Install** it on `benkirk/sam-queries` only.
- Note the numeric **App ID**; generate + download a **private key** (.pem).

### 2. Add two repo secrets
Settings → Secrets and variables → Actions:
- `CIRRUS_DEPLOY_APP_ID` = the App ID
- `CIRRUS_DEPLOY_APP_PRIVATE_KEY` = full contents of the .pem

### 3. Create the cirrus ruleset (do as this lands on `main`)
UI (Settings → Rules → Rulesets → New branch ruleset) or `gh`:

```bash
gh api -X POST repos/benkirk/sam-queries/rulesets --input - <<'JSON'
{
  "name": "Lock cirrus to deploy workflow",
  "target": "branch",
  "enforcement": "active",
  "conditions": { "ref_name": { "include": ["refs/heads/cirrus"], "exclude": [] } },
  "rules": [
    { "type": "creation" },
    { "type": "update" },
    { "type": "deletion" },
    { "type": "non_fast_forward" }
  ],
  "bypass_actors": [
    { "actor_id": <CIRRUS_DEPLOY_APP_ID>, "actor_type": "Integration", "bypass_mode": "always" }
  ]
}
JSON
```
- `creation`/`update`/`deletion` = only bypass actors may create/update/delete;
  `non_fast_forward` = block force pushes (the App bypasses it, so its `--force`
  still works).
- For a GitHub App the bypass `actor_type` is `"Integration"` and `actor_id` is
  the **App ID** (same value as `CIRRUS_DEPLOY_APP_ID`).
- Tip: set `"enforcement": "evaluate"` first to log-without-block and confirm the
  App push is recognized, then flip to `"active"`.

---

## ⏳ Sequencing — why this PR can "sit"

- Merging this to **`staging`** is harmless: the cirrus workflow triggers on
  `main`/tags/dispatch, not on `staging`.
- The danger window is when it reaches **`main`**. Order to avoid breaking
  deploys:
  1. App + secrets exist (steps 1–2). ← do first; harmless until the new
     workflow runs.
  2. This change is on `main` (normal staging → main flow).
  3. Activate the ruleset (step 3). Activating it **before** the new workflow is
     on `main` would block the *old* default-token push and break deploys.

So: let it sit on `staging` as long as you like; coordinate steps 1–3 around the
eventual merge to `main`.

---

## Verification (after it's on `main` + ruleset active)

1. **Negative:** from a clone, try pushing anything to `cirrus` with your normal
   creds → expect rejection citing the ruleset.
2. **Positive (dispatch):** Actions → "Publish Images and CIRRUS Deploy" → Run
   workflow → `update-helm` log shows the App-token push succeeding.
3. **Positive (auto):** merge a webapp change to `main`; confirm a fresh
   `cirrus` pin commit appears.
4. **Audit:** `git log -1 origin/cirrus` shows the pusher/author as
   `<app-name>[bot]`, not `github-actions[bot]`.

## Caveat

Repo admins can always edit/disable the ruleset, so this is not a guard against a
determined admin — it blocks accidental/direct pushes, other workflows, and
non-admins, with a clear audit trail.

https://claude.ai/code/session_01U4UTgLVkCAmjEQ1CdcJaKo

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4UTgLVkCAmjEQ1CdcJaKo)_