### PR TITLE
Public-exposure tooling: weblog audit + shared script lib + R1/R2 hardening

### DIFF
--- a/containers/webapp/gunicorn_config.py
+++ b/containers/webapp/gunicorn_config.py
@@ -47,10 +47,22 @@ keepalive = 5
 preload_app = True   # Load app before forking → faster startup, shared memory
 daemon = False       # Stay in foreground (required for containers)
 
+# Trust X-Forwarded-* from the ingress. gunicorn is only reachable via the
+# in-cluster ingress (ClusterIP service, never published directly), so trusting
+# forwarded headers from any peer is the standard k8s setting and lets it honor
+# X-Forwarded-Proto for correct https scheme detection. Real client-IP recovery
+# for the app is handled by ProxyFix (see webapp/run.py); this is the gunicorn
+# side of the same story.
+forwarded_allow_ips = os.environ.get('FORWARDED_ALLOW_IPS', '*')
+
 # Logging — stdout/stderr by default (Docker captures them)
 accesslog = os.environ.get('GUNICORN_ACCESS_LOG', '-')
 errorlog  = os.environ.get('GUNICORN_ERROR_LOG',  '-')
 loglevel  = os.environ.get('GUNICORN_LOG_LEVEL',  'info')
-access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(D)sµs'
+# %(h)s is the raw socket peer (the in-cluster proxy), so it is NOT the client.
+# The trailing xff="…" logs the full X-Forwarded-For chain: its leftmost entry
+# is the real client, and counting the entries tells us the correct
+# PROXYFIX_X_FOR hop depth (see webapp/run.py).
+access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(D)sµs xff="%({x-forwarded-for}i)s"'
 
 proc_name = 'sam-webapp'

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -63,6 +63,11 @@ spec:
           # spawn ~129 workers on a 64-core node and OOM the pod.
           - name: GUNICORN_WORKERS
             value: {{ mul (.Values.webapp.container.limits.cpu | int) 2 | add 1 | quote }}
+          # Number of trusted proxy hops for ProxyFix (X-Forwarded-For depth).
+          # Must match the real proxy chain exactly — too high allows client IP
+          # spoofing. Confirm from the gunicorn access log's xff="…" field.
+          - name: PROXYFIX_X_FOR
+            value: {{ .Values.webapp.proxyFixForwardedHops | default 1 | quote }}
           {{- if .Values.cache.enabled }}
           # Centralized Redis: DB 0 for cache, DB 1 for rate-limit counters.
           - name: CACHE_REDIS_URL

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     group: {{ .Values.webapp.group }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  # Trim old scaled-to-0 ReplicaSets (rollback history) to cut ArgoCD clutter.
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit | default 3 }}
   {{- if .Values.rollout }}
   strategy:
     type: RollingUpdate

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -7,6 +7,14 @@ metadata:
     group: {{ .Values.webapp.group }}
   annotations:
     cert-manager.io/cluster-issuer: "incommon"
+    {{- with .Values.webapp.ingress.rateLimit }}
+    {{- if gt (int .rps) 0 }}
+    # Edge rate limiting — per-client-IP guardrail ahead of Flask-Limiter.
+    nginx.ingress.kubernetes.io/limit-rps: {{ .rps | quote }}
+    nginx.ingress.kubernetes.io/limit-connections: {{ .connections | quote }}
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: {{ .burstMultiplier | quote }}
+    {{- end }}
+    {{- end }}
 spec:
   ingressClassName: nginx-{{ .Values.webapp.ingress.visibility }}
   tls:

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -9,7 +9,8 @@ metadata:
     cert-manager.io/cluster-issuer: "incommon"
     {{- with .Values.webapp.ingress.rateLimit }}
     {{- if gt (int .rps) 0 }}
-    # Edge rate limiting — per-client-IP guardrail ahead of Flask-Limiter.
+    # Edge rate limiting ahead of Flask-Limiter (currently a GLOBAL bucket on
+    # this controller — see values.yaml webapp.ingress.rateLimit).
     nginx.ingress.kubernetes.io/limit-rps: {{ .rps | quote }}
     nginx.ingress.kubernetes.io/limit-connections: {{ .connections | quote }}
     nginx.ingress.kubernetes.io/limit-burst-multiplier: {{ .burstMultiplier | quote }}

--- a/helm/templates/redis-deployment.yaml
+++ b/helm/templates/redis-deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     group: {{ .Values.webapp.group }}
 spec:
   replicas: 1
+  # Trim old scaled-to-0 ReplicaSets (rollback history) to cut ArgoCD clutter.
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit | default 3 }}
   selector:
     matchLabels:
       app: {{ .Values.cache.name }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -68,6 +68,20 @@ webapp:
     secretName: incommon-cert-samuel      # Unique TLS secret name for your FQDN
   ingress:
     visibility: external                  # internal or external
+    # Edge rate limiting (nginx ingress controller). A coarse per-client-IP
+    # guardrail IN FRONT of the app-layer Flask-Limiter that sheds floods
+    # before they reach a gunicorn worker. Effectiveness depends on the
+    # controller seeing real client IPs (same X-Forwarded-For concern as
+    # proxyFixForwardedHops below). Set rps: 0 to disable all three annotations.
+    rateLimit:
+      rps: 20                             # requests/sec per client IP (limit-rps)
+      connections: 20                     # concurrent connections per IP (limit-connections)
+      burstMultiplier: 5                  # short-burst allowance = rps * this (limit-burst-multiplier)
+  # Trusted proxy hops for ProxyFix (X-Forwarded-For depth). Sets PROXYFIX_X_FOR.
+  # MUST equal the exact number of proxies that append to X-Forwarded-For, or a
+  # client can spoof its IP. Start at 1 (safe), then confirm the real depth from
+  # the gunicorn access-log xff="…" field and bump to match. See webapp/run.py.
+  proxyFixForwardedHops: 1
   # Kubernetes probes. Endpoints from src/webapp/api/v1/health.py:
   #   /live  -> process up, no DB call          (liveness + startup)
   #   /ready -> DB-gated, 200 healthy / 503 not  (readiness: gates rollout

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -68,14 +68,17 @@ webapp:
     secretName: incommon-cert-samuel      # Unique TLS secret name for your FQDN
   ingress:
     visibility: external                  # internal or external
-    # Edge rate limiting (nginx ingress controller). A coarse per-client-IP
-    # guardrail IN FRONT of the app-layer Flask-Limiter that sheds floods
-    # before they reach a gunicorn worker. Effectiveness depends on the
-    # controller seeing real client IPs (same X-Forwarded-For concern as
-    # proxyFixForwardedHops below). Set rps: 0 to disable all three annotations.
+    # Edge rate limiting (nginx ingress controller), IN FRONT of the app-layer
+    # Flask-Limiter. IMPORTANT: on the nwc1 nginx-external controller every
+    # client currently presents as 127.0.0.1 — X-Forwarded-For is not
+    # propagated to the controller (see proxyFixForwardedHops) — so limit-rps /
+    # limit-connections act as ONE GLOBAL bucket, NOT per-client. Values below
+    # are a deliberately HIGH blunt flood-backstop that legitimate aggregate
+    # traffic should not reach; revisit to proper per-IP values once the
+    # controller forwards real client IPs. Set rps: 0 to disable all three.
     rateLimit:
-      rps: 20                             # requests/sec per client IP (limit-rps)
-      connections: 20                     # concurrent connections per IP (limit-connections)
+      rps: 100                            # global req/sec backstop (limit-rps)
+      connections: 200                    # global concurrent connections (limit-connections)
       burstMultiplier: 5                  # short-burst allowance = rps * this (limit-burst-multiplier)
   # Trusted proxy hops for ProxyFix (X-Forwarded-For depth). Sets PROXYFIX_X_FOR.
   # MUST equal the exact number of proxies that append to X-Forwarded-For, or a

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -10,6 +10,11 @@ rollout:
   maxUnavailable: 0
   maxSurge: 1
 
+# Old (scaled-to-0) ReplicaSets retained per Deployment for rollback history.
+# k8s defaults to 10, which clutters the ArgoCD view; GitOps rollback is via
+# git revert + resync, so keep a small number. Applies to webapp AND redis.
+revisionHistoryLimit: 3
+
 # PodDisruptionBudget — keep >=minAvailable webapp pods serving during
 # VOLUNTARY disruptions (node drains, cluster maintenance). Without this, a
 # single node drain can evict both replicas at once and take the app down.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,13 @@ Organized scripts for SAM Queries project setup, maintenance, and utilities.
 ```
 scripts/
 ├── README.md                    # This file
+├── cirrus_healthcheck.sh        # CIRRUS/k8s health probe (samuel release)
+├── cirrus_weblog_audit.sh       # CIRRUS/k8s traffic + rate-limit + abuse audit
+├── zap_probe_docker.sh          # Dockerized OWASP ZAP scan of the webapp
+├── lib/                         # Sourceable shell helpers (see below)
+│   ├── common.sh               # Generic: colors, log/verdict helpers, usage
+│   ├── cirrus_common.sh        # CIRRUS layer: release names, KCTL, arg parse
+│   └── prereqs.sh              # Dependency checks (require_cmd, check_docker…)
 ├── setup/                       # Setup and utility scripts
 │   ├── README.md               # Setup scripts documentation
 │   ├── switch_to_production_db.sh
@@ -27,6 +34,55 @@ scripts/
 ```
 
 ## Script Categories
+
+### Cluster Operations (CIRRUS / `nwc1`)
+
+Read-only operator tools for the public `samuel` release on the `nwc1`
+cluster. All use the same idioms: colored PASS/WARN/FAIL output, exit codes
+`0` (all pass) / `1` (≥1 warn) / `2` (≥1 fail), and the shared `--no-color`,
+`-n/--namespace`, `-r/--release`, `--context`, `-v/--verbose`, `-h/--help`
+flags.
+
+- **`cirrus_healthcheck.sh`** — "is the cluster healthy?" 11-section probe of
+  the Helm release: pods, rollout safety, Redis, resource usage, ingress/TLS,
+  edge security headers, ExternalSecrets, the in-pod health endpoint, recent
+  logs, and events.
+
+- **`cirrus_weblog_audit.sh`** — "who's hitting the public site, and is anything
+  abusive getting through?" Harvests the webapp's stdout (and the Redis
+  `ratelimit:events` set) and reports traffic volume + status mix, top talkers,
+  vulnerability-probe path signatures, rate-limit (429) offenders, and
+  auth/CSRF failures. Built for the public-exposure cutover.
+
+  ```bash
+  scripts/cirrus_weblog_audit.sh --since 6h          # last 6 hours
+  scripts/cirrus_weblog_audit.sh --since 24h --top 25 -v
+  ```
+
+  Its `--help` also lists hardening recommendations (R1–R5: edge rate limiting,
+  ProxyFix/X-Forwarded-For, scheduling, CSP reporting, durable log shipping)
+  that the audit surfaces but does not enforce.
+
+- **`zap_probe_docker.sh`** — Dockerized OWASP ZAP passive/active scan of the
+  webapp (local throwaway target by default). See its `--help`.
+
+### Shared Library (`lib/`)
+
+Sourceable helpers so the cluster scripts stop duplicating boilerplate. Two
+layers:
+
+- **`lib/common.sh`** — generic, no Kubernetes knowledge: `setup_colors`
+  (TTY/`NO_COLOR`-aware), plain log primitives (`info`/`ok`/`die`), verdict
+  primitives with PASS/WARN/FAIL counters (`section`/`pass`/`warn`/`fail`/`run`)
+  + `verdict_exit`, `usage_from_header`, and `repo_paths`.
+- **`lib/cirrus_common.sh`** — the CIRRUS layer (sources `common.sh`): baked-in
+  release/object names, `build_kctl` (KCTL/KCTL_NS arrays), `handle_common_arg`
+  (shared flag parsing), and K8s resource-unit converters.
+
+`cirrus_healthcheck.sh` and `cirrus_weblog_audit.sh` source
+`cirrus_common.sh`; `zap_probe_docker.sh` sources only `common.sh`.
+`lib/prereqs.sh` (`require_cmd`, `check_vpn`, `check_docker`, `check_aws_cli`)
+remains the dependency-check helper used by the setup/infra scripts.
 
 ### Setup Scripts (`setup/`)
 

