### PR TITLE
Make SAMuel publicly visible: flip CIRRUS ingress to external

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -67,7 +67,7 @@ webapp:
     fqdn: samuel.k8s.ucar.edu             # Must be unique and end in .k8s.ucar.edu
     secretName: incommon-cert-samuel      # Unique TLS secret name for your FQDN
   ingress:
-    visibility: internal                  # internal or external
+    visibility: external                  # internal or external
   # Kubernetes probes. Endpoints from src/webapp/api/v1/health.py:
   #   /live  -> process up, no DB call          (liveness + startup)
   #   /ready -> DB-gated, 200 healthy / 503 not  (readiness: gates rollout


### PR DESCRIPTION
## TL;DR

This PR changes **one line**:

```diff
   ingress:
-    visibility: internal                  # internal or external
+    visibility: external                  # internal or external
```

That flag moves `samuel.k8s.ucar.edu` from VPN-only to internet-facing. The change
is one line; the justification is the **defense-in-depth hardening program in
PRs #295–#313**, all already deployed and verified in production. This description
is the stand-alone case for why SAMuel is now safe to expose publicly.

> Helm changes only reach the live cluster via the `main → cirrus` promotion path.
> Merging this to `staging` is the first hop; the ingress does not actually change
> until this is promoted to `main` and the CIRRUS workflow redeploys.

---

## Why now

SAMuel began life as an internal CISL tool reachable only from inside the NCAR VPN.
Moving it to an internet-facing application changes the threat model entirely, so
before flipping the switch we ran a deliberate, **audit-first** hardening program
structured around two questions:

1. **Application layer** — can the app be made to fail *closed*, and are the
   browser-side and authorization gaps shut?
2. **Infrastructure layer** — if the app is ever compromised anyway, how small can
   we make the blast radius?

An independent security audit established the baseline; successive PRs closed the
findings, added browser-side defenses, shrank the container/cluster blast radius,
and then **re-scanned to prove** the findings were actually closed. Everything
below is merged and running today — this PR only removes the VPN boundary.

---

## The hardening program at a glance

