### PR TITLE
fix(schemas): admin_username always null + panel 500 on orphan projects [P0-5, P0-6]

### DIFF
--- a/src/sam/schemas/project.py
+++ b/src/sam/schemas/project.py
@@ -66,6 +66,8 @@ class ProjectListSchema(BaseSchema):
 
     def get_admin_username(self, obj):
         """Get admin username."""
+        return obj.admin.username if obj.admin else None
+
 
 class ProjectSchema(BaseSchema):
     """
@@ -119,7 +121,7 @@ class ProjectSchema(BaseSchema):
 
     def get_panel(self,obj):
         """Get associated panel"""
-        return obj.allocation_type.panel.panel_name if obj.allocation_type.panel else None
+        return obj.allocation_type.panel.panel_name if obj.allocation_type and obj.allocation_type.panel else None
 
     def get_contracts(self,obj):
         """Get associated contracts"""

--- a/tests/api/test_schemas.py
+++ b/tests/api/test_schemas.py
@@ -169,6 +169,11 @@ class TestProjectSchemas:
         assert 'lead_username' in result
         assert isinstance(result['lead_username'], (str, type(None)))
         assert 'admin_username' in result
+        assert isinstance(result['admin_username'], (str, type(None)))
+        # Value, not just presence: admin_username must reflect the actual
+        # admin (a None-only result is what hid PR295 P0-5).
+        expected_admin = real_project.admin.username if real_project.admin else None
+        assert result['admin_username'] == expected_admin
 
         # Should NOT have full nested user objects
         assert 'lead' not in result or not isinstance(result.get('lead'), dict)
@@ -291,6 +296,38 @@ class TestSchemaEdgeCases:
             result = ProjectSchema().dump(project)
             # admin should be None
             assert result.get('admin') is None
+
+    def test_admin_username_reflects_admin(self, session):
+        """ProjectListSchema.admin_username returns the admin's username [PR295 P0-5].
+
+        Regression: get_admin_username had an empty body, so admin_username
+        silently serialized to null for every project, even with an admin set.
+        """
+        from factories import make_project, make_user
+
+        project = make_project(session)
+        admin = make_user(session)
+        project.admin = admin
+        session.flush()
+
+        result = ProjectListSchema().dump(project)
+        assert result['admin_username'] == admin.username
+
+    def test_panel_none_on_orphan_project(self, session):
+        """ProjectSchema.panel is None (not a 500) for an orphan project [PR295 P0-6].
+
+        Regression: get_panel dereferenced obj.allocation_type without a None
+        guard, so a project with no allocation_type raised AttributeError → 500
+        on the /api/v1/projects/<projcode> detail endpoint. make_project() builds
+        exactly such an orphan (no allocation_type assigned).
+        """
+        from factories import make_project
+
+        orphan = make_project(session)
+        assert orphan.allocation_type is None  # precondition: it's an orphan
+
+        result = ProjectSchema().dump(orphan)
+        assert result['panel'] is None
 
     def test_empty_list_serialization(self, session):
         """Test that empty lists serialize correctly."""


### PR DESCRIPTION
## Summary

Two tiny, long-latent serialization bugs in `src/sam/schemas/project.py`, flagged by the NRIT audit (PR #295) and deferred out of the Phase A/B hardening work. Both ship on `staging`/prod today.

- **P0-5 — `ProjectListSchema.get_admin_username` returned null for everyone.** The method body was a docstring with no `return`, so it implicitly returned `None`. `admin_username` serialized to `null` for every project on the `/api/v1/projects/` list endpoint, even when an admin was set — silent data loss, not a crash. Now mirrors the sibling `get_lead_username`:
  ```python
  return obj.admin.username if obj.admin else None
  ```
- **P0-6 — `ProjectSchema.get_panel` 500s on orphan projects.** It dereferenced `obj.allocation_type` without a None guard, so a project with no `allocation_type` (an "orphan", per the `Project.facility_name` docstring) raised `AttributeError` → HTTP 500 on the `/api/v1/projects/<projcode>` detail endpoint. Now guards `allocation_type` first, matching the `facility_name` property's chain handling:
  ```python
  return obj.allocation_type.panel.panel_name if obj.allocation_type and obj.allocation_type.panel else None
  ```

Both fixes are pure read-path serialization — no schema/migration/DB impact. No other resolver in the file needs changing; the rest (`get_area_of_interest`, `get_type`, `get_contracts`, `get_lead_username`) already guard their None cases.

## Why they hid

`tests/api/test_schemas.py` only asserted *key presence* for `admin_username` and only ever dumped a fully-populated `real_project`, never the None-value or orphan paths.

## Tests

- New `test_admin_username_reflects_admin` (factory-built project + admin) and `test_panel_none_on_orphan_project` (`make_project()` builds an orphan — no allocation_type). Both verified **RED against the unfixed code** (the orphan test reproduces the exact `AttributeError`), **GREEN after the fix**.
- Tightened `test_project_list_schema` to assert the `admin_username` value, not just its presence.
- `pytest tests/api/test_schemas.py`: 17 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)