--- a/scripts/cirrus_healthcheck.sh
+++ b/scripts/cirrus_healthcheck.sh
@@ -22,21 +22,13 @@
 
 set -euo pipefail
 
-NAMESPACE="sam-queries"
-RELEASE="samuel"
-CONTEXT=""
-USE_COLOR=1
-VERBOSE=0
+# Load shared helpers: generic presentation/control-flow (common.sh) plus the
+# cirrus/k8s layer (cirrus_common.sh) — release/object names, KCTL builders,
+# the common-arg parser, and resource-unit converters all live there now.
+_LIBDIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib"
+# shellcheck source=lib/cirrus_common.sh
+source "${_LIBDIR}/cirrus_common.sh"
 
-# Names baked into helm/templates/*.yaml. If you rename objects in the chart,
-# update these in lockstep. Resource limits below are read live from the pod
-# spec, not hard-coded.
-WEBAPP_NAME="samuel"
-WEBAPP_PORT=5050
-REDIS_NAME="samuel-redis"
-REDIS_PORT=6379
-INGRESS_HOST="samuel.k8s.ucar.edu"
-TLS_SECRET="incommon-cert-samuel"
 # ExternalSecret resource names carry the '-esos' suffix per
 # helm/templates/external_secret.yaml; the produced Secret (consumed
 # via env secretKeyRef in the Deployment) drops the suffix.
@@ -47,108 +39,20 @@ EXTERNAL_SECRETS=(
     "samuel-jh-credentials-esos"
     "samuel-oidc-credentials-esos"
 )
-HEALTH_PATH="/api/v1/health/ready"
 
-PASS_COUNT=0
-WARN_COUNT=0
-FAIL_COUNT=0
+# Tuning hints accumulate across sections and print in the summary.
 TUNING_HINTS=()
+hint() { TUNING_HINTS+=("$1"); }
 
 while [[ $# -gt 0 ]]; do
+    if handle_common_arg "$@"; then shift "$_CONSUMED"; continue; fi
     case "$1" in
-        -n|--namespace) NAMESPACE="$2"; shift 2;;
-        -r|--release)   RELEASE="$2";   shift 2;;
-        --context)      CONTEXT="$2";   shift 2;;
-        --no-color)     USE_COLOR=0;    shift;;
-        -v|--verbose)   VERBOSE=1;      shift;;
-        -h|--help)      sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
         *) echo "Unknown option: $1" >&2; exit 2;;
     esac
 done
 
-if [[ $USE_COLOR -eq 1 && -t 1 ]]; then
-    BLUE=$'\033[0;34m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'
-    RED=$'\033[0;31m';  CYAN=$'\033[0;36m';  BOLD=$'\033[1m'; NC=$'\033[0m'
-else
-    BLUE=""; GREEN=""; YELLOW=""; RED=""; CYAN=""; BOLD=""; NC=""
-fi
-
-KCTL=(kubectl)
-[[ -n "$CONTEXT" ]] && KCTL+=(--context "$CONTEXT")
-KCTL_NS=("${KCTL[@]}" -n "$NAMESPACE")
-
-# --- helpers ----------------------------------------------------------------
-
-section() {
-    echo
-    echo -e "${BOLD}${BLUE}═══ $* ═══${NC}"
-}
-
-explain() {
-    echo -e "  ${CYAN}↳ $*${NC}"
-}
-
-pass() { echo -e "  ${GREEN}✔ PASS${NC} — $*"; PASS_COUNT=$((PASS_COUNT+1)); }
-warn() { echo -e "  ${YELLOW}⚠ WARN${NC} — $*"; WARN_COUNT=$((WARN_COUNT+1)); }
-fail() { echo -e "  ${RED}✘ FAIL${NC} — $*"; FAIL_COUNT=$((FAIL_COUNT+1)); }
-info() { echo -e "  ${CYAN}ℹ${NC} $*"; }
-hint() { TUNING_HINTS+=("$1"); }
-
-# Run a command and indent its output for readability.
-run() {
-    "$@" 2>&1 | sed 's/^/    /' || true
-}
-
-require_cmd() {
-    command -v "$1" >/dev/null 2>&1 || { fail "$1 not found in PATH"; exit 1; }
-}
-
-human_bytes() {
-    awk -v b="$1" 'BEGIN{
-        split("B KB MB GB TB PB",u);
-        i=1; while (b>=1024 && i<6){ b/=1024; i++ }
-        printf "%.1f%s", b, u[i]
-    }'
-}
-
-# Strip K8s resource units to a plain number.
-# CPU: 16 -> 16 cores, 250m -> 0.25, 100000000n -> 0.1
-# Mem: 128Gi -> 128*1024^3, 4096Mi -> 4096*1024^2, 4096M -> 4096*1e6
-to_cores() {
-    local v="$1"
-    case "$v" in
-        *n) awk -v x="${v%n}" 'BEGIN{printf "%.3f", x/1e9}';;
-        *u) awk -v x="${v%u}" 'BEGIN{printf "%.3f", x/1e6}';;
-        *m) awk -v x="${v%m}" 'BEGIN{printf "%.3f", x/1000}';;
-        *)  awk -v x="$v"     'BEGIN{printf "%.3f", x+0}';;
-    esac
-}
-to_bytes() {
-    local v="$1"
-    case "$v" in
-        *Ki) awk -v x="${v%Ki}" 'BEGIN{printf "%.0f", x*1024}';;
-        *Mi) awk -v x="${v%Mi}" 'BEGIN{printf "%.0f", x*1024*1024}';;
-        *Gi) awk -v x="${v%Gi}" 'BEGIN{printf "%.0f", x*1024*1024*1024}';;
-        *Ti) awk -v x="${v%Ti}" 'BEGIN{printf "%.0f", x*1024*1024*1024*1024}';;
-        *K)  awk -v x="${v%K}"  'BEGIN{printf "%.0f", x*1000}';;
-        *M)  awk -v x="${v%M}"  'BEGIN{printf "%.0f", x*1000000}';;
-        *G)  awk -v x="${v%G}"  'BEGIN{printf "%.0f", x*1000000000}';;
-        *T)  awk -v x="${v%T}"  'BEGIN{printf "%.0f", x*1000000000000}';;
-        *)   awk -v x="$v"      'BEGIN{printf "%.0f", x+0}';;
-    esac
-}
-
-# Convert RFC3339 timestamp to "N days/hours ago" via portable date(1).
-# Echoes a single integer in seconds; "" if the date is unparseable.
-seconds_since() {
-    awk -v d="$1" 'BEGIN{
-        cmd="date -u +%s"; cmd | getline now; close(cmd);
-        cmd="date -u -d \"" d "\" +%s 2>/dev/null || date -u -j -f %Y-%m-%dT%H:%M:%SZ \"" d "\" +%s 2>/dev/null"
-        cmd | getline t; close(cmd);
-        if (t=="" || t==0) exit 1;
-        printf "%.0f", (now-t)
-    }'
-}
+setup_colors
+build_kctl
 
 # ============================================================================
 section "0. Preflight"

