### PR TITLE
Unity Styling

### DIFF
--- a/docs/plans/implemented/ALLOCATION_TREE_EDITING.md
+++ b/docs/plans/implemented/ALLOCATION_TREE_EDITING.md
@@ -376,7 +376,7 @@ Add universal roll-up warning inside the "Break inheritance" collapse:
 </div>
 
 <div class="mb-3">
-  <button type="button" class="btn btn-sm btn-outline-danger"
+  <button type="button" class="btn  btn-outline-danger"
           data-bs-toggle="collapse" data-bs-target="#breakInheritanceSection">
     <i class="fas fa-unlink me-1"></i> Break inheritance...
   </button>
@@ -414,7 +414,7 @@ Add universal roll-up warning inside the "Break inheritance" collapse:
         </label>
       </div>
       <div class="mt-2">
-        <button type="button" class="btn btn-sm btn-danger"
+        <button type="button" class="btn  btn-danger"
                 hx-post="{{ url_for('admin_dashboard.htmx_detach_allocation', alloc_id=allocation.allocation_id) }}"
                 hx-target="#editAllocationFormContainer"
                 hx-confirm="Permanently detach allocation #{{ allocation.allocation_id }}?">
@@ -478,7 +478,7 @@ Split into two clearly separate sections:
   active sub-project{{ 's' if unlinked_descendants_count != 1 else '' }}
   {{ 'do' if unlinked_descendants_count != 1 else 'does' }} not yet have
   an allocation for this resource.
-  <button type="button" class="btn btn-sm btn-outline-secondary ms-2"
+  <button type="button" class="btn  btn-outline-secondary ms-2"
           hx-post="{{ url_for('admin_dashboard.htmx_propagate_to_remaining', alloc_id=allocation.allocation_id) }}"
           hx-target="#editAllocationFormContainer"
           hx-confirm="Create linked child allocations for {{ unlinked_descendants_count }} remaining sub-project(s)?">

