### PR TITLE
helm: rollout-safety primitives for webapp Deployment (probes, strategy, PDB, spread)

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -8,6 +8,13 @@ metadata:
     group: {{ .Values.webapp.group }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.rollout }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ .Values.rollout.maxUnavailable }}
+      maxSurge: {{ .Values.rollout.maxSurge }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Values.webapp.name }}
@@ -16,6 +23,15 @@ spec:
       labels:
         app: {{ .Values.webapp.name }}
     spec:
+      {{- if and .Values.topologySpread .Values.topologySpread.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.topologySpread.maxSkew }}
+          topologyKey: {{ .Values.topologySpread.topologyKey }}
+          whenUnsatisfiable: {{ .Values.topologySpread.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: {{ .Values.webapp.name }}
+      {{- end }}
       containers:
       - name: {{ .Values.webapp.name }}
         image: {{ .Values.webapp.container.image }}
@@ -114,3 +130,30 @@ spec:
             cpu: {{ .Values.webapp.container.limits.cpu }}
         ports:
         - containerPort: {{ .Values.webapp.container.port }}
+        {{- if and .Values.webapp.probes .Values.webapp.probes.enabled }}
+        # Startup gate: give a slow gunicorn boot time before liveness kicks
+        # in. Until this passes, liveness/readiness are not evaluated.
+        startupProbe:
+          httpGet:
+            path: {{ .Values.webapp.probes.path }}/live
+            port: {{ .Values.webapp.container.port }}
+          periodSeconds: {{ .Values.webapp.probes.startup.periodSeconds }}
+          failureThreshold: {{ .Values.webapp.probes.startup.failureThreshold }}
+        # Liveness: /live makes no DB call, so only a wedged process restarts.
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.webapp.probes.path }}/live
+            port: {{ .Values.webapp.container.port }}
+          periodSeconds: {{ .Values.webapp.probes.liveness.periodSeconds }}
+          timeoutSeconds: {{ .Values.webapp.probes.liveness.timeoutSeconds }}
+          failureThreshold: {{ .Values.webapp.probes.liveness.failureThreshold }}
+        # Readiness: /ready pings the DBs; a 503 pulls the pod from the
+        # Service and stalls a rollout instead of promoting a broken build.
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.webapp.probes.path }}/ready
+            port: {{ .Values.webapp.container.port }}
+          periodSeconds: {{ .Values.webapp.probes.readiness.periodSeconds }}
+          timeoutSeconds: {{ .Values.webapp.probes.readiness.timeoutSeconds }}
+          failureThreshold: {{ .Values.webapp.probes.readiness.failureThreshold }}
+        {{- end }}

--- a/helm/templates/pdb.yaml
+++ b/helm/templates/pdb.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.podDisruptionBudget .Values.podDisruptionBudget.enabled }}
+# Keeps >=minAvailable webapp pods serving during VOLUNTARY disruptions
+# (node drains, maintenance, autoscaler scale-down). Does not protect against
+# involuntary loss (node crash) — that's what topologySpread + replicaCount
+# are for. With replicaCount:2 and minAvailable:1 a drain evicts one pod at a
+# time, waiting for its replacement to pass the readiness probe in between.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.webapp.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.webapp.name }}
+    group: {{ .Values.webapp.group }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ .Values.webapp.name }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,5 +1,31 @@
 replicaCount: 2                           # Number of identical pods to run
 
+# Rollout safety: never drop below replicaCount Ready pods during an update.
+# maxUnavailable:0 + maxSurge:1 means "bring up one new pod, wait for it to
+# pass the readiness probe, THEN retire an old one." Without the readiness
+# probe (webapp.probes) this gating is meaningless — a pod is "Ready" the
+# instant its process starts, so a broken build would still complete the
+# rollout while serving errors.
+rollout:
+  maxUnavailable: 0
+  maxSurge: 1
+
+# PodDisruptionBudget — keep >=minAvailable webapp pods serving during
+# VOLUNTARY disruptions (node drains, cluster maintenance). Without this, a
+# single node drain can evict both replicas at once and take the app down.
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+# Spread replicas across nodes so one node failure can't take out all of them.
+# whenUnsatisfiable: ScheduleAnyway keeps scheduling best-effort on a lopsided
+# cluster rather than leaving a pod Pending (which is what wedged us at 1/2).
+topologySpread:
+  enabled: true
+  maxSkew: 1
+  topologyKey: kubernetes.io/hostname
+  whenUnsatisfiable: ScheduleAnyway
+
 # Centralized Redis backend used by:
 #   - Flask-Caching chart cache (CACHE_REDIS_URL → DB 0)
 #   - Flask-Limiter rate-limit counters (RATELIMIT_STORAGE_URI → DB 1)