--- a/scripts/cirrus_weblog_audit.sh
+++ b/scripts/cirrus_weblog_audit.sh
@@ -198,6 +198,34 @@ else
     else
         pass "4xx rate ${PCT4}% within tolerance"
     fi
+
+    # Edge rate-limit headroom (R1). Compares observed peak load to the live
+    # ingress limit-rps. On this controller the limit is a GLOBAL bucket (every
+    # client = 127.0.0.1), so peak-vs-ceiling is the signal for whether to raise
+    # it. NOTE: actual edge rejections are 503s returned by the controller and
+    # do NOT appear in these app logs — this is a headroom indicator, not a
+    # rejection count.
+    EDGE_RPS=$("${KCTL_NS[@]}" get ingress "$WEBAPP_NAME" \
+        -o jsonpath='{.metadata.annotations.nginx\.ingress\.kubernetes\.io/limit-rps}' 2>/dev/null || true)
+    if [[ "$EDGE_RPS" =~ ^[0-9]+$ && "$EDGE_RPS" -gt 0 ]]; then
+        PEAK_RPS=$(printf '%s\n' "$LOGS" | awk -F'"' '
+            $2 ~ /^(GET|POST|PUT|DELETE|HEAD|PATCH|OPTIONS|CONNECT|TRACE) / {
+                if (match($1, /\[[^]]+\]/)) {
+                    ts = substr($1, RSTART+1, RLENGTH-2); sub(/ .*/, "", ts); c[ts]++
+                }
+            }
+            END { m = 0; for (k in c) if (c[k] > m) m = c[k]; print m + 0 }')
+        echo
+        echo "  Edge limit-rps: ${EDGE_RPS}/s (global) · observed peak: ${PEAK_RPS}/s in a single second"
+        if [[ "$PEAK_RPS" -ge "$EDGE_RPS" ]]; then
+            warn "peak load ${PEAK_RPS}/s ≥ edge limit ${EDGE_RPS}/s — legit traffic may be hitting 503s at the ingress; raise webapp.ingress.rateLimit.rps"
+        elif awk -v p="$PEAK_RPS" -v l="$EDGE_RPS" 'BEGIN{exit !(p >= 0.8*l)}'; then
+            warn "peak load ${PEAK_RPS}/s within 80% of edge limit ${EDGE_RPS}/s — consider raising webapp.ingress.rateLimit.rps"
+        else
+            pass "peak load ${PEAK_RPS}/s well under edge limit ${EDGE_RPS}/s"
+        fi
+        explain "Edge-limit 503s are returned by the controller and aren't in app logs; this compares observed load to the ceiling."
+    fi
 fi
 
 # ============================================================================

--- a/scripts/cirrus_weblog_audit.sh
+++ b/scripts/cirrus_weblog_audit.sh
@@ -33,16 +33,16 @@
 # ── Hardening recommendations (NOT enforced by this script) ──────────────────
 # This audit only surfaces signals; the layered defenses below are follow-ups
 # tracked in docs/plans (see the approved plan). Quick reference:
-#   R1  Edge rate limiting — configurable via webapp.ingress.rateLimit in
-#       helm/values.yaml (limit-rps / limit-connections / limit-burst-multiplier
-#       on the ingress): a per-client-IP guardrail ahead of Flask-Limiter that
-#       sheds floods before they cost a worker. Tune to expected burst; rps: 0
-#       disables it.
-#   R2  Real client IP — the access log now carries xff="…" and the ProxyFix
-#       hop depth is set by PROXYFIX_X_FOR (helm webapp.proxyFixForwardedHops).
-#       Confirm the count against the logged X-Forwarded-For chain — too high
-#       lets clients spoof their IP. Section 2 warns if xff is missing or still
-#       collapses to ≤2 IPs.
+#   R1  Edge rate limiting — webapp.ingress.rateLimit in helm/values.yaml
+#       (limit-rps / limit-connections / limit-burst-multiplier). NOTE: on the
+#       nwc1 controller every client collapses to 127.0.0.1 (see R2), so these
+#       act as a GLOBAL bucket, not per-IP — set high as a flood backstop.
+#       rps: 0 disables it.
+#   R2  Real client IP — CONFIRMED lost upstream: the nginx-external controller
+#       hands the app X-Forwarded-For: 127.0.0.1 (verified from an external,
+#       off-VPN request). Not fixable here — needs the controller's
+#       use-forwarded-headers / use-proxy-protocol config. PROXYFIX_X_FOR stays
+#       1 (there is no real client IP to recover). Section 2 flags the symptom.
 #   R3  Scheduling — run on a cron/CI runner with --no-color and alert on a
 #       non-zero exit (wire into scripts/cron/).
 #   R4  CSP reporting — add a report-uri so injection attempts become a
@@ -210,9 +210,17 @@ else
     N_IPS=$(printf '%s\n' "$ACCESS_TSV" | cut -f1 | sort -u | grep -c . || true)
     echo "  Distinct source IPs: $N_IPS"
     XFF_SEEN=$(printf '%s\n' "$LOGS" | grep -cE 'xff="[0-9a-fA-F]' || true)
+    # Public = not loopback/RFC1918/link-local. Zero public IPs on a public site
+    # means the real client IP never reached the app (controller not forwarding).
+    N_PUBLIC=$(printf '%s\n' "$ACCESS_TSV" | cut -f1 | sort -u \
+        | grep -vE '^(127\.|10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.|::1|fe80|f[cd])' \
+        | grep -c . || true)
     if [[ "$XFF_SEEN" -eq 0 ]]; then
         warn "access log carries no X-Forwarded-For — IPs above are the in-cluster proxy, not real clients"
         explain "Deploy the R2 gunicorn change (xff logging) so this attributes real clients; see R2 in --help."
+    elif [[ "$N_PUBLIC" -eq 0 && "$N_ACCESS" -ge 10 ]]; then
+        warn "no public client IPs across $N_ACCESS requests — real client IP not propagated by the ingress"
+        explain "The controller hands the app X-Forwarded-For: 127.0.0.1; the fix is controller-side (R2 in --help)."
     elif [[ "$N_IPS" -le 2 && "$N_ACCESS" -ge 50 ]]; then
         warn "only $N_IPS distinct client IP(s) across $N_ACCESS requests despite X-Forwarded-For"
         explain "Either genuinely few clients, or PROXYFIX_X_FOR hop depth is still mis-set (see R2 in --help)."

