### PR TITLE
QoS visibility: surface single-value QoS as a badge + fix Factor rounding

### DIFF
--- a/src/sam/fmt.py
+++ b/src/sam/fmt.py
@@ -286,6 +286,38 @@ def hours(
     return f"{seconds / 3600:,.{decimals}f}"
 
 
+def factor(
+    x:        Optional[Union[int, float]],
+    *,
+    decimals: int  = 2,
+    null:     str  = '—',
+) -> str:
+    """Format a charging multiplier (a QoS / queue factor) as ``×N.NN``.
+
+    Charging factors are small fractional ratios — economy ``0.7``,
+    premium ``1.5``, regular ``1.0`` — so they must NOT go through
+    :func:`number`, which rounds to whole numbers and would render
+    ``0.7`` as ``1`` (indistinguishable from regular).  The leading
+    multiplication sign signals "multiplier" rather than "count".
+
+    Args:
+        x:        Multiplier value.  None → null.
+        decimals: Fractional digits to keep.  Default 2 (matches the
+                  hpc-usage-queries plugin's ``qos_factor`` ``.2f`` spec).
+        null:     Placeholder returned for None values.
+
+    Examples:
+        factor(0.7)   → '×0.70'
+        factor(1.5)   → '×1.50'
+        factor(1.0)   → '×1.00'
+        factor(0.0)   → '×0.00'
+        factor(None)  → '—'
+    """
+    if x is None:
+        return null
+    return f"×{x:.{decimals}f}"
+
+
 def pct(
     x:        Optional[Union[int, float]],
     *,
@@ -396,12 +428,15 @@ def register_jinja_filters(app) -> None:
         fmt_date    — {{ value | fmt_date }}
                       {{ value | fmt_date(fmt='%b %Y') }}
         fmt_size    — {{ value | fmt_size }}
+        fmt_hours   — {{ seconds | fmt_hours }}
+        fmt_factor  — {{ multiplier | fmt_factor }}   → '×0.70'
     """
     app.jinja_env.filters['fmt_number']   = number
     app.jinja_env.filters['fmt_pct']      = pct
     app.jinja_env.filters['fmt_date']     = date_str
     app.jinja_env.filters['fmt_size']     = size
     app.jinja_env.filters['fmt_hours']    = hours
+    app.jinja_env.filters['fmt_factor']   = factor
     app.jinja_env.filters['to_local_dt']  = to_local_dt
     # Global (not a filter) so templates can render "{{ local_tz_label() }}"
     # alongside naive-local timestamps that don't go through to_local_dt.

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -254,6 +254,22 @@ def jobs_fragment(project):
         else []
     )
 
+    # When the column is suppressed because all rows share one QoS value,
+    # surface that value (and its charging factor) as a header badge so the
+    # single-value case isn't silent — this is exactly the case (uniform
+    # economy / premium) where the multiplier matters most. None
+    # (uncharacterized) gets no badge.
+    qos_badge = None
+    if rows and not qos_has_variation:
+        (shared_qos,) = qos_in_rows         # exactly one element when rows non-empty
+        if shared_qos is not None:
+            factors = {r.get('qos_factor') for r in rows
+                       if r.get('qos_factor') is not None}
+            qos_badge = {
+                'name': shared_qos,
+                'factor': next(iter(factors)) if len(factors) == 1 else None,
+            }
+
     column_specs = _load_column_specs()
     fragment_url = url_for('jobs.jobs_fragment', projcode=project.projcode)
 
@@ -277,6 +293,7 @@ def jobs_fragment(project):
         column_specs=column_specs,
         sortable_columns=sorted(_SORT_WHITELIST),
         qos_options=template_qos_options,
+        qos_badge=qos_badge,
         fragment_url=fragment_url,
         target_id=target_id,
         enabled=True,

--- a/src/webapp/templates/dashboards/user/partials/jobs_fragment.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_fragment.html
@@ -147,6 +147,14 @@
         {% endfor %}
       </select>
     {% endif %}
+    {% if qos_badge %}
+      {# Single shared QoS across all rows: the per-row column is suppressed,
+         so surface the value (and charging multiplier) here instead of
+         leaving it silent. #}
+      <span class="badge bg-light text-dark me-1">
+        QoS: {{ qos_badge.name }}{% if qos_badge.factor is not none %} (×{{ qos_badge.factor }}){% endif %}
+      </span>
+    {% endif %}
     <span class="ms-auto text-muted small">
       {{ total | fmt_number }} job{{ '' if total == 1 else 's' }}
     </span>

--- a/src/webapp/templates/dashboards/user/partials/jobs_fragment.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_fragment.html
@@ -46,6 +46,11 @@
     <span title="{{ val }}">{{ val }}</span>
   {%- elif col in _seconds_to_hours -%}
     {{ val | fmt_hours }}
+  {%- elif col == 'qos_factor' -%}
+    {# A fractional charging multiplier (economy 0.7 / premium 1.5) — must
+       NOT go through fmt_number, which rounds to whole numbers and would
+       render 0.7 as "1" (indistinguishable from regular). #}
+    {{ val | fmt_factor }}
   {%- elif col in _byte_cols -%}
     {{ val | fmt_size }}
   {%- elif col in _numeric_cols -%}
@@ -152,7 +157,7 @@
          so surface the value (and charging multiplier) here instead of
          leaving it silent. #}
       <span class="badge bg-light text-dark me-1">
-        QoS: {{ qos_badge.name }}{% if qos_badge.factor is not none %} (×{{ qos_badge.factor }}){% endif %}
+        QoS: {{ qos_badge.name }}{% if qos_badge.factor is not none %} ({{ qos_badge.factor | fmt_factor }}){% endif %}
       </span>
     {% endif %}
     <span class="ms-auto text-muted small">

--- a/tests/unit/test_fmt.py
+++ b/tests/unit/test_fmt.py
@@ -13,6 +13,7 @@ from sam.fmt import (
     COMPACT_THRESHOLD,
     configure,
     date_str,
+    factor,
     naive_local_to_utc,
     number,
     pct,
@@ -109,6 +110,40 @@ class TestNumber:
     def test_per_call_overrides_global(self):
         configure(raw=True)
         assert number(68_567_808, raw=False) == '68.6M'
+
+
+# ============================================================================
+# factor()
+# ============================================================================
+
+
+class TestFactor:
+
+    def test_economy_does_not_round_to_one(self):
+        # The whole point: 0.7 must NOT collapse to "1" the way number() would.
+        assert factor(0.7) == '×0.70'
+        assert number(0.7) == '1'  # contrast — the bug this guards against
+
+    def test_premium(self):
+        assert factor(1.5) == '×1.50'
+
+    def test_regular_and_zero(self):
+        assert factor(1.0) == '×1.00'
+        assert factor(0.0) == '×0.00'
+
+    def test_decimals_override(self):
+        assert factor(0.7, decimals=1) == '×0.7'
+        assert factor(0.75, decimals=3) == '×0.750'
+
+    def test_none_returns_null(self):
+        assert factor(None) == '—'
+        assert factor(None, null='N/A') == 'N/A'
+
+    def test_unaffected_by_raw_config(self):
+        # Charging factors are always fractional — raw mode (which makes
+        # number() emit bare integers) must not strip their decimals.
+        configure(raw=True)
+        assert factor(0.7) == '×0.70'
 
 
 # ============================================================================

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -875,11 +875,10 @@ def test_jobs_fragment_hides_qos_column_and_dropdown_when_single_value(
     assert 'sort_by=qos' not in body
     # The dropdown control is gone (no ?qos= in URL, no variation in rows).
     assert 'All QoS' not in body
-    # And with no queue badge / no dropdown / no column header, the
-    # repeated 'special' value is correctly absent from the fragment
-    # entirely — that's the whole point of the suppression. (Parent
-    # context — the row the user drilled into — surfaces it.)
-    assert 'special' not in body
+    # The redundant per-row column/dropdown are suppressed, but the single
+    # shared value is NOT silent — it collapses into a header badge so the
+    # QoS (and its charging factor) stays visible at a glance.
+    assert 'QoS: special' in body
 
 
 def test_jobs_fragment_shows_qos_column_when_rows_have_variation(
@@ -927,6 +926,110 @@ def test_jobs_fragment_keeps_dropdown_when_user_filtered_explicitly(
     assert 'sort_by=qos' not in body
     # Dropdown stays (explicit filter ⇒ user needs a way to reset).
     assert 'All QoS' in body
+
+
+def test_jobs_fragment_single_qos_badge_shows_name_and_factor(
+    app, auth_client, active_project, monkeypatch,
+):
+    """All rows in economy ⇒ the suppressed column collapses into a header
+    badge that surfaces both the QoS name and its charging multiplier — the
+    exact case (uniform economy, charges = 0.7× usage) the bare suppression
+    rule made invisible."""
+    _install_mock_plugin(
+        app, monkeypatch,
+        jobs_search_return=[
+            _make_row(job_id='1.x', qos='economy', qos_factor=0.7),
+            _make_row(job_id='2.x', qos='economy', qos_factor=0.7),
+        ],
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'QoS: economy' in body
+    assert '×0.7' in body
+
+
+def test_jobs_fragment_no_qos_badge_when_rows_have_variation(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Mixed-QoS rows render the column/dropdown, NOT the single-value
+    badge."""
+    _install_mock_plugin(
+        app, monkeypatch,
+        jobs_search_return=[
+            _make_row(job_id='1.x', qos='premium', qos_factor=1.5),
+            _make_row(job_id='2.x', qos='economy', qos_factor=0.7),
+        ],
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'QoS: ' not in body
+
+
+def test_jobs_fragment_no_qos_badge_when_all_null(
+    app, auth_client, active_project, monkeypatch,
+):
+    """All-NULL (uncharacterized) QoS ⇒ no badge — nothing actionable to
+    show."""
+    _install_mock_plugin(
+        app, monkeypatch,
+        jobs_search_return=[
+            _make_row(job_id='1.x', qos=None, qos_factor=None),
+            _make_row(job_id='2.x', qos=None, qos_factor=None),
+        ],
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'QoS: ' not in body
+
+
+def test_jobs_fragment_qos_badge_with_explicit_filter_shows_both(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Explicit ?qos= ⇒ the dropdown stays (to reset) AND the badge renders
+    too — a single consistent rule, mild redundancy is fine."""
+    _install_mock_plugin(
+        app, monkeypatch,
+        jobs_search_return=[
+            _make_row(job_id='1.x', qos='economy', qos_factor=0.7),
+            _make_row(job_id='2.x', qos='economy', qos_factor=0.7),
+        ],
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}'
+        '?machine=derecho&qos=economy'
+    )
+    body = resp.get_data(as_text=True)
+    # Dropdown stays so the user can reset.
+    assert 'All QoS' in body
+    # Badge renders alongside it.
+    assert 'QoS: economy' in body
+
+
+def test_jobs_fragment_qos_badge_name_only_when_factor_varies(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Same QoS name but inconsistent qos_factor across rows ⇒ the badge
+    shows the name but omits the multiplier (no single factor to trust)."""
+    _install_mock_plugin(
+        app, monkeypatch,
+        jobs_search_return=[
+            _make_row(job_id='1.x', qos='economy', qos_factor=0.7),
+            _make_row(job_id='2.x', qos='economy', qos_factor=0.5),
+        ],
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'QoS: economy' in body
+    # No "(×…)" multiplier when the factor isn't consistent.
+    assert '(×' not in body
 
 
 def test_resource_details_includes_jobs_fragment_url(

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -947,7 +947,31 @@ def test_jobs_fragment_single_qos_badge_shows_name_and_factor(
     )
     body = resp.get_data(as_text=True)
     assert 'QoS: economy' in body
-    assert '×0.7' in body
+    assert '×0.70' in body
+
+
+def test_jobs_fragment_drawer_renders_fractional_qos_factor(
+    app, auth_client, active_project, monkeypatch,
+):
+    """The per-row drawer's "Factor" is a fractional charging multiplier
+    and must render with decimals (×0.70 / ×1.50), NOT be rounded to a
+    whole number — the old fmt_number path turned economy's 0.7 into a
+    misleading "1". Two distinct QoS values keep the single-value badge
+    OFF, so the rendered factors must be coming from the drawers."""
+    _install_mock_plugin(
+        app, monkeypatch,
+        jobs_search_return=[
+            _make_row(job_id='1.x', qos='economy', qos_factor=0.7),
+            _make_row(job_id='2.x', qos='premium', qos_factor=1.5),
+        ],
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'QoS: ' not in body          # mixed QoS ⇒ no badge
+    assert '×0.70' in body              # economy factor, with decimals
+    assert '×1.50' in body              # premium factor, with decimals
 
 
 def test_jobs_fragment_no_qos_badge_when_rows_have_variation(


### PR DESCRIPTION
## Summary

Two related fixes to how QoS / charging-priority is surfaced in the per-job
drill-down on the resource-details page. Both came out of investigating why
an **economy** job (charges = 0.7× usage) gave no at-a-glance signal of its
QoS, and then why its drawer showed a misleading `Factor: 1`.

This builds on PR #276 (which first surfaced QoS in the per-job UI).

---

## Commit 1 — `webapp/jobs: surface single-value QoS as a header badge`

PR #276 suppresses both the QoS **column** and the filter **dropdown** when
every job in view shares one QoS value (the rationale was "a single-valued
column is just noise"). The unintended consequence: that silences exactly
the case where QoS matters most — when *all* jobs ran in economy, the charges
are 0.7× usage but nothing in the table says so. The multiplier survived only
in each row's expand drawer. It also made the UI inconsistent day to day (a
dropdown appears on mixed-QoS days and vanishes on uniform ones).

**Fix:** when the column is suppressed because all rows share one value, the
route derives a `qos_badge` from the existing `qos_in_rows` / `qos_has_variation`
signals and the header strip renders it, e.g. `QoS: economy (×0.70)`, matching
the existing `user:` / `queue:` badge styling.

- Name + factor; falls back to name-only when `qos_factor` isn't consistent
  across the rows.
- Shown whenever the column is suppressed for single-value reasons, including
  the explicit `?qos=` filter case (badge + dropdown coexist).
- All-NULL (uncharacterized) single value gets no badge — nothing actionable.

Touches `src/webapp/jobs/routes.py`, `jobs_fragment.html`, and adds five
`test_webapp_jobs.py` cases (the existing single-value suppression test was
updated: it asserted the value was *absent*; it now asserts the badge surfaces it).

---

## Commit 2 — `webapp/jobs: render QoS factor with decimals, not rounded to an integer`

While verifying commit 1, an economy job's drawer showed `Factor: 1` even
though its stored `qos_factor` is `0.7` (and the new badge on the same row
correctly read `×0.7`). Root cause: the drawer routed `qos_factor` through
`fmt_number`, which formats with `,.0f` (zero decimals), so a fractional
multiplier collapses:

| QoS | factor | displayed |
|---|---|---|
| economy | 0.7 | **1** ← bug |
| premium | 1.5 | 2 |
| regular | 1.0 | 1 (correct by coincidence) |

The `hpc-usage-queries` plugin already formats `qos_factor` as `.2f` — only
SAM's webapp re-rounded it, so this is a **SAM-only** fix (no plugin change).

**Fix:**
- Add `fmt.factor()` + `fmt_factor` Jinja filter rendering a multiplier as
  `×N.NN` (2 decimals, matching the plugin). Kept in the central `sam.fmt`
  module per the formatting convention rather than an inline `%.2f`.
- `jobs_fragment.html` renders `qos_factor` via `fmt_factor` in the drawer and
  reuses the same filter in the badge so both read identically.
- `TestFactor` in `test_fmt.py` pins the regression contrast
  (`factor(0.7) == '×0.70'` vs `number(0.7) == '1'`); a new webapp test proves
  the drawer renders fractional factors with decimals.

---

## Verification

```bash
source etc/config_env.sh && pytest tests/unit/test_fmt.py tests/unit/test_webapp_jobs.py
```

Manual: open `/user/resource-details?projcode=UTAM0017&resource=Derecho`,
expand fredc / 2026-05-19 / `6176773.desched1` — the drawer now reads
`Factor ×0.70`, consistent with the `QoS: economy (×0.70)` header badge.

## Out of scope (noted for follow-up)
- PBS recycles job-id strings (`6176773.desched1` maps to two unrelated jobs
  in the raw data). The scoped drill-down filters correctly, so this only
  matters if a job-id-wide search is ever exposed.
- The same `fmt_number` path also rounds the drawer's `cpu_hours` / `gpu_hours`
  / `memory_hours` (a 0.12-hour job shows `0`) — same latent issue, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)