### PR TITLE
Close residual ZAP header findings (CORP + Permissions-Policy) + HSTS edge probe

### DIFF
--- a/scripts/cirrus_healthcheck.sh
+++ b/scripts/cirrus_healthcheck.sh
@@ -618,7 +618,57 @@ else
 fi
 
 # ============================================================================
-section "7. ExternalSecrets (OpenBao sync)"
+section "7. Edge security headers (HSTS / CSP / nosniff)"
+# ============================================================================
+
+explain "Fetches response headers from the public HTTPS edge (https://$INGRESS_HOST/)
+  and checks the browser-defense headers the app emits via
+  src/webapp/utils/security_headers.py. HSTS in particular can ONLY be observed
+  over HTTPS, so this is the canonical place to verify it post-deploy (a local /
+  HTTP scan can't). Needs the ingress reachable from where you run this (VPN)."
+
+if ! command -v curl >/dev/null 2>&1; then
+    warn "curl not found — skipping edge security-header checks"
+else
+    HDR_URL="https://${INGRESS_HOST}/"
+    # -D - dumps response headers; we read the first response (security headers
+    # ride every response incl. the unauthenticated 302 → /status, so no -L).
+    if ! HDRS=$(curl -sS -m 15 -D - -o /dev/null "$HDR_URL" 2>/dev/null); then
+        warn "could not reach ${HDR_URL} — is the ingress reachable from here (VPN)? Skipping header checks"
+    else
+        HDRS_LC=$(printf '%s' "$HDRS" | tr 'A-Z' 'a-z')
+        have() { printf '%s' "$HDRS_LC" | grep -q "^$1:"; }
+        hval() { printf '%s' "$HDRS" | awk -F': ' -v k="$1" 'tolower($1)==k{sub(/\r$/,"",$2); print $2; exit}'; }
+
+        # HSTS is the security-critical one and the whole reason for this section.
+        if have 'strict-transport-security'; then
+            pass "HSTS present — Strict-Transport-Security: $(hval strict-transport-security)"
+        else
+            fail "HSTS missing — no Strict-Transport-Security at the edge (expected in prod; app gates it on SESSION_COOKIE_SECURE)"
+        fi
+
+        # Defense-in-depth headers — advisory (WARN) if absent.
+        for hdr in content-security-policy x-content-type-options referrer-policy \
+                   cross-origin-resource-policy permissions-policy; do
+            if have "$hdr"; then
+                pass "${hdr} present"
+            else
+                warn "${hdr} missing from edge response"
+            fi
+        done
+
+        if [[ $VERBOSE -eq 1 ]]; then
+            echo
+            echo "  Raw security headers:"
+            printf '%s\n' "$HDRS" \
+                | grep -iE 'strict-transport|content-security|x-content-type|referrer-policy|cross-origin|permissions-policy|x-frame' \
+                | sed 's/^/    /'
+        fi
+    fi
+fi
+
+# ============================================================================
+section "8. ExternalSecrets (OpenBao sync)"
 # ============================================================================
 
 if ! "${KCTL_NS[@]}" get externalsecret >/dev/null 2>&1; then
@@ -658,7 +708,7 @@ else
 fi
 
 # ============================================================================
-section "8. In-pod HTTP health probe"
+section "9. In-pod HTTP health probe"
 # ============================================================================
 
 WEBAPP_POD=$("${KCTL_NS[@]}" get pod -l "app=$WEBAPP_NAME" \
@@ -731,7 +781,7 @@ except Exception as e:
 fi
 
 # ============================================================================
-section "9. Recent logs"
+section "10. Recent logs"
 # ============================================================================
 
 echo "  webapp (last 500 lines, scanning for ERROR/CRITICAL/Exception/Traceback):"
@@ -766,7 +816,7 @@ else
 fi
 
 # ============================================================================
-section "10. Recent namespace events"
+section "11. Recent namespace events"
 # ============================================================================
 
 EV=$("${KCTL_NS[@]}" get events --sort-by=.lastTimestamp 2>/dev/null | tail -20 || echo "")

--- a/src/webapp/utils/security_headers.py
+++ b/src/webapp/utils/security_headers.py
@@ -12,6 +12,10 @@ Notes:
 - Referrer-Policy must stay at strict-origin-when-cross-origin (not
   stricter): Flask-WTF's CSRF referrer check on HTTPS POSTs requires
   same-origin requests to carry a referrer.
+- Cross-Origin-Resource-Policy and Permissions-Policy ride every response
+  unconditionally (scheme-independent, safe in dev + prod). They closed the
+  two residual Low findings from the 2026-06 ZAP re-scan; see
+  docs/nrit-review-2026-05/09_zap_rescan-2026-06.md.
 - X-Frame-Options is superseded by the policy's frame-ancestors 'self'
   once CSP enforces; in report-only/off modes it must survive, because
   browsers ignore frame-ancestors in a Report-Only policy.
@@ -48,6 +52,12 @@ def init_security_headers(app):
         h = response.headers
         h.setdefault('X-Content-Type-Options', 'nosniff')
         h.setdefault('Referrer-Policy', 'strict-origin-when-cross-origin')
+        # Defense-in-depth, scheme-independent (safe in dev + prod): isolate our
+        # resources from cross-origin embedders, and disable powerful browser
+        # features this dashboard never uses.
+        h.setdefault('Cross-Origin-Resource-Policy', 'same-origin')
+        h.setdefault('Permissions-Policy',
+                     'geolocation=(), camera=(), microphone=(), payment=(), usb=()')
         if mode != 'enforce':
             h.setdefault('X-Frame-Options', 'SAMEORIGIN')
         if hsts:

--- a/tests/unit/test_security_headers.py
+++ b/tests/unit/test_security_headers.py
@@ -20,6 +20,15 @@ class TestHeadersOnApp:
         resp = client.get('/auth/login')
         assert resp.headers['X-Content-Type-Options'] == 'nosniff'
         assert resp.headers['Referrer-Policy'] == 'strict-origin-when-cross-origin'
+        assert resp.headers['Cross-Origin-Resource-Policy'] == 'same-origin'
+        assert 'Permissions-Policy' in resp.headers
+
+    def test_defense_in_depth_headers_on_api_routes_too(self, client):
+        """CORP + Permissions-Policy are unconditional — they ride API responses
+        too, independent of HTTPS/CSP mode."""
+        resp = client.get('/api/v1/health/live')
+        assert resp.headers['Cross-Origin-Resource-Policy'] == 'same-origin'
+        assert 'geolocation=()' in resp.headers['Permissions-Policy']
 
     def test_headers_on_api_routes_too(self, client):
         resp = client.get('/api/v1/health/live')


### PR DESCRIPTION
Direct follow-up to #311 — remediates the two residual Low findings the 2026-06 ZAP re-scan surfaced, and gives HSTS a durable verification home.

## App headers — `src/webapp/utils/security_headers.py`
Two always-on, scheme-independent headers added next to `X-Content-Type-Options` / `Referrer-Policy`:

- `Cross-Origin-Resource-Policy: same-origin` — isolates our (now fully self-hosted) resources from cross-origin embedders.
- `Permissions-Policy: geolocation=(), camera=(), microphone=(), payment=(), usb=()` — disables powerful features this dashboard never uses.

Both are safe in dev + prod (no HTTPS dependency), so — unlike HSTS — they're verifiable by the local Docker ZAP probe from #311. Unit test extended (`tests/unit/test_security_headers.py`).

## HSTS evidence — `scripts/cirrus_healthcheck.sh`
New **section 7 "Edge security headers"** curls the public HTTPS edge (`https://samuel.k8s.ucar.edu/`) and asserts the browser-defense header set. HSTS can only be observed over HTTPS, so this is the canonical post-deploy check — it folds the previously-manual `curl -sI … | grep strict-transport` one-liner (from `PRODUCTION_IMPROVEMENTS.md`) into the existing health probe.

- HSTS absent → **FAIL** (security-critical, the whole point).
- CSP / nosniff / Referrer-Policy / CORP / Permissions-Policy absent → **WARN**.
- Edge unreachable (no VPN) or `curl` missing → **skip**.
- Subsequent sections renumbered 8–11.

### Why HSTS isn't in the app's unit tests / local scan
It's gated on `SESSION_COOKIE_SECURE` (prod-only) and browsers only honor it over HTTPS; ZAP only evaluates it over HTTPS. So the live edge probe is the right instrument — see the discussion captured in #311's `09_zap_rescan-2026-06.md`.

## Verify
```
pytest tests/unit/test_security_headers.py          # CORP + Permissions-Policy
scripts/cirrus_healthcheck.sh                        # section 7, against live edge (VPN)
```

After this deploys, re-running the #311 probe (`./scripts/zap_probe_docker.sh`) should show the CORP + Permissions-Policy Lows cleared; HSTS confirmed via `cirrus_healthcheck.sh` section 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)