--- a/scripts/cirrus_weblog_audit.sh
+++ b/scripts/cirrus_weblog_audit.sh
@@ -1,0 +1,332 @@
+#!/bin/bash
+# cirrus_weblog_audit.sh — read-only traffic / rate-limit / security-failure
+# audit for the public sam-queries (samuel) release on nwc1.
+#
+# A companion to cirrus_healthcheck.sh (same idioms, same exit codes). Where the
+# health check answers "is the cluster healthy?", this answers "who is hitting
+# the public site, and is anything abusive getting through?". It only reads —
+# `kubectl logs`, `kubectl get`, and a read-only `redis-cli ZREVRANGE`. It never
+# mutates cluster state.
+#
+# Everything it inspects already exists on the webapp's stdout (≈45-day cluster
+# retention) and in Redis; this script just harvests and summarizes it:
+#   - gunicorn access logs   (containers/webapp/gunicorn_config.py)
+#   - the app request logger  ("METHOD path → status (ms) rid=…")
+#   - rate-limit 429 events   (log line + Redis set 'ratelimit:events', DB 1)
+#   - auth/CSRF failure logs   (auth/blueprint.py, run.py CSRF handler)
+#
+# Usage:
+#   scripts/cirrus_weblog_audit.sh [options]
+#
+# Options:
+#       --since DURATION  Log look-back window, e.g. 30m, 6h, 2d  (default: 1h)
+#       --top N           How many rows in each "top N" list       (default: 15)
+#   -n, --namespace NS    Namespace the release lives in   (default: sam-queries)
+#   -r, --release    REL  Helm release name                (default: samuel)
+#       --context    CTX  kubectl context to target        (default: current)
+#       --no-color        Disable ANSI color
+#   -v, --verbose         Extra detail per section
+#   -h, --help            Show this help
+#
+# Exit codes:  0 = all PASS · 1 = at least one WARN · 2 = at least one FAIL.
+#
+# ── Hardening recommendations (NOT enforced by this script) ──────────────────
+# This audit only surfaces signals; the layered defenses below are follow-ups
+# tracked in docs/plans (see the approved plan). Quick reference:
+#   R1  Edge rate limiting — the nginx-external ingress has NO limit-rps /
+#       limit-connections annotations; Flask-Limiter is the only gatekeeper.
+#       Adding them (helm/templates/ingress.yaml, via main→cirrus) sheds floods
+#       before they cost a worker.
+#   R2  Real client IP — if section 2 reports ≤2 distinct source IPs, gunicorn's
+#       %(h)s is the ingress pod IP, not the client. Confirm ProxyFix /
+#       X-Forwarded-For so per-IP limiting and these stats key on the real
+#       client.
+#   R3  Scheduling — run on a cron/CI runner with --no-color and alert on a
+#       non-zero exit (wire into scripts/cron/).
+#   R4  CSP reporting — add a report-uri so injection attempts become a
+#       server-side signal.
+#   R5  Durable logs — stdout (~45d) is the only sink; confirm cluster log
+#       shipping for forensics beyond --since reach.
+
+set -euo pipefail
+
+# Load shared helpers: generic presentation/control-flow (common.sh) plus the
+# cirrus/k8s layer (cirrus_common.sh) — release/object names, KCTL builders,
+# the common-arg parser.
+_LIBDIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib"
+# shellcheck source=lib/cirrus_common.sh
+source "${_LIBDIR}/cirrus_common.sh"
+
+SINCE="1h"
+TOP=15
+
+while [[ $# -gt 0 ]]; do
+    if handle_common_arg "$@"; then shift "$_CONSUMED"; continue; fi
+    case "$1" in
+        --since) SINCE="$2"; shift 2;;
+        --top)   TOP="$2";   shift 2;;
+        *) echo "Unknown option: $1" >&2; exit 2;;
+    esac
+done
+
+[[ "$TOP" =~ ^[0-9]+$ && "$TOP" -ge 1 ]] || { echo "--top must be a positive integer (got '$TOP')" >&2; exit 2; }
+
+setup_colors
+build_kctl
+
+# Scanner/abuse fingerprints. Probe PATHS first, then probe USER-AGENTS.
+PROBE_PATH_RE='/\.env|/\.git|/wp-login|/wp-admin|/phpmyadmin|/\.aws|/actuator|/vendor/|/cgi-bin/|\.php([?/]|$)|/xmlrpc|/config\.(json|php)|/\.ssh|/server-status|/solr/|/owa/|/boaform|/\.well-known/security'
+SCANNER_UA_RE='nikto|sqlmap|nmap|masscan|zgrab|nuclei|wpscan|dirbuster|gobuster|semrush|censys|python-requests|curl/|go-http-client|libwww-perl'
+
+# Convert a kubectl --since duration (e.g. 30m, 6h, 2d, 90s) to minutes;
+# echoes "" if unparseable (rate line is then skipped).
+since_to_min() {
+    local s="$1"
+    [[ "$s" =~ ^([0-9]+)([smhd])$ ]] || { echo ""; return; }
+    local n="${BASH_REMATCH[1]}" unit="${BASH_REMATCH[2]}"
+    case "$unit" in
+        s) awk -v n="$n" 'BEGIN{printf "%.3f", n/60}';;
+        m) echo "$n";;
+        h) echo $((n * 60));;
+        d) echo $((n * 1440));;
+    esac
+}
+
+# Render "count<TAB>value" rows (from sort|uniq -c) as an indented top-N list.
+top_list() {
+    sort | uniq -c | sort -rn | head -n "$TOP" \
+        | awk '{ c=$1; $1=""; sub(/^ /,""); printf "    %8d  %s\n", c, $0 }'
+}
+
+# ============================================================================
+section "0. Preflight"
+# ============================================================================
+
+require_cmd kubectl
+require_cmd awk
+require_cmd jq
+
+CUR_CTX=$("${KCTL[@]}" config current-context 2>/dev/null || echo "")
+echo "  kubectl context: ${CUR_CTX:-<none>}"
+if [[ -z "$CUR_CTX" ]]; then
+    fail "no kubectl context selected"
+    exit 1
+elif [[ "$CUR_CTX" != "nwc1" && -z "$CONTEXT" ]]; then
+    warn "current context is '$CUR_CTX' (expected 'nwc1'); pass --context to override"
+else
+    pass "kubectl reachable, context='$CUR_CTX'"
+fi
+
+if "${KCTL[@]}" get namespace "$NAMESPACE" >/dev/null 2>&1; then
+    pass "namespace '$NAMESPACE' exists"
+else
+    fail "namespace '$NAMESPACE' not found"
+    exit 1
+fi
+
+if ! "${KCTL_NS[@]}" get deploy "$WEBAPP_NAME" >/dev/null 2>&1; then
+    fail "Deployment '$WEBAPP_NAME' not found — nothing to read logs from"
+    exit 1
+fi
+pass "Deployment '$WEBAPP_NAME' present"
+explain "Reading the last '$SINCE' of webapp stdout across all '$WEBAPP_NAME' pods."
+
+# --- harvest once -----------------------------------------------------------
+# All signals (gunicorn access + app logger + 429 warnings + auth failures)
+# share one stdout stream, so a single fetch feeds every section below.
+LOGS=$("${KCTL_NS[@]}" logs -l "app=$WEBAPP_NAME" --since="$SINCE" \
+       --all-containers=true --timestamps=false 2>/dev/null || true)
+
+# Normalize gunicorn access lines to "ip<TAB>status<TAB>method<TAB>path<TAB>ua".
+# An access line is identified by its quoted request field ("METHOD path HTTP…"),
+# which app-logger lines never carry — robust against stray quotes in messages.
+ACCESS_TSV=$(printf '%s\n' "$LOGS" | awk -F'"' '
+    $2 ~ /^(GET|POST|PUT|DELETE|HEAD|PATCH|OPTIONS|CONNECT|TRACE) / {
+        split($1, a, " "); ip = a[1];
+        split($2, r, " "); method = r[1]; path = r[2];
+        sub(/\?.*/, "", path);                 # drop query string for grouping
+        split($3, s, " "); status = s[1];
+        ua = $6; if (ua == "") ua = "-";
+        printf "%s\t%s\t%s\t%s\t%s\n", ip, status, method, path, ua
+    }')
+# Guard: grep -c over an empty string still returns 1 line; count real rows.
+N_ACCESS=$(printf '%s' "$ACCESS_TSV" | grep -c . || true)
+
+# ============================================================================
+section "1. Traffic volume & status mix"
+# ============================================================================
+
+if [[ "$N_ACCESS" -eq 0 ]]; then
+    info "no access-log lines in the last $SINCE (quiet window, or logs rotated)"
+    pass "nothing to analyze"
+else
+    MIN=$(since_to_min "$SINCE")
+    if [[ -n "$MIN" ]]; then
+        RATE=$(awk -v n="$N_ACCESS" -v m="$MIN" 'BEGIN{ printf "%.1f", (m>0)? n/m : 0 }')
+        echo "  $N_ACCESS requests over $SINCE  (~${RATE}/min)"
+    else
+        echo "  $N_ACCESS requests over $SINCE"
+    fi
+
+    # Status histogram by leading digit.
+    read -r C2 C3 C4 C5 CX < <(printf '%s\n' "$ACCESS_TSV" | awk -F'\t' '
+        $2 ~ /^[0-9]/ { c[substr($2,1,1)]++ }
+        END { printf "%d %d %d %d %d\n", c["2"]+0, c["3"]+0, c["4"]+0, c["5"]+0, (c["1"]+0) }')
+    PCT4=$(awk -v a="$C4" -v t="$N_ACCESS" 'BEGIN{ printf "%.1f", (t>0)? 100*a/t : 0 }')
+    PCT5=$(awk -v a="$C5" -v t="$N_ACCESS" 'BEGIN{ printf "%.1f", (t>0)? 100*a/t : 0 }')
+    echo "    2xx=$C2  3xx=$C3  4xx=$C4 (${PCT4}%)  5xx=$C5 (${PCT5}%)  1xx=$CX"
+
+    if awk -v p="$PCT5" 'BEGIN{exit !(p>5)}'; then
+        fail "5xx rate ${PCT5}% (> 5%) — the app is erroring, not just being probed"
+    else
+        pass "5xx rate ${PCT5}% within tolerance"
+    fi
+    if awk -v p="$PCT4" 'BEGIN{exit !(p>40)}'; then
+        warn "4xx rate ${PCT4}% (> 40%) — heavy probing / scanning likely"
+    else
+        pass "4xx rate ${PCT4}% within tolerance"
+    fi
+fi
+
+# ============================================================================
+section "2. Top talkers"
+# ============================================================================
+
+if [[ "$N_ACCESS" -eq 0 ]]; then
+    info "no access lines to rank"
+else
+    N_IPS=$(printf '%s\n' "$ACCESS_TSV" | cut -f1 | sort -u | grep -c . || true)
+    echo "  Distinct source IPs: $N_IPS"
+    if [[ "$N_IPS" -le 2 && "$N_ACCESS" -ge 50 ]]; then
+        warn "only $N_IPS distinct source IP(s) across $N_ACCESS requests"
+        explain "Likely gunicorn %(h)s = the ingress pod IP, not the real client (see R2 in --help)."
+        explain "Per-IP rate limiting and these rankings are degraded until ProxyFix/X-Forwarded-For is confirmed."
+    fi
+
+    echo
+    echo "  Top $TOP client IPs:"
+    printf '%s\n' "$ACCESS_TSV" | cut -f1 | top_list
+    echo
+    echo "  Top $TOP paths:"
+    printf '%s\n' "$ACCESS_TSV" | cut -f4 | top_list
+    echo
+    echo "  Top $TOP user-agents:"
+    printf '%s\n' "$ACCESS_TSV" | cut -f5 | top_list
+
+    SCAN_UA=$(printf '%s\n' "$ACCESS_TSV" | cut -f5 | grep -ciE "$SCANNER_UA_RE" || true)
+    if [[ "$SCAN_UA" -gt 0 ]]; then
+        warn "$SCAN_UA request(s) from known scanner/CLI user-agents"
+        if [[ $VERBOSE -eq 1 ]]; then
+            printf '%s\n' "$ACCESS_TSV" | awk -F'\t' -v re="$SCANNER_UA_RE" 'tolower($5) ~ re {print $1"\t"$5}' \
+                | sort | uniq -c | sort -rn | head -n "$TOP" | sed 's/^/      /'
+        fi
+    else
+        pass "no obvious scanner/CLI user-agents"
+    fi
+fi
+
+# ============================================================================
+section "3. Scanner / probe path signatures"
+# ============================================================================
+
+if [[ "$N_ACCESS" -eq 0 ]]; then
+    info "no access lines to scan for probes"
+else
+    PROBES=$(printf '%s\n' "$ACCESS_TSV" | awk -F'\t' -v re="$PROBE_PATH_RE" '$4 ~ re {print}')
+    N_PROBE=$(printf '%s' "$PROBES" | grep -c . || true)
+    if [[ "$N_PROBE" -eq 0 ]]; then
+        pass "no known vulnerability-probe paths requested"
+    else
+        warn "$N_PROBE request(s) for known probe paths (triage; not auto-blocked)"
+        echo "  Top probe paths:"
+        printf '%s\n' "$PROBES" | cut -f4 | top_list
+        echo "  Source IPs hitting probe paths:"
+        printf '%s\n' "$PROBES" | cut -f1 | top_list
+    fi
+fi
+
+# ============================================================================
+section "4. Rate-limit events (429)"
+# ============================================================================
+
+RL_LINES=$(printf '%s\n' "$LOGS" | grep -F 'rate_limit_exceeded' || true)
+N_429=$(printf '%s' "$RL_LINES" | grep -c . || true)
+if [[ "$N_429" -eq 0 ]]; then
+    pass "no rate_limit_exceeded events logged in the last $SINCE"
+else
+    info "$N_429 rate_limit_exceeded event(s) in the last $SINCE"
+    echo "  Top offenders (from app logs):"
+    OFFENDERS=$(printf '%s\n' "$RL_LINES" | grep -oE 'actor=[^ ]+' | sed 's/^actor=//')
+    printf '%s\n' "$OFFENDERS" | top_list
+    # Concentration check: a single actor dominating 429s is a likely single abuser.
+    TOPN=$(printf '%s\n' "$OFFENDERS" | sort | uniq -c | sort -rn | head -1 | awk '{print $1}')
+    if [[ "${TOPN:-0}" -ge 10 ]] && awk -v a="$TOPN" -v t="$N_429" 'BEGIN{exit !(a > t/2)}'; then
+        warn "one actor accounts for $TOPN/$N_429 of the 429s — inspect /admin/htmx/rate-limits"
+    fi
+fi
+
+# Best-effort Redis enrichment: authoritative offenders straight from the
+# 'ratelimit:events' set (survives log rotation). Read-only; skip on any error.
+REDIS_POD=$("${KCTL_NS[@]}" get pods -l "app=$REDIS_NAME" \
+            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+if [[ -n "$REDIS_POD" ]]; then
+    EVENTS=$("${KCTL_NS[@]}" exec "$REDIS_POD" -- \
+             redis-cli -n 1 ZREVRANGE ratelimit:events 0 -1 2>/dev/null || true)
+    N_EV=$(printf '%s' "$EVENTS" | grep -c . || true)
+    if [[ "$N_EV" -gt 0 ]]; then
+        echo
+        echo "  Redis 'ratelimit:events' set: $N_EV event(s) retained — top offenders:"
+        printf '%s\n' "$EVENTS" \
+            | jq -r 'select(length>0) | fromjson | .actor' 2>/dev/null \
+            | top_list
+    else
+        explain "Redis 'ratelimit:events' set is empty (no recent 429s, or memory:// fallback in use)."
+    fi
+else
+    explain "Redis pod not found via app=$REDIS_NAME — skipped authoritative event read."
+fi
+
+# ============================================================================
+section "5. Auth & security failures"
+# ============================================================================
+
+N_LOGIN=$(printf '%s\n' "$LOGS" | grep -cE 'Login failed' || true)
+N_OIDC=$(printf '%s\n'  "$LOGS" | grep -cF 'OIDC callback failed' || true)
+N_CSRF=$(printf '%s\n'  "$LOGS" | grep -cF 'CSRF failure' || true)
+if [[ "$N_ACCESS" -gt 0 ]]; then
+    N_401=$(printf '%s\n' "$ACCESS_TSV" | awk -F'\t' '$2=="401"' | grep -c . || true)
+    N_403=$(printf '%s\n' "$ACCESS_TSV" | awk -F'\t' '$2=="403"' | grep -c . || true)
+else
+    N_401=0; N_403=0
+fi
+echo "  login failures=$N_LOGIN  OIDC failures=$N_OIDC  CSRF failures=$N_CSRF  401=$N_401  403=$N_403"
+
+if [[ "$N_LOGIN" -gt 20 ]]; then
+    warn "$N_LOGIN login failures in the last $SINCE — possible credential stuffing"
+elif [[ "$N_LOGIN" -gt 0 ]]; then
+    info "$N_LOGIN login failure(s) — within normal range"
+else
+    pass "no login failures"
+fi
+if [[ "$N_CSRF" -gt 0 ]]; then
+    warn "$N_CSRF CSRF failure(s) — usually stale tabs, but watch for forgery attempts"
+else
+    pass "no CSRF failures"
+fi
+
+# ============================================================================
+section "Summary"
+# ============================================================================
+
+echo "  Results: ${GREEN}${PASS_COUNT} PASS${NC}  ${YELLOW}${WARN_COUNT} WARN${NC}  ${RED}${FAIL_COUNT} FAIL${NC}"
+echo
+echo "  Next steps:"
+echo "    • Rate-limit admin UI: https://${INGRESS_HOST}/admin/htmx/rate-limits"
+echo "    • Follow live logs:"
+echo "        kubectl -n $NAMESPACE logs -l app=$WEBAPP_NAME -f --all-containers=true"
+echo "    • Widen the window with --since (e.g. --since 24h) for a broader picture."
+
+if   [[ $FAIL_COUNT -gt 0 ]]; then exit 2
+elif [[ $WARN_COUNT -gt 0 ]]; then exit 1
+else                               exit 0
+fi

--- a/scripts/cirrus_weblog_audit.sh
+++ b/scripts/cirrus_weblog_audit.sh
@@ -33,14 +33,16 @@
 # ── Hardening recommendations (NOT enforced by this script) ──────────────────
 # This audit only surfaces signals; the layered defenses below are follow-ups
 # tracked in docs/plans (see the approved plan). Quick reference:
-#   R1  Edge rate limiting — the nginx-external ingress has NO limit-rps /
-#       limit-connections annotations; Flask-Limiter is the only gatekeeper.
-#       Adding them (helm/templates/ingress.yaml, via main→cirrus) sheds floods
-#       before they cost a worker.
-#   R2  Real client IP — if section 2 reports ≤2 distinct source IPs, gunicorn's
-#       %(h)s is the ingress pod IP, not the client. Confirm ProxyFix /
-#       X-Forwarded-For so per-IP limiting and these stats key on the real
-#       client.
+#   R1  Edge rate limiting — configurable via webapp.ingress.rateLimit in
+#       helm/values.yaml (limit-rps / limit-connections / limit-burst-multiplier
+#       on the ingress): a per-client-IP guardrail ahead of Flask-Limiter that
+#       sheds floods before they cost a worker. Tune to expected burst; rps: 0
+#       disables it.
+#   R2  Real client IP — the access log now carries xff="…" and the ProxyFix
+#       hop depth is set by PROXYFIX_X_FOR (helm webapp.proxyFixForwardedHops).
+#       Confirm the count against the logged X-Forwarded-For chain — too high
+#       lets clients spoof their IP. Section 2 warns if xff is missing or still
+#       collapses to ≤2 IPs.
 #   R3  Scheduling — run on a cron/CI runner with --no-color and alert on a
 #       non-zero exit (wire into scripts/cron/).
 #   R4  CSP reporting — add a report-uri so injection attempts become a
@@ -149,7 +151,12 @@ ACCESS_TSV=$(printf '%s\n' "$LOGS" | awk -F'"' '
         split($2, r, " "); method = r[1]; path = r[2];
         sub(/\?.*/, "", path);                 # drop query string for grouping
         if (path ~ /^\/api\/v[0-9]+\/health(\/|$)/) next;   # infra probe noise, not traffic
+        # Client IP: prefer the leftmost X-Forwarded-For entry (the real client)
+        # when the access log carries the xff="…" field; else the socket peer
+        # in %(h)s (which behind the ingress is the proxy, not the client).
         split($1, a, " "); ip = a[1];
+        xff = (NF >= 8) ? $8 : "";
+        if (xff != "" && xff != "-") { split(xff, xa, ","); ip = xa[1]; gsub(/[ \t]/, "", ip) }
         split($3, s, " "); status = s[1];
         ua = $6; if (ua == "") ua = "-";
         printf "%s\t%s\t%s\t%s\t%s\n", ip, status, method, path, ua
@@ -202,10 +209,13 @@ if [[ "$N_ACCESS" -eq 0 ]]; then
 else
     N_IPS=$(printf '%s\n' "$ACCESS_TSV" | cut -f1 | sort -u | grep -c . || true)
     echo "  Distinct source IPs: $N_IPS"
-    if [[ "$N_IPS" -le 2 && "$N_ACCESS" -ge 50 ]]; then
-        warn "only $N_IPS distinct source IP(s) across $N_ACCESS requests"
-        explain "Likely gunicorn %(h)s = the ingress pod IP, not the real client (see R2 in --help)."
-        explain "Per-IP rate limiting and these rankings are degraded until ProxyFix/X-Forwarded-For is confirmed."
+    XFF_SEEN=$(printf '%s\n' "$LOGS" | grep -cE 'xff="[0-9a-fA-F]' || true)
+    if [[ "$XFF_SEEN" -eq 0 ]]; then
+        warn "access log carries no X-Forwarded-For — IPs above are the in-cluster proxy, not real clients"
+        explain "Deploy the R2 gunicorn change (xff logging) so this attributes real clients; see R2 in --help."
+    elif [[ "$N_IPS" -le 2 && "$N_ACCESS" -ge 50 ]]; then
+        warn "only $N_IPS distinct client IP(s) across $N_ACCESS requests despite X-Forwarded-For"
+        explain "Either genuinely few clients, or PROXYFIX_X_FOR hop depth is still mis-set (see R2 in --help)."
     fi
 
     echo
@@ -241,7 +251,9 @@ section "3. Scanner / probe path signatures"
 if [[ "$N_ACCESS" -eq 0 ]]; then
     info "no access lines to scan for probes"
 else
-    PROBES=$(printf '%s\n' "$ACCESS_TSV" | awk -F'\t' -v re="$PROBE_PATH_RE" '$4 ~ re {print}')
+    # Exclude the app's own /static/ assets — /static/vendor/* legitimately
+    # matches the /vendor/ probe signature but is served, not a probe.
+    PROBES=$(printf '%s\n' "$ACCESS_TSV" | awk -F'\t' -v re="$PROBE_PATH_RE" '$4 !~ /^\/static\// && $4 ~ re {print}')
     N_PROBE=$(printf '%s' "$PROBES" | grep -c . || true)
     if [[ "$N_PROBE" -eq 0 ]]; then
         pass "no known vulnerability-probe paths requested"

--- a/scripts/cirrus_weblog_audit.sh
+++ b/scripts/cirrus_weblog_audit.sh
@@ -74,9 +74,13 @@ done
 setup_colors
 build_kctl
 
-# Scanner/abuse fingerprints. Probe PATHS first, then probe USER-AGENTS.
+# Scanner/abuse fingerprints. Probe PATHS first, then USER-AGENTS.
 PROBE_PATH_RE='/\.env|/\.git|/wp-login|/wp-admin|/phpmyadmin|/\.aws|/actuator|/vendor/|/cgi-bin/|\.php([?/]|$)|/xmlrpc|/config\.(json|php)|/\.ssh|/server-status|/solr/|/owa/|/boaform|/\.well-known/security'
-SCANNER_UA_RE='nikto|sqlmap|nmap|masscan|zgrab|nuclei|wpscan|dirbuster|gobuster|semrush|censys|python-requests|curl/|go-http-client|libwww-perl'
+# Aggressive scanners / exploitation tools — flagged as WARN.
+SCANNER_UA_RE='nikto|sqlmap|nmap|masscan|zgrab|nuclei|wpscan|dirbuster|gobuster|hydra|fimap|acunetix'
+# Generic CLI / library / crawler agents — usually benign automation (legit
+# uptime monitors and this repo's own scripts use curl), so reported as info.
+CLI_UA_RE='python-requests|curl/|wget/|go-http-client|libwww-perl|semrush|censys'
 
 # Convert a kubectl --since duration (e.g. 30m, 6h, 2d, 90s) to minutes;
 # echoes "" if unparseable (rate line is then skipped).
@@ -142,9 +146,10 @@ LOGS=$("${KCTL_NS[@]}" logs -l "app=$WEBAPP_NAME" --since="$SINCE" \
 # which app-logger lines never carry — robust against stray quotes in messages.
 ACCESS_TSV=$(printf '%s\n' "$LOGS" | awk -F'"' '
     $2 ~ /^(GET|POST|PUT|DELETE|HEAD|PATCH|OPTIONS|CONNECT|TRACE) / {
-        split($1, a, " "); ip = a[1];
         split($2, r, " "); method = r[1]; path = r[2];
         sub(/\?.*/, "", path);                 # drop query string for grouping
+        if (path ~ /^\/api\/v[0-9]+\/health(\/|$)/) next;   # infra probe noise, not traffic
+        split($1, a, " "); ip = a[1];
         split($3, s, " "); status = s[1];
         ua = $6; if (ua == "") ua = "-";
         printf "%s\t%s\t%s\t%s\t%s\n", ip, status, method, path, ua
@@ -214,14 +219,18 @@ else
     printf '%s\n' "$ACCESS_TSV" | cut -f5 | top_list
 
     SCAN_UA=$(printf '%s\n' "$ACCESS_TSV" | cut -f5 | grep -ciE "$SCANNER_UA_RE" || true)
+    CLI_UA=$(printf '%s\n'  "$ACCESS_TSV" | cut -f5 | grep -ciE "$CLI_UA_RE" || true)
     if [[ "$SCAN_UA" -gt 0 ]]; then
-        warn "$SCAN_UA request(s) from known scanner/CLI user-agents"
+        warn "$SCAN_UA request(s) from known exploitation/scanner tools"
         if [[ $VERBOSE -eq 1 ]]; then
             printf '%s\n' "$ACCESS_TSV" | awk -F'\t' -v re="$SCANNER_UA_RE" 'tolower($5) ~ re {print $1"\t"$5}' \
                 | sort | uniq -c | sort -rn | head -n "$TOP" | sed 's/^/      /'
         fi
     else
-        pass "no obvious scanner/CLI user-agents"
+        pass "no exploitation/scanner-tool user-agents"
+    fi
+    if [[ "$CLI_UA" -gt 0 ]]; then
+        info "$CLI_UA request(s) from generic CLI/crawler agents (curl, python-requests, …) — usually benign"
     fi
 fi
 

--- a/scripts/lib/cirrus_common.sh
+++ b/scripts/lib/cirrus_common.sh
@@ -1,0 +1,132 @@
+# shellcheck shell=bash
+#
+# cirrus_common.sh — Kubernetes / cirrus layer shared by the SAM cluster
+# scripts (cirrus_healthcheck.sh, cirrus_weblog_audit.sh).
+#
+# Sits ON TOP of common.sh (sourced automatically here) and adds the bits
+# that know about the 'samuel' release on the nwc1 cluster:
+#
+#   - baked-in release/object names + defaults (NAMESPACE/RELEASE/CONTEXT)
+#   - build_kctl            populate KCTL / KCTL_NS command arrays
+#   - handle_common_arg     parse the shared -n/-r/--context/--no-color/-v/-h
+#                           flags; return 1 for flags the caller owns
+#   - human_bytes / to_cores / to_bytes / seconds_since
+#                           K8s resource-unit + RFC3339 conversions
+#
+# Source from a script in scripts/ with:
+#
+#   _LIBDIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib"
+#   # shellcheck source=lib/cirrus_common.sh
+#   source "${_LIBDIR}/cirrus_common.sh"
+
+_CIRRUS_COMMON_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "${_CIRRUS_COMMON_DIR}/common.sh"
+
+# --- release / object names (match helm/templates/*.yaml) -------------------
+# If you rename objects in the chart, update these in lockstep. Resource
+# limits are always read live from the pod spec, never hard-coded here.
+NAMESPACE="${NAMESPACE:-sam-queries}"
+RELEASE="${RELEASE:-samuel}"
+CONTEXT="${CONTEXT:-}"
+
+WEBAPP_NAME="samuel"
+WEBAPP_PORT=5050
+REDIS_NAME="samuel-redis"
+REDIS_PORT=6379
+INGRESS_HOST="samuel.k8s.ucar.edu"
+TLS_SECRET="incommon-cert-samuel"
+HEALTH_PATH="/api/v1/health/ready"
+
+# --------------------------------------------------------------------------
+# build_kctl
+#
+# Populate the KCTL and KCTL_NS arrays from the current CONTEXT / NAMESPACE.
+# Call AFTER argument parsing (so --context / -n are in effect):
+#
+#   "${KCTL[@]}"    get nodes          # cluster-scoped
+#   "${KCTL_NS[@]}" get pods           # namespace-scoped
+# --------------------------------------------------------------------------
+build_kctl() {
+    KCTL=(kubectl)
+    [[ -n "$CONTEXT" ]] && KCTL+=(--context "$CONTEXT")
+    KCTL_NS=("${KCTL[@]}" -n "$NAMESPACE")
+}
+
+# --------------------------------------------------------------------------
+# handle_common_arg "$@"
+#
+# Process one leading argument if it is a shared flag. On a match, sets
+# _CONSUMED to the number of tokens used (1 or 2) and returns 0; on a flag the
+# caller owns, returns 1 (caller's own case handles it). Usage:
+#
+#   while [[ $# -gt 0 ]]; do
+#       if handle_common_arg "$@"; then shift "$_CONSUMED"; continue; fi
+#       case "$1" in
+#           --since) SINCE="$2"; shift 2;;
+#           *) echo "Unknown option: $1" >&2; exit 2;;
+#       esac
+#   done
+# --------------------------------------------------------------------------
+handle_common_arg() {
+    _CONSUMED=0
+    case "$1" in
+        -n|--namespace) NAMESPACE="$2"; _CONSUMED=2;;
+        -r|--release)   RELEASE="$2";   _CONSUMED=2;;
+        --context)      CONTEXT="$2";   _CONSUMED=2;;
+        --no-color)     USE_COLOR=0;    _CONSUMED=1;;
+        -v|--verbose)   VERBOSE=1;      _CONSUMED=1;;
+        -h|--help)      usage_from_header "$0"; exit 0;;
+        *) return 1;;
+    esac
+    return 0
+}
+
+# --- K8s resource-unit + timestamp conversions -----------------------------
+
+human_bytes() {
+    awk -v b="$1" 'BEGIN{
+        split("B KB MB GB TB PB",u);
+        i=1; while (b>=1024 && i<6){ b/=1024; i++ }
+        printf "%.1f%s", b, u[i]
+    }'
+}
+
+# Strip K8s resource units to a plain number.
+# CPU: 16 -> 16 cores, 250m -> 0.25, 100000000n -> 0.1
+to_cores() {
+    local v="$1"
+    case "$v" in
+        *n) awk -v x="${v%n}" 'BEGIN{printf "%.3f", x/1e9}';;
+        *u) awk -v x="${v%u}" 'BEGIN{printf "%.3f", x/1e6}';;
+        *m) awk -v x="${v%m}" 'BEGIN{printf "%.3f", x/1000}';;
+        *)  awk -v x="$v"     'BEGIN{printf "%.3f", x+0}';;
+    esac
+}
+# Mem: 128Gi -> 128*1024^3, 4096Mi -> 4096*1024^2, 4096M -> 4096*1e6
+to_bytes() {
+    local v="$1"
+    case "$v" in
+        *Ki) awk -v x="${v%Ki}" 'BEGIN{printf "%.0f", x*1024}';;
+        *Mi) awk -v x="${v%Mi}" 'BEGIN{printf "%.0f", x*1024*1024}';;
+        *Gi) awk -v x="${v%Gi}" 'BEGIN{printf "%.0f", x*1024*1024*1024}';;
+        *Ti) awk -v x="${v%Ti}" 'BEGIN{printf "%.0f", x*1024*1024*1024*1024}';;
+        *K)  awk -v x="${v%K}"  'BEGIN{printf "%.0f", x*1000}';;
+        *M)  awk -v x="${v%M}"  'BEGIN{printf "%.0f", x*1000000}';;
+        *G)  awk -v x="${v%G}"  'BEGIN{printf "%.0f", x*1000000000}';;
+        *T)  awk -v x="${v%T}"  'BEGIN{printf "%.0f", x*1000000000000}';;
+        *)   awk -v x="$v"      'BEGIN{printf "%.0f", x+0}';;
+    esac
+}
+
+# Convert RFC3339 timestamp to seconds-ago via portable date(1).
+# Echoes a single integer in seconds; non-zero exit if unparseable.
+seconds_since() {
+    awk -v d="$1" 'BEGIN{
+        cmd="date -u +%s"; cmd | getline now; close(cmd);
+        cmd="date -u -d \"" d "\" +%s 2>/dev/null || date -u -j -f %Y-%m-%dT%H:%M:%SZ \"" d "\" +%s 2>/dev/null"
+        cmd | getline t; close(cmd);
+        if (t=="" || t==0) exit 1;
+        printf "%.0f", (now-t)
+    }'
+}

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,0 +1,113 @@
+# shellcheck shell=bash
+#
+# common.sh — generic, sourceable helpers shared by SAM operational scripts.
+#
+# This is the LOWEST layer: pure presentation + control-flow helpers with no
+# Kubernetes / cirrus knowledge (that lives in cirrus_common.sh). Source it
+# from any script:
+#
+#   _LIBDIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib"
+#   # shellcheck source=lib/common.sh
+#   source "${_LIBDIR}/common.sh"
+#
+# Provides:
+#   - setup_colors            TTY- and --no-color-aware ANSI palette
+#   - say/info/ok/note/die     plain log primitives (no verdict counters)
+#   - section/explain/pass/    verdict primitives (maintain PASS/WARN/FAIL
+#     warn/fail/run/require_cmd  counters)
+#   - verdict_exit             print the tally + exit 2/1/0
+#   - usage_from_header         print the script's leading comment block
+#   - repo_paths               set SCRIPT_DIR / REPO_ROOT
+#
+# Sourcing has no side effects beyond defining functions and initializing the
+# shared defaults below; callers parse args, then call setup_colors.
+
+# --- shared defaults (callers may override via args) ------------------------
+USE_COLOR="${USE_COLOR:-1}"
+VERBOSE="${VERBOSE:-0}"
+PASS_COUNT=0
+WARN_COUNT=0
+FAIL_COUNT=0
+
+# Color vars are empty until setup_colors runs (so unset-color is the default).
+BLUE=""; GREEN=""; YELLOW=""; RED=""; CYAN=""; BOLD=""; NC=""
+
+# --------------------------------------------------------------------------
+# setup_colors
+#
+# Enable ANSI color only when all of: USE_COLOR=1, the de-facto NO_COLOR env
+# var is unset, and stdout is a TTY. Uses $'...' ANSI-C quoting so the escapes
+# are literal — `echo`/`echo -e`/`printf '%s'` all render them correctly.
+# Call AFTER argument parsing so --no-color can take effect.
+# --------------------------------------------------------------------------
+setup_colors() {
+    if [[ "${USE_COLOR:-1}" -eq 1 && -z "${NO_COLOR:-}" && -t 1 ]]; then
+        BLUE=$'\033[0;34m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'
+        RED=$'\033[0;31m';  CYAN=$'\033[0;36m';  BOLD=$'\033[1m'; NC=$'\033[0m'
+    else
+        BLUE=""; GREEN=""; YELLOW=""; RED=""; CYAN=""; BOLD=""; NC=""
+    fi
+}
+
+# --- plain log primitives (no counters) -------------------------------------
+say()  { echo -e "$*"; }
+note() { echo -e "  ${CYAN}↳ $*${NC}"; }
+die()  { echo -e "${RED}ERROR:${NC} $*" >&2; exit 1; }
+
+# --- verdict primitives (maintain PASS/WARN/FAIL counters) ------------------
+section() { echo; echo -e "${BOLD}${BLUE}═══ $* ═══${NC}"; }
+explain() { echo -e "  ${CYAN}↳ $*${NC}"; }
+pass() { echo -e "  ${GREEN}✔ PASS${NC} — $*"; PASS_COUNT=$((PASS_COUNT+1)); }
+warn() { echo -e "  ${YELLOW}⚠ WARN${NC} — $*"; WARN_COUNT=$((WARN_COUNT+1)); }
+fail() { echo -e "  ${RED}✘ FAIL${NC} — $*"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+info() { echo -e "  ${CYAN}ℹ${NC} $*"; }
+
+# Run a command and indent its output for readability (never aborts the run).
+run() { "$@" 2>&1 | sed 's/^/    /' || true; }
+
+# Verdict-style hard dependency check: FAIL + exit 1 when missing.
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || { fail "$1 not found in PATH"; exit 1; }
+}
+
+# --------------------------------------------------------------------------
+# verdict_exit
+#
+# Print "  Results: N PASS  N WARN  N FAIL" and exit with the conventional
+# code: 2 if any FAIL, 1 if any WARN, else 0. Convenience for check scripts
+# that want the standard summary; scripts with a bespoke summary can inline
+# the same exit ladder instead.
+# --------------------------------------------------------------------------
+verdict_exit() {
+    echo "  Results: ${GREEN}${PASS_COUNT} PASS${NC}  ${YELLOW}${WARN_COUNT} WARN${NC}  ${RED}${FAIL_COUNT} FAIL${NC}"
+    if   [[ $FAIL_COUNT -gt 0 ]]; then exit 2
+    elif [[ $WARN_COUNT -gt 0 ]]; then exit 1
+    else                               exit 0
+    fi
+}
+
+# --------------------------------------------------------------------------
+# usage_from_header [file]
+#
+# Print the leading comment block (everything after the shebang up to the
+# first non-comment line), stripping the leading "# " / "#". Lets every script
+# keep its usage text in one place — the header comment.
+# --------------------------------------------------------------------------
+usage_from_header() {
+    local f="${1:-$0}"
+    awk 'NR==1{next} /^#/{sub(/^#[ ]?/,""); print; next} {exit}' "$f"
+}
+
+# --------------------------------------------------------------------------
+# repo_paths
+#
+# Resolve and export SCRIPT_DIR (dir of the calling script) and REPO_ROOT
+# (git toplevel, falling back to SCRIPT_DIR/..). Safe to call once near the
+# top of a script that needs repo-relative paths.
+# --------------------------------------------------------------------------
+repo_paths() {
+    SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[1]}")" && pwd)"
+    REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"
+    [[ -n "$REPO_ROOT" ]] || REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+    export SCRIPT_DIR REPO_ROOT
+}