| PR | Axis | What it did |
|---|---|---|
| [#295](https://github.com/benkirk/sam-queries/pull/295) | Audit | Independent NRIT Web Team security & code audit; findings, action register, baseline ZAP scans |
| [#296](https://github.com/benkirk/sam-queries/pull/296) | App (Phase A) | Fail-closed prod auth, security headers, vendor-asset registry + SRI, app-wide CSRF, Flask-Admin kill-switch, route authorization sweep, OIDC polish |
| [#298](https://github.com/benkirk/sam-queries/pull/298) | Infra (Phase B) | Non-root image (UID 1000), pod/container securityContexts, SA-token off, Redis NetworkPolicy |
| [#300](https://github.com/benkirk/sam-queries/pull/300) | Bugfix | Two audit-flagged serialization bugs (`admin_username` always null; panel 500 on orphan projects) |
| [#303](https://github.com/benkirk/sam-queries/pull/303) | App | Content-Security-Policy — enforce-by-default, all-`'self'`, **zero CDN origins** (all assets vendored) |
| [#306](https://github.com/benkirk/sam-queries/pull/306) | Product guard | `CREATE_PROJECTS_ENABLED` toggle to soft-freeze the create-project mutation |
| [#308](https://github.com/benkirk/sam-queries/pull/308) | App (RBAC) | Fixed a critical missing access check on `/user/resource-details`, facility-scoped-admin fix, docstring corrections, dead-permission removal |
| [#309](https://github.com/benkirk/sam-queries/pull/309) | Observability | Mirror model-audit log to STDOUT for durable 45-day capture in k8s |
| [#311](https://github.com/benkirk/sam-queries/pull/311) | Verification | Dockerized OWASP ZAP probe + post-hardening re-scan |
| [#312](https://github.com/benkirk/sam-queries/pull/312) | Verification | Closed residual ZAP Lows (CORP + Permissions-Policy); HSTS edge probe |
| [#313](https://github.com/benkirk/sam-queries/pull/313) | Verification | Canonical post-hardening ZAP baseline, accepted-risk rationale, scoped active-scan tooling + f-string-SQL regression guard |

Full assessment and phased plans: `docs/plans/implemented/PRODUCTION_IMPROVEMENTS.md`,
`docs/plans/implemented/PRODUCTION_IMPROVEMENTS-phase-B.md`,
`docs/plans/implemented/CSP.md`, and the audit corpus under
`docs/nrit-review-2026-05/`.

---

## 1. Independent audit established the baseline (#295)

A full directional security & code audit of both the codebase and the deployed
application was conducted by the **NRIT Web Team (D. Vance), May–June 2026** — a
read-only review with no application code changed. It produced:

- Per-subsystem findings (`01`–`07_*.md`), an executive synthesis
  (`08_synthesis.md`), a prioritized action register (`08_action_register.md`), and
  a notable-strengths writeup — all under `docs/nrit-review-2026-05/`.
- Baseline ZAP passive scans (unauthenticated + authenticated): **no high-risk
  findings**, with the scanning tooling checked in for repeatable re-scans.

Every subsequent change traces back to a numbered finding (P0-*/P1-*/P2-*), so the
hardening is auditable end-to-end rather than ad hoc.

## 2. The app now fails *closed* in production (#296)

Phase A is pure Python/templates/config — the application-layer gaps an
internet-facing app can't tolerate:

- **Fail-closed production auth** — `ProductionConfig.validate()` refuses to boot
  with `AUTH_PROVIDER != oidc` or `DISABLE_AUTH=1`; the dev auto-login path is
  unregistrable outside `DevelopmentConfig`; silent `declarative_base` / `memory://`
  fallbacks now warn loudly. [P0-1, P0-2]
- **Security headers** — HSTS (prod-gated), `X-Content-Type-Options: nosniff`,
  `X-Frame-Options`, `Referrer-Policy`.
- **Vendor-asset registry + SRI** — every third-party asset centralized in
  `src/webapp/vendor_assets.py` with integrity digests (and the prerequisite for the
  later CSP).
- **App-wide CSRF** — `CSRFProtect` everywhere, htmx token plumbing via
  `<body hx-headers>`, machine-to-machine token-auth routes exempted, HTMX-aware 400
  handler.
- **Flask-Admin kill-switch** — `FLASK_ADMIN_ENABLED`, **off in production**. The
  admin DB UI is simply not present in the public deployment. [P0-3]
- **Route authorization sweep** — centralized project-scoped decorators
  (`webapp/api/access_control.py`) replace hand-rolled checks; gates added to the
  allocations, user-search, charges, and HTMX-fragment routes. [P0-4, P1-4/5/6/7]
- **OIDC polish** — rate-limited callback, `id_token_hint` on logout. [P2-4, P1-3]

Verified by the full test suite after every commit **plus** an interactive
Playwright/curl pass: headers present on both dev and gunicorn stacks; negative-boot
tests (production config with bad auth refuses to start); CSRF round-trips; SRI
loads; authz enforced in the browser.

## 3. Blast radius is small if the app is ever compromised (#298)

Phase B is pure Dockerfile + Helm — no app-logic change — and assumes breach:

- **Non-root production image** — gunicorn runs as fixed **UID 1000** (was root).
  Trivy's `AVD-DS-0002` is now *satisfied*, not suppressed. (Dev image deliberately
  unchanged.)
- **Pod + container `securityContext`** for webapp and redis: `runAsNonRoot`,
  seccomp `RuntimeDefault`, `allowPrivilegeEscalation: false`, **drop ALL
  capabilities** — values-driven so they can be reverted independently.
- **`automountServiceAccountToken: false`** on both pods — neither calls the k8s
  API, so the auto-mounted SA token (a free cluster credential for any code-exec
  foothold) is gone.
- **Redis NetworkPolicy** — Redis was previously reachable by *any* pod in the
  cluster with no auth, and DB 0 caches *rendered HTML fragments* (write access ≈
  stored XSS in logged-in dashboards). Ingress is now restricted to webapp pods on
  TCP 6379, Cilium-enforced.

**Production-verified post-deploy (2026-06-10):** rolling deploy clean, all pods
Ready/zero restarts; webapp `uid=1000`, redis `uid=999`; SA-token directory absent;
Redis `PING` succeeds *through* the NetworkPolicy; `cirrus_healthcheck.sh` 20 PASS /
0 FAIL.

## 4. XSS is made non-exploitable by a strict CSP (#303)

A **Content-Security-Policy** shipped straight to **enforcing**, stricter than the
original sketch — essentially all-`'self'` with **zero third-party origins**:

```
default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';
font-src 'self'; img-src 'self' data:; connect-src 'self';
frame-src 'self' [+ Google Calendar origin when configured];
frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'
```

CSP is the XSS backstop: every other defense (Jinja autoescaping, CSRF, SRI, cookie
flags) tries to *prevent* injection; CSP makes a slip *non-exploitable* — an injected
`<script>` won't execute and can't exfiltrate. Key decisions:

- **Vendored everything (zero CDN origins).** All six asset families (Bootstrap,
  jQuery, htmx, Font Awesome + webfonts, Poppins) are self-hosted under
  `static/vendor/`, committed, and re-hashed by the test suite. Allowlisting a CDN
  would let an injected `<script src>` pull any npm package — a known CSP bypass.
- **Nonce-free by design** — every inline script/handler was extracted to static JS
  (data rides `data-*` attrs and non-executable JSON blocks), so per-user cached HTML
  fragments stay valid.
- **`CSP_MODE` rollback knob** — `enforce | report-only | off`, env-overridable via
  helm values, no image rebuild to fall back.
- A **CI ratchet** (`test_template_csp_lint.py`) forbids any new inline
  script/handler/`hx-on`/`<style>` — the allowlist is at **zero**.

Verified with a full Playwright smoke pass under a **real OIDC + 2FA** session
against live prod: **zero CSP violations** across the interaction-heavy admin,
allocations, user, and status surfaces.

## 5. Authorization gaps closed, including a critical one (#308)

Audit-driven RBAC hardening:

- 🔴 **Critical — `/user/resource-details` had no access check.** It was
  `@login_required` only and read `projcode`/`resource` from the query string, so any
  authenticated user could view *any* project's detailed usage, per-user charge
  breakdowns, and allocation history by editing the URL. Converted to a path param +
  `@require_project_access(include_ancestors=True)`, matching every sibling route.
- Facility-scoped-admin fix (read-only card no longer demands an edit permission
  system-wide), corrected misleading M2M-endpoint docstrings, and removed a dead
  `VIEW_SYSTEM_STATUS` permission.
- Residual report-only findings are **documented**, not silently dropped (group-member
  enumeration; facility-scoped expiring-projects access) — known and tracked.

## 6. Supporting product & observability guards

- **`CREATE_PROJECTS_ENABLED` toggle (#306)** — a soft kill-switch for the
  create-project mutation: UI stays visible but the submit button goes inert and the
  POST route 403s as defense-in-depth. Lets the public deployment run read-mostly
  while write workflows are validated.
- **Durable audit logging (#309)** — the `model_audit` change log now mirrors to
  STDOUT (on by default), where CIRRUS captures and retains it for **45 days**. The
  prior file-only handler wrote to the pod's ephemeral filesystem and didn't survive
  a reschedule. Pragmatic interim durability ahead of the deferred DB-table approach.
- **Two long-latent serialization bugs fixed (#300)** — `admin_username` serialized
  null for everyone, and the project-detail endpoint 500'd on orphan projects. Both
  audit-flagged, both now covered by red/green tests.

## 7. We re-scanned and proved the findings are closed (#311, #312, #313)

The hardening isn't self-asserted — it's verified against the original ZAP baseline:

- **#311** — a rerunnable, install-free Dockerized OWASP ZAP probe
  (`scripts/zap_probe_docker.sh`) and a recorded re-scan. **All three original
  Medium findings** (CSP not set, missing anti-clickjacking, missing SRI) → **PASS**;
  the original Lows resolved.
- **#312** — closed the two residual Low findings the re-scan surfaced
  (`Cross-Origin-Resource-Policy`, `Permissions-Policy`) and added **HSTS edge
  verification** as `cirrus_healthcheck.sh` § 7 (HSTS is only observable over HTTPS at
  the live edge).
- **#313** — the **canonical post-hardening baseline** (authenticated, 131 URLs):
  **FAIL-NEW 0**. All 3 original Mediums + all 7 Lows resolved; HSTS confirmed live.
  Adds a **time-boxed scoped active scan** (localhost-only, refuses prod): a ~48-min
  active scan of the primary surface found **no exploitable injection** — the only
  active-class alert (SQL Injection ×35) is a **verified false positive** (bound ORM
  expressions throughout; the sole `text(f"…")` interpolates only placeholder names +
  hardcoded table names, never request data). Locked in by a static
  **regression guard** (`test_no_fstring_sql.py`) that fails CI on any new
  request-adjacent raw-SQL f-string.

---

## Security posture at the public edge (what a visitor gets)

- **TLS + HSTS** at the edge (verified via `cirrus_healthcheck.sh` § 7).
- **Strict CSP** (enforce, all-`'self'`, zero CDN origins) + `nosniff`,
  `Referrer-Policy`, `frame-ancestors 'self'`, `Cross-Origin-Resource-Policy`,
  `Permissions-Policy`.
- **OIDC + 2FA** the only production auth path; app refuses to boot otherwise.
- **App-wide CSRF**; Flask-Admin DB UI **not present** in production.
- **Centralized, tested project-scoped authorization** on every project route.
- **Non-root, capability-dropped, SA-token-less pods**; Redis network-isolated.
- **Durable 45-day audit trail** of all DB mutations.

## Accepted risks & deliberately deferred (tracked, not forgotten)

Documented with rationale in the phase-B plan and the ZAP baseline note:

- **CSP `style-src 'unsafe-inline'`** — *accepted*: CSS can't execute script;
  exploiting the residual needs an HTML-injection foothold that doesn't exist here
  (autoescape on, `|safe` only on first-party markup, `script-src 'self'` + CSRF).
- **COOP/COEP site isolation** — *deferred*: low practical risk, COEP is disruptive.
- **Redis `--requirepass`** — *deferred*: the NetworkPolicy captures ~90% of the value
  without secret-plumbing friction.
- **`readOnlyRootFilesystem`**, durable DB-backed audit table, auth-event/5xx
  alerting, and supply-chain items (Action SHA-pinning, workflow `permissions:`).

## Verification of *this* PR

- Diff is exactly one line: `git diff origin/staging..HEAD --stat` →
  `helm/values.yaml | 1 file changed, 1 insertion(+), 1 deletion(-)`.
- The flag is inert on `staging`; it reaches the live cluster only via the
  `main → cirrus` promotion. After promotion, confirm public reachability and the
  edge header set with `scripts/cirrus_healthcheck.sh` § 7 against
  `https://samuel.k8s.ucar.edu/`.

## Rollback

Revert this one line (`external → internal`) and promote — the ingress returns to
VPN-only. No data, schema, or image impact.
