### PR TITLE
Add CREATE_PROJECTS_ENABLED toggle to soft-disable project creation

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -151,6 +151,8 @@ webapp:
     JOB_HISTORY_PG_HOST: "csg-postgres.k8s.ucar.edu"
     JOB_HISTORY_PG_PORT: "5432"
     JOB_HISTORY_MACHINES: "derecho,casper"
+    # disable creating projects until ID system transition & GID pool
+    CREATE_PROJECTS_ENABLED: "0"
 
   # system_status DB credentials (injected as STATUS_DB_USERNAME / STATUS_DB_PASSWORD).
   # MUST be a non-superuser role — connecting as the postgres SUPERUSER causes

--- a/src/webapp/config.py
+++ b/src/webapp/config.py
@@ -41,6 +41,11 @@ class SAMWebappConfig(SAMConfig):
     # env var explicitly either way.
     FLASK_ADMIN_ENABLED = os.getenv('FLASK_ADMIN_ENABLED', '1').lower() in ('1', 'true', 'yes')
 
+    # Create Project workflow. When off, the modal still renders with all inputs
+    # editable but its submit button is replaced with a disabled indicator, and
+    # the create POST route 403s. Lets ops temporarily freeze project creation.
+    CREATE_PROJECTS_ENABLED = os.getenv('CREATE_PROJECTS_ENABLED', '1').lower() in ('1', 'true', 'yes')
+
     # OIDC configuration (active when AUTH_PROVIDER='oidc')
     OIDC_CLIENT_ID = os.getenv('OIDC_CLIENT_ID', '')
     OIDC_CLIENT_SECRET = os.getenv('OIDC_CLIENT_SECRET', '')

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -12,7 +12,7 @@ from webapp.utils.fk_validation import FKValidationError, validate_fk_existence
 from flask_login import login_required, current_user
 
 from webapp.extensions import db
-from flask import abort
+from flask import abort, current_app
 from webapp.utils.rbac import (
     require_permission, require_permission_any_facility,
     has_permission, has_permission_for_facility,
@@ -341,6 +341,11 @@ def htmx_project_next_projcode():
 @require_permission_any_facility(Permission.CREATE_PROJECTS)
 def htmx_project_create():
     """Validate form and create a new project."""
+    # Soft feature flag: when project creation is disabled the modal renders a
+    # disabled submit button, but refuse here too in case a request is forged.
+    if not current_app.config.get('CREATE_PROJECTS_ENABLED', True):
+        abort(403)
+
     from sam.projects.projects import Project
     from sam.projects.areas import AreaOfInterest
     from sam.projects.contracts import Contract, ProjectContract

--- a/src/webapp/run.py
+++ b/src/webapp/run.py
@@ -314,6 +314,15 @@ def create_app(*, config_overrides: dict | None = None):
     from webapp.vendor_assets import vendor_assets_context_processor
     app.context_processor(vendor_assets_context_processor)
 
+    # Expose runtime feature flags to all templates
+    @app.context_processor
+    def feature_flags_context_processor():
+        return {
+            'feature_flags': {
+                'create_projects_enabled': app.config.get('CREATE_PROJECTS_ENABLED', True),
+            }
+        }
+
     # Expose optional build provenance (set by CI via Docker build args) to all templates
     @app.context_processor
     def build_info_context_processor():

--- a/src/webapp/templates/dashboards/admin/fragments/create_project_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/create_project_form_htmx.html
@@ -14,7 +14,8 @@
     url_for('admin_dashboard.htmx_project_create'),
     '#createProjectFormContainer',
     'Create Project',
-    submit_icon='folder-plus'
+    submit_icon='folder-plus',
+    disabled=not feature_flags.create_projects_enabled
 ) %}
         <div class="row">
             <div class="col-md-6">

--- a/src/webapp/templates/dashboards/fragments/modal_form.html
+++ b/src/webapp/templates/dashboards/fragments/modal_form.html
@@ -24,9 +24,13 @@
     errors        - Optional list of validation-error strings; rendered as a
                     Bootstrap danger alert above the footer.  Omit / pass none
                     (the default) on forms that have no error surface.
+    disabled      - When truthy, the submit button is replaced with an inert
+                    "Disabled" indicator so the form cannot be submitted. Inputs
+                    stay visible/editable. Used to soft-disable a workflow via a
+                    feature flag.
 #}
 
-{% macro htmx_form(post_url, target, submit_text, submit_icon='save', is_edit=False, submit_class=None, errors=none) %}
+{% macro htmx_form(post_url, target, submit_text, submit_icon='save', is_edit=False, submit_class=None, errors=none, disabled=False) %}
 {% set _btn_class = submit_class if submit_class else 'btn-primary' %}
 <form hx-post="{{ post_url }}"
       hx-target="{{ target }}"
@@ -49,9 +53,15 @@
     <div class="modal-footer">
         <button type="button" class="btn btn-secondary"
                 data-bs-dismiss="modal">Cancel</button>
+        {% if disabled %}
+        <button type="button" class="btn btn-secondary" disabled>
+            <i class="fas fa-ban"></i> Disabled
+        </button>
+        {% else %}
         <button type="submit" class="btn {{ _btn_class }}">
             <i class="fas fa-{{ submit_icon }}"></i> {{ submit_text }}
         </button>
+        {% endif %}
     </div>
 </form>
 {% endmacro %}


### PR DESCRIPTION
## Summary

Adds a single environment variable, `CREATE_PROJECTS_ENABLED` (default on), to temporarily freeze the "Create Project" workflow without removing the UI.

When disabled (`CREATE_PROJECTS_ENABLED=0`):
- The Create Project modal still opens with all inputs visible and editable.
- The "Create Project" submit button is replaced with an inert "Disabled" indicator, so the form cannot be submitted.
- The `htmx_project_create` POST route returns 403 as defense-in-depth in case a request is forged.

## Changes

| File | Change |
|---|---|
| `config.py` | New `CREATE_PROJECTS_ENABLED` flag, mirroring the existing `FLASK_ADMIN_ENABLED` env-var pattern |
| `run.py` | `feature_flags` context processor exposing the flag to templates |
| `modal_form.html` | Shared `htmx_form` macro gains a backward-compatible `disabled=False` param that swaps the submit button for a disabled indicator |
| `create_project_form_htmx.html` | Passes `disabled=not feature_flags.create_projects_enabled` |
| `projects_routes.py` | 403 guard at the top of `htmx_project_create` |

The macro's new param defaults to `False`, so every other modal form (Create Facility, etc.) is unchanged.

## Verification

- Python syntax-checked all modified `.py` files.
- Rendered the `htmx_form` macro in both states: `disabled=False` → normal submit button; `disabled=True` → submit button gone, inert "Disabled" indicator present.

End-to-end (requires the `mysql-test` container, not available in the authoring session):
1. `docker compose up`, open the Admin Dashboard, click "Create Project" — modal opens with a normal submit button; creation works.
2. Restart with `CREATE_PROJECTS_ENABLED=0` — modal opens with all inputs editable, but the footer shows a greyed-out "Disabled" button and cannot submit.
3. With the flag off, POST directly to `/admin/htmx/project-create` and confirm it returns 403.
4. Regression: another modal using `htmx_form` (e.g. Create Facility) still renders its normal submit button.

https://claude.ai/code/session_012mffQ9JmA9CeY7NGurD4jc

---
_Generated by [Claude Code](https://claude.ai/code/session_012mffQ9JmA9CeY7NGurD4jc)_