--- a/scripts/zap_probe_docker.sh
+++ b/scripts/zap_probe_docker.sh
@@ -46,16 +46,20 @@
 
 set -euo pipefail
 
-# ── Colors ────────────────────────────────────────────────────────────────
-BLUE='\033[0;34m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+# ── Shared helpers ──────────────────────────────────────────────────────────
+_LIBDIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib"
+# shellcheck source=lib/common.sh
+source "${_LIBDIR}/common.sh"
+setup_colors   # TTY/NO_COLOR-aware palette (set NO_COLOR=1 to disable)
+
+# This tool uses a lighter, non-verdict log style than the cirrus check
+# scripts, so it keeps its own info/ok/warn; die() comes from common.sh.
 info()  { echo -e "${BLUE}==>${NC} $*"; }
 ok()    { echo -e "${GREEN}OK:${NC} $*"; }
 warn()  { echo -e "${YELLOW}WARN:${NC} $*" >&2; }
-die()   { echo -e "${RED}ERROR:${NC} $*" >&2; exit 1; }
 
 # ── Paths ─────────────────────────────────────────────────────────────────
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+repo_paths   # sets SCRIPT_DIR + REPO_ROOT
 COMPOSE_FILE="${REPO_ROOT}/compose.yaml"
 WRKDIR="${REPO_ROOT}/docs/nrit-review-2026-05"   # holds gen.conf + the saved baseline
 