@@ -27,6 +53,27 @@ webapp:
     secretName: incommon-cert-samuel      # Unique TLS secret name for your FQDN
   ingress:
     visibility: internal                  # internal or external
+  # Kubernetes probes. Endpoints from src/webapp/api/v1/health.py:
+  #   /live  -> process up, no DB call          (liveness + startup)
+  #   /ready -> DB-gated, 200 healthy / 503 not  (readiness: gates rollout
+  #             completion AND Service membership)
+  # Liveness uses /live (no DB) so a transient DB blip can't trigger a
+  # restart storm; readiness uses /ready so a DB outage pulls the pod from
+  # the Service without killing it.
+  probes:
+    enabled: true
+    path: /api/v1/health                 # base; /live and /ready appended
+    startup:
+      periodSeconds: 5
+      failureThreshold: 30               # ~150s budget for gunicorn (33 workers) to boot
+    liveness:
+      periodSeconds: 15
+      timeoutSeconds: 3
+      failureThreshold: 3
+    readiness:
+      periodSeconds: 10
+      timeoutSeconds: 5                  # readiness pings the DBs
+      failureThreshold: 3
   container:                              # full image path
     image: ghcr.io/benkirk/sam-queries/webapp:main
     port: 5050                            # Port your container listens on

--- a/scripts/cirrus_healthcheck.sh
+++ b/scripts/cirrus_healthcheck.sh
@@ -235,8 +235,54 @@ else
     UPDATED=$(echo "$DEPLOY_JSON" | jq -r '.status.updatedReplicas // 0')
     AVAIL=$(echo "$DEPLOY_JSON"   | jq -r '.status.availableReplicas // 0')
 