--- a/docs/plans/implemented/CREATE_PROJECTS.md
+++ b/docs/plans/implemented/CREATE_PROJECTS.md
@@ -245,7 +245,7 @@ POST /admin/htmx/project-create              → validate + create + htmx_succes
 - In the "Search Projects" card header, add:
   ```html
   {% if has_permission(Permission.CREATE_PROJECTS) %}
-  <button class="btn btn-sm btn-success" ... hx-get=".../project-create-form" ...>
+  <button class="btn  btn-success" ... hx-get=".../project-create-form" ...>
       <i class="fas fa-plus"></i> Create Project
   </button>
   {% endif %}

--- a/docs/plans/implemented/EDIT_PROJECTS.md
+++ b/docs/plans/implemented/EDIT_PROJECTS.md
@@ -404,7 +404,7 @@ Add (immediately after the `render_project_card` macro call):
 {% if has_permission(Permission.EDIT_PROJECTS) %}
 <div class="d-flex justify-content-end mt-1 mb-3">
   <a href="{{ url_for('admin_dashboard.edit_project_page', projcode=project_data.project.projcode) }}"
-     class="btn btn-sm btn-outline-warning">
+     class="btn  btn-outline-warning">
     <i class="fas fa-edit"></i> Edit Project
   </a>
 </div>

--- a/src/webapp/static/css/allocations.css
+++ b/src/webapp/static/css/allocations.css
@@ -1,85 +1,10 @@
 /**
  * SAM Allocations Dashboard CSS
- * Styles specific to the allocations dashboard
+ * Styles specific to the allocations dashboard.
+ *
+ * Note: Shared .filter-sidebar styles live in dashboard.css (loaded sitewide
+ * via base.html). Page-specific tweaks for the allocations layout stay here.
  */
-
-/* ===================================================================
-   Filter Sidebar — Unity NCAR style (dark navy panel, right column).
-   Reusable: any page can drop a .filter-sidebar block in a sidebar col.
-   =================================================================== */
-
-.filter-sidebar {
-    background-color: var(--ncar-navy);
-    color: #fff;
-    padding: 1.5rem;
-}
-
-/* Stretch BOTH columns + their content so the tab area (left) and filter
-   sidebar (right) have identical top AND bottom edges regardless of which
-   side has more content. Without this, Bootstrap stretches the .col
-   elements but not their inner panels — leaving the white tab-content or
-   the navy filter visibly short at top or bottom. */
-@media (min-width: 992px) {
-    .row.g-0 > .col-lg-9,
-    .row.g-0 > .col-lg-3 {
-        display: flex;
-        flex-direction: column;
-    }
-
-    .row.g-0 > .col-lg-9 > .tab-content,
-    .row.g-0 > .col-lg-3 > .filter-sidebar {
-        flex: 1;
-    }
-}
-
-.filter-sidebar-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-    padding-bottom: 0.75rem;
-    margin-bottom: 1.25rem;
-}
-
-/* Selector needs to beat .main-content h2 (specificity 0,1,1) — chain the
-   parent class so we hit 0,2,1 and the gold color wins over navy-on-navy.
-   Fixed 1rem font keeps it from inheriting the giant h2 desktop scale. */
-.filter-sidebar .filter-sidebar-title {
-    color: var(--ncar-gold);
-    font-size: 1rem;
-    line-height: 1.5;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    margin: 0;
-}
-
-.filter-sidebar-clear {
-    color: #fff;
-    font-size: 0.875rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    text-decoration: none;
-    font-weight: var(--font-weight-semi-bold);
-}
-
-.filter-sidebar-clear:hover {
-    color: var(--ncar-sky);
-}
-
-.filter-sidebar .form-label,
-.filter-sidebar .form-check-label {
-    color: #fff;
-}
-
-.filter-sidebar .form-text {
-    color: rgba(255, 255, 255, 0.7);
-}
-
-.filter-sidebar select,
-.filter-sidebar input[type="date"] {
-    background-color: #fff;
-    color: var(--ncar-space-blue);
-}
 
 /* ===================================================================
    Allocation Cards

--- a/src/webapp/static/css/components.css
+++ b/src/webapp/static/css/components.css
@@ -82,7 +82,7 @@
    Button Sizes
    =================================================================== */
 
-.btn-xs {
+.xs {
     padding: 0.125rem 0.375rem;
     font-size: 0.75rem;
     line-height: 1.5;

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -126,6 +126,7 @@ body {
     list-style: none;
     justify-content: space-between;
     width: 100%;
+
 }
 
 /* Mobile toggler */
@@ -303,7 +304,7 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
 }
 
 .card > .card-header {
-    border-bottom: 2px solid var(--ncar-blue);
+    padding-bottom: 2rem;
     font-weight: var(--font-weight-semi-bold);
     color: var(--ncar-space-blue);
 }
@@ -334,6 +335,9 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     --bs-btn-box-shadow: none;
     text-transform: uppercase;
     letter-spacing: 0.05rem;
+    line-height: 24px;
+    font-size: 1.25rem;
+    padding: .75rem 1.5rem;
 }
 
 .btn-primary {
@@ -367,6 +371,21 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     --bs-btn-hover-color: #fff;
 }
 
+/* Unity .btn-outline-white — for buttons on dark/navy backgrounds (e.g.
+   inside .filter-sidebar). White outline, transparent fill; hover dims to
+   a translucent white wash matching Unity's exact spec (not a full invert). */
+.btn-outline-white {
+    --bs-btn-color: #fff;
+    --bs-btn-border-color: #fff;
+    --bs-btn-bg: transparent;
+    --bs-btn-hover-bg: rgba(255, 255, 255, 0.1);
+    --bs-btn-hover-border-color: #fff;
+    --bs-btn-hover-color: #fff;
+    --bs-btn-active-bg: rgba(255, 255, 255, 0.1);
+    --bs-btn-active-border-color: #fff;
+    --bs-btn-active-color: #fff;
+}
+
 /* Unity-style :disabled — transparent fill, transparent 3px border (keeps
    the button's footprint so layout doesn't shift / nothing visually
    disappears), gray text. opacity:1 overrides Bootstrap's default .65 fade.
@@ -392,6 +411,24 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
 
 .btn-link:hover {
     text-decoration: underline;
+}
+
+.btn.btn-sm,
+.btn-group-sm > .btn {
+    line-height: 18px;
+    font-size: 0.95rem;
+    padding: 0.45rem 0.9rem;
+}
+
+.btn-group-sm > .btn {
+    --bs-btn-border-width: 2px;
+    line-height: 18px;
+    font-size: 0.95rem;
+    padding: 0.45rem 0.9rem;
+}
+
+.btn-group-sm > .btn:not(:first-child) {
+    margin-left: calc(-1 * var(--bs-btn-border-width));
 }
 
 /* Unity NCAR defines only .btn-primary and .btn-outline-primary. Other
@@ -764,6 +801,9 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
 
 .nav-tabs .nav-item {
     flex-shrink: 0;
+    font-size: 1rem !important;
+    font-weight: 600;
+    color: var(--ncar-blue);
 }
 
 /* When tabs are followed by tab-content, kill any mb-* utility margin so the
@@ -779,7 +819,7 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     background-color: #fff;
     border: none;
     border-radius: 0;
-    padding: 0.375rem 1rem;
+    padding: 1.125rem 1.875rem;
     transition: background-color var(--transition-base), color var(--transition-base);
 }
 
@@ -808,11 +848,82 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
 }
 
 /* ============================================================================
+   FILTER SIDEBAR — Unity NCAR navy panel for any filter form on the site.
+   Defined here (not allocations.css) so it's available on every page.
+   ========================================================================= */
+
+.filter-sidebar {
+    background-color: var(--ncar-navy);
+    color: #fff;
+    padding: 1.5rem;
+}
+
+.filter-sidebar-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    /* Negative horizontal margin cancels .filter-sidebar's 1.5rem padding so
+       the divider spans the full panel width; inner padding re-establishes
+       the text inset. */
+    margin: 0 -1.5rem 1.25rem;
+    padding: 0 1.5rem 0.75rem;
+    border-bottom: 1px solid var(--ncar-gray-light);
+}
+
+/* Selector needs to beat .main-content h2 (specificity 0,1,1) — chain the
+   parent class so we hit 0,2,1 and the gold color wins over navy-on-navy.
+   Fixed 1rem font keeps it from inheriting the giant h2 desktop scale. */
+.filter-sidebar .filter-sidebar-title {
+    color: var(--ncar-gold);
+    font-size: 1rem;
+    line-height: 1.5;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin: 0;
+}
+
+.filter-sidebar-clear {
+    color: #fff;
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    text-decoration: none;
+    font-weight: var(--font-weight-semi-bold);
+}
+
+.filter-sidebar-clear:hover {
+    color: var(--ncar-sky);
+}
+
+.filter-sidebar .form-label,
+.filter-sidebar .form-check-label {
+    color: #fff;
+}
+
+.filter-sidebar .form-text {
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.filter-sidebar select,
+.filter-sidebar input[type="date"],
+.filter-sidebar input[type="text"],
+.filter-sidebar input[type="search"],
+.filter-sidebar input[type="email"],
+.filter-sidebar input[type="number"] {
+    background-color: #fff;
+    color: var(--ncar-space-blue);
+}
+
+.filter-sidebar input::placeholder {
+    color: var(--ncar-gray);
+}
+
+/* ============================================================================
    PROJECT CARDS (User Dashboard Specific)
    ========================================================================= */
 
 .project-card {
-    margin-bottom: 24px;
+    margin-bottom: 0px !important;
 }
 
 /* Project-card headers follow the same invert pattern as .nav-tabs and
@@ -823,10 +934,10 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
 .project-card .card-header {
     cursor: pointer;
     user-select: none;
-    padding: 8px 16px;
-    background-color: var(--ncar-blue);
-    color: #fff;
-    border-bottom: 1px solid var(--ncar-blue);
+    padding: 16px;
+    background-color: var(--bg-light);
+    color: var(--ncar-blue);
+    border-bottom: 1px solid #dee2e6;
     transition: background-color var(--transition-base), color var(--transition-base);
 }
 
@@ -835,7 +946,7 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
    the .text-primary utility class on the icon. */
 .project-card .card-header h5 i,
 .project-card .card-header .accordion-chevron {
-    color: #fff !important;
+    color: var(--ncar-space-blue) !important;
 }
 
 /* Match Unity's .accordion-button: fixed 1rem font, semi-bold, single weight
@@ -851,25 +962,17 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     font-weight: inherit;
 }
 
-.project-card .card-header:hover {
-    background-color: var(--ncar-navy);
-}
-
 /* Expanded (active) state: white surface with blue text — the "settled" look
    matching .nav-tabs.active and .btn-group .btn-secondary.active. */
 .project-card .card-header[aria-expanded="true"] {
-    background-color: #fff;
-    color: var(--ncar-blue);
+    background-color: var(--ncar-blue);
+    color: #fff;
     border-bottom-color: var(--ncar-gray-light);
 }
 
 .project-card .card-header[aria-expanded="true"] h5 i,
 .project-card .card-header[aria-expanded="true"] .accordion-chevron {
-    color: var(--ncar-blue) !important;
-}
-
-.project-card .card-header[aria-expanded="true"]:hover {
-    background-color: rgba(var(--ncar-teal-rgb), 0.08);
+    color: #fff !important;
 }
 
 /* Accordion chevron — reusable affordance for any collapsible header.
@@ -1014,6 +1117,7 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
 .collapse-toggle {
     cursor: pointer;
     user-select: none;
+    border-bottom: 1px solid var(--ncar-gray-light);
 }
 
 .collapse-toggle::after {

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -303,10 +303,31 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     margin-bottom: 1.5rem;
 }
 
-.card > .card-header {
-    padding-bottom: 2rem;
+.inner-card {
+    padding: 1.875rem;
+}
+
+.inner-card > .card-header {
+    padding: 0 !important;
     font-weight: var(--font-weight-semi-bold);
     color: var(--ncar-space-blue);
+}
+
+.inner-card > .card-header h5 {
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1;
+    text-transform: uppercase;
+    color: var(--ncar-navy);
+}
+
+.inner-card > .card-body {
+    padding: 0;
+}
+
+.inner-card p {
+    font-size: 1.125rem;
+    line-height: 1.875rem;
 }
 
 /* Opt-in modifier: a card with a visible 1px hairline border. Use when a
@@ -323,8 +344,8 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     margin: 0;
 }
 
-.dashboard-inner-card {
-    border: 1px solid var(--bs-border-color);
+.inner-card {
+    border: 1px solid var(--ncar-blue);
     box-shadow: none !important;
 }
 

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -156,7 +156,7 @@ body {
 
 /* Nav row border */
 .navbar-wrapper.border-top {
-    border-top-color: var(--ncar-gray-light) !important;
+    border-top-color: #dee2e6 !important;
 }
 
 .navbar .navbar-collapse {
@@ -321,6 +321,11 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     color: var(--ncar-space-blue);
     font-weight: var(--font-weight-semi-bold);
     margin: 0;
+}
+
+.dashboard-inner-card {
+    border: 1px solid var(--bs-border-color);
+    box-shadow: none !important;
 }
 
 /* ============================================================================
@@ -1130,10 +1135,6 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
 
 .collapse-toggle.collapsed::after {
     transform: rotate(-90deg);
-}
-
-.collapse-toggle:hover {
-    color: var(--ncar-sky);
 }
 
 /* ============================================================================

--- a/src/webapp/static/css/status.css
+++ b/src/webapp/static/css/status.css
@@ -120,7 +120,7 @@
 .load-stack {
     display: flex;
     flex-direction: column;
-    gap: 0;
+    gap: 8px;
     min-width: 80px;
 }
 

--- a/src/webapp/static/css/status.css
+++ b/src/webapp/static/css/status.css
@@ -120,7 +120,7 @@
 .load-stack {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 0;
     min-width: 80px;
 }
 

--- a/src/webapp/static/js/dashboard-init.js
+++ b/src/webapp/static/js/dashboard-init.js
@@ -114,6 +114,14 @@
         loadExpirationsView(activeExpirationsView());
     });
 
+    /* Clear filters — reset the form, then reload the active tab so the
+     * expirations view reflects the cleared (default) filters. */
+    registerAction('expirations-clear', function () {
+        var form = document.getElementById('expirations-filters-form');
+        if (form) { form.reset(); }
+        loadExpirationsView(activeExpirationsView());
+    });
+
     /* Export CSV of the active tab, carrying the filter form */
     registerAction('expirations-export-csv', function () {
         var params = new URLSearchParams(

--- a/src/webapp/static/js/fk-picker.js
+++ b/src/webapp/static/js/fk-picker.js
@@ -12,7 +12,7 @@
 //
 //       <div class="fk-picker-selected mb-1" style="display:none;">
 //           <span class="badge bg-info py-1 px-2 fk-picker-badge"></span>
-//           <button type="button" class="btn btn-xs btn-outline-secondary ms-1 fk-picker-clear">
+//           <button type="button" class="btn btn-sm btn-outline-secondary ms-1 fk-picker-clear">
 //               <i class="fas fa-times"></i>
 //           </button>
 //       </div>

--- a/src/webapp/templates/admin/master.html
+++ b/src/webapp/templates/admin/master.html
@@ -4,7 +4,7 @@
 <div class="navbar-text">
     {% if current_user.is_authenticated %}
     <div class="btn-group">
-        <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <button type="button" class="btn  btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <i class="glyphicon glyphicon-user"></i>
             <strong>{{ current_user.username }}</strong>
             {% if current_user.roles %}

--- a/src/webapp/templates/dashboards/admin/dashboard.html
+++ b/src/webapp/templates/dashboards/admin/dashboard.html
@@ -100,9 +100,11 @@
         <div class="row">
             <!-- Search Projects Section -->
             <div class="col-md-6">
-                <div class="card dashboard-inner-card mb-3">
-                    <div class="card-header d-flex justify-content-between align-items-center">
-                        <h5 class="mb-0"><i class="fas fa-search"></i> Search Projects</h5>
+                <div class="card inner-card">
+                    <div class="card-header d-flex justify-content-between align-items-center mb-4">
+                        <h5>
+                            <i class="fas fa-search"></i>Search Projects
+                        </h5>
                         {% if has_permission_any_facility(Permission.CREATE_PROJECTS) %}
                         <button type="button" class="btn btn-primary"
                                 data-bs-toggle="modal"
@@ -306,8 +308,8 @@
         <div class="row">
             <!-- Search Users Section -->
             <div class="col-md-6">
-                <div class="card dashboard-inner-card mb-3">
-                    <div class="card-header">
+                <div class="card inner-card">
+                    <div class="card-header mb-4">
                         <h5><i class="fas fa-users"></i> Search Users</h5>
                     </div>
                     <div class="card-body">
@@ -338,8 +340,8 @@
 
             <!-- Search Groups Section -->
             <div class="col-md-6">
-                <div class="card dashboard-inner-card mb-3">
-                    <div class="card-header">
+                <div class="card inner-card">
+                    <div class="card-header mb-4">
                         <h5><i class="fas fa-users-cog"></i> Search Groups</h5>
                     </div>
                     <div class="card-body">

--- a/src/webapp/templates/dashboards/admin/dashboard.html
+++ b/src/webapp/templates/dashboards/admin/dashboard.html
@@ -67,6 +67,12 @@
     <!-- Tab 1: Projects -->
     <div class="tab-pane fade show active" id="tab-projects" role="tabpanel" aria-labelledby="projects-tab">
 
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <h5 class="mb-0 flex-grow-1">
+                <i class="fas fa-folder-open"></i> Projects
+            </h5>
+        </div>
+
         <!-- Projects sub-tab navigation -->
         <ul class="nav nav-tabs mb-3" id="projectsSubTabs" role="tablist">
             <li class="nav-item" role="presentation">
@@ -98,7 +104,7 @@
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <h5 class="mb-0"><i class="fas fa-search"></i> Search Projects</h5>
                         {% if has_permission_any_facility(Permission.CREATE_PROJECTS) %}
-                        <button type="button" class="btn btn-sm btn-outline-success"
+                        <button type="button" class="btn btn-primary"
                                 data-bs-toggle="modal"
                                 data-bs-target="#createProjectModal"
                                 hx-get="{{ url_for('admin_dashboard.htmx_project_create_form') }}"
@@ -151,7 +157,7 @@
         <!-- Expirations Section -->
         <div class="row mt-4">
             <div class="col-12">
-                <div class="card mb-3">
+                <div class="card project-card mb-3">
                     <div class="card-header collapse-toggle collapsed"
                          data-bs-toggle="collapse" data-bs-target="#expirations-section"
                          role="button" aria-expanded="false" aria-controls="expirations-section">
@@ -161,54 +167,57 @@
                     </div>
                     <div id="expirations-section" class="collapse">
                         <div class="card-body py-3">
-                            <!-- Filters Form -->
-                            <form id="expirations-filters-form"
-                                  class="d-flex flex-wrap align-items-start gap-4 mb-3">
-                                <div>
-                                    <label for="facilities-filter" class="form-label small mb-1"><strong>Facilities</strong></label>
-                                    <select class="form-control form-control-sm" id="facilities-filter"
-                                            name="facilities" multiple size="4" style="width: 200px;">
-                                        {% for facility_name in allowed_facility_names %}
-                                        <option value="{{ facility_name }}"
-                                            {% if facility_name in default_selected_facilities %}selected{% endif %}>
-                                            {{ facility_name }}
-                                        </option>
-                                        {% endfor %}
-                                    </select>
-                                    <small class="form-text text-muted">Hold Ctrl/Cmd to select multiple</small>
+                            <!-- Filters Form — Unity navy panel, matches the
+                                 global filter-sidebar pattern used elsewhere -->
+                            <form id="expirations-filters-form" class="filter-sidebar mb-3">
+                                <div class="filter-sidebar-header">
+                                    <h2 class="filter-sidebar-title">Filters</h2>
+                                    {# CSP-clean reset: expirations-clear (static/js/dashboard-init.js)
+                                       resets the form and reloads the active tab — no inline onclick. #}
+                                    <a class="filter-sidebar-clear" style="cursor: pointer;"
+                                       data-action="expirations-clear">Clear filters</a>
                                 </div>
 
-                                <div>
-                                    <label for="resource-filter" class="form-label small mb-1"><strong>Resource</strong> <span class="text-muted">(optional)</span></label>
-                                    <input type="text" class="form-control form-control-sm" id="resource-filter"
-                                           name="resource"
-                                           placeholder="e.g., Derecho, GLADE"
-                                           style="width: 200px;">
-                                    <small class="form-text text-muted">Leave blank for all</small>
-                                </div>
+                                <div class="d-flex flex-wrap align-items-start gap-3">
+                                    <div>
+                                        <label for="facilities-filter" class="form-label"><strong>Facilities</strong></label>
+                                        <select class="form-control" id="facilities-filter"
+                                                name="facilities" multiple size="4" style="width: 200px;">
+                                            {% for facility_name in allowed_facility_names %}
+                                            <option value="{{ facility_name }}"
+                                                {% if facility_name in default_selected_facilities %}selected{% endif %}>
+                                                {{ facility_name }}
+                                            </option>
+                                            {% endfor %}
+                                        </select>
+                                        <small class="form-text">Hold Ctrl/Cmd to select multiple</small>
+                                    </div>
 
-                                <div>
-                                    <label for="time-range-filter" class="form-label small mb-1"><strong>Time Range</strong></label>
-                                    <select class="form-control form-control-sm" id="time-range-filter"
-                                            name="time_range" style="width: 160px;">
-                                        <option value="7days">Next 7 days</option>
-                                        <option value="31days" selected>Next 31 days</option>
-                                        <option value="60days">Next 60 days</option>
-                                    </select>
-                                    <small class="form-text text-muted">For upcoming</small>
-                                </div>
+                                    <div>
+                                        <label for="resource-filter" class="form-label"><strong>Resource</strong> <span class="fw-normal">(optional)</span></label>
+                                        <input type="text" class="form-control" id="resource-filter"
+                                               name="resource"
+                                               placeholder="e.g., Derecho, GLADE"
+                                               style="width: 200px;">
+                                        <small class="form-text">Leave blank for all</small>
+                                    </div>
 
-                                <div class="d-flex flex-column gap-2">
-                                    <label class="form-label small mb-1 invisible">Actions</label>
-                                    <button type="button" class="btn btn-sm btn-primary"
-                                            style="width: 160px;"
-                                            data-action="expirations-reload">
-                                        <i class="fas fa-search"></i> Apply Filters
+                                    <div>
+                                        <label for="time-range-filter" class="form-label"><strong>Time Range</strong></label>
+                                        <select class="form-control" id="time-range-filter"
+                                                name="time_range" style="width: 160px;">
+                                            <option value="7days">Next 7 days</option>
+                                            <option value="31days" selected>Next 31 days</option>
+                                            <option value="60days">Next 60 days</option>
+                                        </select>
+                                        <small class="form-text">For upcoming</small>
+                                    </div>
+
+                                    <button type="button" class="btn btn-outline-white align-self-end"
+                                            data-action="expirations-reload">Apply Filters
                                     </button>
-                                    <button type="button" class="btn btn-sm btn-outline-primary"
-                                            style="width: 160px;"
-                                            data-action="expirations-export-csv">
-                                        <i class="fas fa-download"></i> Export CSV
+                                    <button type="button" class="btn btn-outline-white align-self-end"
+                                            data-action="expirations-export-csv">Export CSV
                                     </button>
                                 </div>
                             </form>

--- a/src/webapp/templates/dashboards/admin/dashboard.html
+++ b/src/webapp/templates/dashboards/admin/dashboard.html
@@ -100,7 +100,7 @@
         <div class="row">
             <!-- Search Projects Section -->
             <div class="col-md-6">
-                <div class="card mb-3">
+                <div class="card dashboard-inner-card mb-3">
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <h5 class="mb-0"><i class="fas fa-search"></i> Search Projects</h5>
                         {% if has_permission_any_facility(Permission.CREATE_PROJECTS) %}
@@ -306,7 +306,7 @@
         <div class="row">
             <!-- Search Users Section -->
             <div class="col-md-6">
-                <div class="card mb-3">
+                <div class="card dashboard-inner-card mb-3">
                     <div class="card-header">
                         <h5><i class="fas fa-users"></i> Search Users</h5>
                     </div>
@@ -338,7 +338,7 @@
 
             <!-- Search Groups Section -->
             <div class="col-md-6">
-                <div class="card mb-3">
+                <div class="card dashboard-inner-card mb-3">
                     <div class="card-header">
                         <h5><i class="fas fa-users-cog"></i> Search Groups</h5>
                     </div>

--- a/src/webapp/templates/dashboards/admin/edit_project.html
+++ b/src/webapp/templates/dashboards/admin/edit_project.html
@@ -23,11 +23,11 @@
   {% if can_access_admin %}
   {# Pass projcode so the admin index re-renders this project's card on
      return — otherwise the user lands on a blank search page. #}
-  <a href="{{ url_for('admin_dashboard.index', projcode=project.projcode) }}" class="btn btn-outline-secondary btn-sm ms-auto">
+  <a href="{{ url_for('admin_dashboard.index', projcode=project.projcode) }}" class="btn btn-outline-secondary  ms-auto">
     <i class="fas fa-arrow-left"></i> Back to Admin
   </a>
   {% else %}
-  <a href="{{ url_for('user_dashboard.index') }}" class="btn btn-outline-secondary btn-sm ms-auto">
+  <a href="{{ url_for('user_dashboard.index') }}" class="btn btn-outline-secondary  ms-auto">
     <i class="fas fa-arrow-left"></i> Back to Dashboard
   </a>
   {% endif %}
@@ -100,7 +100,7 @@
   <div class="tab-pane fade" id="tab-allocations" role="tabpanel">
     {% if can_modify_allocations %}
     <div class="d-flex justify-content-end gap-2 mb-3">
-      <button class="btn btn-sm btn-primary"
+      <button class="btn  btn-primary"
               hx-get="{{ url_for('admin_dashboard.htmx_extend_allocations_form', projcode=project.projcode) }}"
               hx-target="#extendAllocationsFormContainer"
               hx-include="#alloc-active-at"
@@ -109,7 +109,7 @@
               data-bs-target="#extendAllocationsModal">
         <i class="fas fa-calendar-plus"></i> Extend
       </button>
-      <button class="btn btn-sm btn-primary"
+      <button class="btn  btn-primary"
               hx-get="{{ url_for('admin_dashboard.htmx_renew_allocations_form', projcode=project.projcode) }}"
               hx-target="#renewAllocationsFormContainer"
               hx-include="#alloc-active-at"
@@ -118,7 +118,7 @@
               data-bs-target="#renewAllocationsModal">
         <i class="fas fa-sync-alt"></i> Renew
       </button>
-      <button class="btn btn-sm btn-primary"
+      <button class="btn  btn-primary"
               hx-get="{{ url_for('admin_dashboard.htmx_add_allocation_form', projcode=project.projcode) }}"
               hx-target="#addAllocationFormContainer"
               hx-trigger="click"

--- a/src/webapp/templates/dashboards/admin/fragments/abandoned_users_table.html
+++ b/src/webapp/templates/dashboards/admin/fragments/abandoned_users_table.html
@@ -36,7 +36,7 @@
                 </td>
                 <td>
                     <button type="button"
-                            class="btn btn-sm btn-outline-primary impersonate-user-btn"
+                            class="btn  btn-outline-primary impersonate-user-btn"
                             data-username="{{ user_info.username }}">
                         <i class="fas fa-user-secret"></i> Impersonate
                     </button>

--- a/src/webapp/templates/dashboards/admin/fragments/bulk_deactivate_project_directories_preview_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/bulk_deactivate_project_directories_preview_htmx.html
@@ -73,7 +73,7 @@
             <i class="fas fa-arrow-left"></i> Back
         </button>
         {% if matches %}
-        <button type="submit" class="btn btn-danger">
+        <button type="submit" class="btn btn-outline-primary">
             <i class="fas fa-trash-alt"></i>
             Deactivate {{ matches|length }} director{{ 'ies' if matches|length != 1 else 'y' }}
         </button>

--- a/src/webapp/templates/dashboards/admin/fragments/configuration_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/configuration_card.html
@@ -45,7 +45,7 @@
 
         {# ── Application (config-shaped facts only) ───────────────────── #}
         <div class="col-12 col-xl-6">
-            <div class="card h-100">
+            <div class="card dashboard-inner-card mb-3 h-100">
                 <div class="card-header py-2">
                     <strong><i class="fas fa-cube me-1"></i> Application</strong>
                 </div>
@@ -73,7 +73,7 @@
             is the *point*: it surfaces the per-worker reality (different PID,
             different RSS each time). #}
         <div class="col-12 col-xl-6">
-            <div class="card h-100">
+            <div class="card dashboard-inner-card mb-3 h-100">
                 <div class="card-header py-2 d-flex justify-content-between align-items-center">
                     <strong><i class="fas fa-server me-1"></i> Server Information</strong>
                     <button type="button"
@@ -99,7 +99,7 @@
 
         {# ── Database ─────────────────────────────────────────────────── #}
         <div class="col-12 col-xl-6">
-            <div class="card h-100">
+            <div class="card dashboard-inner-card mb-3 h-100">
                 <div class="card-header py-2">
                     <strong><i class="fas fa-database me-1"></i> Database</strong>
                 </div>
@@ -142,7 +142,7 @@
 
         {# ── Authentication ───────────────────────────────────────────── #}
         <div class="col-12 col-xl-6">
-            <div class="card h-100">
+            <div class="card dashboard-inner-card mb-3 h-100">
                 <div class="card-header py-2">
                     <strong><i class="fas fa-lock me-1"></i> Authentication</strong>
                 </div>
@@ -212,7 +212,7 @@
         {% endmacro %}
 
         <div class="col-12 col-xl-6">
-            <div class="card h-100">
+            <div class="card dashboard-inner-card mb-3 h-100">
                 <div class="card-header py-2">
                     <strong><i class="fas fa-bolt me-1"></i> Caching</strong>
                 </div>
@@ -294,7 +294,7 @@
 
         {# ── Rate limiting (Flask-Limiter facade; webapp.limiter) ──────── #}
         <div class="col-12 col-xl-6">
-            <div class="card h-100">
+            <div class="card dashboard-inner-card mb-3 h-100">
                 <div class="card-header py-2 d-flex justify-content-between align-items-center">
                     <strong><i class="fas fa-traffic-light me-1"></i> Rate limiting</strong>
                     {# Link target lands in the dedicated admin page commit; left
@@ -344,7 +344,7 @@
 
         {# ── Audit & Logging (full width; recent entries inline) ──────── #}
         <div class="col-12">
-            <div class="card">
+            <div class="card dashboard-inner-card mb-3 h-100">
                 <div class="card-header py-2">
                     <strong><i class="fas fa-clipboard-list me-1"></i> Audit &amp; Logging</strong>
                 </div>
@@ -363,7 +363,7 @@
                         <small class="text-muted fw-normal ms-1">(last 25)</small>
                     </h6>
                     {% if state.audit_tail is none %}
-                        <p class="text-muted small mb-0">
+                        <p class="text-muted small mb-0 h-100">
                             <i class="fas fa-inbox"></i> Audit log not readable
                             ({% if state.audit_logging.audit_log_path %}
                                 missing or permission denied

--- a/src/webapp/templates/dashboards/admin/fragments/configuration_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/configuration_card.html
@@ -45,9 +45,9 @@
 
         {# ── Application (config-shaped facts only) ───────────────────── #}
         <div class="col-12 col-xl-6">
-            <div class="card dashboard-inner-card mb-3 h-100">
-                <div class="card-header py-2">
-                    <strong><i class="fas fa-cube me-1"></i> Application</strong>
+            <div class="card inner-card h-100">
+                <div class="card-header mb-4">
+                    <h5><i class="fas fa-cube me-1"></i> Application</h5>
                 </div>
                 <div class="card-body">
                     <dl class="config-stats mb-0 small">
@@ -73,9 +73,9 @@
             is the *point*: it surfaces the per-worker reality (different PID,
             different RSS each time). #}
         <div class="col-12 col-xl-6">
-            <div class="card dashboard-inner-card mb-3 h-100">
-                <div class="card-header py-2 d-flex justify-content-between align-items-center">
-                    <strong><i class="fas fa-server me-1"></i> Server Information</strong>
+            <div class="card inner-card h-100">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5><i class="fas fa-server me-1"></i> Server Information</h5>
                     <button type="button"
                             class="btn btn-sm btn-outline-secondary py-0 px-2"
                             hx-get="{{ url_for('admin_dashboard.htmx_server_card') }}"
@@ -99,9 +99,9 @@
 
         {# ── Database ─────────────────────────────────────────────────── #}
         <div class="col-12 col-xl-6">
-            <div class="card dashboard-inner-card mb-3 h-100">
-                <div class="card-header py-2">
-                    <strong><i class="fas fa-database me-1"></i> Database</strong>
+            <div class="card inner-card h-100">
+                <div class="card-header mb-4">
+                    <h5><i class="fas fa-database me-1"></i> Database</h5>
                 </div>
                 <div class="card-body">
                     {% for db_info in state.databases %}
@@ -142,9 +142,9 @@
 
         {# ── Authentication ───────────────────────────────────────────── #}
         <div class="col-12 col-xl-6">
-            <div class="card dashboard-inner-card mb-3 h-100">
-                <div class="card-header py-2">
-                    <strong><i class="fas fa-lock me-1"></i> Authentication</strong>
+            <div class="card inner-card h-100">
+                <div class="card-header mb-4">
+                    <h5><i class="fas fa-lock me-1"></i> Authentication</h5>
                 </div>
                 <div class="card-body">
                     <dl class="config-stats mb-0 small">
@@ -212,9 +212,9 @@
         {% endmacro %}
 
         <div class="col-12 col-xl-6">
-            <div class="card dashboard-inner-card mb-3 h-100">
-                <div class="card-header py-2">
-                    <strong><i class="fas fa-bolt me-1"></i> Caching</strong>
+            <div class="card inner-card h-100">
+                <div class="card-header mb-4">
+                    <h5><i class="fas fa-bolt me-1"></i> Caching</h5>
                 </div>
                 <div class="card-body">
                     <dl class="config-stats mb-0 small">
@@ -294,9 +294,9 @@
 
         {# ── Rate limiting (Flask-Limiter facade; webapp.limiter) ──────── #}
         <div class="col-12 col-xl-6">
-            <div class="card dashboard-inner-card mb-3 h-100">
-                <div class="card-header py-2 d-flex justify-content-between align-items-center">
-                    <strong><i class="fas fa-traffic-light me-1"></i> Rate limiting</strong>
+            <div class="card inner-card h-100">
+                <div class="card-header mb-4 d-flex justify-content-between align-items-center">
+                    <h5><i class="fas fa-traffic-light me-1"></i> Rate limiting</h5>
                     {# Link target lands in the dedicated admin page commit; left
                        as a relative path so this tile renders before that route
                        is registered. #}
@@ -344,9 +344,9 @@
 
         {# ── Audit & Logging (full width; recent entries inline) ──────── #}
         <div class="col-12">
-            <div class="card dashboard-inner-card mb-3 h-100">
-                <div class="card-header py-2">
-                    <strong><i class="fas fa-clipboard-list me-1"></i> Audit &amp; Logging</strong>
+            <div class="card inner-card h-100">
+                <div class="card-header mb-4">
+                    <h5><i class="fas fa-clipboard-list me-1"></i> Audit &amp; Logging</h5>
                 </div>
                 <div class="card-body">
                     <dl class="config-stats mb-3 small">

--- a/src/webapp/templates/dashboards/admin/fragments/disk_root_directories_section.html
+++ b/src/webapp/templates/dashboards/admin/fragments/disk_root_directories_section.html
@@ -18,7 +18,7 @@
         </span>
     </div>
     {% if has_permission(Permission.EDIT_RESOURCES) %}
-    <button type="button" class="btn btn-sm btn-success"
+    <button type="button" class="btn btn-primary"
             data-bs-toggle="modal"
             data-bs-target="#addDiskRootModal"
             hx-get="{{ url_for('admin_dashboard.htmx_admin_disk_root_new_form') }}"

--- a/src/webapp/templates/dashboards/admin/fragments/edit_allocation_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/edit_allocation_form_htmx.html
@@ -56,7 +56,7 @@
   </div>
 
   <div class="mb-3">
-    <button type="button" class="btn btn-sm btn-outline-danger"
+    <button type="button" class="btn  btn-outline-danger"
             data-bs-toggle="collapse" data-bs-target="#breakInheritanceSection">
       <i class="fas fa-unlink me-1"></i> Break inheritance...
     </button>
@@ -86,7 +86,7 @@
           </label>
         </div>
         <div class="mt-2">
-          <button type="button" class="btn btn-sm btn-outline-primary"
+          <button type="button" class="btn  btn-outline-primary"
                   hx-post="{{ url_for('admin_dashboard.htmx_detach_allocation', allocation_id=allocation.allocation_id) }}"
                   hx-target="#editAllocationFormContainer"
                   hx-confirm="Permanently detach allocation #{{ allocation.allocation_id }}? This breaks inheritance and cannot be undone from this view."
@@ -145,7 +145,7 @@
     active sub-project{{ 's' if unlinked_descendants_count != 1 else '' }}
     {{ 'do' if unlinked_descendants_count != 1 else 'does' }} not yet have
     an allocation for this resource.
-    <button type="button" class="btn btn-sm btn-outline-secondary ms-2"
+    <button type="button" class="btn  btn-outline-secondary ms-2"
             hx-post="{{ url_for('admin_dashboard.htmx_propagate_to_remaining', allocation_id=allocation.allocation_id) }}"
             hx-target="#editAllocationFormContainer"
             hx-confirm="Create linked child allocations for {{ unlinked_descendants_count }} remaining sub-project(s)?"
@@ -176,7 +176,7 @@
     Re-linking will overwrite this allocation's amount and dates to match the parent,
     making it functionally identical to an originally-linked child.
     <div class="mt-2">
-      <button type="button" class="btn btn-sm btn-primary"
+      <button type="button" class="btn  btn-primary"
               hx-post="{{ url_for('admin_dashboard.htmx_link_allocation_to_parent', allocation_id=allocation.allocation_id) }}"
               hx-vals='{"parent_allocation_id": {{ relink_candidate.allocation_id }}}'
               hx-target="#editAllocationFormContainer"

--- a/src/webapp/templates/dashboards/admin/fragments/exchange_allocation_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/exchange_allocation_form_htmx.html
@@ -24,7 +24,7 @@
     '#exchangeAllocationFormContainer',
     'Exchange',
     submit_icon='exchange-alt',
-    submit_class='btn-info',
+    submit_class='btn-outline-primary',
     errors=errors
 ) %}
 

--- a/src/webapp/templates/dashboards/admin/fragments/expirations_cards.html
+++ b/src/webapp/templates/dashboards/admin/fragments/expirations_cards.html
@@ -3,7 +3,7 @@
 {% if projects_data %}
     {% if view_type == 'expired' and has_permission_any_facility(Permission.EDIT_PROJECTS) %}
     <div class="mb-3 text-end">
-        <button type="button" class="btn btn-sm btn-outline-danger"
+        <button type="button" class="btn  btn-outline-danger"
                 hx-post="{{ url_for('admin_dashboard.deactivate_expired') }}"
                 hx-include="#expirations-filters-form"
                 hx-target="#expired-container"

--- a/src/webapp/templates/dashboards/admin/fragments/facility_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/facility_card.html
@@ -154,7 +154,7 @@
         </span>
         {% if has_permission(Permission.CREATE_FACILITIES) %}
         <div class="d-flex gap-2">
-            <button class="btn btn-sm btn-outline-success"
+            <button class="btn btn-primary"
                     data-bs-toggle="modal"
                     data-bs-target="#createFacilityModal"
                     hx-get="{{ url_for('admin_dashboard.htmx_facility_create_form') }}"
@@ -162,7 +162,7 @@
                     hx-trigger="click">
                 <i class="fas fa-plus"></i> Create Facility
             </button>
-            <button class="btn btn-sm btn-outline-success"
+            <button class="btn btn-primary"
                     data-bs-toggle="modal"
                     data-bs-target="#createPanelModal"
                     hx-get="{{ url_for('admin_dashboard.htmx_panel_create_form') }}"
@@ -170,7 +170,7 @@
                     hx-trigger="click">
                 <i class="fas fa-plus"></i> Create Panel
             </button>
-            <button class="btn btn-sm btn-outline-success"
+            <button class="btn btn-primary"
                     data-bs-toggle="modal"
                     data-bs-target="#createAllocationTypeModal"
                     hx-get="{{ url_for('admin_dashboard.htmx_allocation_type_create_form') }}"

--- a/src/webapp/templates/dashboards/admin/fragments/institution_filters.html
+++ b/src/webapp/templates/dashboards/admin/fragments/institution_filters.html
@@ -25,7 +25,6 @@
                              show_users_projects=False,
                              active_users_projects=False) %}
 <form id="{{ form_id }}"
-      class="card mb-3"
       hx-get="{{ fragment_url }}"
       hx-target="#{{ target_id }}"
       hx-swap="innerHTML"
@@ -34,94 +33,98 @@
     {# Outer Organizations-card state — preserved across inner submits. #}
     <input type="hidden" name="active_only" value="{{ 1 if active_only else 0 }}">
 
-    <div class="card-body py-3">
-        <div class="d-flex flex-wrap align-items-end gap-3">
+    <div class="filter-sidebar-header">
+        <h2 class="filter-sidebar-title">Filters</h2>
+        {# CSP-clean reset: form-reset-submit (static/js/actions.js) resets the
+           form and re-triggers its htmx submit — no inline onclick. #}
+        <a class="filter-sidebar-clear" style="cursor: pointer;"
+           data-action="form-reset-submit" data-form-id="{{ form_id }}">Clear filters</a>
+    </div>
 
-            <div>
-                <label class="form-label small mb-1">
-                    <strong><i class="fas fa-globe me-1 text-muted"></i>Country</strong>
-                </label>
-                <select class="form-select form-select-sm"
-                        name="country_id"
-                        hx-get="{{ fragment_url }}"
-                        hx-target="#{{ target_id }}"
-                        hx-swap="innerHTML"
-                        hx-trigger="change"
-                        hx-include="#{{ form_id }}"
-                        style="width:220px;">
-                    <option value="">Any</option>
-                    {% for c in countries %}
-                    <option value="{{ c.ext_country_id }}"
-                        {% if country_id and country_id == c.ext_country_id %}selected{% endif %}>
-                        {{ c.name }}{% if c.code %} ({{ c.code }}){% endif %}
-                    </option>
-                    {% endfor %}
-                </select>
-            </div>
+    <div class="d-flex flex-wrap align-items-start gap-3">
 
-            <div>
-                <label class="form-label small mb-1">
-                    <strong><i class="fas fa-map-marker-alt me-1 text-muted"></i>State / Province</strong>
-                </label>
-                <select class="form-select form-select-sm"
-                        name="state_prov_id"
-                        {% if not country_id %}disabled{% endif %}
-                        style="width:220px;">
-                    <option value="">
-                        {% if country_id %}Any{% else %}Select country first{% endif %}
-                    </option>
-                    {% for sp in state_provs %}
-                    <option value="{{ sp.ext_state_prov_id }}"
-                        {% if state_prov_id and state_prov_id == sp.ext_state_prov_id %}selected{% endif %}>
-                        {{ sp.name }}{% if sp.code %} ({{ sp.code }}){% endif %}
-                    </option>
-                    {% endfor %}
-                </select>
-            </div>
-
-            <div class="d-flex flex-column gap-1 align-self-center">
-                <div class="form-check form-check-sm">
-                    <input class="form-check-input" type="checkbox"
-                           name="show_users_projects" value="1"
-                           id="{{ form_id }}-show-up"
-                           {% if show_users_projects %}checked{% endif %}
-                           hx-get="{{ fragment_url }}"
-                           hx-target="#{{ target_id }}"
-                           hx-swap="innerHTML"
-                           hx-include="#{{ form_id }}">
-                    <label class="form-check-label small" for="{{ form_id }}-show-up">
-                        Show users &amp; projects
-                    </label>
-                </div>
-                {% if show_users_projects %}
-                <div class="form-check form-check-sm">
-                    <input class="form-check-input" type="checkbox"
-                           name="active_users_projects" value="1"
-                           id="{{ form_id }}-active-up"
-                           {% if active_users_projects %}checked{% endif %}
-                           hx-get="{{ fragment_url }}"
-                           hx-target="#{{ target_id }}"
-                           hx-swap="innerHTML"
-                           hx-include="#{{ form_id }}">
-                    <label class="form-check-label small" for="{{ form_id }}-active-up">
-                        Active users &amp; projects only
-                    </label>
-                </div>
-                {% endif %}
-            </div>
-
-            <div class="d-flex gap-2 align-self-center">
-                <button type="submit" class="btn btn-sm btn-primary">
-                    <i class="fas fa-search"></i> Search
-                </button>
-                <button type="button" class="btn btn-sm btn-outline-secondary"
-                        data-action="form-reset-submit" data-form-id="{{ form_id }}"
-                        title="Reset filters">
-                    <i class="fas fa-rotate-left"></i> Reset
-                </button>
-            </div>
-
+        <div>
+            <label class="form-label">
+                <strong><i class="fas fa-globe me-1"></i>Country</strong>
+            </label>
+            <select class="form-control"
+                    name="country_id"
+                    hx-get="{{ fragment_url }}"
+                    hx-target="#{{ target_id }}"
+                    hx-swap="innerHTML"
+                    hx-trigger="change"
+                    hx-include="#{{ form_id }}"
+                    style="width:220px;">
+                <option value="">Any</option>
+                {% for c in countries %}
+                <option value="{{ c.ext_country_id }}"
+                    {% if country_id and country_id == c.ext_country_id %}selected{% endif %}>
+                    {{ c.name }}{% if c.code %} ({{ c.code }}){% endif %}
+                </option>
+                {% endfor %}
+            </select>
         </div>
+
+        <div>
+            <label class="form-label">
+                <strong><i class="fas fa-map-marker-alt me-1"></i>State / Province</strong>
+            </label>
+            <select class="form-control"
+                    name="state_prov_id"
+                    {% if not country_id %}disabled{% endif %}
+                    style="width:220px;">
+                <option value="">
+                    {% if country_id %}Any{% else %}Select country first{% endif %}
+                </option>
+                {% for sp in state_provs %}
+                <option value="{{ sp.ext_state_prov_id }}"
+                    {% if state_prov_id and state_prov_id == sp.ext_state_prov_id %}selected{% endif %}>
+                    {{ sp.name }}{% if sp.code %} ({{ sp.code }}){% endif %}
+                </option>
+                {% endfor %}
+            </select>
+        </div>
+
+        <div class="d-flex flex-column gap-1">
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox"
+                       name="show_users_projects" value="1"
+                       id="{{ form_id }}-show-up"
+                       {% if show_users_projects %}checked{% endif %}
+                       hx-get="{{ fragment_url }}"
+                       hx-target="#{{ target_id }}"
+                       hx-swap="innerHTML"
+                       hx-include="#{{ form_id }}">
+                <label class="form-check-label" for="{{ form_id }}-show-up">
+                    Show users &amp; projects
+                </label>
+            </div>
+            {% if show_users_projects %}
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox"
+                       name="active_users_projects" value="1"
+                       id="{{ form_id }}-active-up"
+                       {% if active_users_projects %}checked{% endif %}
+                       hx-get="{{ fragment_url }}"
+                       hx-target="#{{ target_id }}"
+                       hx-swap="innerHTML"
+                       hx-include="#{{ form_id }}">
+                <label class="form-check-label" for="{{ form_id }}-active-up">
+                    Active users &amp; projects only
+                </label>
+            </div>
+            {% endif %}
+        </div>
+
+        <button type="submit" class="btn btn-outline-white align-self-end">
+            <i class="fas fa-search"></i> Search
+        </button>
+        <button type="button" class="btn btn-outline-white align-self-end"
+                data-action="form-reset-submit" data-form-id="{{ form_id }}"
+                title="Reset filters">
+            <i class="fas fa-rotate-left"></i> Reset
+        </button>
+
     </div>
 </form>
 {% endmacro %}

--- a/src/webapp/templates/dashboards/admin/fragments/institutions_table.html
+++ b/src/webapp/templates/dashboards/admin/fragments/institutions_table.html
@@ -21,7 +21,8 @@
 #}
 {% set ncols = 7 if show_users_projects else 5 %}
 
-<div class="p-3">
+
+<div class="filter-sidebar mb-3">
     {{ institution_filters('inst-filters',
                            url_for('admin_dashboard.htmx_institutions_fragment'),
                            'institutions-pane',
@@ -218,7 +219,7 @@
     </span>
     {% if has_permission(Permission.CREATE_ORG_METADATA) %}
     <div class="d-flex gap-2">
-        <button class="btn btn-sm btn-outline-success"
+        <button class="btn  btn-primary"
                 data-bs-toggle="modal"
                 data-bs-target="#createInstitutionTypeModal"
                 hx-get="{{ url_for('admin_dashboard.htmx_institution_type_create_form') }}"
@@ -226,7 +227,7 @@
                 hx-trigger="click">
             <i class="fas fa-plus"></i> Create Type
         </button>
-        <button class="btn btn-sm btn-outline-success"
+        <button class="btn  btn-primary"
                 data-bs-toggle="modal"
                 data-bs-target="#createInstitutionModal"
                 hx-get="{{ url_for('admin_dashboard.htmx_institution_create_form') }}"
@@ -234,7 +235,7 @@
                 hx-trigger="click">
             <i class="fas fa-plus"></i> Create Institution
         </button>
-        <button class="btn btn-sm btn-outline-success"
+        <button class="btn  btn-primary"
                 data-bs-toggle="modal"
                 data-bs-target="#createMnemonicCodeModal"
                 hx-get="{{ url_for('admin_dashboard.htmx_mnemonic_code_create_form') }}"

--- a/src/webapp/templates/dashboards/admin/fragments/organization_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/organization_card.html
@@ -6,7 +6,7 @@
 #}
 <div class="card-body p-0">
     <!-- Tab navigation -->
-    <ul class="nav nav-tabs px-3 pt-3" id="organizationsTabs" role="tablist">
+    <ul class="nav nav-tabs" id="organizationsTabs" role="tablist">
         <li class="nav-item" role="presentation">
             <button class="nav-link active" id="orgs-tab" data-bs-toggle="tab"
                     data-bs-target="#orgs-pane" type="button" role="tab"
@@ -109,7 +109,7 @@
                     Showing {{ organizations|length }} organization{{ 's' if organizations|length != 1 else '' }}
                 </span>
                 {% if has_permission(Permission.CREATE_ORG_METADATA) %}
-                <button class="btn btn-sm btn-outline-success"
+                <button class="btn  btn-primary"
                         data-bs-toggle="modal"
                         data-bs-target="#createOrganizationModal"
                         hx-get="{{ url_for('admin_dashboard.htmx_organization_create_form') }}"
@@ -217,7 +217,7 @@
                 </span>
                 {% if has_permission(Permission.CREATE_ORG_METADATA) %}
                 <div class="d-flex gap-2">
-                    <button class="btn btn-sm btn-outline-success"
+                    <button class="btn  btn-primary"
                             data-bs-toggle="modal"
                             data-bs-target="#createAoiGroupModal"
                             hx-get="{{ url_for('admin_dashboard.htmx_aoi_group_create_form') }}"
@@ -225,7 +225,7 @@
                             hx-trigger="click">
                         <i class="fas fa-plus"></i> Create Group
                     </button>
-                    <button class="btn btn-sm btn-outline-success"
+                    <button class="btn  btn-primary"
                             data-bs-toggle="modal"
                             data-bs-target="#createAoiModal"
                             hx-get="{{ url_for('admin_dashboard.htmx_aoi_create_form') }}"
@@ -338,7 +338,7 @@
                 </span>
                 {% if has_permission(Permission.CREATE_ORG_METADATA) %}
                 <div class="d-flex gap-2">
-                    <button class="btn btn-sm btn-outline-success"
+                    <button class="btn  btn-primary"
                             data-bs-toggle="modal"
                             data-bs-target="#createContractSourceModal"
                             hx-get="{{ url_for('admin_dashboard.htmx_contract_source_create_form') }}"
@@ -346,7 +346,7 @@
                             hx-trigger="click">
                         <i class="fas fa-plus"></i> Create Source
                     </button>
-                    <button class="btn btn-sm btn-outline-success"
+                    <button class="btn  btn-primary"
                             data-bs-toggle="modal"
                             data-bs-target="#createContractModal"
                             hx-get="{{ url_for('admin_dashboard.htmx_contract_create_form') }}"
@@ -401,7 +401,7 @@
                     Showing {{ nsf_programs|length }} program{{ 's' if nsf_programs|length != 1 else '' }}
                 </span>
                 {% if has_permission(Permission.CREATE_ORG_METADATA) %}
-                <button class="btn btn-sm btn-outline-success"
+                <button class="btn  btn-primary"
                         data-bs-toggle="modal"
                         data-bs-target="#createNsfProgramModal"
                         hx-get="{{ url_for('admin_dashboard.htmx_nsf_program_create_form') }}"

--- a/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
@@ -140,7 +140,7 @@
           {# Col 5: edit pencil (or shared badge for inherited allocations) #}
           <td style="vertical-align:middle;">
             {% if can_modify_allocations and root_alloc and root_alloc.allocation_id and not root_alloc.is_inheriting %}
-            <button class="btn btn-xs btn-outline-warning py-0 px-1"
+            <button class="btn btn-sm btn-outline-warning py-0 px-1"
                     style="font-size:0.7rem;"
                     hx-get="{{ url_for('admin_dashboard.htmx_edit_allocation_form', allocation_id=root_alloc.allocation_id) }}"
                     hx-target="#editAllocationFormContainer"

--- a/src/webapp/templates/dashboards/admin/fragments/project_directories_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directories_card.html
@@ -39,7 +39,7 @@
                 </label>
             </div>
             {% if has_permission(Permission.EDIT_PROJECTS) %}
-            <button type="button" class="btn btn-sm btn-success"
+            <button type="button" class="btn  btn-primary"
                     data-bs-toggle="modal"
                     data-bs-target="#addProjectDirectoryModal"
                     hx-get="{{ url_for('admin_dashboard.htmx_admin_project_directory_new_form') }}"
@@ -49,7 +49,7 @@
             </button>
             {% endif %}
             {% if has_permission(Permission.DELETE_PROJECTS) %}
-            <button type="button" class="btn btn-sm btn-outline-warning"
+            <button type="button" class="btn  btn-outline-warning"
                     data-bs-toggle="modal"
                     data-bs-target="#bulkDeactivateProjectDirectoriesModal"
                     hx-get="{{ url_for('admin_dashboard.htmx_admin_project_directory_bulk_deactivate_form') }}"

--- a/src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html
@@ -27,7 +27,7 @@
         <i class="fas fa-building me-1 text-primary"></i> Organizations
       </span>
       {% if can_edit_governance %}
-      <button class="btn btn-sm btn-outline-success"
+      <button class="btn  btn-primary"
               type="button"
               data-action="le-toggle" data-target-id="addOrgForm">
         <i class="fas fa-plus"></i> Add
@@ -51,10 +51,10 @@
                                  search_class='form-control form-control-sm',
                                  id_prefix='linkedOrg') }}
             </div>
-            <button type="submit" class="btn btn-sm btn-primary">
+            <button type="submit" class="btn  btn-primary">
               <i class="fas fa-check"></i> Link
             </button>
-            <button type="button" class="btn btn-sm btn-outline-secondary"
+            <button type="button" class="btn btn-outline-secondary"
                     data-action="le-toggle" data-target-id="addOrgForm">
               Cancel
             </button>
@@ -87,7 +87,7 @@
             </td>
             <td class="text-end">
               {% if can_edit_governance %}
-              <button class="btn btn-xs btn-outline-danger"
+              <button class="btn btn-sm btn-outline-danger"
                       title="Remove organization link"
                       hx-post="{{ url_for('admin_dashboard.htmx_remove_project_organization', projcode=project.projcode, po_id=po.project_organization_id) }}"
                       hx-target="#linkedElementsContainer"
@@ -116,7 +116,7 @@
         <i class="fas fa-file-contract me-1 text-warning"></i> Contracts
       </span>
       {% if can_edit_governance %}
-      <button class="btn btn-sm btn-outline-success"
+      <button class="btn  btn-primary"
               type="button"
               data-action="le-toggle" data-target-id="addContractForm">
         <i class="fas fa-plus"></i> Add
@@ -140,10 +140,10 @@
                                  search_class='form-control form-control-sm',
                                  id_prefix='linkedContract') }}
             </div>
-            <button type="submit" class="btn btn-sm btn-primary">
+            <button type="submit" class="btn  btn-primary">
               <i class="fas fa-check"></i> Link
             </button>
-            <button type="button" class="btn btn-sm btn-outline-secondary"
+            <button type="button" class="btn btn-outline-secondary"
                     data-action="le-toggle" data-target-id="addContractForm">
               Cancel
             </button>
@@ -174,7 +174,7 @@
             <td class="text-muted small">{{ pc.creation_time | fmt_date }}</td>
             <td class="text-end">
               {% if can_edit_governance %}
-              <button class="btn btn-xs btn-outline-danger"
+              <button class="btn btn-sm btn-outline-danger"
                       title="Remove contract link"
                       hx-post="{{ url_for('admin_dashboard.htmx_remove_project_contract', projcode=project.projcode, pc_id=pc.project_contract_id) }}"
                       hx-target="#linkedElementsContainer"
@@ -202,7 +202,7 @@
         <i class="fas fa-folder me-1 text-secondary"></i> Directories
       </span>
       {% if can_edit_governance %}
-      <button class="btn btn-sm btn-outline-success"
+      <button class="btn  btn-primary"
               type="button"
               data-action="le-toggle" data-target-id="addDirForm">
         <i class="fas fa-plus"></i> Add
@@ -282,7 +282,7 @@
             </td>
             <td class="text-end text-nowrap">
               {% if can_edit_governance %}
-              <button class="btn btn-xs btn-outline-secondary"
+              <button class="btn btn-sm btn-outline-secondary"
                       title="Edit directory"
                       data-bs-toggle="modal"
                       data-bs-target="#editProjectDirectoryModal"
@@ -291,7 +291,7 @@
                       hx-trigger="click">
                 <i class="fas fa-edit"></i>
               </button>
-              <button class="btn btn-xs btn-outline-danger ms-1"
+              <button class="btn btn-sm btn-outline-danger ms-1"
                       title="Remove directory"
                       hx-post="{{ url_for('admin_dashboard.htmx_remove_project_directory', projcode=project.projcode, pd_id=pd.project_directory_id) }}"
                       hx-target="#linkedElementsContainer"

--- a/src/webapp/templates/dashboards/admin/fragments/rate_limits_blocks.html
+++ b/src/webapp/templates/dashboards/admin/fragments/rate_limits_blocks.html
@@ -24,7 +24,7 @@
                       hx-confirm="Clear all rate-limit buckets for {{ b.actor }}?"
                       class="d-inline">
                     <input type="hidden" name="actor" value="{{ b.actor }}">
-                    <button type="submit" class="btn btn-sm btn-outline-warning">
+                    <button type="submit" class="btn  btn-outline-warning">
                         <i class="fas fa-unlock"></i> Unblock
                     </button>
                 </form>

--- a/src/webapp/templates/dashboards/admin/fragments/resources_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/resources_card.html
@@ -6,7 +6,7 @@
 #}
 <div class="card-body p-0">
     <!-- Tab navigation -->
-    <ul class="nav nav-tabs px-3 pt-3" id="resourcesTabs" role="tablist">
+    <ul class="nav nav-tabs" id="resourcesTabs" role="tablist">
         <li class="nav-item" role="presentation">
             <button class="nav-link active" id="resources-tab" data-bs-toggle="tab"
                     data-bs-target="#resources-pane" type="button" role="tab"
@@ -126,7 +126,7 @@
                 </span>
                 {% if has_permission(Permission.CREATE_RESOURCES) %}
                 <div class="d-flex gap-2">
-                    <button class="btn btn-sm btn-outline-success"
+                    <button class="btn btn-primary"
                             data-bs-toggle="modal"
                             data-bs-target="#createResourceTypeModal"
                             hx-get="{{ url_for('admin_dashboard.htmx_resource_type_create_form') }}"
@@ -134,7 +134,7 @@
                             hx-trigger="click">
                         <i class="fas fa-plus"></i> Create Type
                     </button>
-                    <button class="btn btn-sm btn-outline-success"
+                    <button class="btn btn-primary"
                             data-bs-toggle="modal"
                             data-bs-target="#createResourceModal"
                             hx-get="{{ url_for('admin_dashboard.htmx_resource_create_form') }}"
@@ -213,7 +213,7 @@
                     Showing {{ machines|length }} machine{{ 's' if machines|length != 1 else '' }}
                 </span>
                 {% if has_permission(Permission.CREATE_RESOURCES) %}
-                <button class="btn btn-sm btn-outline-success"
+                <button class="btn  btn-primary"
                         data-bs-toggle="modal"
                         data-bs-target="#createMachineModal"
                         hx-get="{{ url_for('admin_dashboard.htmx_machine_create_form') }}"
@@ -315,7 +315,7 @@
                     </span>
                 </div>
                 {% if has_permission(Permission.EDIT_USERS) %}
-                <button type="button" class="btn btn-sm btn-success"
+                <button type="button" class="btn btn-primary"
                         data-bs-toggle="modal"
                         data-bs-target="#addExemptionModal"
                         hx-get="{{ url_for('admin_dashboard.htmx_admin_exemption_form') }}"

--- a/src/webapp/templates/dashboards/admin/fragments/user_search_results_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/user_search_results_htmx.html
@@ -31,7 +31,7 @@
           data-confirm-variant="warning" data-confirm-label="Impersonate">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <input type="hidden" name="username" value="{{ user.username }}">
-        <button type="submit" class="btn btn-sm btn-outline-warning" title="Impersonate {{ user.username }}">
+        <button type="submit" class="btn  btn-outline-warning" title="Impersonate {{ user.username }}">
             <i class="fas fa-user-secret"></i>
         </button>
     </form>

--- a/src/webapp/templates/dashboards/admin/rate_limits.html
+++ b/src/webapp/templates/dashboards/admin/rate_limits.html
@@ -18,7 +18,7 @@
                 {% else %}<span class="text-danger">disabled</span>{% endif %}
             </p>
         </div>
-        <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('admin_dashboard.index') }}">
+        <a class="btn btn-outline-secondary " href="{{ url_for('admin_dashboard.index') }}">
             <i class="fas fa-chevron-left"></i> Back to Admin
         </a>
     </div>
@@ -50,7 +50,7 @@
         <div class="card h-100">
             <div class="card-header py-2 d-flex justify-content-between align-items-center">
                 <strong>Top offenders (24h)</strong>
-                <button class="btn btn-sm btn-outline-secondary"
+                <button class="btn  btn-outline-secondary"
                         hx-get="{{ url_for('admin_dashboard.rate_limits_offenders') }}"
                         hx-target="#offenders-body" hx-swap="innerHTML">
                     <i class="fas fa-sync"></i>
@@ -69,7 +69,7 @@
         <div class="card h-100">
             <div class="card-header py-2 d-flex justify-content-between align-items-center">
                 <strong>Active blocks</strong>
-                <button class="btn btn-sm btn-outline-secondary"
+                <button class="btn  btn-outline-secondary"
                         hx-get="{{ url_for('admin_dashboard.rate_limits_blocks') }}"
                         hx-target="#blocks-body" hx-swap="innerHTML">
                     <i class="fas fa-sync"></i>
@@ -98,7 +98,7 @@
                         <option value="1h">Last 1h</option>
                         <option value="24h" selected>Last 24h</option>
                     </select>
-                    <button type="submit" class="btn btn-sm btn-outline-secondary">
+                    <button type="submit" class="btn  btn-outline-secondary">
                         <i class="fas fa-sync"></i>
                     </button>
                 </form>

--- a/src/webapp/templates/dashboards/allocations/dashboard.html
+++ b/src/webapp/templates/dashboards/allocations/dashboard.html
@@ -10,7 +10,7 @@
 {% block content %}
 <!-- Page Header -->
 <div class="d-flex justify-content-between align-items-center mb-4">
-    <h2><i class="fas fa-chart-pie"></i> Allocations Dashboard</h2>
+    <h1><i class="fas fa-chart-pie"></i> Allocations Dashboard</h1>
 </div>
 
 <!-- Top-level tab navigation -->

--- a/src/webapp/templates/dashboards/allocations/dashboard.html
+++ b/src/webapp/templates/dashboards/allocations/dashboard.html
@@ -143,80 +143,52 @@
 </div>
 {% endif %}
 
-<!-- Filter Panel: collapsed-by-default summary bar; placed below the chart
-     since changes are infrequent. Expanded form lives in the .collapse body.
-     The .collapse[id] is auto-persisted by nav-view-persistence.js so a
-     user who expands it once keeps it expanded across reloads. -->
-{% set _resource_summary -%}
-    {%- if selected_resources|length == all_resources|length -%}All resources
-    {%- elif selected_resources|length > 3 -%}{{ selected_resources|length }} resources
-    {%- else -%}{{ selected_resources|join(', ') }}
-    {%- endif %}
-{%- endset %}
-{% set _facility_summary -%}
-    {%- if selected_facilities|length == allowed_facility_names|length -%}All facilities
-    {%- elif selected_facilities|length > 3 -%}{{ selected_facilities|length }} facilities
-    {%- else -%}{{ selected_facilities|join(', ') }}
-    {%- endif %}
-{%- endset %}
-<div class="card mb-3">
-    <div class="card-header py-2 collapse-toggle collapsed"
-         data-bs-toggle="collapse" data-bs-target="#allocationsFilterPanel"
-         role="button" aria-expanded="false" aria-controls="allocationsFilterPanel"
-         style="cursor: pointer;">
-        <span class="text-muted small">
-            <i class="fas fa-filter me-1"></i>
-            <strong class="text-dark me-2">Filters</strong>
-            Facilities: <strong class="text-dark">{{ _facility_summary }}</strong>
-            <span class="mx-2">·</span>
-            Resources: <strong class="text-dark">{{ _resource_summary }}</strong>
-            <span class="mx-2">·</span>
-            Active at: <strong class="text-dark">{{ active_at }}</strong>
-        </span>
+<!-- Filter Panel: Unity NCAR navy panel, always visible, sits above content.
+     Reuses .filter-sidebar (same design tokens as the original sidebar-style
+     filter); form fields arranged horizontally for top-of-page placement. -->
+<div class="filter-sidebar mb-3">
+    <div class="filter-sidebar-header">
+        <h2 class="filter-sidebar-title">Filters</h2>
+        <a href="{{ url_for('allocations_dashboard.index') }}"
+           class="filter-sidebar-clear">Clear filters</a>
     </div>
-    <div class="collapse" id="allocationsFilterPanel">
-        <div class="card-body py-3">
-            <form method="GET" class="d-flex flex-wrap align-items-start gap-4 mb-0"
-                  id="allocations-facility-filter-form">
-                <div>
-                    <label for="facilities" class="form-label small mb-1"><strong>Facilities</strong></label>
-                    <select class="form-control form-control-sm" id="facilities" name="facilities"
-                            multiple size="{{ [allowed_facility_names|length, 4]|min if allowed_facility_names|length else 4 }}"
-                            style="width: 200px;">
-                        {% for facility_name in allowed_facility_names %}
-                        <option value="{{ facility_name }}"
-                            {% if facility_name in selected_facilities %}selected{% endif %}>
-                            {{ facility_name }}
-                        </option>
-                        {% endfor %}
-                    </select>
-                    <small class="form-text text-muted">Hold Ctrl/Cmd to select multiple</small>
-                </div>
-                <div>
-                    <label for="resources" class="form-label small mb-1"><strong>Resources</strong></label>
-                    <select class="form-control form-control-sm" id="resources" name="resources"
-                            multiple size="4" style="width: 240px;">
-                        {% for res in all_resources %}
-                        <option value="{{ res }}" {% if res in selected_resources %}selected{% endif %}>{{ res }}</option>
-                        {% endfor %}
-                    </select>
-                    <small class="form-text text-muted">Hold Ctrl/Cmd to select multiple</small>
-                </div>
 
-                <div class="d-flex flex-column gap-2">
-                    <div>
-                        <label for="active_at" class="form-label small mb-1"><strong>Active at</strong></label>
-                        <input type="date" class="form-control form-control-sm" id="active_at"
-                               name="active_at" value="{{ active_at }}" style="width: 160px;">
-                    </div>
-
-                    <button type="submit" class="btn btn-sm btn-primary" style="width: 160px;">
-                        <i class="fas fa-search"></i> Update
-                    </button>
-                </div>
-            </form>
+    <form method="GET" class="d-flex flex-wrap align-items-start gap-3 mb-0"
+          id="allocations-facility-filter-form">
+        <div>
+            <label for="active_at" class="form-label"><strong>Active at</strong></label>
+            <input type="date" class="form-control" id="active_at"
+                   name="active_at" value="{{ active_at }}" style="width: 160px;">
         </div>
-    </div>
+        <div>
+            <label for="facilities" class="form-label"><strong>Facilities</strong></label>
+            <select class="form-control" id="facilities" name="facilities"
+                    multiple size="{{ [allowed_facility_names|length, 4]|min if allowed_facility_names|length else 4 }}"
+                    style="width: 200px;">
+                {% for facility_name in allowed_facility_names %}
+                <option value="{{ facility_name }}"
+                    {% if facility_name in selected_facilities %}selected{% endif %}>
+                    {{ facility_name }}
+                </option>
+                {% endfor %}
+            </select>
+            <small class="form-text">Hold Ctrl/Cmd to select multiple</small>
+        </div>
+
+        <div>
+            <label for="resources" class="form-label"><strong>Resources</strong></label>
+            <select class="form-control" id="resources" name="resources"
+                    multiple size="4" style="width: 240px;">
+                {% for res in all_resources %}
+                <option value="{{ res }}"
+                    {% if res in selected_resources %}selected{% endif %}>{{ res }}</option>
+                {% endfor %}
+            </select>
+            <small class="form-text">Hold Ctrl/Cmd to select multiple</small>
+        </div>
+
+        <button type="submit" class="btn btn-outline-white align-self-end">Update</button>
+    </form>
 </div>
 
 <!-- Resource Tabs -->
@@ -466,12 +438,14 @@
 
 <!-- Tab 2: Transactions — sortable/paginated audit log, lazy-loaded -->
 <div class="tab-pane fade" id="tab-alloc-transactions" role="tabpanel" aria-labelledby="alloc-transactions-tab">
-    {{ audit_filters(
-        form_id='tx-filters',
-        fragment_url=url_for('allocations_dashboard.transactions_fragment'),
-        target_id='alloc-transactions-fragment',
-        start_date=audit_start_date, end_date=audit_end_date,
-        all_resources=all_resources, selected_resources=[]) }}
+    <div class="filter-sidebar mb-3">
+        {{ audit_filters(
+            form_id='tx-filters',
+            fragment_url=url_for('allocations_dashboard.transactions_fragment'),
+            target_id='alloc-transactions-fragment',
+            start_date=audit_start_date, end_date=audit_end_date,
+            all_resources=all_resources, selected_resources=[]) }}
+    </div>
 
     <div id="alloc-transactions-fragment"
          hx-get="{{ url_for('allocations_dashboard.transactions_fragment') }}"
@@ -490,22 +464,24 @@
 <div class="tab-pane fade" id="tab-alloc-adjustments" role="tabpanel" aria-labelledby="alloc-adjustments-tab">
     {% if has_permission(Permission.EDIT_ALLOCATIONS) %}
     <div class="d-flex justify-content-end mb-2">
-        <button type="button" class="btn btn-sm btn-success"
+        <button type="button" class="btn btn-primary"
                 data-bs-toggle="modal" data-bs-target="#createAdjustmentModal"
                 hx-get="{{ url_for('allocations_dashboard.htmx_create_adjustment_form') }}"
                 hx-target="#createAdjustmentFormContainer"
                 hx-swap="innerHTML">
-            <i class="fas fa-plus"></i> Create Adjustment
+            Create Adjustment
         </button>
     </div>
     {% endif %}
 
-    {{ audit_filters(
-        form_id='adj-filters',
-        fragment_url=url_for('allocations_dashboard.adjustments_fragment'),
-        target_id='alloc-adjustments-fragment',
-        start_date=audit_start_date, end_date=audit_end_date,
-        all_resources=all_resources, selected_resources=[]) }}
+    <div class="filter-sidebar mb-3">
+        {{ audit_filters(
+            form_id='adj-filters',
+            fragment_url=url_for('allocations_dashboard.adjustments_fragment'),
+            target_id='alloc-adjustments-fragment',
+            start_date=audit_start_date, end_date=audit_end_date,
+            all_resources=all_resources, selected_resources=[]) }}
+    </div>
 
     {# data-refresh-url: read by dashboard-init.js on refreshAdjustmentsTab #}
     <div id="alloc-adjustments-fragment"

--- a/src/webapp/templates/dashboards/allocations/partials/pace_chart.html
+++ b/src/webapp/templates/dashboards/allocations/partials/pace_chart.html
@@ -34,7 +34,7 @@
                     ('future', 'Future Risk'),
                 ] %}
                 <button type="button"
-                        class="btn btn-{% if sort_by == opt_val %}primary{% else %}outline-primary{% endif %}"
+                        class="btn {% if sort_by == opt_val %}btn-secondary active{% else %}btn-outline-secondary{% endif %}"
                         hx-get="{{ url_for('allocations_dashboard.htmx_pace_chart',
                                            resource_name=resource_name,
                                            **dict(selector_kwargs, sort_by=opt_val)) }}"

--- a/src/webapp/templates/dashboards/base.html
+++ b/src/webapp/templates/dashboards/base.html
@@ -143,7 +143,7 @@
         <div class="container d-flex justify-content-center align-items-center">
             <i class="fas fa-user-secret me-2"></i>
             <strong>You are currently impersonating {{ current_user.display_name }} ({{ current_user.username }}).</strong>
-            <a href="{{ url_for('admin_dashboard.stop_impersonating') }}" class="btn btn-sm btn-outline-dark ms-3">
+            <a href="{{ url_for('admin_dashboard.stop_impersonating') }}" class="btn  btn-outline-dark ms-3">
                 <i class="fas fa-times"></i> Stop Impersonating
             </a>
         </div>

--- a/src/webapp/templates/dashboards/fragments/audit_filters.html
+++ b/src/webapp/templates/dashboards/fragments/audit_filters.html
@@ -20,86 +20,67 @@
                        start_date='', end_date='',
                        projcode='', username='',
                        all_resources=[], selected_resources=[]) %}
+{# Unity NCAR navy panel — same .filter-sidebar tokens as the allocations
+   facility filter, so audit filters match the rest of the dashboard. #}
 <form id="{{ form_id }}"
-      class="card mb-3"
       hx-get="{{ fragment_url }}"
       hx-target="#{{ target_id }}"
       hx-swap="innerHTML"
       hx-trigger="submit">
-    <div class="card-body py-3">
-        <div class="d-flex flex-wrap align-items-start gap-3">
+    <div class="filter-sidebar-header">
+        <h2 class="filter-sidebar-title">Filters</h2>
+        {# CSP-clean reset: form-reset-submit (static/js/actions.js) resets the
+           form and re-triggers its htmx submit — no inline onclick. #}
+        <a class="filter-sidebar-clear" style="cursor: pointer;"
+           data-action="form-reset-submit" data-form-id="{{ form_id }}">Clear filters</a>
+    </div>
 
-            {# Left column: four inputs stacked over the Search/Reset row. #}
-            <div class="d-flex flex-column gap-3">
+    <div class="d-flex flex-wrap align-items-start gap-3">
 
-                <div class="d-flex flex-wrap gap-3">
-                    <div>
-                        <label class="form-label small mb-1">
-                            <strong><i class="fas fa-calendar me-1 text-muted"></i>From</strong>
-                        </label>
-                        <input type="date" class="form-control form-control-sm"
-                               name="start_date" value="{{ start_date }}"
-                               style="width:150px;">
-                    </div>
-
-                    <div>
-                        <label class="form-label small mb-1"><strong>To</strong></label>
-                        <input type="date" class="form-control form-control-sm"
-                               name="end_date" value="{{ end_date }}"
-                               style="width:150px;">
-                    </div>
-
-                    <div>
-                        <label class="form-label small mb-1">
-                            <strong><i class="fas fa-folder-open me-1 text-muted"></i>Project</strong>
-                        </label>
-                        <input type="text" class="form-control form-control-sm"
-                               name="projcode" value="{{ projcode or '' }}"
-                               placeholder="e.g. SCSG0001" style="width:140px;">
-                    </div>
-
-                    <div>
-                        <label class="form-label small mb-1">
-                            <strong><i class="fas fa-user me-1 text-muted"></i>Responsible user</strong>
-                        </label>
-                        <input type="text" class="form-control form-control-sm"
-                               name="username" value="{{ username or '' }}"
-                               placeholder="username" style="width:160px;">
-                    </div>
-                </div>
-
-                <div class="d-flex gap-2">
-                    <button type="submit" class="btn btn-sm btn-primary">
-                        <i class="fas fa-search"></i> Search
-                    </button>
-                    <button type="button" class="btn btn-sm btn-outline-secondary"
-                            data-action="form-reset-submit" data-form-id="{{ form_id }}"
-                            title="Reset to default filters">
-                        <i class="fas fa-rotate-left"></i> Reset
-                    </button>
-                </div>
-
-            </div>
-
-            {# Right column: the tall Resources picker sits alongside the left column. #}
-            {% if all_resources %}
-            <div>
-                <label class="form-label small mb-1">
-                    <strong><i class="fas fa-server me-1 text-muted"></i>Resources</strong>
-                </label>
-                <select class="form-control form-control-sm"
-                        name="resource_name" multiple size="4"
-                        style="width:220px;">
-                    {% for res in all_resources %}
-                    <option value="{{ res }}"
-                        {% if res in selected_resources %}selected{% endif %}>{{ res }}</option>
-                    {% endfor %}
-                </select>
-                <small class="form-text text-muted">Hold Ctrl/Cmd to select multiple</small>
-            </div>
-            {% endif %}
-
+        <div>
+            <label class="form-label"><strong>From</strong></label>
+            <input type="date" class="form-control"
+                   name="start_date" value="{{ start_date }}"
+                   style="width:150px;">
         </div>
+
+        <div>
+            <label class="form-label"><strong>To</strong></label>
+            <input type="date" class="form-control"
+                   name="end_date" value="{{ end_date }}"
+                   style="width:150px;">
+        </div>
+
+        <div>
+            <label class="form-label"><strong>Project</strong></label>
+            <input type="text" class="form-control"
+                   name="projcode" value="{{ projcode or '' }}"
+                   placeholder="e.g. SCSG0001" style="width:140px;">
+        </div>
+
+        <div>
+            <label class="form-label"><strong>Responsible user</strong></label>
+            <input type="text" class="form-control"
+                   name="username" value="{{ username or '' }}"
+                   placeholder="username" style="width:160px;">
+        </div>
+
+        {% if all_resources %}
+        <div>
+            <label class="form-label"><strong>Resources</strong></label>
+            <select class="form-control"
+                    name="resource_name" multiple size="4"
+                    style="width:220px;">
+                {% for res in all_resources %}
+                <option value="{{ res }}"
+                    {% if res in selected_resources %}selected{% endif %}>{{ res }}</option>
+                {% endfor %}
+            </select>
+            <small class="form-text">Hold Ctrl/Cmd to select multiple</small>
+        </div>
+        {% endif %}
+
+        <button type="submit" class="btn btn-outline-white align-self-end">Search</button>
     </div>
 </form>
 {% endmacro %}

--- a/src/webapp/templates/dashboards/fragments/date_range_picker.html
+++ b/src/webapp/templates/dashboards/fragments/date_range_picker.html
@@ -45,7 +45,7 @@
 
                 <!-- Custom date range toggle -->
                 <button type="button"
-                        class="btn btn-sm btn-outline-primary"
+                        class="btn btn-outline-primary"
                         data-action="drp-toggle-custom">
                     <i class="fas fa-calendar-alt"></i> Custom
                 </button>
@@ -59,7 +59,7 @@
                     <input type="date" name="end_date"
                            value="{{ end_date }}"
                            class="form-control form-control-sm" style="width:140px">
-                    <button type="submit" class="btn btn-sm btn-primary">
+                    <button type="submit" class="btn  btn-primary">
                         <i class="fas fa-check"></i> Apply
                     </button>
                 </div>

--- a/src/webapp/templates/dashboards/fragments/form_fields.html
+++ b/src/webapp/templates/dashboards/fragments/form_fields.html
@@ -298,7 +298,7 @@
     <div id="{{ _selected_id }}" class="fk-picker-selected mb-1"
          {% if not _has_value %}style="display:none;"{% endif %}>
         <span class="badge {{ badge_class }} fk-picker-badge" id="{{ _badge_id }}">{{ _form_label or '' }}</span>
-        <button type="button" class="btn btn-xs btn-outline-secondary ms-1 fk-picker-clear">
+        <button type="button" class="btn btn-sm btn-outline-secondary ms-1 fk-picker-clear">
             <i class="fas fa-times"></i>
         </button>
     </div>

--- a/src/webapp/templates/dashboards/fragments/modals.html
+++ b/src/webapp/templates/dashboards/fragments/modals.html
@@ -57,7 +57,7 @@
             <div class="modal-body" id="samConfirmModalBody"></div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-danger" id="samConfirmModalConfirm">Confirm</button>
+                <button type="button" class="btn btn-outline-primary" id="samConfirmModalConfirm">Confirm</button>
             </div>
         </div>
     </div>

--- a/src/webapp/templates/dashboards/shared/project_tree.html
+++ b/src/webapp/templates/dashboards/shared/project_tree.html
@@ -94,7 +94,7 @@
         <span class="badge bg-secondary bg-opacity-25 text-dark border small">shared</span>
         {%- endif -%}
         {%- if can_edit_allocations and res.allocation_id -%}
-        <button class="btn btn-xs btn-outline-warning py-0 px-1 flex-shrink-0"
+        <button class="btn btn-sm btn-outline-warning py-0 px-1 flex-shrink-0"
                 style="font-size:0.7rem;"
                 hx-get="{{ url_for('admin_dashboard.htmx_edit_allocation_form', allocation_id=res.allocation_id) }}"
                 hx-target="#editAllocationFormContainer"
@@ -237,7 +237,7 @@
     <span class="badge bg-secondary bg-opacity-25 text-dark border small">shared</span>
     {%- endif -%}
     {%- if can_edit_allocations and res and res.allocation_id -%}
-    <button class="btn btn-xs btn-outline-warning py-0 px-1 ms-1"
+    <button class="btn btn-sm btn-outline-warning py-0 px-1 ms-1"
             style="font-size:0.7rem;"
             hx-get="{{ url_for('admin_dashboard.htmx_edit_allocation_form', allocation_id=res.allocation_id) }}"
             hx-target="#editAllocationFormContainer"
@@ -253,7 +253,7 @@
         ≥2 descendant projects hold dedicated allocations on this
         resource. See projects_routes.py:htmx_project_allocation_tree. -#}
     {%- if is_current and exchange_url -%}
-    <button class="btn btn-xs btn-outline-info py-0 px-1 ms-1"
+    <button class="btn btn-sm btn-outline-info py-0 px-1 ms-1"
             style="font-size:0.7rem;"
             hx-get="{{ exchange_url }}"
             hx-target="#exchangeAllocationFormContainer"

--- a/src/webapp/templates/dashboards/status/dashboard.html
+++ b/src/webapp/templates/dashboards/status/dashboard.html
@@ -12,9 +12,9 @@
 <!-- Page Header -->
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1><i class="fas fa-server"></i> System Status Dashboard</h1>
-    <div class="d-flex align-items-center gap-2">
+    <div class="d-flex align-items-center flex-column gap-2">
         {% if has_permission(Permission.EDIT_SYSTEM_STATUS) %}
-        <button class="btn btn-sm btn-outline-danger" data-bs-toggle="modal" data-bs-target="#createOutageModal">
+        <button class="btn  btn-outline-danger" data-bs-toggle="modal" data-bs-target="#createOutageModal">
             <i class="fas fa-exclamation-circle"></i> Report Outage
         </button>
         {% endif %}
@@ -46,7 +46,7 @@
                     <span class="text-muted small">{{ outage.start_time | to_local_dt | fmt_date(fmt='%Y-%m-%d %H:%M %Z') }}</span>
                     {% if has_permission(Permission.EDIT_SYSTEM_STATUS) %}
                     <div class="btn-group btn-group-sm ms-2">
-                        <button class="btn btn-outline-secondary btn-sm"
+                        <button class="btn btn-outline-secondary "
                                 title="Edit outage"
                                 {# estimated_resolution is naive-UTC; mark with 'Z' so JS can
                                    parse it as a real instant and convert to operator-local
@@ -60,7 +60,7 @@
                                 data-outage-title="{{ outage.title }}">
                             <i class="fas fa-edit"></i>
                         </button>
-                        <button class="btn btn-outline-success btn-sm"
+                        <button class="btn btn-primary "
                                 title="Mark resolved"
                                 hx-post="{{ url_for('status_dashboard.htmx_resolve_outage', outage_id=outage.outage_id) }}"
                                 hx-confirm="Mark this outage as resolved?"
@@ -69,7 +69,7 @@
                                 data-confirm-label="Mark resolved">
                             <i class="fas fa-check"></i>
                         </button>
-                        <button class="btn btn-outline-danger btn-sm"
+                        <button class="btn btn-outline-danger "
                                 title="Delete outage"
                                 hx-delete="{{ url_for('status_dashboard.htmx_delete_outage', outage_id=outage.outage_id) }}"
                                 hx-confirm="Delete outage: {{ outage.title }}?"

--- a/src/webapp/templates/dashboards/status/jupyterhub.html
+++ b/src/webapp/templates/dashboards/status/jupyterhub.html
@@ -10,7 +10,7 @@
         <h5 class="mb-3"><i class="fas fa-eye"></i> At a Glance</h5>
         <div class="row mb-4">
             <div class="col-md-3">
-                <div class="card border h-100">
+                <div class="card inner-card h-100">
                     <div class="card-body text-center d-flex flex-column justify-content-center">
                         <div class="mb-3">
                             {% if jupyterhub_status.available %}
@@ -25,7 +25,7 @@
                 </div>
             </div>
             <div class="col-md-3">
-                <div class="card border h-100">
+                <div class="card inner-card h-100">
                     <div class="card-body text-center d-flex flex-column justify-content-center">
                         <div class="mb-3">
                             <i class="fas fa-users text-primary icon-jumbo"></i>
@@ -36,7 +36,7 @@
                 </div>
             </div>
             <div class="col-md-3">
-                <div class="card border h-100">
+                <div class="card inner-card h-100">
                     <div class="card-body text-center d-flex flex-column justify-content-center">
                         <div class="mb-3">
                             <i class="fas fa-desktop text-info icon-jumbo"></i>
@@ -53,7 +53,7 @@
                 {% set used_slots = (cpus_used / 2)|int %}
                 {% set available_slots = total_slots - used_slots %}
                 {% set slot_percent = ((used_slots / total_slots * 100)|round)|int if total_slots > 0 else 0 %}
-                <div class="card border h-100">
+                <div class="card inner-card h-100">
                     <div class="card-body text-center d-flex flex-column justify-content-center">
                         <div style="height: 70px; display: flex; flex-direction: column; justify-content: center; margin-bottom: 1rem;">
                             <div class="d-flex justify-content-end mb-1">
@@ -80,7 +80,7 @@
         <h5 class="mb-3"><i class="fas fa-th"></i> Session Breakouts</h5>
         <div class="row mb-4">
             <div class="col-md-3">
-                <div class="card border border-status-success h-100">
+                <div class="card inner-card h-100">
                     <div class="card-body">
                         <div class="d-flex justify-content-between align-items-start mb-3">
                             <h6 class="text-muted mb-0">Casper Login Jobs</h6>
@@ -91,7 +91,7 @@
                 </div>
             </div>
             <div class="col-md-3">
-                <div class="card border border-status-info h-100">
+                <div class="card inner-card h-100">
                     <div class="card-body">
                         <div class="d-flex justify-content-between align-items-start mb-3">
                             <h6 class="text-muted mb-0">Casper Batch Jobs</h6>
@@ -102,7 +102,7 @@
                 </div>
             </div>
             <div class="col-md-3">
-                <div class="card border border-status-primary h-100">
+                <div class="card inner-card h-100">
                     <div class="card-body">
                         <div class="d-flex justify-content-between align-items-start mb-3">
                             <h6 class="text-muted mb-0">Derecho Batch Jobs</h6>
@@ -113,7 +113,7 @@
                 </div>
             </div>
             <div class="col-md-3">
-                <div class="card border border-status-warning h-100">
+                <div class="card inner-card h-100">
                     <div class="card-body">
                         <div class="d-flex justify-content-between align-items-start mb-3">
                             <h6 class="text-muted mb-0">Broken Jobs</h6>
@@ -136,7 +136,7 @@
                 {% set cpus_total = jupyterhub_status.cpus_total or 0 %}
                 {% set cpus_used = jupyterhub_status.cpus_used or 0 %}
                 {% set cpu_percent = ((cpus_used / cpus_total * 100)|round(1))|default(0, true) if cpus_total > 0 else 0 %}
-                <div class="card border h-100">
+                <div class="card inner-card h-100">
                     <div class="card-body">
                         <div class="d-flex justify-content-between align-items-center mb-3">
                             <h6 class="mb-0">CPU Utilization</h6>
@@ -163,7 +163,7 @@
                 {% set mem_total = jupyterhub_status.memory_total_gb or 0 %}
                 {% set mem_used = jupyterhub_status.memory_used_gb or 0 %}
                 {% set mem_percent = ((mem_used / mem_total * 100)|round(1))|default(0, true) if mem_total > 0 else 0 %}
-                <div class="card border h-100">
+                <div class="card inner-card h-100">
                     <div class="card-body">
                         <div class="d-flex justify-content-between align-items-center mb-3">
                             <h6 class="mb-0">Memory Utilization</h6>

--- a/src/webapp/templates/dashboards/status/nodetype_history.html
+++ b/src/webapp/templates/dashboards/status/nodetype_history.html
@@ -7,7 +7,7 @@
    types inherits the user's chosen time range. #}
 {% set _idx_kwargs = {'hours': hours} if hours else {} %}
 <div class="back-link mb-3">
-    <a href="{{ url_for('status_dashboard.index', **_idx_kwargs) }}" class="btn btn-sm btn-outline-secondary">
+    <a href="{{ url_for('status_dashboard.index', **_idx_kwargs) }}" class="btn  btn-outline-secondary">
         <i class="fas fa-arrow-left"></i> <span class="back-link-text">Back to Status Dashboard</span>
     </a>
 </div>

--- a/src/webapp/templates/dashboards/status/partials/user_proj_chart.html
+++ b/src/webapp/templates/dashboards/status/partials/user_proj_chart.html
@@ -25,13 +25,13 @@
 <div id="{{ chart_dom_id }}"
      data-chart-persist-id="{{ chart_dom_id }}"
      data-chart-persist-keys="group_by state metric rank_by">
-    <div class="d-flex flex-wrap gap-3 mb-3 align-items-center">
+    <div class="d-flex flex-wrap flex-lg-nowrap gap-2 mb-3 align-items-end">
         <div>
             <label class="form-label small text-muted mb-1 me-2">Group by</label>
             <div class="btn-group btn-group-sm" role="group" aria-label="Group by">
                 {% for opt_val, opt_lbl in [('user', 'User'), ('project', 'Project code')] %}
                 <button type="button"
-                        class="btn btn-{% if group_by == opt_val %}primary{% else %}outline-primary{% endif %}"
+                        class="btn {% if group_by == opt_val %}btn-secondary active{% else %}btn-outline-secondary{% endif %}"
                         hx-get="{{ url_for(endpoint_name,
                                            **dict(endpoint_kwargs, **dict(_selector_kwargs, group_by=opt_val))) }}"
                         hx-target="#{{ chart_dom_id }}"
@@ -50,7 +50,7 @@
                    valid combo in one click. #}
                 {% set _state_metric = 'cores' if (metric == 'nodes' and opt_val != 'running') else metric %}
                 <button type="button"
-                        class="btn btn-{% if state == opt_val %}primary{% else %}outline-primary{% endif %}"
+                        class="btn {% if state == opt_val %}btn-secondary active{% else %}btn-outline-secondary{% endif %}"
                         hx-get="{{ url_for(endpoint_name,
                                            **dict(endpoint_kwargs, **dict(_selector_kwargs, state=opt_val, metric=_state_metric))) }}"
                         hx-target="#{{ chart_dom_id }}"
@@ -72,7 +72,7 @@
                 {% for opt_val, opt_lbl in _metric_options %}
                 {% set is_invalid = (opt_val == 'nodes' and state != 'running') %}
                 <button type="button"
-                        class="btn btn-{% if metric == opt_val %}primary{% else %}outline-primary{% endif %}"
+                        class="btn {% if metric == opt_val %}btn-secondary active{% else %}btn-outline-secondary{% endif %}"
                         {% if is_invalid %}
                           disabled
                           title="Nodes only available for state=Running"
@@ -94,7 +94,7 @@
                    Current: top_n by value at the latest tick (who is hot right now). #}
                 {% for opt_val, opt_lbl in [('current', 'Current'), ('peak', 'Peak')] %}
                 <button type="button"
-                        class="btn btn-{% if rank_by == opt_val %}primary{% else %}outline-primary{% endif %}"
+                        class="btn {% if rank_by == opt_val %}btn-secondary active{% else %}btn-outline-secondary{% endif %}"
                         hx-get="{{ url_for(endpoint_name,
                                            **dict(endpoint_kwargs, **dict(_selector_kwargs, rank_by=opt_val))) }}"
                         hx-target="#{{ chart_dom_id }}"

--- a/src/webapp/templates/dashboards/user/dashboard.html
+++ b/src/webapp/templates/dashboards/user/dashboard.html
@@ -5,7 +5,10 @@
 {% block title %}User Dashboard - SAM{% endblock %}
 
 {% block content %}
-<h1>User Dashboard</h1>
+<div class="mb-4">
+    <h1>User Dashboard</h1>
+</div>
+
 
 <!-- Tab Navigation -->
 <ul class="nav nav-tabs mb-0" id="dashboardTabs" role="tablist">

--- a/src/webapp/templates/dashboards/user/fragments/primary_gid_display_htmx.html
+++ b/src/webapp/templates/dashboards/user/fragments/primary_gid_display_htmx.html
@@ -13,7 +13,7 @@
     {% endif %}
     {% if can_edit_primary_gid %}
     <button type="button"
-            class="btn btn-xs btn-outline-secondary ms-2 py-0"
+            class="btn btn-sm btn-outline-secondary ms-2 py-0"
             title="Change primary GID"
             hx-get="{{ url_for('user_dashboard.htmx_primary_gid_form', username=sam_user.username) }}"
             hx-target="#primary-gid-row-{{ sam_user.username }}"

--- a/src/webapp/templates/dashboards/user/fragments/primary_gid_form_htmx.html
+++ b/src/webapp/templates/dashboards/user/fragments/primary_gid_form_htmx.html
@@ -18,10 +18,10 @@
             </option>
             {% endfor %}
         </select>
-        <button type="submit" class="btn btn-xs btn-success py-0" title="Save">
+        <button type="submit" class="btn btn-sm btn-primary py-0" title="Save">
             <i class="fas fa-check"></i>
         </button>
-        <button type="button" class="btn btn-xs btn-secondary py-0" title="Cancel"
+        <button type="button" class="btn btn-sm btn-secondary py-0" title="Cancel"
                 hx-get="{{ url_for('user_dashboard.htmx_primary_gid_display', username=sam_user.username) }}"
                 hx-target="#primary-gid-row-{{ sam_user.username }}"
                 hx-swap="innerHTML">

--- a/src/webapp/templates/dashboards/user/fragments/shell_display_htmx.html
+++ b/src/webapp/templates/dashboards/user/fragments/shell_display_htmx.html
@@ -14,7 +14,7 @@
     {% endif %}
     {% if can_edit_shell %}
     <button type="button"
-            class="btn btn-xs btn-outline-secondary ms-2 py-0"
+            class="btn btn-sm btn-outline-secondary ms-2 py-0"
             title="Change login shell"
             hx-get="{{ url_for('user_dashboard.htmx_shell_form', username=sam_user.username) }}"
             hx-target="#shell-row-{{ sam_user.username }}"

--- a/src/webapp/templates/dashboards/user/fragments/shell_form_htmx.html
+++ b/src/webapp/templates/dashboards/user/fragments/shell_form_htmx.html
@@ -17,10 +17,10 @@
             <option value="{{ sh }}" {% if sh == current_shell %}selected{% endif %}>{{ sh }}</option>
             {% endfor %}
         </select>
-        <button type="submit" class="btn btn-xs btn-success py-0" title="Save">
+        <button type="submit" class="btn btn-sm btn-primary py-0" title="Save">
             <i class="fas fa-check"></i>
         </button>
-        <button type="button" class="btn btn-xs btn-secondary py-0" title="Cancel"
+        <button type="button" class="btn btn-sm btn-secondary py-0" title="Cancel"
                 hx-get="{{ url_for('user_dashboard.htmx_shell_display', username=sam_user.username) }}"
                 hx-target="#shell-row-{{ sam_user.username }}"
                 hx-swap="innerHTML">

--- a/src/webapp/templates/dashboards/user/partials/_resource_details_macros.html
+++ b/src/webapp/templates/dashboards/user/partials/_resource_details_macros.html
@@ -9,7 +9,7 @@
    (user, user+queue, or user+queue+date). #}
 {% macro jobs_button(jid) %}
 <button type="button"
-        class="btn btn-sm btn-link p-0 ms-2 text-decoration-none"
+        class="btn  btn-link p-0 ms-2 text-decoration-none"
         data-bs-toggle="collapse"
         data-bs-target="#{{ jid }}"
         aria-expanded="false" aria-controls="{{ jid }}"

--- a/src/webapp/templates/dashboards/user/partials/project_card.html
+++ b/src/webapp/templates/dashboards/user/partials/project_card.html
@@ -203,7 +203,7 @@
                             {% if can_edit_allocations %}
                             <td class="text-center" data-stop-propagation>
                                 {% if resource.allocation_id and not resource.is_inheriting %}
-                                <button class="btn btn-xs btn-outline-primary"
+                                <button class="btn btn-sm btn-outline-primary"
                                         title="Edit allocation"
                                         data-bs-toggle="modal" data-bs-target="#editAllocationModal"
                                         hx-get="{{ url_for('user_dashboard.htmx_edit_allocation_form', allocation_id=resource.allocation_id) }}?projcode={{ project.projcode }}"
@@ -236,7 +236,7 @@
 <div class="mt-3">
     <h6 class="mb-2">
         <i class="fas fa-users"></i> Project Members
-        <button class="btn btn-sm btn-link" data-bs-toggle="collapse" data-bs-target="#members-{{ unique_id }}" aria-expanded="false">
+        <button class="btn  btn-link" data-bs-toggle="collapse" data-bs-target="#members-{{ unique_id }}" aria-expanded="false">
             <i class="fas fa-chevron-down"></i>
         </button>
     </h6>
@@ -368,7 +368,7 @@
                                 <label class="form-check-label small text-muted fw-normal"
                                        for="treeActiveOnly-{{ card_id }}">Active only</label>
                             </div>
-                            <button class="btn btn-sm btn-link p-0" data-bs-toggle="collapse"
+                            <button class="btn  btn-link p-0" data-bs-toggle="collapse"
                                     data-bs-target="#tree-{{ card_id }}" aria-expanded="false">
                                 <i class="fas fa-chevron-down"></i>
                             </button>
@@ -395,7 +395,7 @@
                 {% if can_act_on_project(Permission.EDIT_PROJECTS, project) %}
                 <div class="d-flex justify-content-end mt-3 pt-2 border-top">
                     <a href="{{ url_for('admin_dashboard.edit_project_page', projcode=project.projcode) }}"
-                       class="btn btn-sm btn-primary">
+                       class="btn  btn-primary">
                         <i class="fas fa-edit"></i> Edit Project
                     </a>
                 </div>

--- a/src/webapp/templates/dashboards/user/partials/project_details_modal.html
+++ b/src/webapp/templates/dashboards/user/partials/project_details_modal.html
@@ -15,7 +15,7 @@
         {% if can_act_on_project(Permission.EDIT_PROJECTS, project) %}
         <div class="d-flex justify-content-end mb-2">
             <a href="{{ url_for('admin_dashboard.edit_project_page', projcode=project.projcode) }}"
-               class="btn btn-sm btn-primary">
+               class="btn btn-primary">
                 <i class="fas fa-edit"></i> Edit Project
             </a>
         </div>
@@ -36,7 +36,7 @@
         <div class="mt-3">
             <h6 class="mb-2">
                 <i class="fas fa-sitemap"></i> Project Hierarchy
-                <button class="btn btn-sm btn-link" data-bs-toggle="collapse"
+                <button class="btn  btn-link" data-bs-toggle="collapse"
                         data-bs-target="#tree-modal" aria-expanded="false">
                     <i class="fas fa-chevron-down"></i>
                 </button>

--- a/src/webapp/templates/dashboards/user/partials/user_card.html
+++ b/src/webapp/templates/dashboards/user/partials/user_card.html
@@ -165,23 +165,23 @@
                     {% set branches = user_groups.keys() | list | sort %}
                     {% if branches %}
                     {% set tab_id = 'groupsTabs-' ~ sam_user.username %}
-                    <ul class="nav nav-pills nav-sm mb-2" id="{{ tab_id }}" role="tablist">
+                    <div class="btn-group btn-group-sm mb-2" role="tablist" id="{{ tab_id }}">
                         {% for branch in branches %}
                         {% set pane_id = 'groupsPane-' ~ sam_user.username ~ '-' ~ loop.index %}
-                        <li class="nav-item" role="presentation">
-                            <button class="nav-link py-1 px-2 {% if loop.first %}active{% endif %}"
-                                    id="{{ pane_id }}-tab"
-                                    data-bs-toggle="pill"
-                                    data-bs-target="#{{ pane_id }}"
-                                    type="button" role="tab"
-                                    aria-controls="{{ pane_id }}"
-                                    aria-selected="{{ 'true' if loop.first else 'false' }}">
-                                {{ branch }}
-                                <span class="badge bg-secondary ms-1">{{ user_groups[branch] | length }}</span>
-                            </button>
-                        </li>
+                        <input type="radio" class="btn-check" name="{{ tab_id }}-options" id="{{ pane_id }}-tab"
+                               autocomplete="off" {% if loop.first %}checked{% endif %}>
+                        <label class="btn btn-outline-primary"
+                               for="{{ pane_id }}-tab"
+                               data-bs-toggle="pill"
+                               data-bs-target="#{{ pane_id }}"
+                               role="tab"
+                               aria-controls="{{ pane_id }}"
+                               aria-selected="{{ 'true' if loop.first else 'false' }}">
+                            {{ branch }}
+                            <span class="badge bg-primary ms-1">{{ user_groups[branch] | length }}</span>
+                        </label>
                         {% endfor %}
-                    </ul>
+                    </div>
                     <div class="tab-content">
                         {% for branch in branches %}
                         {% set pane_id = 'groupsPane-' ~ sam_user.username ~ '-' ~ loop.index %}
@@ -235,7 +235,7 @@
         <div class="d-flex justify-content-between align-items-center mb-2">
             <strong><i class="fas fa-clock"></i> Wallclock Exemptions</strong>
             {% if is_admin and has_permission(Permission.EDIT_USERS) %}
-            <button class="btn btn-sm btn-outline-success"
+            <button class="btn  btn-primary"
                     data-bs-toggle="modal" data-bs-target="#addExemptionModal"
                     hx-get="{{ url_for('admin_dashboard.htmx_add_exemption_form', username=sam_user.username) }}"
                     hx-target="#addExemptionFormContainer"
@@ -274,7 +274,7 @@
                         <td>{{ ex.comment or '' }}</td>
                         {% if is_admin and has_permission(Permission.EDIT_USERS) %}
                         <td>
-                            <button class="btn btn-sm btn-outline-warning py-0"
+                            <button class="btn  btn-outline-warning py-0"
                                     data-bs-toggle="modal" data-bs-target="#editExemptionModal"
                                     hx-get="{{ url_for('admin_dashboard.htmx_edit_exemption_form', exemption_id=ex.wallclock_exemption_id) }}"
                                     hx-target="#editExemptionFormContainer"
@@ -303,7 +303,7 @@
               data-confirm-variant="warning" data-confirm-label="Impersonate">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="username" value="{{ sam_user.username }}">
-            <button type="submit" class="btn btn-sm btn-primary">
+            <button type="submit" class="btn  btn-primary">
                 <i class="fas fa-user-secret"></i> Impersonate {{ sam_user.username }}
             </button>
         </form>

--- a/src/webapp/templates/dashboards/user/partials/user_card.html
+++ b/src/webapp/templates/dashboards/user/partials/user_card.html
@@ -25,10 +25,11 @@
     <div class="card-body">
         <div class="row g-3">
         <div class="col-lg-6">
-        <div class="project-stats-box mb-0"
+        <div class="card inner-card h-100"
              style="grid-template-columns: auto minmax(0, 1fr); align-content: start;">
-            <h6><i class="fas fa-id-card"></i> User Information</h6>
-
+            <div class="card-header mb-4">
+                <h5><i class="fas fa-id-card"></i> User Information</h5>
+            </div>
             <div class="stat-item">
                 <span class="stat-label">Username:</span>
                 <span class="stat-value">{{ sam_user.username }}</span>
@@ -119,9 +120,11 @@
         </div>
         </div>
         <div class="col-lg-6">
-        <div class="project-stats-box mb-0"
+        <div class="card inner-card h-100"
              style="grid-template-columns: auto minmax(0, 1fr); align-content: start;">
-            <h6><i class="fas fa-sitemap"></i> Projects &amp; Groups</h6>
+            <div class="card-header mb-4">
+                <h5><i class="fas fa-sitemap"></i> Projects &amp; Groups</h5>
+            </div>
 
             <!-- Active projects -->
             <div class="stat-item stat-item-block mt-2">

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -229,11 +229,11 @@
 {% set _from_admin = request.args.get('from') == 'admin' %}
 <div class="back-link mb-3">
     {% if _from_admin %}
-    <a href="{{ url_for('admin_dashboard.index', projcode=projcode) }}" class="btn btn-sm btn-outline-secondary">
+    <a href="{{ url_for('admin_dashboard.index', projcode=projcode) }}" class="btn  btn-outline-secondary">
         <i class="fas fa-arrow-left"></i> <span class="back-link-text">Back to Admin</span>
     </a>
     {% else %}
-    <a href="{{ url_for('user_dashboard.index') }}" class="btn btn-sm btn-outline-secondary">
+    <a href="{{ url_for('user_dashboard.index') }}" class="btn  btn-outline-secondary">
         <i class="fas fa-arrow-left"></i> <span class="back-link-text">Back to Dashboard</span>
     </a>
     {% endif %}
@@ -297,7 +297,7 @@
                         {% if has_permission and Permission and has_permission(Permission.EDIT_ALLOCATIONS) %}
                         <td class="text-center">
                             {% if summary.allocation_id and not summary.is_inheriting %}
-                            <button class="btn btn-xs btn-outline-primary"
+                            <button class="btn btn-sm btn-outline-primary"
                                     title="Edit allocation"
                                     data-bs-toggle="modal" data-bs-target="#editAllocationModal"
                                     hx-get="{{ url_for('user_dashboard.htmx_edit_allocation_form', allocation_id=summary.allocation_id) }}?projcode={{ projcode }}"

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -62,11 +62,11 @@
 {% set _from_admin = request.args.get('from') == 'admin' %}
 <div class="back-link mb-3">
     {% if _from_admin %}
-    <a href="{{ url_for('admin_dashboard.index', projcode=projcode) }}" class="btn btn-sm btn-outline-secondary">
+    <a href="{{ url_for('admin_dashboard.index', projcode=projcode) }}" class="btn  btn-outline-secondary">
         <i class="fas fa-arrow-left"></i> <span class="back-link-text">Back to Admin</span>
     </a>
     {% else %}
-    <a href="{{ url_for('user_dashboard.index') }}" class="btn btn-sm btn-outline-secondary">
+    <a href="{{ url_for('user_dashboard.index') }}" class="btn  btn-outline-secondary">
         <i class="fas fa-arrow-left"></i> <span class="back-link-text">Back to Dashboard</span>
     </a>
     {% endif %}

--- a/src/webapp/templates/project_members/fragments/members_table.html
+++ b/src/webapp/templates/project_members/fragments/members_table.html
@@ -5,7 +5,7 @@
         {{ members|length }} member{{ 's' if members|length != 1 else '' }}
     </span>
     {% if can_manage %}
-    <button class="btn btn-sm btn-primary"
+    <button class="btn  btn-primary"
             data-bs-toggle="modal" data-bs-target="#addMemberModal"
             hx-get="{{ url_for('project_members.htmx_add_member_form', projcode=projcode) }}"
             hx-target="#addMemberFormContainer"
@@ -64,7 +64,7 @@
                     {% elif member.role == 'Admin' %}
                         {# Admin actions - only lead can change admin #}
                         {% if can_change_admin %}
-                        <button class="btn btn-xs btn-outline-warning"
+                        <button class="btn btn-sm btn-outline-warning"
                                 title="Remove admin role (keep as member)"
                                 hx-put="{{ url_for('project_members.htmx_change_admin', projcode=projcode) }}"
                                 hx-vals='{"admin_username": ""}'
@@ -77,7 +77,7 @@
                             <i class="fas fa-user-minus"></i>
                         </button>
                         {% endif %}
-                        <button class="btn btn-xs btn-outline-danger"
+                        <button class="btn btn-sm btn-outline-danger"
                                 title="Remove from project"
                                 hx-delete="{{ url_for('project_members.htmx_remove_member', projcode=projcode, username=member.username) }}"
                                 hx-target="#htmx-members-{{ projcode }}"
@@ -88,7 +88,7 @@
                     {% else %}
                         {# Regular member actions #}
                         {% if can_change_admin %}
-                        <button class="btn btn-xs btn-outline-info"
+                        <button class="btn btn-sm btn-outline-info"
                                 title="Make project admin"
                                 hx-put="{{ url_for('project_members.htmx_change_admin', projcode=projcode) }}"
                                 hx-vals='{"admin_username": "{{ member.username }}"}'
@@ -101,7 +101,7 @@
                             <i class="fas fa-user-shield"></i>
                         </button>
                         {% endif %}
-                        <button class="btn btn-xs btn-outline-danger"
+                        <button class="btn btn-sm btn-outline-danger"
                                 title="Remove from project"
                                 hx-delete="{{ url_for('project_members.htmx_remove_member', projcode=projcode, username=member.username) }}"
                                 hx-target="#htmx-members-{{ projcode }}"


### PR DESCRIPTION
## Summary

Unifies the filter forms and buttons across **every** dashboard under the NCAR
Unity visual style, so the admin, allocations, status, and user dashboards share
one consistent look. The change is **presentational only** — CSS and template
classes/markup. No routes, query logic, or behavior change.

## What changed

**Filter sidebars (navy panels).** The reusable `.filter-sidebar` pattern (dark
navy panel, gold uppercase title, "Clear filters" link) is promoted from
`allocations.css` into sitewide `dashboard.css` and applied to every dashboard's
filter form — allocations, admin expirations, admin institutions, and the shared
audit filters. White form controls on navy, consistent
`d-flex flex-wrap align-items-start gap-3` layout.

**Buttons (Unity style).**
- New `.btn-outline-white` for buttons on dark/navy backgrounds (white outline,
  translucent hover wash).
- Unified button sizing across `.btn`, `.btn-sm`, and `.btn-group-sm`; dropped
  ad-hoc `btn-sm` usages for consistency.

**Inner cards.** New `.inner-card` treatment — 1px Unity border, no dropshadow,
uppercase card headers — plus header-border and accordion refinements on nested
cards.

## Files

- CSS: `static/css/{dashboard,allocations,components,status}.css`
- ~40 dashboard templates (class/markup only) across admin, allocations, status,
  user, and shared fragments
- 3 implemented-plan doc touch-ups

## Rebase + CSP note

This branch was forked before the CSP hardening work (#303) landed on `staging`,
and has now been **rebased onto current `staging`**. #303 made the dashboard
templates CSP-clean (`script-src 'self'`: no inline `<script>`, no `on*=`
handlers, no `<style>` blocks), and several of those refactors touched the same
elements this PR restyles.

Conflicts were resolved by **keeping staging's CSP-clean structure and layering
the Unity styling on top** — so the new navy filter panels stay CSP-compliant:
- "Clear filters" / "Reset" controls use the delegated `form-reset-submit`
  action (or, for the admin expirations panel, a new `expirations-clear` action
  in `static/js/dashboard-init.js`) instead of inline `onclick`.
- The date-range / linked-element buttons keep their `data-action` wiring; only
  the visual classes changed.

The template CSP lint (`tests/unit/test_template_csp_lint.py`) passes with zero
debt, and the full suite is green (**2280 passed, 23 skipped, 1 xfailed**).