@@ -72,9 +76,9 @@ KEEP_APP=""
 EXTERNAL_TARGET=""
 STAMP="$(date +%Y%m%d-%H%M%S)"
 
-# Print the leading comment header (everything from line 2 up to the first
-# non-comment line), stripping the "# " prefix. Robust to header length.
-usage() { awk 'NR>1 && /^#/{sub(/^# ?/,""); print; next} NR>1{exit}' "${BASH_SOURCE[0]}"; exit "${1:-0}"; }
+# Help text is the leading comment header; usage_from_header (common.sh) prints
+# it. Wrapped so callers can pass an explicit exit code.
+usage() { usage_from_header "${BASH_SOURCE[0]}"; exit "${1:-0}"; }
 
 # ── Arg parsing ───────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do

--- a/src/webapp/run.py
+++ b/src/webapp/run.py
@@ -64,8 +64,17 @@ def create_app(*, config_overrides: dict | None = None):
 
     app = Flask(__name__)
 
+    # Trust N proxy hops in X-Forwarded-* so request.remote_addr / url scheme
+    # reflect the real client behind the ingress (and any LB in front of it).
+    # Flask-Limiter and audit tooling key on request.remote_addr, so this is
+    # what makes per-IP limiting honest. The correct N is the EXACT number of
+    # trusted proxies that append to X-Forwarded-For — setting it too high lets
+    # a client spoof its IP (ProxyFix would trust an attacker-supplied entry),
+    # so it defaults to 1 (safe) and is tuned via PROXYFIX_X_FOR once the real
+    # chain is confirmed from the gunicorn access log (which now logs xff=…).
     from werkzeug.middleware.proxy_fix import ProxyFix