+    # Diagnose not-Ready pods up front so the verdict can tell a genuinely
+    # STUCK rollout (a pod wedged in ImagePullBackOff/CrashLoop for many
+    # minutes) apart from one that is healthily mid-roll. We print the *why*
+    # (waiting reason + message + node), not just the ready count.
+    STUCK_AFTER_MIN=10
+    PODS_JSON=$("${KCTL_NS[@]}" get pods -l "app=$WEBAPP_NAME" -o json 2>/dev/null)
+    notready_diag=""     # human-readable lines, one block per not-Ready pod
+    stuck_pods=0         # not-Ready pods in a back-off/error state past threshold
+    # Fields are joined with US (0x1f), NOT tab: tab is an IFS-whitespace char,
+    # so empty optional fields (message, terminated.*) would collapse and shift
+    # every column. US is non-whitespace, so empty fields are preserved. The
+    # message is also stripped of CR/LF/TAB so it can't break line/field parsing.
+    while IFS=$'\x1f' read -r pname pready pphase wreason wmsg treason texit pnode pstart; do
+        [[ -z "$pname" ]] && continue
+        [[ "$pready" == "true" ]] && continue
+        detail="${wreason:-phase=$pphase}"
+        [[ -n "$treason" ]] && detail="$detail (last exit: ${treason}/${texit})"
+        sec=$(seconds_since "$pstart" 2>/dev/null || echo "")
+        if [[ -n "$sec" ]]; then
+            age_min=$(awk -v s="$sec" 'BEGIN{printf "%.0f", s/60}')
+            age_str="${age_min}m"
+        else
+            age_min=0; age_str="?"
+        fi
+        notready_diag+="pod $pname: not Ready — $detail on ${pnode:-<unscheduled>} (age ${age_str})"$'\n'
+        [[ -n "$wmsg" ]] && notready_diag+="    ↳ ${wmsg}"$'\n'
+        # A back-off/error waiting reason that has persisted is stuck, not in-flight.
+        case "$wreason" in
+            ImagePullBackOff|ErrImagePull|CrashLoopBackOff|CreateContainerConfigError|InvalidImageName|ErrImageNeverPull)
+                [[ "${age_min:-0}" -ge "$STUCK_AFTER_MIN" ]] && stuck_pods=$((stuck_pods+1))
+                ;;
+        esac
+    done < <(echo "$PODS_JSON" | jq -r '.items[] | [
+        .metadata.name,
+        ((.status.containerStatuses[0].ready // false) | tostring),
+        (.status.phase // ""),
+        (.status.containerStatuses[0].state.waiting.reason // ""),
+        (.status.containerStatuses[0].state.waiting.message // "" | gsub("[\\n\\r\\t]"; " ")),
+        (.status.containerStatuses[0].lastState.terminated.reason // ""),
+        ((.status.containerStatuses[0].lastState.terminated.exitCode // "") | tostring),
+        (.spec.nodeName // ""),
+        (.metadata.creationTimestamp // "")
+    ] | join("")' 2>/dev/null)
+
     if [[ "$READY" == "$DESIRED" && "$AVAIL" == "$DESIRED" && "$UPDATED" == "$DESIRED" ]]; then
         pass "Deployment $WEBAPP_NAME: $READY/$DESIRED ready, all updated and available"
+    elif [[ "$stuck_pods" -gt 0 ]]; then
+        fail "Deployment $WEBAPP_NAME: $READY/$DESIRED ready — $stuck_pods pod(s) STUCK >${STUCK_AFTER_MIN}m (see diagnosis below), not a healthy rollout"
     elif [[ "$UPDATED" != "$DESIRED" ]]; then
         warn "Deployment $WEBAPP_NAME: rollout in progress ($UPDATED/$DESIRED pods updated)"
     else
@@ -247,6 +293,13 @@ else
     echo
     run "${KCTL_NS[@]}" get pods -l "app=$WEBAPP_NAME" \
         -o 'custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[0].ready,STATUS:.status.phase,RESTARTS:.status.containerStatuses[0].restartCount,AGE:.metadata.creationTimestamp,NODE:.spec.nodeName'
+
+    # Per-pod "why not Ready" — the detail that previously required `kubectl describe`
+    if [[ -n "$notready_diag" ]]; then
+        echo
+        echo "  Not-Ready pod diagnosis:"
+        printf '%s' "$notready_diag" | sed 's/^/    /'
+    fi
 
     # Recent-restart scan
     restarts=$("${KCTL_NS[@]}" get pods -l "app=$WEBAPP_NAME" \
@@ -293,7 +346,106 @@ else
 fi
 
 # ============================================================================
-section "3. Redis cache Deployment & pod"
+section "3. Rollout safety (probes, strategy, PDB, spread)"
+# ============================================================================
+
+explain "These guard the *next* rollout, not the current moment: a readiness
+  probe gates traffic + rollout promotion, a PDB survives node drains, topology
+  spread avoids single-node concentration. Gaps here are advisory (WARN)."
+
+if ! "${KCTL_NS[@]}" get deploy "$WEBAPP_NAME" >/dev/null 2>&1; then
+    info "Deployment '$WEBAPP_NAME' not found — skipping rollout-safety checks"
+else
+    SAFE_JSON=$("${KCTL_NS[@]}" get deploy "$WEBAPP_NAME" -o json)
+    REPLICAS=$(echo "$SAFE_JSON" | jq -r '.spec.replicas // 1')
+    CTR=$(echo "$SAFE_JSON" | jq -c --arg n "$WEBAPP_NAME" \
+            '.spec.template.spec.containers[] | select(.name==$n)')
+
+    # --- Probes: readiness/liveness gate rollouts; startup gives slow boots air ---
+    rprobe=0; lprobe=0
+    for probe in readinessProbe livenessProbe startupProbe; do
+        if echo "$CTR" | jq -e --arg p "$probe" '.[$p] != null' >/dev/null 2>&1; then
+            ppath=$(echo "$CTR" | jq -r --arg p "$probe" \
+                      '.[$p].httpGet.path // .[$p].tcpSocket.port // "set"')
+            info "$probe → ${ppath}"
+            [[ "$probe" == "readinessProbe" ]] && rprobe=1
+            [[ "$probe" == "livenessProbe"  ]] && lprobe=1
+        else
+            case "$probe" in
+                readinessProbe) warn "no readinessProbe — rollouts can't gate on real health; a broken build promotes anyway" ;;
+                livenessProbe)  warn "no livenessProbe — a wedged process won't be auto-restarted" ;;
+                startupProbe)   info "no startupProbe (optional; a slow boot can trip liveness)" ;;
+            esac
+        fi
+    done
+    [[ "$rprobe" -eq 1 && "$lprobe" -eq 1 ]] && pass "webapp has readiness + liveness probes"
+
+    # --- Rollout strategy: can it drop below 1 Ready? (maxUnavailable rounds DOWN) ---
+    echo
+    STYPE=$(echo "$SAFE_JSON" | jq -r '.spec.strategy.type // "RollingUpdate"')
+    MU=$(echo "$SAFE_JSON"    | jq -r '.spec.strategy.rollingUpdate.maxUnavailable // "25%"')
+    MS=$(echo "$SAFE_JSON"    | jq -r '.spec.strategy.rollingUpdate.maxSurge // "25%"')
+    echo "  strategy: $STYPE (maxUnavailable=$MU, maxSurge=$MS, replicas=$REPLICAS)"
+    case "$MU" in
+        *%) mu_n=$(awk -v p="${MU%\%}" -v t="$REPLICAS" 'BEGIN{printf "%d", int(p*t/100)}') ;;
+        *)  mu_n="$MU" ;;
+    esac
+    min_avail=$(( REPLICAS - mu_n ))
+    if [[ "$min_avail" -lt 1 ]]; then
+        warn "strategy allows 0 Ready mid-rollout (maxUnavailable=$MU → $mu_n of $REPLICAS)"
+    else
+        pass "strategy keeps ≥${min_avail} Ready mid-rollout"
+    fi
+
+    # --- PodDisruptionBudget: survives node drains? ---
+    echo
+    PDB_JSON=$("${KCTL_NS[@]}" get pdb -o json 2>/dev/null || echo '{"items":[]}')
+    pdb_name=$(echo "$PDB_JSON" | jq -r --arg n "$WEBAPP_NAME" \
+                 '.items[] | select(.spec.selector.matchLabels.app==$n) | .metadata.name' | head -1)
+    if [[ -z "$pdb_name" ]]; then
+        warn "no PodDisruptionBudget selects app=$WEBAPP_NAME — a node drain can evict all replicas at once"
+    else
+        pdb_min=$(echo "$PDB_JSON" | jq -r --arg p "$pdb_name" \
+                    '.items[] | select(.metadata.name==$p) | (.spec.minAvailable // .spec.maxUnavailable // "—")')
+        pdb_allowed=$(echo "$PDB_JSON" | jq -r --arg p "$pdb_name" \
+                    '.items[] | select(.metadata.name==$p) | .status.disruptionsAllowed // 0')
+        echo "  PDB $pdb_name: minAvailable=$pdb_min, allowedDisruptions=$pdb_allowed"
+        if [[ "$REPLICAS" -gt 1 && "${pdb_allowed:-0}" -eq 0 ]]; then
+            warn "PDB allows 0 disruptions — at the floor (or below minAvailable); a drain will block"
+        else
+            pass "PDB present ($pdb_name), allowedDisruptions=$pdb_allowed"
+        fi
+    fi
+
+    # --- Spread: config (topologySpread/anti-affinity) + runtime (distinct nodes) ---
+    echo
+    has_tsc=$(echo "$SAFE_JSON" | jq -e '(.spec.template.spec.topologySpreadConstraints // []) | length > 0' >/dev/null 2>&1 && echo 1 || echo 0)
+    has_paa=$(echo "$SAFE_JSON" | jq -e '.spec.template.spec.affinity.podAntiAffinity != null' >/dev/null 2>&1 && echo 1 || echo 0)
+    if [[ "$has_tsc" -eq 1 || "$has_paa" -eq 1 ]]; then
+        info "spread configured (topologySpreadConstraints=$has_tsc, podAntiAffinity=$has_paa)"
+    elif [[ "$REPLICAS" -gt 1 ]]; then
+        warn "no topologySpreadConstraints/podAntiAffinity — replicas may co-locate on one node"
+    fi
+    nodes_ready=$(echo "$PODS_JSON" | jq -r \
+        '[.items[] | select(.status.containerStatuses[0].ready==true) | .spec.nodeName] | unique | length' 2>/dev/null)
+    nodes_ready=${nodes_ready:-0}
+    echo "  Ready webapp pods span ${nodes_ready} distinct node(s)"
+    if [[ "$REPLICAS" -gt 1 && "$nodes_ready" -le 1 ]]; then
+        warn "all Ready webapp pods are on a single node — one node failure takes the app down"
+    elif [[ "$nodes_ready" -ge 2 ]]; then
+        pass "Ready pods spread across ${nodes_ready} nodes"
+    fi
+
+    # --- imagePullSecrets: anonymous ghcr pulls are rate-limit-prone (today's failure class) ---
+    has_ips=$(echo "$SAFE_JSON" | jq -r '(.spec.template.spec.imagePullSecrets // []) | length')
+    img=$(echo "$SAFE_JSON" | jq -r '.spec.template.spec.containers[0].image // ""')
+    if [[ "${has_ips:-0}" -eq 0 && "$img" == ghcr.io/* ]]; then
+        hint "webapp pulls $img anonymously (no imagePullSecrets) — anonymous ghcr.io pulls are rate-limited per node IP and can wedge a pod in ImagePullBackOff; consider an authenticated pull secret"
+    fi
+fi
+
+# ============================================================================
+section "4. Redis cache Deployment & pod"
 # ============================================================================
 
 if ! "${KCTL_NS[@]}" get deploy "$REDIS_NAME" >/dev/null 2>&1; then
@@ -348,7 +500,7 @@ else
 fi
 
 # ============================================================================
-section "4. Resource usage vs limits"
+section "5. Resource usage vs limits"
 # ============================================================================
 
 if ! "${KCTL_NS[@]}" top pods --no-headers >/dev/null 2>&1; then
@@ -411,7 +563,7 @@ else
 fi
 
 # ============================================================================
-section "5. Service, Ingress, TLS"
+section "6. Service, Ingress, TLS"
 # ============================================================================
 
 run "${KCTL_NS[@]}" get svc "$WEBAPP_NAME" "$REDIS_NAME" 2>/dev/null
@@ -466,7 +618,7 @@ else
 fi
 
 # ============================================================================
-section "6. ExternalSecrets (OpenBao sync)"
+section "7. ExternalSecrets (OpenBao sync)"
 # ============================================================================
 
 if ! "${KCTL_NS[@]}" get externalsecret >/dev/null 2>&1; then
@@ -506,7 +658,7 @@ else
 fi
 
 # ============================================================================
-section "7. In-pod HTTP health probe"
+section "8. In-pod HTTP health probe"
 # ============================================================================
 
 WEBAPP_POD=$("${KCTL_NS[@]}" get pod -l "app=$WEBAPP_NAME" \
@@ -579,7 +731,7 @@ except Exception as e:
 fi
 
 # ============================================================================
-section "8. Recent logs"
+section "9. Recent logs"
 # ============================================================================
 
 echo "  webapp (last 500 lines, scanning for ERROR/CRITICAL/Exception/Traceback):"
@@ -614,7 +766,7 @@ else
 fi
 
 # ============================================================================
-section "9. Recent namespace events"
+section "10. Recent namespace events"
 # ============================================================================
 
 EV=$("${KCTL_NS[@]}" get events --sort-by=.lastTimestamp 2>/dev/null | tail -20 || echo "")


### PR DESCRIPTION
## Summary

A `cirrus_healthcheck.sh` run found the `samuel` webapp at **1/2 ready** — one replica wedged in `ImagePullBackOff` on a node doing **anonymous** ghcr pulls (no `imagePullSecret`). Root cause was node-local (anonymous pull rate-limit / transient registry hiccup), **not** a broken image or dead node — the image is public and the healthy replica runs the same SHA. That incident surfaced that the webapp Deployment shipped with **none** of the standard rollout-safety primitives (the redis Deployment had probes; the webapp did not).

This PR adds the four highest-value ones, all gated behind `enabled`/presence flags in `values.yaml`.

## Changes

| Change | Effect |
|---|---|
| **Probes** — startup/liveness → `/api/v1/health/live` (no DB), readiness → `/api/v1/health/ready` (DB-gated) | Readiness now gates rollout promotion + Service membership. A build that boots but can't serve **stalls** the rollout instead of completing it while erroring. Endpoints already exist in `src/webapp/api/v1/health.py`. |
| **Explicit strategy** `maxUnavailable:0 / maxSurge:1` | Replaces reliance on 25%-rounding. |
| **PodDisruptionBudget** `minAvailable:1` (new `pdb.yaml`) | A node drain can no longer evict both replicas at once. |
| **topologySpreadConstraints** on `kubernetes.io/hostname` (`ScheduleAnyway`) | Enforces the cross-node spread that was previously incidental. |

**Deferred:** authenticated `imagePullSecret` for ghcr (fixes the anonymous pull-rate-limit class of failure; heavier ExternalSecret-backed lift).

## Verification

`helm template samuel ./helm --namespace sam-queries` renders all four additions cleanly into valid manifests — webapp container gets all three probes, Deployment carries strategy + spread constraints, PDB renders with `minAvailable: 1`.

## Note for deploy

With the new readiness gate, a bad image now **stalls** the rollout (old pod keeps serving) rather than silently completing — so watch `kubectl rollout status deploy/samuel -n sam-queries`; "not progressing" is now a real signal. Startup budget is ~150s for a 33-worker gunicorn boot — tune `webapp.probes.startup` if real boot time differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)