-    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
+    _pf_for = int(os.environ.get('PROXYFIX_X_FOR', '1'))
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=_pf_for, x_proto=1, x_host=1, x_prefix=1)
 
     # Apply all UPPERCASE class attributes as Flask config
     app.config.from_object(cfg)


### PR DESCRIPTION
## Summary

Operational tooling and hardening for the now-public `samuel` deployment, built and **live-tested on CIRRUS (`nwc1`)** via manual `workflow_dispatch` deploys. Three parts:

1. **`scripts/cirrus_weblog_audit.sh`** — a read-only, on-demand traffic / rate-limit / abuse audit, companion to `cirrus_healthcheck.sh`. Harvests the webapp's stdout (+ the Redis `ratelimit:events` set) and reports traffic & status mix, top talkers, scanner/probe signatures, 429 offenders, auth/CSRF failures, and edge-rate-limit headroom — with a PASS/WARN/FAIL verdict (exit 0/1/2).
2. **`scripts/lib/{common,cirrus_common}.sh`** — a two-layer shared shell library; `cirrus_healthcheck.sh` and `zap_probe_docker.sh` migrated onto it (behavior-preserving) to stop duplicating colors/log helpers/arg-parsing/constants.
3. **R1 + R2 public-exposure hardening** (helm + app), described below.

## Key finding: the real client IP is lost at the ingress (R2)

Verified live with an **external, off-VPN request** (from Anthropic infra): the `nginx-external` controller hands the app `X-Forwarded-For: 127.0.0.1` for **every** client. Two consequences:

- **R2 (real client IP)** cannot be fixed in this repo — there is no client IP in the headers to recover. `ProxyFix` is wired and now env-tunable (`PROXYFIX_X_FOR`, default **1**, safe), and gunicorn now logs the `xff="…"` chain so we can verify a fix later. Nothing to tune until the controller forwards real IPs.
- **R1 (edge rate limiting)** therefore keys every client into **one global bucket**, not per-IP. Set as a deliberately **high global flood-backstop** (`limit-rps: 100`, `limit-connections: 200`) so legitimate aggregate traffic won't trip 503s; `rps: 0` disables it. The audit's section 1 shows live `limit-rps` vs observed peak load so we'll know if it needs raising (actual edge 503s happen at the controller and aren't in app logs — noted in-tool).

## ⛳ Forward work — ingress-NGINX controller (needs the `nwc1` platform team)

This is the keystone that fixes R2 **and** makes R1 per-IP meaningful, in one cluster-side change (out of scope for this repo — controller ConfigMap, affects all ingresses on that controller):

- Enable `use-forwarded-headers: "true"` + `compute-full-forwarded-for: "true"` **if** a trusted L7 proxy/LB already sets `X-Forwarded-For`; **or**
- `use-proxy-protocol: "true"` if the upstream LB (`llb-128.117.41.126`) speaks PROXY protocol instead.
- Set `proxy-real-ip-cidr` to the LB range so client-supplied XFF can't be spoofed.

Once in place: re-run `cirrus_weblog_audit.sh` to confirm real client IPs flow, then bump `webapp.proxyFixForwardedHops` to the now-visible hop count and re-shape `webapp.ingress.rateLimit` back to sane **per-IP** values.

## Testing

- `bash -n` clean on all scripts/libs; `helm template` renders R1 annotations and the `rps: 0` off-switch; `cirrus_healthcheck.sh` migration verified live (26 PASS / 2 WARN / 0 FAIL, unrelated transient rollout warns).
- `cirrus_weblog_audit.sh` exercised live with controlled traffic: status mix, probe detection, scanner-vs-CLI UA split, Redis `ZREVRANGE` enrichment, the "no public client IPs" detector, and the edge-headroom indicator all confirmed firing. Health-probe paths and `/static/` assets excluded from analysis.
- `shellcheck` not run (not installed locally).

## Deploy notes

- CIRRUS deploys from `main`; this branch was tested via manual `workflow_dispatch`.
- R2 plumbing is safe/inert at `PROXYFIX_X_FOR=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)