### PR TITLE
fs-scans Phase 2+3: Filesystem Scans web UI + reusable directory explorer (stacked on #321)

### DIFF
--- a/docs/plans/FS_SCANS_PHASE3.md
+++ b/docs/plans/FS_SCANS_PHASE3.md
@@ -1,0 +1,282 @@
+# fs-scans Phase 3 — Reusable "Large directories": filter page, per-user drill-down, project + resource (elevated) modes
+
+## Context
+
+Phase 2 shipped the **Filesystem Scans** card on the disk resource-details page
+(four tabs: Large directories, User/group counts, Access history, File sizes).
+The "Large directories" table is the most valuable view but currently exposes
+only `sort_by` + `limit`. The plugin facade (`fs_scans/queries/facade.py
+:list_directories`) **already supports** far more — `sort_by` (size/files/dirs),
+`accessed_before`, `accessed_after`, `leaves_only`, and `owner_id` — none of it
+surfaced. **No plugin change is needed.**
+
+Goal (four threads):
+1. **Tab**: expose the three primary *server-side* sorts (size / #files / #dirs)
+   as a pill — like the File Sizes Data/Files pill — since top-50-by-size is a
+   genuinely different row set than top-50-by-files (facade sorts then `LIMIT`s).
+2. **Standalone page** ("Open full view ↗" from the tab) hosting a **filters
+   panel** above the reusable table: accessed-before/after dates, a leaves-only
+   toggle, and a user picker. North-star: grow this into a file-browser UI.
+3. **Per-user drill-down**: make User/group-tab *owner* rows expandable; expanding
+   loads the default Large-directories search filtered to that user (`owner_uid`).
+4. **Two scope modes** for the page + reusable fragment (built together, one PR):
+   - **Project mode** (existing, unchanged): `require_project_access`, scoped to
+     the project's `path_prefixes`. Members explore within their tree.
+   - **Resource mode** (new, elevated/global RBAC): browse the *entire* resource's
+     collections (Campaign_Store ↔ `campaign` CNPG; future Destor), no project
+     scoping. This is where the file-browser UI shines — start at collection roots,
+     drill via `?fileset=`.
+
+Caching: filtered/owner permutations go into a **separate short-TTL cache bucket**
+so a heavy interactive filterer can't crowd the hot default-path entries that
+passive landers depend on (both Redis-backed; explorer bucket self-expires).
+
+## Handoff / how to resume
+This doc is the implementation handoff — start a fresh session and work top to
+bottom. SAM branch `fs_scans_plugin_phase2` (PR #322), built on `fs_scans_plugin`.
+Decisions already locked with the user: filters panel = dates + leaves-only +
+user picker; tab = sort pill + "open full view" link (supplement, not replace);
+caching = two Redis buckets (default 8-day, explorer 30-min TTL); resource mode
+gated by a **global** permission; **both modes built in one PR**.
+
+## Plugin / PR #77 (still open — fix friction there if cleaner)
+The facade (`/Users/benkirk/codes/hpc-usage-queries/devel`, branch
+`fs_scans_module`, **PR #77 open, checked out locally**) already exposes every
+filter this phase needs (`list_directories(sort_by, accessed_before,
+accessed_after, leaves_only, owner_id, path_prefixes=None, limit, …)`) — **no
+plugin change is planned.** But PR #77 has NOT merged, so if friction appears
+during implementation that's better solved in the plugin — e.g. a missing/oddly-
+named facade param, the `filesystem` key absent from directory rows, or the
+real **resource→CNPG-database mapping** needed for Destor (today
+`collections_for_resource` just returns `get_collections()`) — fix it in the
+plugin and land both in lockstep. No backwards-compat concern; they deploy
+together (conda-env rebuilds on the local checkout). Run plugin tests with
+`env -u FS_SCAN_DB_BACKEND -u FS_SCAN_PG_DB pytest`.
+
+## Key facts (from exploration)
+
+- Facade `list_directories(..., sort_by, accessed_before, accessed_after,
+  leaves_only, owner_id, path_prefixes, limit, ...)` — all filters exist;
+  `_DIR_SORT_KEYS` includes `size|files|dirs` (+ `_r`/`_nr` variants, `atime_r`,
+  `path`, `depth`). Rows: `path, depth, total_size_r, file_count_r, dir_count_r,
+  max_atime_r, owner_uid, owner_gid` (no `filesystem` key — template already
+  doesn't render it).
+- `directories_fragment` (`src/webapp/disk_scans/routes.py:103`) already takes
+  `?sort_by/limit/scope/fileset/resource/target_id`; `_DIR_SORT_WHITELIST =
+  {'size','files','atime_r','path','dirs'}`. Service `scan_directories`
+  (`service.py:115`) already has `single_owner/min_depth/max_depth` plumbing —
+  add the rest alongside.
+- Cache (`disk_scans/cache.py`) is a **bounded LRU** (`TTLCacheAdapter` maxsize
+  256, or Redis `allkeys-lru`). Key already folds `opts` in. Single lazy
+  module-level `_adapter`; a second bucket = a second named adapter.
+- `sortable_table.js` **multi-tbody mode** (`tbody.sortable-group`) is purpose-
+  built to keep "a user's row + adjacent lazy-subtree placeholder" together when
+  sorting — exact precedent for the owner drill-down (see `user_subtree.html`).
+- Filter-panel house style: hidden form + `hx-include`; `type="date"` inputs
+  (`audit_filters.html`); `form-check`/`form-switch` toggle with
+  `hx-trigger="change"`; `fk_search_field` macro (`form_fields.html` + `fk-picker.js`)
+  for the user picker; reusable-macro pattern keyed by `form_id`/`target_id`
+  (`audit_filters` reused across Transactions/Adjustments tabs).
+- Resource→collection: **no SAM-side map today** — `session.get_collections()`
+  returns all warmed schemas, which today *are* the whole `campaign` DB (one DB
+  per resource via the plugin's `FS_SCAN_PG_DB`). Unrestricted query is just
+  `path_prefixes=None` → facade `_resolve_scope` returns `{fs: None}` → whole-
+  collection fast path. (`resolve_scan_scope` ties resource→collections *via a
+  project's `ProjectDirectory` paths*; resource mode bypasses that.)
+- RBAC: `rbac.py` has `@require_permission(Permission.X)` (global, 401/403) and
+  `@require_permission_any_facility(...)`; `Permission` enum + `GROUP_PERMISSIONS`
+  bundles (csg/ssg/nusd). No existing permission fits "browse all filesystem
+  data" → add one, gated globally.
+
+## Changes
+
+### 1. Service — `src/webapp/disk_scans/service.py` (mode-agnostic core)
+Factor a private `_scan_directories(collections, path_prefixes, *, sort_by, limit,
+owner_uid, accessed_before, accessed_after, leaves_only, mode)` that builds
+`FsScanQueries(filesystems=collections)`, assembles `opts`, picks the bucket
+(`'filtered'` when any of owner_uid/accessed_before/accessed_after/leaves_only is
+set, else `'default'`), and calls `cached_scan(..., bucket=…)`. It forwards the
+new kwargs to the facade (`owner_id=owner_uid`, `accessed_before=…`,
+`accessed_after=…`, `leaves_only=…`).
+
+Two public wrappers resolve scope, then delegate:
+- `scan_directories(session, project, resource_name, *, …)` — **project mode**
+  (existing safety intact): `_scoped(...)` → `(collections, path_prefixes)`;
+  refuses unscoped (empty → `[]`). Gains the four new filter kwargs.
+- `scan_directories_resource(session, resource_name, *, subpath=None, …)` —
+  **resource mode** (NEW): `collections = collections_for_resource(resource_name)`
+  (see session helper); `path_prefixes = [subpath]` if a fileset is given else
+  `None` (whole-collection fast path). Deliberately *not* project-scoped — only
+  reachable behind the elevated route. Same filter kwargs + bucket logic.
+
+### 2. Cache — `src/webapp/disk_scans/cache.py` (two buckets, short-TTL explorer)
+Generalize the single `_adapter` into a small per-name registry
+(`_adapters: dict[str, CacheBase]`) with `get_cache_adapter(bucket='default')`.
+**Both buckets use the same backend** (`RedisTTLAdapter` when `CACHE_REDIS_URL`
+is reachable — shared across gunicorn workers — else per-worker
+`TTLCacheAdapter`), differing only in name, size, and TTL:
+
+- **`default` bucket** (`fs_scans`) — passive/landing + tab-pill queries. Size
+  `FS_SCANS_CACHE_SIZE` (256), TTL `FS_SCANS_CACHE_TTL` (691200 = 8 days; the
+  scan-date key is what guarantees freshness, TTL is a backstop).
+- **`filtered` bucket** (`fs_scans_filtered`) — owner/date/leaves-only queries.
+  Size `FS_SCANS_FILTERED_CACHE_SIZE` (default 128), **TTL
+  `FS_SCANS_FILTERED_CACHE_TTL` (default 1800 = 30 min)**. The short TTL keeps
+  the volatile exploration permutations from accumulating, so they hold only a
+  small, transient slice of Redis and rarely linger long enough to pressure
+  eviction of the long-lived default entries. Still Redis-backed, so repeated
+  filters are shared across workers.
+
+Note (document in code): this is a *soft* protection — `allkeys-lru` is
+instance-global, so under genuine Redis memory pressure recent filtered writes
+could still evict default entries; the 30-min TTL minimizes that window by
+keeping the filtered footprint small and self-expiring. (Chosen over an
+off-Redis filtered bucket to keep cross-worker sharing.)
+
+`cached_scan(..., bucket='default')` selects the adapter; service passes
+`bucket='filtered'` when any nonstandard filter is set. Admin hooks
+(`purge_fs_scans_cache`, `fs_scans_cache_info`) cover both buckets; wire both into
+`webapp/caching/__init__.py` `stats()/clear()/adapters()` (the Config card's
+`scans` entry becomes a 2-row list — adjust `configuration_card.html` to loop;
+show each bucket's TTL so the 30-min explorer TTL is visible).
+
+### 3. Routes — `src/webapp/disk_scans/routes.py`
+Shared filter parsing helper `_dir_filters()`: read `owner_uid` (`type=int`),
+`leaves_only` (truthy), `accessed_before`/`accessed_after` (`YYYY-MM-DD` →
+datetime, mirror `jobs_fragment` query-date parsing; GET, not POST/PUT, so no
+forms-schema needed), `sort_by` (whitelist), `limit`. Used by all four routes.
+
+**Project mode** (existing blueprint, `require_project_access`):
+- `directories_fragment` (`/<projcode>/directories`) — add `_dir_filters()` →
+  `scan_directories(...)`. Thread active filters into `_common_ctx` so the
+  hidden form carries them across sort re-fetches.
+- `directories_page` (NEW, `/<projcode>/directories/explore`),
+  `@login_required @require_project_access` — renders the standalone page in
+  project mode (header shows project + resource).
+
+**Resource mode** (NEW, elevated — `@login_required
+@require_permission(Permission.VIEW_ALL_FILESYSTEM_DATA)`):
+- `directories_resource_fragment` (`/resource/<resource>/directories`) →
+  `scan_directories_resource(...)`. Same `_dir_filters()` + `?fileset=` subpath.
+- `directories_resource_page` (`/resource/<resource>/explore`) — standalone page
+  in resource mode (header shows resource + a fileset breadcrumb from collection
+  roots; file-browser entry).
+
+Both fragment routes render the **same** `disk_scans_directories.html` partial;
+both pages render the **same** page template, parameterized by `mode`
+('project'|'resource'), `fragment_url` (which fragment to lazy-load), and the
+scope context. `target_id` namespacing already prevents DOM collisions when the
+fragment appears in multiple places.
+
+### 3b. Resource→collection helper + RBAC permission
+- `src/webapp/disk_scans/session.py`: add `collections_for_resource(resource_name)`
+  → today returns `get_collections()` (single `campaign` DB = all warmed
+  collections). This is the **seam** where a future resource→DB map (Destor)
+  plugs in; document that and keep it the only place resource→collections is
+  decided for unscoped queries. Returns `[]` when the plugin is off.
+- `src/webapp/utils/rbac.py`: add `Permission.VIEW_ALL_FILESYSTEM_DATA`
+  ("Browse all filesystem-scan data across a disk resource, unscoped"). Grant it
+  globally via `GROUP_PERMISSIONS` to the operator bundles (csg/ssg/nusd) — **not**
+  facility-scoped (campaign collections don't map onto UNIV/WNA/NCAR facilities).
+  No `USER_FACILITY_PERMISSIONS` entry.
+
+### 4. Templates
+- **`disk_scans_directories.html`** (reusable fragment): add `owner_uid`,
+  `accessed_before`, `accessed_after`, `leaves_only` to the hidden
+  `#disk-scans-dir-params-{{target_id}}` form so sort re-fetches preserve the
+  active filter. Optional: a small "filtered: user X · accessed before Y" chip.
+  Keep server-side sort links.
+- **`resource_details_disk.html`** (Large directories tab): add a **sort pill**
+  (Size / # Files / # Subdirs) mirroring the File Sizes Data/Files pill — each
+  `hx-get …?sort_by=size|files|dirs` re-queries server-side; plus an
+  **"Open full view ↗"** link to `directories_page` carrying resource/scope/fileset.
+- **`disk_scans_directories_page.html`** (NEW standalone page, both modes):
+  extends the dashboard base; parameterized by `mode` ('project'|'resource') and
+  `fragment_url`. Header: project+resource (project mode) or resource + a
+  **fileset breadcrumb** from collection roots (resource mode — the file-browser
+  entry; each crumb re-targets the fragment with `?fileset=`). The **filters
+  panel** (partial below) sits above a table-fragment container that lazy-loads
+  the relevant fragment with the panel's params; a `limit` selector
+  (50/100/250/500). Deeper file-browser (live subdir descent) can grow from the
+  breadcrumb later.
+- **`_disk_scans_dir_filters.html`** (NEW partial/macro, audit_filters-style;
+  mode-agnostic): hidden form + visible controls — two `type="date"` inputs
+  (accessed after/before), a leaves-only `form-check form-switch`, an
+  `fk_search_field` user picker (→ `owner_uid`; in resource mode this filters
+  across the whole resource), a Search button; `hx-get` the `fragment_url` into
+  the table container with `hx-include`.
+- **`disk_scans_entities.html`** (owner drill-down): for `kind == 'owner'`, render
+  each row as `<tbody class="sortable-group">` containing the data `<tr>` (with an
+  expand chevron + `data-bs-toggle="collapse"`) and a `<tr class="collapse">`
+  detail row whose inner div lazy-loads `directories_fragment?owner_uid=<uid>
+  &resource=…&scope=…&fileset=…&target_id=…` on `shown.bs.collapse once`
+  (memory feedback_persisted_collapse_htmx). Update the `<thead>` to multi-tbody
+  expectations. Group mode (`kind == 'group'`) unchanged — no expansion (facade
+  filters directories by uid only).
+
+### 5. Registration + entry points
+All four routes are on the existing `disk_scans` blueprint — no new
+`register_blueprint` needed. Resource-mode page entry point: a link from the
+admin/operator area (e.g. Admin dashboard or the disk resource card) guarded by
+the same `VIEW_ALL_FILESYSTEM_DATA` permission in the template
+(`{% if current_user.has_permission(...) %}`), so non-operators never see it.
+
+## Security note
+Resource mode exposes **every user's** paths / sizes / owner UIDs across an
+entire disk resource — cross-project, cross-user visibility. It is therefore
+gated by the global `VIEW_ALL_FILESYSTEM_DATA` permission at the route (not just
+the template link), and the service's project-scoping safety invariant
+(`_scoped` refusing unscoped queries) is left fully intact for project mode —
+resource mode reaches the unscoped path only through its own dedicated,
+permission-gated wrapper. The owner picker + per-user filter in resource mode is
+an operator capability by design.
+
+## Caching policy (summary)
+- **Default bucket** (`fs_scans`, Redis-shared when available, 8-day TTL):
+  no-filter + sort_by + limit — what passive landers and the tab pill hit.
+  High reuse, cross-worker, long-lived.
+- **Filtered bucket** (`fs_scans_filtered`, Redis-shared, 30-min TTL): any of
+  owner_uid / accessed_before / accessed_after / leaves_only set — heavy
+  interactive use and the per-user drill-down. Shared across workers, but
+  self-expires fast so its volatile permutations stay a small, transient
+  footprint rather than crowding the long-lived default entries.
+
+## Tests — `tests/unit/test_webapp_disk_scans.py`
+- `scan_directories` forwards `owner_uid/accessed_before/accessed_after/
+  leaves_only` to the fake facade and into `opts`.
+- Bucket selection: a filtered call routes to `fs_scans_filtered`; a default call
+  to `fs_scans` (assert via the two adapters' `info()` currsize, or a spy).
+- Filtered bucket carries the short TTL: assert `fs_scans_filtered` adapter
+  `info()['ttl'] == 1800` (and default == 691200), so the 30-min explorer TTL is
+  actually applied.
+- `directories_fragment?owner_uid=…&leaves_only=1&accessed_before=2026-01-01`
+  → 200, rows render, hidden form carries the filters.
+- `directories_page` → 200 with the filters panel present.
+- entities `kind=owner` → rows are `sortable-group` tbodies with an expand toggle
+  and a detail container holding `owner_uid=`; `kind=group` → no expansion.
+- Admin Config card lists both scan buckets.
+- **Resource mode**: `directories_resource_fragment` / `_page` → **403 without**
+  `VIEW_ALL_FILESYSTEM_DATA`, **200 with**. `scan_directories_resource` queries
+  `collections_for_resource(...)` with `path_prefixes=None` (whole-collection),
+  bypassing project scope. Project-mode `_scoped` still refuses unscoped queries
+  (unchanged). `collections_for_resource` returns `get_collections()` (and `[]`
+  when the plugin is off).
+
+## Verification
+- `docker compose up webdev --watch`.
+- Disk page → Filesystem Scans → **Large directories**: toggle the Size/#Files/
+  #Subdirs pill, confirm each re-queries a *different* top-N set (not a client
+  re-sort). Click **Open full view ↗**.
+- Standalone page: set accessed-before/after, toggle leaves-only, pick a user;
+  confirm the table re-queries and matches `fs-scans query --sort-by … --accessed-before …
+  --leaves-only --owner …` for the same scope.
+- **User / group counts** → expand a user row → confirm it loads that user's top
+  directories (sortable, stays paired under client-side re-sort).
+- **Resource mode**: as an operator (e.g. benkirk/csg), open
+  `/dashboards/user/disk-scans/resource/Campaign_Store/explore` → confirm it
+  browses all collections unscoped, the user picker filters across the whole
+  resource, and the breadcrumb drills via `?fileset=`. As a plain project member,
+  confirm the entry point is hidden **and** the route returns 403.
+- Admin → Configuration: confirm both `fs_scans` and `fs_scans_filtered` buckets
+  appear; exercise filtered queries and watch only the filtered bucket grow.
+- `source etc/config_env.sh && pytest tests/unit/test_webapp_disk_scans.py -v`.

--- a/src/webapp/caching/__init__.py
+++ b/src/webapp/caching/__init__.py
@@ -118,8 +118,9 @@ class Caching:
         """All adapters known to the facade, including the proxied usage cache.
 
         Order: flask first, then chart caches in registration order, then
-        the usage cache (if enabled). Stable across processes since
-        registration order is deterministic.
+        the usage cache (if enabled), then the two fs-scans buckets (default,
+        filtered). Stable across processes since registration order is
+        deterministic.
         """
         out: List[CacheBase] = [self._flask_adapter, *self._chart_caches]
         try:
@@ -130,12 +131,15 @@ class Caching:
         if usage:
             out.append(usage)
         try:
-            from webapp.disk_scans.cache import get_cache_adapter as get_scans_adapter
-            scans = get_scans_adapter()
+            from webapp.disk_scans.cache import (
+                _BUCKETS, get_cache_adapter as get_scans_adapter,
+            )
+            for bucket in _BUCKETS:
+                scans = get_scans_adapter(bucket)
+                if scans:
+                    out.append(scans)
         except Exception:
-            scans = None
-        if scans:
-            out.append(scans)
+            pass
         return out
 
     def stats(self) -> dict:

--- a/src/webapp/caching/__init__.py
+++ b/src/webapp/caching/__init__.py
@@ -26,7 +26,7 @@ Decorating a chart-generating function::
 Inspecting all caches (used by the admin Configuration card)::
 
     caching.stats()            # → dict for the template
-    caching.clear('chart')     # category in {'flask','chart','usage',None}
+    caching.clear('chart')     # category in {'flask','chart','usage','scans',None}
 """
 
 import logging
@@ -129,12 +129,20 @@ class Caching:
             usage = None
         if usage:
             out.append(usage)
+        try:
+            from webapp.disk_scans.cache import get_cache_adapter as get_scans_adapter
+            scans = get_scans_adapter()
+        except Exception:
+            scans = None
+        if scans:
+            out.append(scans)
         return out
 
     def stats(self) -> dict:
         """Single dict for the admin card. Stable shape, group-by-category."""
         from flask import current_app
         from sam.queries.usage_cache import usage_cache_info
+        from webapp.disk_scans.cache import fs_scans_cache_info
 
         return {
             'backend':         current_app.config.get('CACHE_TYPE'),
@@ -142,6 +150,7 @@ class Caching:
             'flask':           self._flask_adapter.info(),
             'chart':           [c.info() for c in self._chart_caches],
             'usage':           usage_cache_info(),
+            'scans':           fs_scans_cache_info(),
         }
 
     def clear(self, category: Optional[str] = None) -> dict:
@@ -154,6 +163,9 @@ class Caching:
         if category in (None, 'usage'):
             from sam.queries.usage_cache import purge_usage_cache
             result['usage'] = purge_usage_cache()
+        if category in (None, 'scans'):
+            from webapp.disk_scans.cache import purge_fs_scans_cache
+            result['scans'] = purge_fs_scans_cache()
         return result
 
 

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -527,20 +527,58 @@ def generate_user_proj_stacked_area(timeseries, link_kind=None,
 # 1c. Access-time distribution histogram (Filesystem Scans — DISK)
 # ---------------------------------------------------------------------------
 
-def _access_history_cache_key(hist):
-    """Stable key from the per-bucket data/file totals + reference date.
+# Top-N owners drawn as their own stack segment per bar; the rest collapse
+# into one aggregated "other" segment at the base. Matches the table's top-10.
+_AH_TOP_SEGMENTS = 10
 
-    Hashes the bucket order, data and file counts, the snapshot date in the
-    title, and whether each bucket has owners (which governs the bar's
-    drill-down anchor).
+
+def _bucket_segments(owners):
+    """Per-bucket stacked-bar segments, bottom → top.
+
+    Returns a list of segment byte-values ordered as the long-tail "other"
+    aggregate (if any) followed by the top-``_AH_TOP_SEGMENTS`` owners
+    ascending — so the largest owner sits at the top of the bar. Empty list
+    when the bucket has no owners (→ drawn as a single flat bar).
+    """
+    if not owners:
+        return []
+    ranked = sorted((d.get('data', 0) or 0) for d in owners.values())
+    if len(ranked) > _AH_TOP_SEGMENTS:
+        return [sum(ranked[:-_AH_TOP_SEGMENTS])] + ranked[-_AH_TOP_SEGMENTS:]
+    return ranked
+
+
+def _shade_family(base_hex, n, lightest=0.66):
+    """``n`` colors blended from a light tint (index 0) to *base_hex* (index n-1).
+
+    Gives each stacked bar a single-hue gradient: the bottom "other" segment
+    is the palest, the top (largest) owner the boldest base color.
+    """
+    import matplotlib.colors as mcolors
+    base = np.array(mcolors.to_rgb(base_hex))
+    white = np.array([1.0, 1.0, 1.0])
+    if n <= 1:
+        return [tuple(base)]
+    return [
+        tuple(base * (1 - f) + white * f)
+        for j in range(n)
+        for f in (lightest * (1 - j / (n - 1)),)
+    ]
+
+
+def _access_history_cache_key(hist):
+    """Stable key from the per-bucket data/file totals + segment shape + date.
+
+    Hashes the bucket order, file counts, and the exact stacked-bar segment
+    values (top-N owners + "other") plus the snapshot date in the title —
+    everything the rendered SVG depends on.
     """
     labels = list((hist or {}).get('bucket_labels', []))
     buckets = (hist or {}).get('buckets', {})
     payload = [
         (lbl,
-         buckets.get(lbl, {}).get('data', 0),
          buckets.get(lbl, {}).get('files', 0),
-         bool(buckets.get(lbl, {}).get('owners')))
+         tuple(_bucket_segments(buckets.get(lbl, {}).get('owners') or {})))
         for lbl in labels
     ]
     return _content_hash([payload, str((hist or {}).get('reference_scan_date', ''))])
@@ -559,9 +597,11 @@ def generate_access_history_histogram(hist) -> str:
             Bars plot ``data`` (bytes) per bucket; ``files``/``owners`` are
             surfaced in the surrounding table, not the chart.
 
-    Y-axis auto-scales to GiB / TiB / PiB based on the peak bucket. Bars
-    use the Unity 10-color stacked palette in band order (recent → stale).
-    Returns a "no data" placeholder div when the histogram is empty.
+    Y-axis auto-scales to GiB / TiB / PiB based on the peak bucket. Each bar
+    is a single-hue stack: the top owners (largest at top) over an aggregated
+    "other" base, shaded light → dark in that band's Unity color, so the
+    spread between users is legible before clicking. Returns a "no data"
+    placeholder div when the histogram is empty.
     """
     if not hist or not hist.get('bucket_labels'):
         return '<div class="text-center text-muted">No access-history data for this scope</div>'
@@ -581,15 +621,26 @@ def generate_access_history_histogram(hist) -> str:
 
     fig, ax = plt.subplots(figsize=(14, 5))
     colors = [UNITY_STACK_10[i % len(UNITY_STACK_10)] for i in range(len(labels))]
-    bars = ax.bar(range(len(labels)), scaled, color=colors,
-                  edgecolor=UNITY_NCAR_NAVY, linewidth=0.5)
-    # Make each bar a drill-down anchor (#ah-bar-<bucket index>) so a click
-    # expands the matching bucket's per-user detail row — svg-chart-links.js
-    # intercepts the sentinel (mirrors the Usage Trend day-bar pattern). Only
-    # buckets with owners get a link, matching the row's expand toggle.
-    for i, (lbl, rect) in enumerate(zip(labels, bars.patches)):
-        if buckets.get(lbl, {}).get('owners'):
-            rect.set_url(f'#ah-bar-{i}')
+
+    # Each bar is a stack of per-owner segments (bottom "other" + top owners
+    # ascending), shaded within the band's color family. Buckets with owners
+    # also get a drill-down anchor (#ah-bar-<i>) on every segment so a click
+    # anywhere on the bar expands the matching row — svg-chart-links.js
+    # intercepts the sentinel (mirrors the Usage Trend day-bar pattern).
+    for i, lbl in enumerate(labels):
+        owners = buckets.get(lbl, {}).get('owners') or {}
+        segs = [s / scale for s in _bucket_segments(owners)]
+        if not segs:
+            ax.bar(i, scaled[i], color=colors[i],
+                   edgecolor=UNITY_NCAR_NAVY, linewidth=0.5)
+            continue
+        shades = _shade_family(colors[i], len(segs))
+        bottom = 0.0
+        for seg_val, shade in zip(segs, shades):
+            cont = ax.bar(i, seg_val, bottom=bottom, color=shade,
+                          edgecolor='white', linewidth=0.3)
+            cont.patches[0].set_url(f'#ah-bar-{i}')
+            bottom += seg_val
     ax.set_xticks(range(len(labels)))
     ax.set_xticklabels(labels, rotation=30, ha='right')
     ax.set_ylabel(f'Data ({unit_label})')

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -524,7 +524,7 @@ def generate_user_proj_stacked_area(timeseries, link_kind=None,
 
 
 # ---------------------------------------------------------------------------
-# 1c. Access-time distribution histogram (Filesystem Scans — DISK)
+# 1c. Distribution histograms — access-time & file-size (Filesystem Scans — DISK)
 # ---------------------------------------------------------------------------
 
 # Top-N owners drawn as their own stack segment per bar; the rest collapse
@@ -532,17 +532,18 @@ def generate_user_proj_stacked_area(timeseries, link_kind=None,
 _AH_TOP_SEGMENTS = 10
 
 
-def _bucket_segments(owners):
+def _bucket_segments(owners, metric='data'):
     """Per-bucket stacked-bar segments, bottom → top.
 
-    Returns a list of segment byte-values ordered as the long-tail "other"
-    aggregate (if any) followed by the top-``_AH_TOP_SEGMENTS`` owners
-    ascending — so the largest owner sits at the top of the bar. Empty list
-    when the bucket has no owners (→ drawn as a single flat bar).
+    Returns a list of segment values (in *metric* units — ``'data'`` bytes or
+    ``'files'`` counts) ordered as the long-tail "other" aggregate (if any)
+    followed by the top-``_AH_TOP_SEGMENTS`` owners ascending — so the largest
+    owner sits at the top of the bar. Empty list when the bucket has no owners
+    (→ drawn as a single flat bar).
     """
     if not owners:
         return []
-    ranked = sorted((d.get('data', 0) or 0) for d in owners.values())
+    ranked = sorted((d.get(metric, 0) or 0) for d in owners.values())
     if len(ranked) > _AH_TOP_SEGMENTS:
         return [sum(ranked[:-_AH_TOP_SEGMENTS])] + ranked[-_AH_TOP_SEGMENTS:]
     return ranked
@@ -566,84 +567,112 @@ def _shade_family(base_hex, n, lightest=0.66):
     ]
 
 
-def _access_history_cache_key(hist):
-    """Stable key from the per-bucket data/file totals + segment shape + date.
+def _distribution_cache_key(hist, *, log_y=False, metric='data'):
+    """Stable key from the per-bucket totals + segment shape + date + options.
 
-    Hashes the bucket order, file counts, and the exact stacked-bar segment
-    values (top-N owners + "other") plus the snapshot date in the title —
-    everything the rendered SVG depends on.
+    Hashes the bucket order, the exact stacked-bar segment values for the
+    chosen *metric* (top-N owners + "other"), the snapshot date in the title,
+    and the y-scale / metric flags — everything the rendered SVG depends on.
     """
     labels = list((hist or {}).get('bucket_labels', []))
     buckets = (hist or {}).get('buckets', {})
     payload = [
         (lbl,
-         buckets.get(lbl, {}).get('files', 0),
-         tuple(_bucket_segments(buckets.get(lbl, {}).get('owners') or {})))
+         tuple(_bucket_segments(buckets.get(lbl, {}).get('owners') or {}, metric)))
         for lbl in labels
     ]
-    return _content_hash([payload, str((hist or {}).get('reference_scan_date', ''))])
+    return _content_hash(
+        [payload, str((hist or {}).get('reference_scan_date', '')),
+         bool(log_y), str(metric)]
+    )
 
 
-@caching.chart_cached(name='access_history_histogram', maxsize=128,
-                      key_fn=_access_history_cache_key)
-def generate_access_history_histogram(hist) -> str:
-    """Render a bar chart of data volume across access-time buckets.
+@caching.chart_cached(name='distribution_histogram', maxsize=128,
+                      key_fn=_distribution_cache_key)
+def generate_distribution_histogram(hist, *, log_y=False, metric='data') -> str:
+    """Render a stacked bar chart of a metric across distribution buckets.
+
+    Shared by the Access-history and File-size tabs — both consume the same
+    ``{'bucket_labels', 'buckets': {label: {'data','files','owners'}},
+       'reference_scan_date', ...}`` shape (see
+    ``webapp.disk_scans.service.scan_access_history`` /
+    ``scan_file_sizes``). The ``files``/``owners`` detail is surfaced in the
+    surrounding table.
+
+    Each bar is a single-hue stack: the top owners (largest at top) over an
+    aggregated "other" base, shaded light → dark in that band's Unity color,
+    so the spread between users is legible before clicking.
 
     Args:
-        hist: the dict returned by
-            ``webapp.disk_scans.service.scan_access_history`` —
-            ``{'bucket_labels': [...10 bands...],
-               'buckets': {label: {'data', 'files', 'owners'}}, ...}``.
-            Bars plot ``data`` (bytes) per bucket; ``files``/``owners`` are
-            surfaced in the surrounding table, not the chart.
+        metric: ``'data'`` plots bytes per bucket (y-axis auto-scaled to
+            GiB / TiB / PiB); ``'files'`` plots file counts (compact-number
+            y-axis). Per-owner stack segments use the same metric.
+        log_y: use a logarithmic y-axis. A log scale can't represent a stack
+            meaningfully, so this falls back to one solid bar per bucket (the
+            band base color). Useful when bucket totals span many orders of
+            magnitude (file sizes by data), where a linear stack buries small
+            bands.
 
-    Y-axis auto-scales to GiB / TiB / PiB based on the peak bucket. Each bar
-    is a single-hue stack: the top owners (largest at top) over an aggregated
-    "other" base, shaded light → dark in that band's Unity color, so the
-    spread between users is legible before clicking. Returns a "no data"
-    placeholder div when the histogram is empty.
+    Returns a "no data" placeholder div when the histogram is empty.
     """
     if not hist or not hist.get('bucket_labels'):
-        return '<div class="text-center text-muted">No access-history data for this scope</div>'
+        return '<div class="text-center text-muted">No distribution data for this scope</div>'
 
+    is_bytes = (metric != 'files')
     labels = list(hist['bucket_labels'])
     buckets = hist.get('buckets', {})
-    data_vals = [buckets.get(lbl, {}).get('data', 0) or 0 for lbl in labels]
+    vals = [buckets.get(lbl, {}).get(metric, 0) or 0 for lbl in labels]
 
-    peak = max(data_vals) if data_vals else 0
-    if peak >= _BYTES_PER_PIB:
-        scale, unit_label = _BYTES_PER_PIB, 'PiB'
-    elif peak >= _BYTES_PER_TIB:
-        scale, unit_label = _BYTES_PER_TIB, 'TiB'
+    if is_bytes:
+        peak = max(vals) if vals else 0
+        if peak >= _BYTES_PER_PIB:
+            scale, ylabel = _BYTES_PER_PIB, 'Data (PiB)'
+        elif peak >= _BYTES_PER_TIB:
+            scale, ylabel = _BYTES_PER_TIB, 'Data (TiB)'
+        else:
+            scale, ylabel = _BYTES_PER_GIB, 'Data (GiB)'
     else:
-        scale, unit_label = _BYTES_PER_GIB, 'GiB'
-    scaled = [v / scale for v in data_vals]
+        scale, ylabel = 1, 'Files'
+    scaled = [v / scale for v in vals]
 
     fig, ax = plt.subplots(figsize=(14, 5))
     colors = [UNITY_STACK_10[i % len(UNITY_STACK_10)] for i in range(len(labels))]
 
-    # Each bar is a stack of per-owner segments (bottom "other" + top owners
-    # ascending), shaded within the band's color family. Buckets with owners
-    # also get a drill-down anchor (#ah-bar-<i>) on every segment so a click
-    # anywhere on the bar expands the matching row — svg-chart-links.js
-    # intercepts the sentinel (mirrors the Usage Trend day-bar pattern).
-    for i, lbl in enumerate(labels):
-        owners = buckets.get(lbl, {}).get('owners') or {}
-        segs = [s / scale for s in _bucket_segments(owners)]
-        if not segs:
-            ax.bar(i, scaled[i], color=colors[i],
-                   edgecolor=UNITY_NCAR_NAVY, linewidth=0.5)
-            continue
-        shades = _shade_family(colors[i], len(segs))
-        bottom = 0.0
-        for seg_val, shade in zip(segs, shades):
-            cont = ax.bar(i, seg_val, bottom=bottom, color=shade,
-                          edgecolor='white', linewidth=0.3)
-            cont.patches[0].set_url(f'#ah-bar-{i}')
-            bottom += seg_val
+    # Buckets with owners get a drill-down anchor (#ah-bar-<i>) on every
+    # segment so a click anywhere on the bar expands the matching row —
+    # svg-chart-links.js intercepts the sentinel (mirrors the Usage Trend
+    # day-bar pattern) and scopes the lookup to the originating tab pane.
+    if log_y:
+        # Log scale: one solid bar per bucket (stacking is meaningless on a
+        # log axis). Still anchored for drill-down.
+        bars = ax.bar(range(len(labels)), scaled, color=colors,
+                      edgecolor=UNITY_NCAR_NAVY, linewidth=0.5)
+        for i, (lbl, rect) in enumerate(zip(labels, bars.patches)):
+            if buckets.get(lbl, {}).get('owners'):
+                rect.set_url(f'#ah-bar-{i}')
+        ax.set_yscale('log')
+    else:
+        # Linear: stack per-owner segments (bottom "other" + top owners
+        # ascending), shaded within the band's color family.
+        for i, lbl in enumerate(labels):
+            owners = buckets.get(lbl, {}).get('owners') or {}
+            segs = [s / scale for s in _bucket_segments(owners, metric)]
+            if not segs:
+                ax.bar(i, scaled[i], color=colors[i],
+                       edgecolor=UNITY_NCAR_NAVY, linewidth=0.5)
+                continue
+            shades = _shade_family(colors[i], len(segs))
+            bottom = 0.0
+            for seg_val, shade in zip(segs, shades):
+                cont = ax.bar(i, seg_val, bottom=bottom, color=shade,
+                              edgecolor='white', linewidth=0.3)
+                cont.patches[0].set_url(f'#ah-bar-{i}')
+                bottom += seg_val
     ax.set_xticks(range(len(labels)))
     ax.set_xticklabels(labels, rotation=30, ha='right')
-    ax.set_ylabel(f'Data ({unit_label})')
+    ax.set_ylabel(ylabel)
+    if not is_bytes:
+        ax.yaxis.set_major_formatter(fmt.mpl_number_formatter())
     ax.grid(True, axis='y', alpha=0.3)
 
     svg_io = StringIO()

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -530,16 +530,17 @@ def generate_user_proj_stacked_area(timeseries, link_kind=None,
 def _access_history_cache_key(hist):
     """Stable key from the per-bucket data/file totals + reference date.
 
-    Hashes only what the rendered bars depend on (bucket order, data and
-    file counts, and the snapshot date in the title) — not the full
-    per-owner breakdown, which doesn't affect the chart.
+    Hashes the bucket order, data and file counts, the snapshot date in the
+    title, and whether each bucket has owners (which governs the bar's
+    drill-down anchor).
     """
     labels = list((hist or {}).get('bucket_labels', []))
     buckets = (hist or {}).get('buckets', {})
     payload = [
         (lbl,
          buckets.get(lbl, {}).get('data', 0),
-         buckets.get(lbl, {}).get('files', 0))
+         buckets.get(lbl, {}).get('files', 0),
+         bool(buckets.get(lbl, {}).get('owners')))
         for lbl in labels
     ]
     return _content_hash([payload, str((hist or {}).get('reference_scan_date', ''))])
@@ -580,8 +581,15 @@ def generate_access_history_histogram(hist) -> str:
 
     fig, ax = plt.subplots(figsize=(14, 5))
     colors = [UNITY_STACK_10[i % len(UNITY_STACK_10)] for i in range(len(labels))]
-    ax.bar(range(len(labels)), scaled, color=colors,
-           edgecolor=UNITY_NCAR_NAVY, linewidth=0.5)
+    bars = ax.bar(range(len(labels)), scaled, color=colors,
+                  edgecolor=UNITY_NCAR_NAVY, linewidth=0.5)
+    # Make each bar a drill-down anchor (#ah-bar-<bucket index>) so a click
+    # expands the matching bucket's per-user detail row — svg-chart-links.js
+    # intercepts the sentinel (mirrors the Usage Trend day-bar pattern). Only
+    # buckets with owners get a link, matching the row's expand toggle.
+    for i, (lbl, rect) in enumerate(zip(labels, bars.patches)):
+        if buckets.get(lbl, {}).get('owners'):
+            rect.set_url(f'#ah-bar-{i}')
     ax.set_xticks(range(len(labels)))
     ax.set_xticklabels(labels, rotation=30, ha='right')
     ax.set_ylabel(f'Data ({unit_label})')

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -281,6 +281,7 @@ def generate_usage_timeseries_matplotlib(daily_data, link_to_day_rows=False,
 # 1b. Disk usage stacked-area chart (Resource Usage Details — DISK)
 # ---------------------------------------------------------------------------
 
+_BYTES_PER_GIB = 1024 ** 3
 _BYTES_PER_TIB = 1024 ** 4
 _BYTES_PER_PIB = 1024 ** 5
 
@@ -515,6 +516,76 @@ def generate_user_proj_stacked_area(timeseries, link_kind=None,
             text.set_url(url)
 
     fig.autofmt_xdate()
+
+    svg_io = StringIO()
+    fig.savefig(svg_io, format='svg', bbox_inches='tight', transparent=True)
+    plt.close(fig)
+    return svg_io.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# 1c. Access-time distribution histogram (Filesystem Scans — DISK)
+# ---------------------------------------------------------------------------
+
+def _access_history_cache_key(hist):
+    """Stable key from the per-bucket data/file totals + reference date.
+
+    Hashes only what the rendered bars depend on (bucket order, data and
+    file counts, and the snapshot date in the title) — not the full
+    per-owner breakdown, which doesn't affect the chart.
+    """
+    labels = list((hist or {}).get('bucket_labels', []))
+    buckets = (hist or {}).get('buckets', {})
+    payload = [
+        (lbl,
+         buckets.get(lbl, {}).get('data', 0),
+         buckets.get(lbl, {}).get('files', 0))
+        for lbl in labels
+    ]
+    return _content_hash([payload, str((hist or {}).get('reference_scan_date', ''))])
+
+
+@caching.chart_cached(name='access_history_histogram', maxsize=128,
+                      key_fn=_access_history_cache_key)
+def generate_access_history_histogram(hist) -> str:
+    """Render a bar chart of data volume across access-time buckets.
+
+    Args:
+        hist: the dict returned by
+            ``webapp.disk_scans.service.scan_access_history`` —
+            ``{'bucket_labels': [...10 bands...],
+               'buckets': {label: {'data', 'files', 'owners'}}, ...}``.
+            Bars plot ``data`` (bytes) per bucket; ``files``/``owners`` are
+            surfaced in the surrounding table, not the chart.
+
+    Y-axis auto-scales to GiB / TiB / PiB based on the peak bucket. Bars
+    use the Unity 10-color stacked palette in band order (recent → stale).
+    Returns a "no data" placeholder div when the histogram is empty.
+    """
+    if not hist or not hist.get('bucket_labels'):
+        return '<div class="text-center text-muted">No access-history data for this scope</div>'
+
+    labels = list(hist['bucket_labels'])
+    buckets = hist.get('buckets', {})
+    data_vals = [buckets.get(lbl, {}).get('data', 0) or 0 for lbl in labels]
+
+    peak = max(data_vals) if data_vals else 0
+    if peak >= _BYTES_PER_PIB:
+        scale, unit_label = _BYTES_PER_PIB, 'PiB'
+    elif peak >= _BYTES_PER_TIB:
+        scale, unit_label = _BYTES_PER_TIB, 'TiB'
+    else:
+        scale, unit_label = _BYTES_PER_GIB, 'GiB'
+    scaled = [v / scale for v in data_vals]
+
+    fig, ax = plt.subplots(figsize=(14, 5))
+    colors = [UNITY_STACK_10[i % len(UNITY_STACK_10)] for i in range(len(labels))]
+    ax.bar(range(len(labels)), scaled, color=colors,
+           edgecolor=UNITY_NCAR_NAVY, linewidth=0.5)
+    ax.set_xticks(range(len(labels)))
+    ax.set_xticklabels(labels, rotation=30, ha='right')
+    ax.set_ylabel(f'Data ({unit_label})')
+    ax.grid(True, axis='y', alpha=0.3)
 
     svg_io = StringIO()
     fig.savefig(svg_io, format='svg', bbox_inches='tight', transparent=True)

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -7,7 +7,7 @@ Refactored to use server-side rendering with direct ORM queries instead of
 JavaScript API calls for improved performance and simplicity.
 """
 
-from flask import Blueprint, abort, render_template, request, flash, redirect, url_for, session, jsonify, make_response
+from flask import Blueprint, abort, render_template, request, flash, redirect, url_for, session, jsonify, make_response, current_app
 from flask_login import login_required, current_user
 from datetime import datetime, date, timedelta
 from marshmallow import ValidationError
@@ -49,6 +49,8 @@ from webapp.api.access_control import (
     require_threshold_edit,
 )
 from ..charts import generate_usage_timeseries_matplotlib, generate_disk_usage_stacked_area
+from webapp.disk_scans import is_enabled as is_fs_scans_enabled
+from webapp.disk_scans.scope import resolve_scan_scope
 
 
 bp = Blueprint('user_dashboard', __name__, url_prefix='/user')
@@ -978,6 +980,31 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
                 (r['bytes'] / used_bytes * 100) if used_bytes > 0 else 0.0,
         } for r in breakdown]
 
+    # Filesystem Scans card visibility: only when the fs-scans plugin is
+    # loaded AND the viewed resource resolves to a live scan collection
+    # (Campaign_Store today; Destor later). resolve_scan_scope is in-memory
+    # string work over the disk subtree — cheap. Scoped to the page's
+    # current ?scope= node so the card hides when a child scope owns no
+    # scannable dirs even if the root project does.
+    show_scans = False
+    if is_fs_scans_enabled():
+        # `scope` was already validated to be in this project's tree (or
+        # reset to the root projcode), so a non-root scope is a known code.
+        scope_project = (
+            project if scope == project.projcode
+            else Project.get_by_projcode(db.session, scope)
+        )
+        try:
+            _, _scan_collections = resolve_scan_scope(
+                db.session, scope_project, resource_name,
+            )
+            show_scans = bool(_scan_collections)
+        except Exception:
+            current_app.logger.exception(
+                'disk scans: scope resolution failed for project=%s resource=%s',
+                scope_node['projcode'], resource_name,
+            )
+
     percent_used = (used_tib / allocated_tib * 100) if allocated_tib > 0 else 0.0
     # Operators (VIEW_USERS) get clickable legend usernames that pop the
     # user-details modal; non-operators get plain text since the modal
@@ -1003,6 +1030,7 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
         start_date=start_date.strftime('%Y-%m-%d'),
         end_date=end_date.strftime('%Y-%m-%d'),
         usage_chart=usage_chart,
+        show_scans=show_scans,
         capacity={
             'allocated_tib':  allocated_tib,
             'used_tib':       used_tib,

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -50,7 +50,7 @@ from webapp.api.access_control import (
 )
 from ..charts import generate_usage_timeseries_matplotlib, generate_disk_usage_stacked_area
 from webapp.disk_scans import is_enabled as is_fs_scans_enabled
-from webapp.disk_scans.scope import resolve_scan_scope
+from webapp.disk_scans import service as disk_scans_service
 
 
 bp = Blueprint('user_dashboard', __name__, url_prefix='/user')
@@ -980,13 +980,14 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
                 (r['bytes'] / used_bytes * 100) if used_bytes > 0 else 0.0,
         } for r in breakdown]
 
-    # Filesystem Scans card visibility: only when the fs-scans plugin is
-    # loaded AND the viewed resource resolves to a live scan collection
-    # (Campaign_Store today; Destor later). resolve_scan_scope is in-memory
-    # string work over the disk subtree — cheap. Scoped to the page's
-    # current ?scope= node so the card hides when a child scope owns no
+    # Filesystem Scans card: shown only when the fs-scans plugin is loaded
+    # AND the viewed resource resolves to a live scan collection
+    # (Campaign_Store today; Destor later). One scoped call also yields the
+    # per-collection scan dates for the header freshness badge. Scoped to the
+    # page's current ?scope= node so the card hides when a child scope owns no
     # scannable dirs even if the root project does.
     show_scans = False
+    scan_info = None
     if is_fs_scans_enabled():
         # `scope` was already validated to be in this project's tree (or
         # reset to the root projcode), so a non-root scope is a known code.
@@ -995,10 +996,10 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
             else Project.get_by_projcode(db.session, scope)
         )
         try:
-            _, _scan_collections = resolve_scan_scope(
+            scan_info = disk_scans_service.scan_overview(
                 db.session, scope_project, resource_name,
             )
-            show_scans = bool(_scan_collections)
+            show_scans = bool(scan_info['collections'])
         except Exception:
             current_app.logger.exception(
                 'disk scans: scope resolution failed for project=%s resource=%s',
@@ -1031,6 +1032,7 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
         end_date=end_date.strftime('%Y-%m-%d'),
         usage_chart=usage_chart,
         show_scans=show_scans,
+        scan_info=scan_info,
         capacity={
             'allocated_tib':  allocated_tib,
             'used_tib':       used_tib,

--- a/src/webapp/disk_scans/cache.py
+++ b/src/webapp/disk_scans/cache.py
@@ -17,11 +17,29 @@ adapter shared across gunicorn workers when ``CACHE_REDIS_URL`` is set,
 falling back to a per-worker in-process TTL cache otherwise. Registered
 with the ``webapp.caching`` facade so it appears in Admin → Configuration.
 
-Config (Flask app.config or env; 0 disables):
-  FS_SCANS_CACHE_TTL   — TTL seconds (default 691200 = 8 days, a memory
-                         backstop slightly longer than the weekly refresh;
-                         correctness comes from the scan-date key, not TTL)
-  FS_SCANS_CACHE_SIZE  — max LRU entries (default 256)
+Two buckets share this mechanism, differing only in name / size / TTL:
+
+  * ``default`` (``fs_scans``) — passive/landing + tab-pill queries
+    (no-filter + sort_by + limit). High reuse, long-lived.
+  * ``filtered`` (``fs_scans_filtered``) — the explorer's owner / date /
+    leaves-only permutations. Short TTL so the volatile permutations stay a
+    small, transient footprint and self-expire rather than crowding the
+    long-lived default entries. (A *soft* protection: ``allkeys-lru`` is
+    instance-global, so under genuine Redis memory pressure a filtered write
+    could still evict a default entry — the short TTL just keeps that window
+    small. Chosen over an off-Redis bucket to keep cross-worker sharing.)
+
+The service picks ``bucket='filtered'`` whenever any of owner_uid /
+accessed_before / accessed_after / leaves_only is set, else ``'default'``.
+
+Config (Flask app.config or env; 0 disables the corresponding bucket):
+  FS_SCANS_CACHE_TTL            — default TTL seconds (default 691200 = 8 days,
+                                  a memory backstop slightly longer than the
+                                  weekly refresh; correctness comes from the
+                                  scan-date key, not TTL)
+  FS_SCANS_CACHE_SIZE           — default max LRU entries (default 256)
+  FS_SCANS_FILTERED_CACHE_TTL   — filtered TTL seconds (default 1800 = 30 min)
+  FS_SCANS_FILTERED_CACHE_SIZE  — filtered max LRU entries (default 128)
 
 Key shape (hashable tuple):
   (query_type, collections, path_prefixes, opts, scan_date_signature)
@@ -62,43 +80,61 @@ def _norm(value: Any):
 
 
 # ---------------------------------------------------------------------------
-# Lazy-initialised adapter (Redis shared / in-process fallback)
+# Lazy-initialised adapters (Redis shared / in-process fallback), one per bucket
 # ---------------------------------------------------------------------------
 
-_adapter: Optional[CacheBase] = None
+# Bucket specs: name shown in the Admin card + the (config_key, default) pairs
+# for TTL and size. Both buckets use the same backend, differing only here.
+_BUCKETS: Dict[str, Dict[str, Any]] = {
+    'default': {
+        'name': 'fs_scans',
+        'ttl':  ('FS_SCANS_CACHE_TTL', 691200),   # 8 days
+        'size': ('FS_SCANS_CACHE_SIZE', 256),
+    },
+    'filtered': {
+        'name': 'fs_scans_filtered',
+        'ttl':  ('FS_SCANS_FILTERED_CACHE_TTL', 1800),   # 30 minutes
+        'size': ('FS_SCANS_FILTERED_CACHE_SIZE', 128),
+    },
+}
+
+# bucket -> adapter once initialised; a stored ``None`` means "initialised but
+# disabled by config" (so we don't re-probe on every call).
+_adapters: Dict[str, Optional[CacheBase]] = {}
 _init_lock = threading.RLock()
-_disabled = False
 
 
-def get_cache_adapter() -> Optional[CacheBase]:
-    """Return the shared CacheBase adapter, initialising on first call.
+def get_cache_adapter(bucket: str = 'default') -> Optional[CacheBase]:
+    """Return the shared CacheBase adapter for *bucket*, init on first call.
 
-    Returns ``None`` when disabled by config (TTL or SIZE == 0). Backend
-    mirrors ``usage_cache``: ``RedisTTLAdapter`` when ``CACHE_REDIS_URL`` is
-    reachable (all workers share one cache), else a per-worker
+    Returns ``None`` when that bucket is disabled by config (TTL or SIZE == 0).
+    Backend mirrors ``usage_cache``: ``RedisTTLAdapter`` when ``CACHE_REDIS_URL``
+    is reachable (all workers share one cache), else a per-worker
     ``TTLCacheAdapter``.
     """
-    global _adapter, _disabled
+    spec = _BUCKETS[bucket]
 
     with _init_lock:
-        if _adapter is not None or _disabled:
-            return None if _disabled else _adapter
+        if bucket in _adapters:
+            return _adapters[bucket]
 
-        ttl  = _get_config('FS_SCANS_CACHE_TTL', 691200)
-        size = _get_config('FS_SCANS_CACHE_SIZE', 256)
+        ttl  = _get_config(*spec['ttl'])
+        size = _get_config(*spec['size'])
         if ttl <= 0 or size <= 0:
-            _disabled = True
+            _adapters[bucket] = None
             return None
 
+        name = spec['name']
         redis_url = os.environ.get('CACHE_REDIS_URL')
         if redis_url:
             try:
                 client = make_redis_client(redis_url)
                 if client is not None:
-                    _adapter = RedisTTLAdapter(
-                        name='fs_scans', client=client, ttl=ttl, maxsize=size,
+                    adapter = RedisTTLAdapter(
+                        name=name, client=client, ttl=ttl, maxsize=size,
                     )
-                    return _adapter
+                    _adapters[bucket] = adapter
+                    return adapter
             except Exception as exc:
                 logger.warning(
                     "fs_scans cache: CACHE_REDIS_URL=%s set but unreachable (%s); "
@@ -106,8 +142,9 @@ def get_cache_adapter() -> Optional[CacheBase]:
                     redis_url, exc,
                 )
 
-        _adapter = TTLCacheAdapter(name='fs_scans', maxsize=size, ttl=ttl)
-        return _adapter
+        adapter = TTLCacheAdapter(name=name, maxsize=size, ttl=ttl)
+        _adapters[bucket] = adapter
+        return adapter
 
 
 def _scan_date_signature(q, collections) -> Optional[Tuple]:
@@ -134,6 +171,7 @@ def cached_scan(
     path_prefixes: List[str],
     opts: Dict[str, Any],
     compute: Callable[[], Any],
+    bucket: str = 'default',
 ) -> Any:
     """Return a cached scan result or compute + store it.
 
@@ -141,8 +179,12 @@ def cached_scan(
     with resolved usernames already attached), so a cache hit reproduces it
     exactly without re-querying. The cache is keyed on the resolved scope +
     *opts* + the per-collection scan dates.
+
+    *bucket* selects which adapter stores the entry — ``'filtered'`` for the
+    short-TTL explorer permutations, ``'default'`` (the passive/landing path)
+    otherwise.
     """
-    adapter = get_cache_adapter()
+    adapter = get_cache_adapter(bucket)
     if adapter is None:
         return compute()
 
@@ -179,16 +221,29 @@ def cached_scan(
 # ---------------------------------------------------------------------------
 
 def purge_fs_scans_cache() -> int:
-    """Clear all cached scan results. Returns the number of entries cleared."""
-    adapter = get_cache_adapter()
-    return adapter.clear() if adapter is not None else 0
+    """Clear every scan-cache bucket. Returns the total entries cleared."""
+    total = 0
+    for bucket in _BUCKETS:
+        adapter = get_cache_adapter(bucket)
+        if adapter is not None:
+            total += adapter.clear()
+    return total
 
 
-def fs_scans_cache_info() -> Dict:
-    """Uniform CacheBase ``info()`` dict for the Admin → Configuration card."""
-    adapter = get_cache_adapter()
-    if adapter is None:
-        ttl  = _get_config('FS_SCANS_CACHE_TTL', 691200)
-        size = _get_config('FS_SCANS_CACHE_SIZE', 256)
-        return disabled_info('fs_scans', maxsize=size, ttl=ttl)
-    return adapter.info()
+def fs_scans_cache_info() -> List[Dict]:
+    """One uniform CacheBase ``info()`` dict per bucket, for the Admin card.
+
+    Returns a list (default bucket first) so the Configuration card can loop
+    and surface each bucket's TTL — making the 30-min explorer TTL visible
+    alongside the 8-day default.
+    """
+    infos: List[Dict] = []
+    for bucket, spec in _BUCKETS.items():
+        adapter = get_cache_adapter(bucket)
+        if adapter is None:
+            ttl  = _get_config(*spec['ttl'])
+            size = _get_config(*spec['size'])
+            infos.append(disabled_info(spec['name'], maxsize=size, ttl=ttl))
+        else:
+            infos.append(adapter.info())
+    return infos

--- a/src/webapp/disk_scans/cache.py
+++ b/src/webapp/disk_scans/cache.py
@@ -1,0 +1,194 @@
+"""Scan-date-keyed cache for the slow fs-scans service queries.
+
+Filesystem scans refresh ~weekly, so a query's result is valid until the
+collection is re-scanned. We exploit that: every cache key embeds the
+per-collection scan dates, so when a new scan lands the key changes and
+the stale entry is simply never read again (and TTL-evicted later). No
+manual flush, no stale-data window — invalidation is content-addressed.
+
+Why this matters: a project whose directories include a *sub-path* of a
+collection (e.g. ``/ncar/USGS_Water``) takes the on-the-fly path, which is
+30-120s for the large collections (see the per-collection fast-path notes
+in ``facade.py``). Whole-collection-root projects hit the pre-computed
+tables and are sub-second — caching them is cheap insurance, not the win.
+
+Mirrors ``sam.queries.usage_cache``: a lazily-initialised, Redis-backed
+adapter shared across gunicorn workers when ``CACHE_REDIS_URL`` is set,
+falling back to a per-worker in-process TTL cache otherwise. Registered
+with the ``webapp.caching`` facade so it appears in Admin → Configuration.
+
+Config (Flask app.config or env; 0 disables):
+  FS_SCANS_CACHE_TTL   — TTL seconds (default 691200 = 8 days, a memory
+                         backstop slightly longer than the weekly refresh;
+                         correctness comes from the scan-date key, not TTL)
+  FS_SCANS_CACHE_SIZE  — max LRU entries (default 256)
+
+Key shape (hashable tuple):
+  (query_type, collections, path_prefixes, opts, scan_date_signature)
+``opts`` carries every query parameter NOT already captured by the resolved
+scope — sort_by/limit/owner_uid today, and any Phase-3 filter kwargs
+(owner, leaves-only, accessed-before, …) automatically as they're added to
+the call. The default (no-filter) path is just ``opts`` at its defaults, so
+one mechanism caches both the default and any filter selection.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from sam.caching import CacheBase, RedisTTLAdapter, TTLCacheAdapter, make_redis_client
+from sam.caching.ttl import disabled_info
+
+logger = logging.getLogger(__name__)
+
+
+def _get_config(key: str, default: int) -> int:
+    """Read config from Flask app context if available, else env, else default."""
+    try:
+        from flask import current_app
+        return int(current_app.config.get(key, default))
+    except RuntimeError:
+        return int(os.environ.get(key, default))
+
+
+def _norm(value: Any):
+    """Make list values hashable for use as a key component."""
+    if isinstance(value, list):
+        return tuple(sorted(str(v) for v in value))
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Lazy-initialised adapter (Redis shared / in-process fallback)
+# ---------------------------------------------------------------------------
+
+_adapter: Optional[CacheBase] = None
+_init_lock = threading.RLock()
+_disabled = False
+
+
+def get_cache_adapter() -> Optional[CacheBase]:
+    """Return the shared CacheBase adapter, initialising on first call.
+
+    Returns ``None`` when disabled by config (TTL or SIZE == 0). Backend
+    mirrors ``usage_cache``: ``RedisTTLAdapter`` when ``CACHE_REDIS_URL`` is
+    reachable (all workers share one cache), else a per-worker
+    ``TTLCacheAdapter``.
+    """
+    global _adapter, _disabled
+
+    with _init_lock:
+        if _adapter is not None or _disabled:
+            return None if _disabled else _adapter
+
+        ttl  = _get_config('FS_SCANS_CACHE_TTL', 691200)
+        size = _get_config('FS_SCANS_CACHE_SIZE', 256)
+        if ttl <= 0 or size <= 0:
+            _disabled = True
+            return None
+
+        redis_url = os.environ.get('CACHE_REDIS_URL')
+        if redis_url:
+            try:
+                client = make_redis_client(redis_url)
+                if client is not None:
+                    _adapter = RedisTTLAdapter(
+                        name='fs_scans', client=client, ttl=ttl, maxsize=size,
+                    )
+                    return _adapter
+            except Exception as exc:
+                logger.warning(
+                    "fs_scans cache: CACHE_REDIS_URL=%s set but unreachable (%s); "
+                    "falling back to per-worker TTLCacheAdapter.",
+                    redis_url, exc,
+                )
+
+        _adapter = TTLCacheAdapter(name='fs_scans', maxsize=size, ttl=ttl)
+        return _adapter
+
+
+def _scan_date_signature(q, collections) -> Optional[Tuple]:
+    """Per-collection latest scan date, for the cache key.
+
+    Returns ``None`` (→ skip caching) when no collection has a scan date —
+    we can't key on freshness we don't have. Otherwise a sorted tuple of
+    ``(collection, iso-date-or-None)``: when ANY collection is re-scanned
+    the signature changes, busting every entry that depended on it.
+    """
+    sig = []
+    for c in sorted(collections):
+        dates = q.scan_dates(filesystems=[c])
+        sig.append((c, max(dates).isoformat() if dates else None))
+    if all(d is None for _, d in sig):
+        return None
+    return tuple(sig)
+
+
+def cached_scan(
+    query_type: str,
+    q,
+    collections: List[str],
+    path_prefixes: List[str],
+    opts: Dict[str, Any],
+    compute: Callable[[], Any],
+) -> Any:
+    """Return a cached scan result or compute + store it.
+
+    *compute* must produce the FINAL caller-facing result (e.g. owner rows
+    with resolved usernames already attached), so a cache hit reproduces it
+    exactly without re-querying. The cache is keyed on the resolved scope +
+    *opts* + the per-collection scan dates.
+    """
+    adapter = get_cache_adapter()
+    if adapter is None:
+        return compute()
+
+    sig = _scan_date_signature(q, collections)
+    if sig is None:
+        return compute()  # no scan dates to key on — don't cache
+
+    key = (
+        query_type,
+        tuple(sorted(collections)),
+        tuple(sorted(path_prefixes)),
+        tuple(sorted((k, _norm(v)) for k, v in opts.items())),
+        sig,
+    )
+
+    with adapter.lock:
+        if key in adapter:
+            return adapter[key]
+        adapter.pop(key, None)
+
+    result = compute()
+
+    with adapter.lock:
+        try:
+            adapter[key] = result
+        except ValueError:
+            # Cache full and no expired entries to evict — skip the store.
+            pass
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Admin / facade hooks
+# ---------------------------------------------------------------------------
+
+def purge_fs_scans_cache() -> int:
+    """Clear all cached scan results. Returns the number of entries cleared."""
+    adapter = get_cache_adapter()
+    return adapter.clear() if adapter is not None else 0
+
+
+def fs_scans_cache_info() -> Dict:
+    """Uniform CacheBase ``info()`` dict for the Admin → Configuration card."""
+    adapter = get_cache_adapter()
+    if adapter is None:
+        ttl  = _get_config('FS_SCANS_CACHE_TTL', 691200)
+        size = _get_config('FS_SCANS_CACHE_SIZE', 256)
+        return disabled_info('fs_scans', maxsize=size, ttl=ttl)
+    return adapter.info()

--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -28,17 +28,21 @@ today). Like ``jobs_fragment``, a plugin/DB hiccup degrades to an inline
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Optional, Tuple
+from urllib.parse import urlencode
 
 from flask import Blueprint, current_app, render_template, request, url_for
 from flask_login import login_required
 
+from sam.core.users import User
 from sam.projects.projects import Project
 from webapp.api.access_control import require_project_access
 from webapp.dashboards.charts import generate_distribution_histogram
 from webapp.disk_scans import service
 from webapp.disk_scans.session import is_enabled
 from webapp.extensions import db
+from webapp.utils.rbac import Permission, require_permission
 
 bp = Blueprint('disk_scans', __name__)
 
@@ -52,6 +56,8 @@ _DEFAULT_DIR_SORT = 'size'
 
 _DEFAULT_LIMIT = 50
 _MAX_LIMIT = 500
+# Row-count choices offered by the explorer page's limit selector.
+_LIMIT_OPTIONS = (50, 100, 250, 500)
 
 
 def _scope_project(project) -> Project:
@@ -100,46 +106,266 @@ def _limit() -> int:
     return max(1, min(n, _MAX_LIMIT))
 
 
-@bp.route('/<projcode>/directories')
-@login_required
-@require_project_access
-def directories_fragment(project):
-    """HTMX fragment: largest directories for *project* (sortable)."""
-    ctx = _common_ctx(project)
-    if not is_enabled() or not ctx['resource_name']:
-        return render_template(
-            'dashboards/user/partials/disk_scans_directories.html',
-            rows=[], sort={'sort_by': _DEFAULT_DIR_SORT},
-            sortable_columns=sorted(_DIR_SORT_WHITELIST),
-            fragment_url=url_for('disk_scans.directories_fragment',
-                                 projcode=project.projcode),
-            enabled=is_enabled(), error=None, **ctx,
-        )
+def _truthy(v) -> bool:
+    return (v or '').strip().lower() in ('1', 'true', 'on', 'yes')
 
+
+def _query_date(name: str) -> Optional[datetime]:
+    """Parse a ``?<name>=YYYY-MM-DD`` query arg to a datetime (or ``None``).
+
+    GET-only filter parsing — the forms-schema rule is for POST/PUT mutations;
+    here we mirror the lightweight ``request.args`` coercion already used for
+    ``owner_uid``/``leaves_only`` and the ``?metric=``/``?log=`` toggles.
+    """
+    raw = (request.args.get(name) or '').strip()
+    if not raw:
+        return None
+    try:
+        return datetime.strptime(raw, '%Y-%m-%d')
+    except ValueError:
+        return None
+
+
+def _dir_filters() -> dict:
+    """Parse the shared Large-directories filter params (GET, whitelisted).
+
+    Used by all four directory routes. Carries both the service-ready values
+    (``sort_by/limit/owner_uid/leaves_only`` + parsed ``accessed_before/after``
+    datetimes) and the raw date strings (``*_str``) the hidden form / filter
+    panel echo back so a sort re-fetch or page reload preserves them.
+    """
     sort_by = request.args.get('sort_by') or _DEFAULT_DIR_SORT
     if sort_by not in _DIR_SORT_WHITELIST:
         sort_by = _DEFAULT_DIR_SORT
 
+    owner_uid, owner_user_id, owner_label = _resolve_owner()
+
+    return {
+        'sort_by': sort_by,
+        'limit': _limit(),
+        'owner_uid': owner_uid,
+        'owner_user_id': owner_user_id,
+        'owner_label': owner_label,
+        'accessed_before': _query_date('accessed_before'),
+        'accessed_after': _query_date('accessed_after'),
+        'accessed_before_str': (request.args.get('accessed_before') or '').strip(),
+        'accessed_after_str': (request.args.get('accessed_after') or '').strip(),
+        'leaves_only': _truthy(request.args.get('leaves_only')),
+    }
+
+
+def _resolve_owner() -> Tuple[Optional[int], Optional[int], str]:
+    """Resolve the owner filter to ``(owner_uid, owner_user_id, label)``.
+
+    Two entry points feed the same filter: the per-user drill-down passes a
+    unix ``?owner_uid=`` directly, while the filter-panel user picker (the
+    shared ``fk_search_field``, which stores a SAM ``user_id``) passes
+    ``?owner_user_id=``. ``owner_uid`` is the canonical wire param the fragment
+    echoes back across sort re-fetches, so it wins when both are present. The
+    label (``"Display Name (username)"``) repopulates the picker badge / chip
+    on reload and is best-effort — an unresolved UID just shows numerically.
+    """
+    owner_uid = request.args.get('owner_uid', type=int)
+    owner_user_id = request.args.get('owner_user_id', type=int)
+    user = None
+    if owner_user_id is not None:
+        user = db.session.get(User, owner_user_id)
+        if user is not None and owner_uid is None:
+            owner_uid = user.unix_uid
+    if user is None and owner_uid is not None:
+        user = db.session.query(User).filter_by(unix_uid=owner_uid).first()
+    label = f'{user.display_name} ({user.username})' if user is not None else ''
+    return owner_uid, owner_user_id, label
+
+
+def _user_search_url() -> str:
+    """The fk-picker search endpoint for the owner user picker (context='fk')."""
+    return url_for('admin_dashboard.htmx_search_users', context='fk')
+
+
+def _initial_fragment_url(fragment_url: str, ctx: dict, flt: dict) -> str:
+    """Fragment URL pre-loaded by the explorer page (carries current filters).
+
+    The page's table container ``hx-get``s this on load so a deep-link / reload
+    lands on the same filtered view the panel shows. Subsequent panel submits
+    and in-table sorts re-fetch via ``hx-include`` of the live forms.
+    """
+    params = {
+        'resource': ctx['resource_name'],
+        'target_id': ctx['target_id'],
+        'sort_by': flt['sort_by'],
+        'limit': flt['limit'],
+    }
+    if ctx.get('scope'):
+        params['scope'] = ctx['scope']
+    if ctx.get('fileset'):
+        params['fileset'] = ctx['fileset']
+    if flt['owner_uid'] is not None:
+        params['owner_uid'] = flt['owner_uid']
+    if flt['leaves_only']:
+        params['leaves_only'] = '1'
+    if flt['accessed_before_str']:
+        params['accessed_before'] = flt['accessed_before_str']
+    if flt['accessed_after_str']:
+        params['accessed_after'] = flt['accessed_after_str']
+    return f'{fragment_url}?{urlencode(params)}'
+
+
+def _resource_ctx(resource_name: str) -> dict:
+    """``_common_ctx`` analogue for resource mode (no project scoping).
+
+    Resource mode browses the whole resource, so there is no project /
+    scoped_project and ``scope`` is empty; the fragment template treats those
+    as optional. ``fileset`` still drills into a single collection sub-path.
+    """
+    fileset = (request.args.get('fileset') or '').strip() or None
+    target_id = (request.args.get('target_id') or '').strip() or 'disk-scans-explore'
+    return {
+        'project': None,
+        'scoped_project': None,
+        'resource_name': resource_name,
+        'scope': '',
+        'fileset': fileset,
+        'target_id': target_id,
+    }
+
+
+def _render_directories_fragment(ctx, fragment_url, *, mode, scan_call, log_label):
+    """Shared body for the project + resource directory fragments.
+
+    Both render the *same* ``disk_scans_directories.html`` partial; they differ
+    only in scope context, which fragment URL the sort pill / headers re-fetch,
+    and the (already scope-resolved) ``scan_call``. A plugin/DB hiccup degrades
+    to an inline error banner, never a 500.
+    """
+    flt = _dir_filters()
+    base = dict(
+        sort={'sort_by': flt['sort_by']},
+        sortable_columns=sorted(_DIR_SORT_WHITELIST),
+        fragment_url=fragment_url, filters=flt, mode=mode, **ctx,
+    )
+    if not is_enabled() or not ctx['resource_name']:
+        return render_template(
+            'dashboards/user/partials/disk_scans_directories.html',
+            rows=[], enabled=is_enabled(), error=None, **base,
+        )
+
     rows, error = [], None
     try:
-        rows = service.scan_directories(
-            db.session, ctx['scoped_project'], ctx['resource_name'],
-            sort_by=sort_by, limit=_limit(), subpath=ctx['fileset'],
-        )
+        rows = scan_call(flt)
     except Exception as exc:
         current_app.logger.exception(
-            'disk_scans.directories: scan failed for project=%s resource=%s',
-            ctx['scoped_project'].projcode, ctx['resource_name'],
+            'disk_scans.directories(%s): scan failed for %s resource=%s',
+            mode, log_label, ctx['resource_name'],
         )
         error = str(exc)
 
     return render_template(
         'dashboards/user/partials/disk_scans_directories.html',
-        rows=rows, sort={'sort_by': sort_by},
-        sortable_columns=sorted(_DIR_SORT_WHITELIST),
-        fragment_url=url_for('disk_scans.directories_fragment',
-                             projcode=project.projcode),
-        enabled=True, error=error, **ctx,
+        rows=rows, enabled=True, error=error, **base,
+    )
+
+
+@bp.route('/<projcode>/directories')
+@login_required
+@require_project_access
+def directories_fragment(project):
+    """HTMX fragment: largest directories for *project* (sortable, filterable)."""
+    ctx = _common_ctx(project)
+    fragment_url = url_for('disk_scans.directories_fragment',
+                           projcode=project.projcode)
+
+    def _scan(flt):
+        return service.scan_directories(
+            db.session, ctx['scoped_project'], ctx['resource_name'],
+            sort_by=flt['sort_by'], limit=flt['limit'],
+            owner_uid=flt['owner_uid'],
+            accessed_before=flt['accessed_before'],
+            accessed_after=flt['accessed_after'],
+            leaves_only=flt['leaves_only'],
+            subpath=ctx['fileset'],
+        )
+
+    return _render_directories_fragment(
+        ctx, fragment_url, mode='project', scan_call=_scan,
+        log_label=f"project={ctx['scoped_project'].projcode}",
+    )
+
+
+@bp.route('/<projcode>/directories/explore')
+@login_required
+@require_project_access
+def directories_page(project):
+    """Standalone full-page directory explorer for *project* (project mode).
+
+    Renders the filters panel + a table container that lazy-loads
+    ``directories_fragment`` with the panel's params. The reusable fragment is
+    shared verbatim with resource mode; only the header + fragment URL differ.
+    """
+    ctx = _common_ctx(project)
+    ctx['target_id'] = ctx['target_id'] or 'disk-scans-explore'
+    flt = _dir_filters()
+    fragment_url = url_for('disk_scans.directories_fragment',
+                           projcode=project.projcode)
+    return render_template(
+        'dashboards/user/disk_scans_directories_page.html',
+        mode='project', fragment_url=fragment_url,
+        initial_url=_initial_fragment_url(fragment_url, ctx, flt),
+        filters=flt, user_search_url=_user_search_url(),
+        limit_options=_LIMIT_OPTIONS, **ctx,
+    )
+
+
+@bp.route('/resource/<resource>/directories')
+@login_required
+@require_permission(Permission.VIEW_ALL_FILESYSTEM_DATA)
+def directories_resource_fragment(resource):
+    """HTMX fragment: largest directories across an ENTIRE disk resource.
+
+    Resource mode — unscoped, elevated. Gated by ``VIEW_ALL_FILESYSTEM_DATA``
+    at the route (not just the template link), since it exposes every user's
+    paths/sizes across the resource. ``?fileset=`` drills into a sub-path.
+    """
+    ctx = _resource_ctx(resource)
+    fragment_url = url_for('disk_scans.directories_resource_fragment',
+                           resource=resource)
+
+    def _scan(flt):
+        return service.scan_directories_resource(
+            ctx['resource_name'], subpath=ctx['fileset'],
+            sort_by=flt['sort_by'], limit=flt['limit'],
+            owner_uid=flt['owner_uid'],
+            accessed_before=flt['accessed_before'],
+            accessed_after=flt['accessed_after'],
+            leaves_only=flt['leaves_only'],
+        )
+
+    return _render_directories_fragment(
+        ctx, fragment_url, mode='resource', scan_call=_scan,
+        log_label='resource-wide',
+    )
+
+
+@bp.route('/resource/<resource>/explore')
+@login_required
+@require_permission(Permission.VIEW_ALL_FILESYSTEM_DATA)
+def directories_resource_page(resource):
+    """Standalone full-page directory explorer for an entire resource.
+
+    Resource mode — the file-browser entry point. Same page template as
+    project mode, parameterized by ``mode='resource'`` + the resource fragment
+    URL; header shows the resource and a fileset breadcrumb. Elevated route.
+    """
+    ctx = _resource_ctx(resource)
+    flt = _dir_filters()
+    fragment_url = url_for('disk_scans.directories_resource_fragment',
+                           resource=resource)
+    return render_template(
+        'dashboards/user/disk_scans_directories_page.html',
+        mode='resource', fragment_url=fragment_url,
+        initial_url=_initial_fragment_url(fragment_url, ctx, flt),
+        filters=flt, user_search_url=_user_search_url(),
+        limit_options=_LIMIT_OPTIONS, **ctx,
     )
 
 
@@ -186,10 +412,6 @@ def entities_fragment(project):
 
 
 _METRIC_WHITELIST = {'data', 'files'}
-
-
-def _truthy(v) -> bool:
-    return (v or '').strip().lower() in ('1', 'true', 'on', 'yes')
 
 
 def _render_distribution(project, *, service_fn, endpoint, kind,

--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -188,25 +188,36 @@ def entities_fragment(project):
 _METRIC_WHITELIST = {'data', 'files'}
 
 
+def _truthy(v) -> bool:
+    return (v or '').strip().lower() in ('1', 'true', 'on', 'yes')
+
+
 def _render_distribution(project, *, service_fn, endpoint, kind,
-                         bucket_header, metric_toggle=False, log_y=False):
+                         bucket_header, metric_toggle=False, log_toggle=False):
     """Shared body for the two distribution histogram fragments.
 
     The Access-history and File-size tabs are identical end to end — same
     ``{bucket_labels, buckets{...}, owners, username_map}`` shape, same
     template, same chart — differing only in the service query, the bucket
-    column header, and (file-sizes only) a Data ↔ Files metric pill that
-    re-fetches the pane with ``?metric=``. ``kind`` is used only for logging.
+    column header, and (file-sizes only) a Data ↔ Files metric pill plus a
+    Log-scale switch, both of which re-fetch the pane via ``?metric=`` /
+    ``?log=``. ``kind`` is used only for logging.
+
+    A log y-axis can't represent a stack, so ``log_y`` renders solid bars
+    (no per-user gradient); it's offered only where the metric is skewed
+    enough to need it (file-sizes), hence gated on *log_toggle*.
     """
     ctx = _common_ctx(project)
 
     metric = (request.args.get('metric') or 'data').strip().lower()
     if not metric_toggle or metric not in _METRIC_WHITELIST:
         metric = 'data'
-    # url the metric pill re-fetches (carries scope/resource/fileset via the
+    log_on = log_toggle and _truthy(request.args.get('log'))
+    # urls the pill / switch re-fetch (carry scope/resource/fileset via the
     # pane's hidden form + hx-include, exactly like the owner↔group toggle).
     fragment_url = url_for(endpoint, projcode=project.projcode)
     extra = dict(metric=metric, metric_toggle=metric_toggle,
+                 log_on=log_on, log_toggle=log_toggle,
                  bucket_header=bucket_header, fragment_url=fragment_url)
 
     if not is_enabled() or not ctx['resource_name']:
@@ -225,7 +236,7 @@ def _render_distribution(project, *, service_fn, endpoint, kind,
         )
         if hist:
             chart_svg = generate_distribution_histogram(
-                hist, log_y=log_y, metric=metric)
+                hist, log_y=log_on, metric=metric)
     except Exception as exc:
         current_app.logger.exception(
             'disk_scans.%s: scan failed for project=%s resource=%s',
@@ -259,10 +270,12 @@ def file_sizes_fragment(project):
     """HTMX fragment: file-size distribution histogram (server-rendered SVG).
 
     Carries a Data ↔ Files metric pill (``?metric=``) since a file-size
-    distribution is equally meaningful by volume or by file count.
+    distribution is equally meaningful by volume or by file count, plus a
+    Log-scale switch (``?log=``) because file-size *data* spans many orders
+    of magnitude — at the cost of the per-user stack gradient.
     """
     return _render_distribution(
         project, service_fn=service.scan_file_sizes,
         endpoint='disk_scans.file_sizes_fragment', kind='file_sizes',
-        bucket_header='File size', metric_toggle=True,
+        bucket_header='File size', metric_toggle=True, log_toggle=True,
     )

--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -1,0 +1,219 @@
+"""HTMX fragment routes for filesystem-scan analytics on the disk page.
+
+Endpoints (url_prefix ``/dashboards/user/disk-scans``):
+
+  GET /<projcode>/directories     — largest directories (sortable)
+  GET /<projcode>/entities        — owner|group rollups (?kind=)
+  GET /<projcode>/access-history  — access-time histogram (SVG)
+
+Each fragment is lazy-loaded on first tab show (see
+``resource_details_disk.html``). Access control mirrors the rest of the
+project-scoped UI: ``require_project_access`` looks the project up by
+``projcode``, verifies the user can see it, and hands the route a Project.
+The service layer additionally refuses any *unscoped* query, so a fragment
+can only ever surface the project's own directories.
+
+Scope follows the disk page's selection:
+
+  * ``?scope=<projcode>`` re-roots to a child project — hits the plugin's
+    pre-computed whole-collection-root fast path (5-10s).
+  * ``?fileset=<path>`` drills into a single fileset — the inherently slow
+    on-the-fly scan (30-200s); the template lazy-loads + shows a spinner.
+
+``?resource=`` carries the disk resource being viewed (Campaign_Store
+today). Like ``jobs_fragment``, a plugin/DB hiccup degrades to an inline
+``error`` banner rather than 500-ing the surrounding page.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from flask import Blueprint, current_app, render_template, request, url_for
+from flask_login import login_required
+
+from sam.projects.projects import Project
+from webapp.api.access_control import require_project_access
+from webapp.dashboards.charts import generate_access_history_histogram
+from webapp.disk_scans import service
+from webapp.disk_scans.session import is_enabled
+from webapp.extensions import db
+
+bp = Blueprint('disk_scans', __name__)
+
+# scan_directories sort keys the facade understands (see
+# fs_scans/queries/facade.py:_DIR_SORT_KEYS). The facade fixes the sort
+# direction per key (size/files/atime/depth descending, path ascending),
+# so the UI only switches the active key, not a direction.
+_DIR_SORT_WHITELIST = {'size', 'files', 'atime_r', 'path', 'depth'}
+_DEFAULT_DIR_SORT = 'size'
+
+_DEFAULT_LIMIT = 50
+_MAX_LIMIT = 500
+
+
+def _scope_project(project) -> Project:
+    """Resolve the ``?scope=`` child project, or fall back to *project*.
+
+    Mirrors the validation in
+    ``dashboards/user/blueprint.py:_render_disk_resource_details`` — an
+    out-of-tree or unknown scope silently falls back to the root project so
+    the fragment can never escape the project the decorator authorized.
+    """
+    scope = (request.args.get('scope') or '').strip()
+    if not scope or scope == project.projcode:
+        return project
+    candidate = Project.get_by_projcode(db.session, scope)
+    if candidate is None or candidate.tree_root != project.tree_root:
+        return project
+    return candidate
+
+
+def _common_ctx(project) -> dict:
+    """Shared template context: scoped project, resource, fileset, ids.
+
+    ``fragment_url`` + ``target_id`` round-trip so a sort / toggle click
+    re-fetches into the same container this fragment was swapped into.
+    """
+    resource_name = (request.args.get('resource') or '').strip()
+    scoped = _scope_project(project)
+    fileset = (request.args.get('fileset') or '').strip() or None
+    target_id = (request.args.get('target_id') or '').strip()
+    return {
+        'project': project,
+        'scoped_project': scoped,
+        'resource_name': resource_name,
+        'scope': scoped.projcode,
+        'fileset': fileset,
+        'target_id': target_id,
+    }
+
+
+def _limit() -> int:
+    """Read ``?limit=`` with a defensive default + ceiling."""
+    try:
+        n = int(request.args.get('limit', _DEFAULT_LIMIT))
+    except (TypeError, ValueError):
+        n = _DEFAULT_LIMIT
+    return max(1, min(n, _MAX_LIMIT))
+
+
+@bp.route('/<projcode>/directories')
+@login_required
+@require_project_access
+def directories_fragment(project):
+    """HTMX fragment: largest directories for *project* (sortable)."""
+    ctx = _common_ctx(project)
+    if not is_enabled() or not ctx['resource_name']:
+        return render_template(
+            'dashboards/user/partials/disk_scans_directories.html',
+            rows=[], sort={'sort_by': _DEFAULT_DIR_SORT},
+            sortable_columns=sorted(_DIR_SORT_WHITELIST),
+            fragment_url=url_for('disk_scans.directories_fragment',
+                                 projcode=project.projcode),
+            enabled=is_enabled(), error=None, **ctx,
+        )
+
+    sort_by = request.args.get('sort_by') or _DEFAULT_DIR_SORT
+    if sort_by not in _DIR_SORT_WHITELIST:
+        sort_by = _DEFAULT_DIR_SORT
+
+    rows, error = [], None
+    try:
+        rows = service.scan_directories(
+            db.session, ctx['scoped_project'], ctx['resource_name'],
+            sort_by=sort_by, limit=_limit(), subpath=ctx['fileset'],
+        )
+    except Exception as exc:
+        current_app.logger.exception(
+            'disk_scans.directories: scan failed for project=%s resource=%s',
+            ctx['scoped_project'].projcode, ctx['resource_name'],
+        )
+        error = str(exc)
+
+    return render_template(
+        'dashboards/user/partials/disk_scans_directories.html',
+        rows=rows, sort={'sort_by': sort_by},
+        sortable_columns=sorted(_DIR_SORT_WHITELIST),
+        fragment_url=url_for('disk_scans.directories_fragment',
+                             projcode=project.projcode),
+        enabled=True, error=error, **ctx,
+    )
+
+
+@bp.route('/<projcode>/entities')
+@login_required
+@require_project_access
+def entities_fragment(project):
+    """HTMX fragment: per-owner or per-group rollup (``?kind=owner|group``)."""
+    ctx = _common_ctx(project)
+    kind = (request.args.get('kind') or 'owner').strip().lower()
+    if kind not in ('owner', 'group'):
+        kind = 'owner'
+
+    if not is_enabled() or not ctx['resource_name']:
+        return render_template(
+            'dashboards/user/partials/disk_scans_entities.html',
+            rows=[], kind=kind,
+            fragment_url=url_for('disk_scans.entities_fragment',
+                                 projcode=project.projcode),
+            enabled=is_enabled(), error=None, **ctx,
+        )
+
+    rows, error = [], None
+    try:
+        fn = service.scan_owner_summary if kind == 'owner' else service.scan_group_summary
+        rows = fn(
+            db.session, ctx['scoped_project'], ctx['resource_name'],
+            limit=_limit(), subpath=ctx['fileset'],
+        )
+    except Exception as exc:
+        current_app.logger.exception(
+            'disk_scans.entities: %s scan failed for project=%s resource=%s',
+            kind, ctx['scoped_project'].projcode, ctx['resource_name'],
+        )
+        error = str(exc)
+
+    return render_template(
+        'dashboards/user/partials/disk_scans_entities.html',
+        rows=rows, kind=kind,
+        fragment_url=url_for('disk_scans.entities_fragment',
+                             projcode=project.projcode),
+        enabled=True, error=error, **ctx,
+    )
+
+
+@bp.route('/<projcode>/access-history')
+@login_required
+@require_project_access
+def access_history_fragment(project):
+    """HTMX fragment: access-time histogram (server-rendered SVG)."""
+    ctx = _common_ctx(project)
+    if not is_enabled() or not ctx['resource_name']:
+        return render_template(
+            'dashboards/user/partials/disk_scans_access_history.html',
+            hist=None, chart_svg=None,
+            enabled=is_enabled(), error=None, **ctx,
+        )
+
+    owner_uid = request.args.get('owner_uid', type=int)
+    hist, chart_svg, error = None, None, None
+    try:
+        hist = service.scan_access_history(
+            db.session, ctx['scoped_project'], ctx['resource_name'],
+            owner_uid=owner_uid, subpath=ctx['fileset'],
+        )
+        if hist:
+            chart_svg = generate_access_history_histogram(hist)
+    except Exception as exc:
+        current_app.logger.exception(
+            'disk_scans.access_history: scan failed for project=%s resource=%s',
+            ctx['scoped_project'].projcode, ctx['resource_name'],
+        )
+        error = str(exc)
+
+    return render_template(
+        'dashboards/user/partials/disk_scans_access_history.html',
+        hist=hist, chart_svg=chart_svg,
+        enabled=True, error=error, **ctx,
+    )

--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -5,6 +5,7 @@ Endpoints (url_prefix ``/dashboards/user/disk-scans``):
   GET /<projcode>/directories     — largest directories (sortable)
   GET /<projcode>/entities        — owner|group rollups (?kind=)
   GET /<projcode>/access-history  — access-time histogram (SVG)
+  GET /<projcode>/file-sizes      — file-size histogram (SVG)
 
 Each fragment is lazy-loaded on first tab show (see
 ``resource_details_disk.html``). Access control mirrors the rest of the
@@ -34,7 +35,7 @@ from flask_login import login_required
 
 from sam.projects.projects import Project
 from webapp.api.access_control import require_project_access
-from webapp.dashboards.charts import generate_access_history_histogram
+from webapp.dashboards.charts import generate_distribution_histogram
 from webapp.disk_scans import service
 from webapp.disk_scans.session import is_enabled
 from webapp.extensions import db
@@ -184,37 +185,84 @@ def entities_fragment(project):
     )
 
 
-@bp.route('/<projcode>/access-history')
-@login_required
-@require_project_access
-def access_history_fragment(project):
-    """HTMX fragment: access-time histogram (server-rendered SVG)."""
+_METRIC_WHITELIST = {'data', 'files'}
+
+
+def _render_distribution(project, *, service_fn, endpoint, kind,
+                         bucket_header, metric_toggle=False, log_y=False):
+    """Shared body for the two distribution histogram fragments.
+
+    The Access-history and File-size tabs are identical end to end — same
+    ``{bucket_labels, buckets{...}, owners, username_map}`` shape, same
+    template, same chart — differing only in the service query, the bucket
+    column header, and (file-sizes only) a Data ↔ Files metric pill that
+    re-fetches the pane with ``?metric=``. ``kind`` is used only for logging.
+    """
     ctx = _common_ctx(project)
+
+    metric = (request.args.get('metric') or 'data').strip().lower()
+    if not metric_toggle or metric not in _METRIC_WHITELIST:
+        metric = 'data'
+    # url the metric pill re-fetches (carries scope/resource/fileset via the
+    # pane's hidden form + hx-include, exactly like the owner↔group toggle).
+    fragment_url = url_for(endpoint, projcode=project.projcode)
+    extra = dict(metric=metric, metric_toggle=metric_toggle,
+                 bucket_header=bucket_header, fragment_url=fragment_url)
+
     if not is_enabled() or not ctx['resource_name']:
         return render_template(
-            'dashboards/user/partials/disk_scans_access_history.html',
+            'dashboards/user/partials/disk_scans_distribution.html',
             hist=None, chart_svg=None,
-            enabled=is_enabled(), error=None, **ctx,
+            enabled=is_enabled(), error=None, **ctx, **extra,
         )
 
     owner_uid = request.args.get('owner_uid', type=int)
     hist, chart_svg, error = None, None, None
     try:
-        hist = service.scan_access_history(
+        hist = service_fn(
             db.session, ctx['scoped_project'], ctx['resource_name'],
             owner_uid=owner_uid, subpath=ctx['fileset'],
         )
         if hist:
-            chart_svg = generate_access_history_histogram(hist)
+            chart_svg = generate_distribution_histogram(
+                hist, log_y=log_y, metric=metric)
     except Exception as exc:
         current_app.logger.exception(
-            'disk_scans.access_history: scan failed for project=%s resource=%s',
-            ctx['scoped_project'].projcode, ctx['resource_name'],
+            'disk_scans.%s: scan failed for project=%s resource=%s',
+            kind, ctx['scoped_project'].projcode, ctx['resource_name'],
         )
         error = str(exc)
 
     return render_template(
-        'dashboards/user/partials/disk_scans_access_history.html',
+        'dashboards/user/partials/disk_scans_distribution.html',
         hist=hist, chart_svg=chart_svg,
-        enabled=True, error=error, **ctx,
+        enabled=True, error=error, **ctx, **extra,
+    )
+
+
+@bp.route('/<projcode>/access-history')
+@login_required
+@require_project_access
+def access_history_fragment(project):
+    """HTMX fragment: access-time distribution histogram (server-rendered SVG)."""
+    return _render_distribution(
+        project, service_fn=service.scan_access_history,
+        endpoint='disk_scans.access_history_fragment', kind='access_history',
+        bucket_header='Last accessed',
+    )
+
+
+@bp.route('/<projcode>/file-sizes')
+@login_required
+@require_project_access
+def file_sizes_fragment(project):
+    """HTMX fragment: file-size distribution histogram (server-rendered SVG).
+
+    Carries a Data ↔ Files metric pill (``?metric=``) since a file-size
+    distribution is equally meaningful by volume or by file count.
+    """
+    return _render_distribution(
+        project, service_fn=service.scan_file_sizes,
+        endpoint='disk_scans.file_sizes_fragment', kind='file_sizes',
+        bucket_header='File size', metric_toggle=True,
     )

--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -40,7 +40,8 @@ from sam.projects.projects import Project
 from webapp.api.access_control import require_project_access
 from webapp.dashboards.charts import generate_distribution_histogram
 from webapp.disk_scans import service
-from webapp.disk_scans.session import is_enabled
+from webapp.disk_scans.scope import resolve_scan_scope
+from webapp.disk_scans.session import get_module, is_enabled
 from webapp.extensions import db
 from webapp.utils.rbac import Permission, require_permission
 
@@ -183,12 +184,14 @@ def _user_search_url() -> str:
     return url_for('admin_dashboard.htmx_search_users', context='fk')
 
 
-def _initial_fragment_url(fragment_url: str, ctx: dict, flt: dict) -> str:
+def _initial_fragment_url(fragment_url: str, ctx: dict, flt: dict,
+                          browse: bool = False) -> str:
     """Fragment URL pre-loaded by the explorer page (carries current filters).
 
     The page's table container ``hx-get``s this on load so a deep-link / reload
     lands on the same filtered view the panel shows. Subsequent panel submits
-    and in-table sorts re-fetch via ``hx-include`` of the live forms.
+    and in-table sorts re-fetch via ``hx-include`` of the live forms. ``browse``
+    turns on the file-browser affordances (clickable rows + breadcrumb).
     """
     params = {
         'resource': ctx['resource_name'],
@@ -196,6 +199,8 @@ def _initial_fragment_url(fragment_url: str, ctx: dict, flt: dict) -> str:
         'sort_by': flt['sort_by'],
         'limit': flt['limit'],
     }
+    if browse:
+        params['browse'] = '1'
     if ctx.get('scope'):
         params['scope'] = ctx['scope']
     if ctx.get('fileset'):
@@ -209,6 +214,75 @@ def _initial_fragment_url(fragment_url: str, ctx: dict, flt: dict) -> str:
     if flt['accessed_after_str']:
         params['accessed_after'] = flt['accessed_after_str']
     return f'{fragment_url}?{urlencode(params)}'
+
+
+def _dir_breadcrumb(mode: str, ctx: dict, fragment_url: str, flt: dict):
+    """Ancestry breadcrumb items (normalized space) for the explorer drill-down.
+
+    Home clears the fileset (whole scope); each deeper crumb re-anchors the
+    fragment at that path. Bounded at the scan root: the project's prefix
+    (project mode — collapsed to one crumb) or the collection-root first segment
+    (resource mode). Returns a list shaped for the shared ``breadcrumb()`` macro,
+    or ``None`` when the plugin is unavailable.
+    """
+    mod = get_module()
+    if mod is None:
+        return None
+    target_id = ctx['target_id']
+
+    def _attrs(fileset):
+        q = {'sort_by': flt['sort_by']}
+        if fileset:
+            q['fileset'] = fileset
+        return {
+            'hx-get': f'{fragment_url}?{urlencode(q)}',
+            'hx-target': f'#{target_id}',
+            'hx-include': f'#disk-scans-dir-params-{target_id}',
+            'hx-swap': 'innerHTML',
+            'href': '#',
+            'style': 'cursor:pointer',
+        }
+
+    fileset = ctx.get('fileset')
+    home_label = ctx['resource_name'] if mode == 'resource' else 'All'
+    items = [{'label': home_label,
+              'attrs': _attrs(None) if fileset else None,
+              'active': not fileset}]
+    if not fileset:
+        return items
+
+    s = mod.normalize_path(fileset).strip('/')
+    segs = s.split('/')
+
+    # Project mode: collapse everything up to the owning project prefix into a
+    # single crumb (you can't navigate above what the project owns); resource
+    # mode shows every segment from the collection root down.
+    start = 0
+    if mode == 'project':
+        prefixes, _ = resolve_scan_scope(db.session, ctx['scoped_project'],
+                                         ctx['resource_name'])
+        base = ''
+        for p in prefixes:
+            pn = mod.normalize_path(p).strip('/')
+            if pn and (pn == s or s.startswith(pn + '/')) and len(pn) > len(base):
+                base = pn
+        if base:
+            base_segs = base.split('/')
+            start = len(base_segs)
+            acc = '/' + '/'.join(base_segs)
+            last = (start == len(segs))
+            items.append({'label': base_segs[-1],
+                          'attrs': None if last else _attrs(acc),
+                          'active': last})
+
+    acc = '/' + '/'.join(segs[:start]) if start else ''
+    for i in range(start, len(segs)):
+        acc = acc + '/' + segs[i]
+        last = (i == len(segs) - 1)
+        items.append({'label': segs[i],
+                      'attrs': None if last else _attrs(acc),
+                      'active': last})
+    return items
 
 
 def _resource_ctx(resource_name: str) -> dict:
@@ -230,19 +304,24 @@ def _resource_ctx(resource_name: str) -> dict:
     }
 
 
-def _render_directories_fragment(ctx, fragment_url, *, mode, scan_call, log_label):
+def _render_directories_fragment(ctx, fragment_url, *, mode, scan_call,
+                                 log_label, browse=False):
     """Shared body for the project + resource directory fragments.
 
     Both render the *same* ``disk_scans_directories.html`` partial; they differ
     only in scope context, which fragment URL the sort pill / headers re-fetch,
     and the (already scope-resolved) ``scan_call``. A plugin/DB hiccup degrades
-    to an inline error banner, never a 500.
+    to an inline error banner, never a 500. ``browse`` turns on the file-browser
+    drill-down (clickable rows + ancestry breadcrumb), explorer-page only.
     """
     flt = _dir_filters()
+    breadcrumb_items = (_dir_breadcrumb(mode, ctx, fragment_url, flt)
+                        if browse and is_enabled() else None)
     base = dict(
         sort={'sort_by': flt['sort_by']},
         sortable_columns=sorted(_DIR_SORT_WHITELIST),
-        fragment_url=fragment_url, filters=flt, mode=mode, **ctx,
+        fragment_url=fragment_url, filters=flt, mode=mode,
+        browse=browse, breadcrumb_items=breadcrumb_items, **ctx,
     )
     if not is_enabled() or not ctx['resource_name']:
         return render_template(
@@ -289,6 +368,7 @@ def directories_fragment(project):
     return _render_directories_fragment(
         ctx, fragment_url, mode='project', scan_call=_scan,
         log_label=f"project={ctx['scoped_project'].projcode}",
+        browse=_truthy(request.args.get('browse')),
     )
 
 
@@ -310,9 +390,9 @@ def directories_page(project):
     return render_template(
         'dashboards/user/disk_scans_directories_page.html',
         mode='project', fragment_url=fragment_url,
-        initial_url=_initial_fragment_url(fragment_url, ctx, flt),
+        initial_url=_initial_fragment_url(fragment_url, ctx, flt, browse=True),
         filters=flt, user_search_url=_user_search_url(),
-        limit_options=_LIMIT_OPTIONS, **ctx,
+        limit_options=_LIMIT_OPTIONS, browse=True, **ctx,
     )
 
 
@@ -343,6 +423,7 @@ def directories_resource_fragment(resource):
     return _render_directories_fragment(
         ctx, fragment_url, mode='resource', scan_call=_scan,
         log_label='resource-wide',
+        browse=_truthy(request.args.get('browse')),
     )
 
 
@@ -363,9 +444,9 @@ def directories_resource_page(resource):
     return render_template(
         'dashboards/user/disk_scans_directories_page.html',
         mode='resource', fragment_url=fragment_url,
-        initial_url=_initial_fragment_url(fragment_url, ctx, flt),
+        initial_url=_initial_fragment_url(fragment_url, ctx, flt, browse=True),
         filters=flt, user_search_url=_user_search_url(),
-        limit_options=_LIMIT_OPTIONS, **ctx,
+        limit_options=_LIMIT_OPTIONS, browse=True, **ctx,
     )
 
 

--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -43,9 +43,10 @@ bp = Blueprint('disk_scans', __name__)
 
 # scan_directories sort keys the facade understands (see
 # fs_scans/queries/facade.py:_DIR_SORT_KEYS). The facade fixes the sort
-# direction per key (size/files/atime/depth descending, path ascending),
-# so the UI only switches the active key, not a direction.
-_DIR_SORT_WHITELIST = {'size', 'files', 'atime_r', 'path', 'depth'}
+# direction per key (size/files/atime/dirs descending, path ascending),
+# so the UI only switches the active key, not a direction. 'dirs' maps to
+# the recursive subdirectory count (dir_count_r).
+_DIR_SORT_WHITELIST = {'size', 'files', 'atime_r', 'path', 'dirs'}
 _DEFAULT_DIR_SORT = 'size'
 
 _DEFAULT_LIMIT = 50

--- a/src/webapp/disk_scans/service.py
+++ b/src/webapp/disk_scans/service.py
@@ -235,3 +235,32 @@ def scan_access_history(
         'access_history', q, collections, path_prefixes, {'owner_uid': owner_uid},
         lambda: q.access_history(path_prefixes=path_prefixes, owner_uid=owner_uid),
     )
+
+
+def scan_file_sizes(
+    session,
+    project,
+    resource_name: str,
+    *,
+    owner_uid: Optional[int] = None,
+    subpath: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """File-size histogram dict for *project* (or ``None``).
+
+    Identical contract to :func:`scan_access_history` — same return shape
+    (``bucket_labels``, ``buckets{label:{data,files,owners}}``,
+    ``total_data``, ``total_files``, ``username_map``, ``reference_scan_date``,
+    ``fast_path``) — but the buckets are file-size bands rather than
+    access-time bands. Always scoped to the project's directory paths
+    (optionally narrowed to one fileset via *subpath*). Returns ``None`` when
+    the project has no scannable directories, the plugin is unavailable, or
+    no scan dates exist for the targeted collections.
+    """
+    mod, path_prefixes, collections = _scoped(session, project, resource_name, subpath)
+    if not collections:
+        return None
+    q = mod.FsScanQueries(filesystems=collections)
+    return cached_scan(
+        'file_sizes', q, collections, path_prefixes, {'owner_uid': owner_uid},
+        lambda: q.file_size_histogram(path_prefixes=path_prefixes, owner_uid=owner_uid),
+    )

--- a/src/webapp/disk_scans/service.py
+++ b/src/webapp/disk_scans/service.py
@@ -24,7 +24,12 @@ from webapp.disk_scans.scope import resolve_scan_scope
 from webapp.disk_scans.session import get_collections, get_module
 
 
-def _scoped(session, project, resource_name: str) -> Tuple[Optional[Any], List[str], List[str]]:
+def _scoped(
+    session,
+    project,
+    resource_name: str,
+    subpath: Optional[str] = None,
+) -> Tuple[Optional[Any], List[str], List[str]]:
     """Resolve ``(module, path_prefixes, collections)`` for a scan query.
 
     ``collections`` is intersected with the warmed/reachable set so we
@@ -34,12 +39,34 @@ def _scoped(session, project, resource_name: str) -> Tuple[Optional[Any], List[s
     collection list — whenever the query would otherwise be unscoped or
     unsatisfiable; callers MUST treat an empty collection list as "no
     results" and not call the facade.
+
+    ``subpath`` narrows the scope to a single fileset path (the disk page's
+    ``?fileset=`` drill-down). It is kept only if it equals — or is a
+    descendant of — one of the project's already-resolved directory
+    prefixes, so it can never widen scope beyond what the project owns;
+    a stray value simply yields no results. Narrowing to a non-root
+    sub-path defeats the whole-collection-root fast path, so this is the
+    inherently slow on-the-fly query (callers lazy-load it).
     """
     mod = get_module()
     if mod is None:
         return None, [], []
 
     path_prefixes, collections = resolve_scan_scope(session, project, resource_name)
+
+    # Fileset drill-down: keep only prefixes equal to / under `subpath`,
+    # then recompute the owning collections from what survives.
+    if subpath:
+        s = subpath.rstrip('/')
+        path_prefixes = [
+            p for p in path_prefixes
+            if p.rstrip('/') == s or p.startswith(s + '/')
+        ]
+        collections = sorted({
+            coll
+            for p in path_prefixes
+            if (coll := mod.collection_for_path(p)) is not None
+        })
 
     # Keep only collections that are actually reachable (the warmed set).
     collections = [c for c in collections if c in set(get_collections())]
@@ -69,13 +96,15 @@ def scan_directories(
     single_owner: bool = False,
     min_depth: Optional[int] = None,
     max_depth: Optional[int] = None,
+    subpath: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Largest directories for *project* on *resource_name* (sortable view).
 
-    Always scoped to the project's directory paths. Returns ``[]`` when the
-    project has no scannable directories or the plugin is unavailable.
+    Always scoped to the project's directory paths (optionally narrowed to
+    one fileset via *subpath*). Returns ``[]`` when the project has no
+    scannable directories or the plugin is unavailable.
     """
-    mod, path_prefixes, collections = _scoped(session, project, resource_name)
+    mod, path_prefixes, collections = _scoped(session, project, resource_name, subpath)
     if not collections:
         return []
     q = mod.FsScanQueries(filesystems=collections)
@@ -95,13 +124,15 @@ def scan_owner_summary(
     resource_name: str,
     *,
     limit: Optional[int] = 50,
+    subpath: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Per-owner (UID) rollup for *project*, with usernames resolved.
 
-    Always scoped to the project's directory paths. Each row gains a
-    ``username`` key (``None`` if the UID can't be resolved).
+    Always scoped to the project's directory paths (optionally narrowed to
+    one fileset via *subpath*). Each row gains a ``username`` key (``None``
+    if the UID can't be resolved).
     """
-    mod, path_prefixes, collections = _scoped(session, project, resource_name)
+    mod, path_prefixes, collections = _scoped(session, project, resource_name, subpath)
     if not collections:
         return []
     q = mod.FsScanQueries(filesystems=collections)
@@ -119,13 +150,15 @@ def scan_group_summary(
     resource_name: str,
     *,
     limit: Optional[int] = 50,
+    subpath: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Per-group (GID) rollup for *project*, with group names resolved.
 
-    Always scoped to the project's directory paths. Each row gains a
-    ``groupname`` key (``None`` if the GID can't be resolved).
+    Always scoped to the project's directory paths (optionally narrowed to
+    one fileset via *subpath*). Each row gains a ``groupname`` key (``None``
+    if the GID can't be resolved).
     """
-    mod, path_prefixes, collections = _scoped(session, project, resource_name)
+    mod, path_prefixes, collections = _scoped(session, project, resource_name, subpath)
     if not collections:
         return []
     q = mod.FsScanQueries(filesystems=collections)
@@ -143,15 +176,17 @@ def scan_access_history(
     resource_name: str,
     *,
     owner_uid: Optional[int] = None,
+    subpath: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Access-time histogram dict for *project* (or ``None``).
 
-    Always scoped to the project's directory paths. Returns ``None`` when
-    the project has no scannable directories, the plugin is unavailable, or
-    no scan dates exist for the targeted collections. The returned dict
-    already carries its own ``username_map`` for rendering.
+    Always scoped to the project's directory paths (optionally narrowed to
+    one fileset via *subpath*). Returns ``None`` when the project has no
+    scannable directories, the plugin is unavailable, or no scan dates
+    exist for the targeted collections. The returned dict already carries
+    its own ``username_map`` for rendering.
     """
-    mod, path_prefixes, collections = _scoped(session, project, resource_name)
+    mod, path_prefixes, collections = _scoped(session, project, resource_name, subpath)
     if not collections:
         return None
     q = mod.FsScanQueries(filesystems=collections)

--- a/src/webapp/disk_scans/service.py
+++ b/src/webapp/disk_scans/service.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple
 
+from webapp.disk_scans.cache import cached_scan
 from webapp.disk_scans.scope import resolve_scan_scope
 from webapp.disk_scans.session import get_collections, get_module
 
@@ -133,13 +134,20 @@ def scan_directories(
     if not collections:
         return []
     q = mod.FsScanQueries(filesystems=collections)
-    return q.list_directories(
-        path_prefixes=path_prefixes,
-        sort_by=sort_by,
-        limit=limit,
-        single_owner=single_owner,
-        min_depth=min_depth,
-        max_depth=max_depth,
+    opts = {
+        'sort_by': sort_by, 'limit': limit, 'single_owner': single_owner,
+        'min_depth': min_depth, 'max_depth': max_depth,
+    }
+    return cached_scan(
+        'directories', q, collections, path_prefixes, opts,
+        lambda: q.list_directories(
+            path_prefixes=path_prefixes,
+            sort_by=sort_by,
+            limit=limit,
+            single_owner=single_owner,
+            min_depth=min_depth,
+            max_depth=max_depth,
+        ),
     )
 
 
@@ -161,12 +169,16 @@ def scan_owner_summary(
     if not collections:
         return []
     q = mod.FsScanQueries(filesystems=collections)
-    rows = q.owner_summary(path_prefixes=path_prefixes, limit=limit)
-    uids = {r['owner_uid'] for r in rows if r.get('owner_uid') is not None}
-    names = q.resolve_usernames(uids) if uids else {}
-    for r in rows:
-        r['username'] = names.get(r.get('owner_uid'))
-    return rows
+
+    def _compute():
+        rows = q.owner_summary(path_prefixes=path_prefixes, limit=limit)
+        uids = {r['owner_uid'] for r in rows if r.get('owner_uid') is not None}
+        names = q.resolve_usernames(uids) if uids else {}
+        for r in rows:
+            r['username'] = names.get(r.get('owner_uid'))
+        return rows
+
+    return cached_scan('owner', q, collections, path_prefixes, {'limit': limit}, _compute)
 
 
 def scan_group_summary(
@@ -187,12 +199,16 @@ def scan_group_summary(
     if not collections:
         return []
     q = mod.FsScanQueries(filesystems=collections)
-    rows = q.group_summary(path_prefixes=path_prefixes, limit=limit)
-    gids = {r['owner_gid'] for r in rows if r.get('owner_gid') is not None}
-    names = q.resolve_groupnames(gids) if gids else {}
-    for r in rows:
-        r['groupname'] = names.get(r.get('owner_gid'))
-    return rows
+
+    def _compute():
+        rows = q.group_summary(path_prefixes=path_prefixes, limit=limit)
+        gids = {r['owner_gid'] for r in rows if r.get('owner_gid') is not None}
+        names = q.resolve_groupnames(gids) if gids else {}
+        for r in rows:
+            r['groupname'] = names.get(r.get('owner_gid'))
+        return rows
+
+    return cached_scan('group', q, collections, path_prefixes, {'limit': limit}, _compute)
 
 
 def scan_access_history(
@@ -215,4 +231,7 @@ def scan_access_history(
     if not collections:
         return None
     q = mod.FsScanQueries(filesystems=collections)
-    return q.access_history(path_prefixes=path_prefixes, owner_uid=owner_uid)
+    return cached_scan(
+        'access_history', q, collections, path_prefixes, {'owner_uid': owner_uid},
+        lambda: q.access_history(path_prefixes=path_prefixes, owner_uid=owner_uid),
+    )

--- a/src/webapp/disk_scans/service.py
+++ b/src/webapp/disk_scans/service.py
@@ -46,13 +46,23 @@ def _scoped(
     unsatisfiable; callers MUST treat an empty collection list as "no
     results" and not call the facade.
 
-    ``subpath`` narrows the scope to a single fileset path (the disk page's
-    ``?fileset=`` drill-down). It is kept only if it equals — or is a
-    descendant of — one of the project's already-resolved directory
-    prefixes, so it can never widen scope beyond what the project owns;
-    a stray value simply yields no results. Narrowing to a non-root
-    sub-path defeats the whole-collection-root fast path, so this is the
-    inherently slow on-the-fly query (callers lazy-load it).
+    ``subpath`` narrows the scope to a fileset path. Matching is done in
+    NORMALIZED (mount-stripped) space via ``mod.normalize_path`` so it works
+    whether ``subpath`` arrives absolute (the disk page's ``?fileset=``, a
+    ``ProjectDirectory`` path) or already normalized (the explorer's row /
+    breadcrumb drill, which surfaces normalized scan paths — see
+    ``project_fs_scans_paths_normalized``). Two in-scope cases:
+
+      * **Selection** — ``subpath`` equals / is an ancestor of the project's
+        filesets: keep the project prefixes at or under it (pick among the
+        project's own directories).
+      * **Descent** — ``subpath`` is a descendant of a project prefix (a real
+        subdirectory below a registered fileset): query that deeper subtree.
+
+    Anything outside the project's scope yields no results, so this can never
+    widen beyond what the project owns. Narrowing to a non-root sub-path
+    defeats the whole-collection-root fast path, so this is the inherently slow
+    on-the-fly query (callers lazy-load it).
     """
     mod = get_module()
     if mod is None:
@@ -60,14 +70,18 @@ def _scoped(
 
     path_prefixes, collections = resolve_scan_scope(session, project, resource_name)
 
-    # Fileset drill-down: keep only prefixes equal to / under `subpath`,
-    # then recompute the owning collections from what survives.
+    # Fileset drill-down, matched in normalized space, then recompute the
+    # owning collections from what survives.
     if subpath:
-        s = subpath.rstrip('/')
-        path_prefixes = [
-            p for p in path_prefixes
-            if p.rstrip('/') == s or p.startswith(s + '/')
-        ]
+        s = mod.normalize_path(subpath).rstrip('/')
+        norm = {p: mod.normalize_path(p).rstrip('/') for p in path_prefixes}
+        under = [p for p, pn in norm.items() if pn == s or pn.startswith(s + '/')]
+        if under:                                              # selection
+            path_prefixes = under
+        elif any(s == pn or s.startswith(pn + '/') for pn in norm.values()):
+            path_prefixes = [s]                                # descent
+        else:
+            path_prefixes = []                                 # out of scope
         collections = sorted({
             coll
             for p in path_prefixes

--- a/src/webapp/disk_scans/service.py
+++ b/src/webapp/disk_scans/service.py
@@ -18,11 +18,16 @@ so there is no session context manager here — we just construct
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 from webapp.disk_scans.cache import cached_scan
 from webapp.disk_scans.scope import resolve_scan_scope
-from webapp.disk_scans.session import get_collections, get_module
+from webapp.disk_scans.session import (
+    collections_for_resource,
+    get_collections,
+    get_module,
+)
 
 
 def _scoped(
@@ -112,6 +117,63 @@ def scan_overview(session, project, resource_name: str) -> Dict[str, Any]:
     return {'collections': collections, 'scan_dates': scan_dates, 'reference': reference}
 
 
+def _scan_directories(
+    mod,
+    collections: List[str],
+    path_prefixes: Optional[List[str]],
+    *,
+    sort_by: str = 'size',
+    limit: Optional[int] = 50,
+    owner_uid: Optional[int] = None,
+    accessed_before: Optional[datetime] = None,
+    accessed_after: Optional[datetime] = None,
+    leaves_only: bool = False,
+    single_owner: bool = False,
+    min_depth: Optional[int] = None,
+    max_depth: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Mode-agnostic directory query core shared by project + resource modes.
+
+    Callers resolve ``(mod, collections, path_prefixes)`` first — project mode
+    via :func:`_scoped` (refuses unscoped), resource mode via
+    :func:`collections_for_resource` (deliberately unscoped, ``path_prefixes``
+    may be ``None`` for the whole-collection fast path). Any of
+    ``owner_uid / accessed_before / accessed_after / leaves_only`` being set
+    routes the result into the short-TTL ``'filtered'`` cache bucket so heavy
+    interactive exploration can't crowd the hot default-path entries.
+    """
+    q = mod.FsScanQueries(filesystems=collections)
+    filtered = bool(owner_uid is not None or accessed_before or accessed_after
+                    or leaves_only)
+    opts = {
+        'sort_by': sort_by, 'limit': limit,
+        'owner_uid': owner_uid,
+        'accessed_before': accessed_before.isoformat() if accessed_before else None,
+        'accessed_after': accessed_after.isoformat() if accessed_after else None,
+        'leaves_only': leaves_only,
+        'single_owner': single_owner,
+        'min_depth': min_depth, 'max_depth': max_depth,
+    }
+    return cached_scan(
+        'directories', q, collections,
+        # cache key tolerates an unscoped (None) prefix list — normalise to [].
+        path_prefixes or [], opts,
+        lambda: q.list_directories(
+            path_prefixes=path_prefixes,
+            sort_by=sort_by,
+            limit=limit,
+            owner_id=owner_uid,
+            accessed_before=accessed_before,
+            accessed_after=accessed_after,
+            leaves_only=leaves_only,
+            single_owner=single_owner,
+            min_depth=min_depth,
+            max_depth=max_depth,
+        ),
+        bucket='filtered' if filtered else 'default',
+    )
+
+
 def scan_directories(
     session,
     project,
@@ -119,6 +181,10 @@ def scan_directories(
     *,
     sort_by: str = 'size',
     limit: Optional[int] = 50,
+    owner_uid: Optional[int] = None,
+    accessed_before: Optional[datetime] = None,
+    accessed_after: Optional[datetime] = None,
+    leaves_only: bool = False,
     single_owner: bool = False,
     min_depth: Optional[int] = None,
     max_depth: Optional[int] = None,
@@ -126,28 +192,59 @@ def scan_directories(
 ) -> List[Dict[str, Any]]:
     """Largest directories for *project* on *resource_name* (sortable view).
 
-    Always scoped to the project's directory paths (optionally narrowed to
-    one fileset via *subpath*). Returns ``[]`` when the project has no
-    scannable directories or the plugin is unavailable.
+    **Project mode.** Always scoped to the project's directory paths (optionally
+    narrowed to one fileset via *subpath*). The unscoped-refusal safety
+    invariant is intact: returns ``[]`` when the project has no scannable
+    directories or the plugin is unavailable. Filters
+    (``owner_uid / accessed_before / accessed_after / leaves_only``) narrow
+    within that scope.
     """
     mod, path_prefixes, collections = _scoped(session, project, resource_name, subpath)
     if not collections:
         return []
-    q = mod.FsScanQueries(filesystems=collections)
-    opts = {
-        'sort_by': sort_by, 'limit': limit, 'single_owner': single_owner,
-        'min_depth': min_depth, 'max_depth': max_depth,
-    }
-    return cached_scan(
-        'directories', q, collections, path_prefixes, opts,
-        lambda: q.list_directories(
-            path_prefixes=path_prefixes,
-            sort_by=sort_by,
-            limit=limit,
-            single_owner=single_owner,
-            min_depth=min_depth,
-            max_depth=max_depth,
-        ),
+    return _scan_directories(
+        mod, collections, path_prefixes,
+        sort_by=sort_by, limit=limit,
+        owner_uid=owner_uid, accessed_before=accessed_before,
+        accessed_after=accessed_after, leaves_only=leaves_only,
+        single_owner=single_owner, min_depth=min_depth, max_depth=max_depth,
+    )
+
+
+def scan_directories_resource(
+    resource_name: str,
+    *,
+    subpath: Optional[str] = None,
+    sort_by: str = 'size',
+    limit: Optional[int] = 50,
+    owner_uid: Optional[int] = None,
+    accessed_before: Optional[datetime] = None,
+    accessed_after: Optional[datetime] = None,
+    leaves_only: bool = False,
+) -> List[Dict[str, Any]]:
+    """Largest directories across an **entire disk resource**, unscoped.
+
+    **Resource mode** (elevated). Deliberately *not* project-scoped — it
+    browses every collection the resource owns
+    (:func:`collections_for_resource`). With no *subpath* it queries the whole
+    collection (``path_prefixes=None`` → the facade's fast path); a *subpath*
+    drills into a single fileset (the slow on-the-fly scan). This bypasses the
+    project-scoping safety invariant by design, so it is only ever reachable
+    behind the ``VIEW_ALL_FILESYSTEM_DATA``-gated route. Returns ``[]`` when the
+    plugin is unavailable or the resource maps to no reachable collections.
+    """
+    mod = get_module()
+    if mod is None:
+        return []
+    collections = collections_for_resource(resource_name)
+    if not collections:
+        return []
+    path_prefixes = [subpath] if subpath else None
+    return _scan_directories(
+        mod, collections, path_prefixes,
+        sort_by=sort_by, limit=limit,
+        owner_uid=owner_uid, accessed_before=accessed_before,
+        accessed_after=accessed_after, leaves_only=leaves_only,
     )
 
 

--- a/src/webapp/disk_scans/service.py
+++ b/src/webapp/disk_scans/service.py
@@ -86,6 +86,31 @@ def _scoped(
     return mod, path_prefixes, collections
 
 
+def scan_overview(session, project, resource_name: str) -> Dict[str, Any]:
+    """Page-render summary for the Filesystem Scans card header.
+
+    Returns the warmed collections *project* spans on *resource_name* plus
+    their latest scan dates — enough for the caller to (a) decide whether to
+    show the card (``collections`` non-empty) and (b) render a "scanned
+    <date>" freshness badge in the header without lazy-loading a tab.
+
+    ``{'collections': [...], 'scan_dates': {collection: datetime|None},
+       'reference': datetime|None}`` — ``reference`` is the most recent scan
+    date across the project's collections. Cheap: one scoped subtree build
+    plus one ``scan_metadata`` lookup per collection (1-2 in practice).
+    """
+    mod, path_prefixes, collections = _scoped(session, project, resource_name)
+    if not collections:
+        return {'collections': [], 'scan_dates': {}, 'reference': None}
+    q = mod.FsScanQueries(filesystems=collections)
+    scan_dates = {}
+    for c in collections:
+        dates = q.scan_dates(filesystems=[c])
+        scan_dates[c] = max(dates) if dates else None
+    reference = max((d for d in scan_dates.values() if d), default=None)
+    return {'collections': collections, 'scan_dates': scan_dates, 'reference': reference}
+
+
 def scan_directories(
     session,
     project,

--- a/src/webapp/disk_scans/session.py
+++ b/src/webapp/disk_scans/session.py
@@ -199,6 +199,26 @@ def get_collections(app: Optional[Flask] = None) -> List[str]:
     return state.get('collections') or []
 
 
+def collections_for_resource(
+    resource_name: str, app: Optional[Flask] = None
+) -> List[str]:
+    """Warmed collection schemas that make up a disk *resource*, unscoped.
+
+    The single decision point for resource→collections when a query is **not**
+    project-scoped (resource mode). Today every warmed collection lives in the
+    one ``campaign`` CNPG database (one DB per resource via the plugin's
+    ``FS_SCAN_PG_DB``), so this returns :func:`get_collections` verbatim — i.e.
+    the whole resource.
+
+    This is the **seam** where a future resource→database map plugs in: once a
+    second resource (e.g. Destor) ships its own collections, branch here on
+    *resource_name* rather than scattering the mapping across callers. Returns
+    ``[]`` when the plugin is off (so resource-mode callers degrade to "no
+    results", same as project mode).
+    """
+    return get_collections(app)
+
+
 def get_engines(app: Optional[Flask] = None) -> Dict[str, Any]:
     """Return ``{collection: Engine}`` for warmed collections (possibly empty).
 

--- a/src/webapp/run.py
+++ b/src/webapp/run.py
@@ -362,6 +362,7 @@ def create_app(*, config_overrides: dict | None = None):
     # one Engine per collection on the CNPG backend. Disabled in tests
     # (TestingConfig.FS_SCANS_ENABLED = False).
     from webapp.disk_scans import init_fs_scans
+    from webapp.disk_scans.routes import bp as disk_scans_bp
     init_fs_scans(app)
 
     # Register blueprints
@@ -372,6 +373,7 @@ def create_app(*, config_overrides: dict | None = None):
     app.register_blueprint(allocations_dashboard_bp)
     app.register_blueprint(project_members_bp)
     app.register_blueprint(jobs_bp, url_prefix='/dashboards/user/jobs')
+    app.register_blueprint(disk_scans_bp, url_prefix='/dashboards/user/disk-scans')
     # NOTE: admin_bp blueprint removed - Flask-Admin handles /database routing
     # app.register_blueprint(admin_bp, url_prefix='/database')
 

--- a/src/webapp/static/css/components.css
+++ b/src/webapp/static/css/components.css
@@ -243,3 +243,12 @@ tbody.alloc-tree-body.collapsing { transition: none !important; }
 /* resource_details: collapse chevron rotation */
 .collapse-icon { transition: transform 0.2s ease; }
 [aria-expanded="true"] .collapse-icon { transform: rotate(90deg); }
+
+/* Sortable table headers (sortable_table.js, loaded globally in base.html).
+   Pairs the global JS with its indicator so any `.sortable-header` shows a
+   neutral up/down cue (click to sort) and an arrow for the active column.
+   Mirrors the rule duplicated in admin.css / allocations.css. */
+.sortable-header { cursor: pointer; user-select: none; white-space: nowrap; }
+.sortable-header::after { content: ' \2195'; color: #adb5bd; font-size: 0.8em; }
+.sortable-header.sort-asc::after { content: ' \2191'; color: #495057; }
+.sortable-header.sort-desc::after { content: ' \2193'; color: #495057; }

--- a/src/webapp/static/js/svg-chart-links.js
+++ b/src/webapp/static/js/svg-chart-links.js
@@ -37,12 +37,15 @@
     var BAR_DAY_PREFIX = '#day-bar-';
     var BAR_AH_PREFIX = '#ah-bar-';
 
-    // Access-history histogram → expand the matching bucket's per-user
-    // detail row. The bucket <tr> carries data-ah-bucket="<index>" and a
-    // data-bs-target pointing at its collapse row (see
-    // disk_scans_access_history.html).
-    function openBucketRow(index) {
-        var row = document.querySelector('tr[data-ah-bucket="' + index + '"]');
+    // Distribution histogram (Access-history / File-size tabs) → expand the
+    // matching bucket's per-user detail row. The bucket <tr> carries
+    // data-ah-bucket="<index>" and a data-bs-target pointing at its collapse
+    // row (see disk_scans_distribution.html). The lookup is scoped to the
+    // tab pane the clicked bar lives in, so the two tabs' identical
+    // #ah-bar-<index> anchors never cross-fire.
+    function openBucketRow(index, scopeEl) {
+        var root = scopeEl || document;
+        var row = root.querySelector('tr[data-ah-bucket="' + index + '"]');
         if (!row || !window.bootstrap) return;
         var targetSel = row.getAttribute('data-bs-target');
         if (!targetSel) return;
@@ -109,12 +112,12 @@
             return;
         }
 
-        // Bar → Access-history bucket per-user detail row
+        // Bar → distribution bucket per-user detail row (scoped to this pane)
         if (href.indexOf(BAR_AH_PREFIX) === 0) {
             var idx = href.slice(BAR_AH_PREFIX.length);
             if (idx === '') return;
             e.preventDefault();
-            openBucketRow(idx);
+            openBucketRow(idx, a.closest('.tab-pane'));
             return;
         }
 

--- a/src/webapp/static/js/svg-chart-links.js
+++ b/src/webapp/static/js/svg-chart-links.js
@@ -13,6 +13,9 @@
  *     the user-dashboard resource-details page) → expand the day row
  *     in the Historical Usage table below, auto-opening the parent
  *     month row if needed (3-level mode for >45-day spans).
+ *   - Bar href starts with #ah-bar-<index> (Access-history histogram on
+ *     the disk resource-details page) → expand the matching bucket's
+ *     per-user detail row in the table below the chart.
  *
  * Safe on pages where the target containers aren't included — each
  * branch checks for its targets and silently no-ops.
@@ -32,6 +35,24 @@
     };
 
     var BAR_DAY_PREFIX = '#day-bar-';
+    var BAR_AH_PREFIX = '#ah-bar-';
+
+    // Access-history histogram → expand the matching bucket's per-user
+    // detail row. The bucket <tr> carries data-ah-bucket="<index>" and a
+    // data-bs-target pointing at its collapse row (see
+    // disk_scans_access_history.html).
+    function openBucketRow(index) {
+        var row = document.querySelector('tr[data-ah-bucket="' + index + '"]');
+        if (!row || !window.bootstrap) return;
+        var targetSel = row.getAttribute('data-bs-target');
+        if (!targetSel) return;
+        var el = document.querySelector(targetSel);
+        if (!el) return;
+        bootstrap.Collapse.getOrCreateInstance(el, {toggle: false}).show();
+        setTimeout(function () {
+            row.scrollIntoView({behavior: 'smooth', block: 'center'});
+        }, 60);
+    }
 
     function openDayRow(isoDate) {
         var row = document.querySelector('tr[data-date="' + isoDate + '"]');
@@ -85,6 +106,15 @@
             if (!iso) return;
             e.preventDefault();
             openDayRow(iso);
+            return;
+        }
+
+        // Bar → Access-history bucket per-user detail row
+        if (href.indexOf(BAR_AH_PREFIX) === 0) {
+            var idx = href.slice(BAR_AH_PREFIX.length);
+            if (idx === '') return;
+            e.preventDefault();
+            openBucketRow(idx);
             return;
         }
 

--- a/src/webapp/templates/dashboards/admin/edit_project.html
+++ b/src/webapp/templates/dashboards/admin/edit_project.html
@@ -1,5 +1,6 @@
 {% extends 'dashboards/base.html' %}
 {% from 'dashboards/admin/fragments/user_search_results_fk_htmx.html' import render_fk_search_results with context %}
+{% from 'dashboards/fragments/_breadcrumb.html' import breadcrumb %}
 
 {% block title %}Edit Project {{ project.projcode }} — SAM{% endblock %}
 
@@ -11,15 +12,14 @@
 {% block content %}
 <!-- Breadcrumb + Back button -->
 <div class="d-flex align-items-center mb-3">
-  <nav aria-label="breadcrumb" class="mb-0">
-    <ol class="breadcrumb mb-0">
-      {% if can_access_admin %}
-      <li class="breadcrumb-item"><a href="{{ url_for('admin_dashboard.index') }}">Admin</a></li>
-      {% endif %}
-      <li class="breadcrumb-item active">Edit Project</li>
-      <li class="breadcrumb-item active">{{ project.projcode }}</li>
-    </ol>
-  </nav>
+  {% set _crumbs = [] %}
+  {% if can_access_admin %}
+    {% set _ = _crumbs.append({'label': 'Admin',
+                               'attrs': {'href': url_for('admin_dashboard.index')}}) %}
+  {% endif %}
+  {% set _ = _crumbs.append({'label': 'Edit Project', 'active': True}) %}
+  {% set _ = _crumbs.append({'label': project.projcode, 'active': True}) %}
+  {{ breadcrumb(_crumbs, classes='mb-0') }}
   {% if can_access_admin %}
   {# Pass projcode so the admin index re-renders this project's card on
      return — otherwise the user lands on a blank search page. #}

--- a/src/webapp/templates/dashboards/admin/fragments/configuration_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/configuration_card.html
@@ -253,7 +253,19 @@
                     {% if state.caching.scans %}
                     <hr class="my-3">
                     <div class="text-muted small mb-2"><strong>Filesystem-scan cache</strong></div>
-                    {{ cache_row(state.caching.scans) }}
+                    {# Two buckets: the long-lived default (passive/landing +
+                       tab pill) and the short-TTL explorer (filtered) bucket.
+                       Looping surfaces each bucket's TTL so the 30-min explorer
+                       TTL is visible next to the 8-day default. #}
+                    {% for _b in state.caching.scans %}
+                      <div class="text-muted small mb-1">
+                        {{ 'Explorer (filtered)' if _b.name == 'fs_scans_filtered'
+                           else 'Default (passive)' }}
+                        <code class="ms-1">{{ _b.name }}</code>
+                      </div>
+                      {{ cache_row(_b) }}
+                      {% if not loop.last %}<div class="mb-2"></div>{% endif %}
+                    {% endfor %}
                     {% endif %}
 
                     {% if state.caching.flask %}

--- a/src/webapp/templates/dashboards/admin/fragments/configuration_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/configuration_card.html
@@ -250,6 +250,12 @@
                     {{ cache_row(state.caching.usage) }}
                     {% endif %}
 
+                    {% if state.caching.scans %}
+                    <hr class="my-3">
+                    <div class="text-muted small mb-2"><strong>Filesystem-scan cache</strong></div>
+                    {{ cache_row(state.caching.scans) }}
+                    {% endif %}
+
                     {% if state.caching.flask %}
                     <hr class="my-3">
                     <div class="text-muted small mb-2"><strong>Flask-Cache (HTTP-level)</strong></div>

--- a/src/webapp/templates/dashboards/fragments/_breadcrumb.html
+++ b/src/webapp/templates/dashboards/fragments/_breadcrumb.html
@@ -1,0 +1,33 @@
+{#
+  Shared Bootstrap breadcrumb macro. Attribute-agnostic so it serves both
+  href (full-page) and htmx (fetch-into-container) call sites.
+
+  items: list of dicts, each:
+    - label  (required): the crumb text
+    - attrs  (optional): dict of HTML attributes for the <a> (e.g.
+              {'href': url}  OR  {'hx-get': url, 'hx-target': '#x',
+              'hx-include': '#f', 'hx-swap': 'innerHTML', 'href': '#'})
+    - active (optional): True → rendered as plain text (current page)
+  An item with no attrs (or active) renders as plain text.
+
+  Usage:
+    {% from 'dashboards/fragments/_breadcrumb.html' import breadcrumb %}
+    {{ breadcrumb([{'label': 'Admin', 'attrs': {'href': url}},
+                   {'label': 'Edit', 'active': True}]) }}
+#}
+{% macro breadcrumb(items, classes='small mb-0') %}
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb {{ classes }}">
+    {% for it in items %}
+      <li class="breadcrumb-item{% if it.active %} active{% endif %}"
+          {% if it.active %}aria-current="page"{% endif %}>
+        {%- if it.active or not it.attrs -%}
+          {{ it.label }}
+        {%- else -%}
+          <a {% for k, v in it.attrs.items() %}{{ k }}="{{ v }}" {% endfor %}>{{ it.label }}</a>
+        {%- endif -%}
+      </li>
+    {% endfor %}
+  </ol>
+</nav>
+{% endmacro %}

--- a/src/webapp/templates/dashboards/user/disk_scans_directories_page.html
+++ b/src/webapp/templates/dashboards/user/disk_scans_directories_page.html
@@ -1,0 +1,80 @@
+{% extends 'dashboards/base.html' %}
+{% from 'dashboards/user/partials/_disk_scans_dir_filters.html' import dir_filters %}
+{#
+  Standalone directory-explorer page — both modes, parameterized by *mode*
+  ('project'|'resource') and *fragment_url* (which directory fragment to
+  lazy-load). Renders a filters panel above a table container; the container
+  hx-get's *initial_url* (fragment_url pre-loaded with the current filters)
+  on load, and the filter panel / in-table sort re-fetch into the same
+  container thereafter.
+
+  Context (set in webapp/disk_scans/routes.py directories_page /
+  directories_resource_page): mode, fragment_url, initial_url, filters,
+  user_search_url, limit_options, plus the scope context (project,
+  scoped_project, resource_name, scope, fileset, target_id).
+#}
+
+{% block title %}Directory explorer — SAM{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+
+  <div class="d-flex align-items-center flex-wrap gap-2 mb-2">
+    <h3 class="mb-0">
+      <i class="fas fa-folder-tree me-2"></i>
+      {% if mode == 'resource' %}
+        {{ resource_name }}
+        <small class="text-muted fw-normal">— all directories</small>
+      {% else %}
+        {{ scoped_project.projcode if scoped_project else project.projcode }}
+        <small class="text-muted fw-normal">directories on {{ resource_name }}</small>
+      {% endif %}
+    </h3>
+    {% if mode == 'resource' %}
+      <span class="badge bg-warning-subtle text-dark border">
+        <i class="fas fa-shield-halved me-1"></i> Resource-wide (operator view)
+      </span>
+    {% endif %}
+  </div>
+
+  {% if mode == 'resource' %}
+    {# Fileset breadcrumb — the file-browser entry point. Each crumb re-roots
+       the explorer at a collection sub-path via ?fileset=. #}
+    <nav aria-label="breadcrumb" class="mb-3">
+      <ol class="breadcrumb small mb-0">
+        <li class="breadcrumb-item">
+          <a href="{{ url_for('disk_scans.directories_resource_page',
+                              resource=resource_name) }}">{{ resource_name }}</a>
+        </li>
+        {% if fileset %}
+          <li class="breadcrumb-item active" aria-current="page">
+            <code>{{ fileset }}</code>
+          </li>
+        {% endif %}
+      </ol>
+    </nav>
+  {% endif %}
+
+  <div class="card mb-3">
+    <div class="card-body">
+      {{ dir_filters('disk-scans-filters-' ~ target_id, fragment_url, target_id,
+                     filters, user_search_url, resource_name, scope, fileset,
+                     limit_options) }}
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-body p-2">
+      <div id="{{ target_id }}"
+           hx-get="{{ initial_url }}"
+           hx-trigger="load"
+           hx-swap="innerHTML">
+        <p class="text-muted small mb-0 p-2">
+          <i class="fas fa-spinner fa-spin me-1"></i> Loading directories…
+        </p>
+      </div>
+    </div>
+  </div>
+
+</div>
+{% endblock %}

--- a/src/webapp/templates/dashboards/user/disk_scans_directories_page.html
+++ b/src/webapp/templates/dashboards/user/disk_scans_directories_page.html
@@ -37,23 +37,8 @@
     {% endif %}
   </div>
 
-  {% if mode == 'resource' %}
-    {# Fileset breadcrumb — the file-browser entry point. Each crumb re-roots
-       the explorer at a collection sub-path via ?fileset=. #}
-    <nav aria-label="breadcrumb" class="mb-3">
-      <ol class="breadcrumb small mb-0">
-        <li class="breadcrumb-item">
-          <a href="{{ url_for('disk_scans.directories_resource_page',
-                              resource=resource_name) }}">{{ resource_name }}</a>
-        </li>
-        {% if fileset %}
-          <li class="breadcrumb-item active" aria-current="page">
-            <code>{{ fileset }}</code>
-          </li>
-        {% endif %}
-      </ol>
-    </nav>
-  {% endif %}
+  {# The live, drill-aware ancestry breadcrumb is rendered inside the table
+     fragment (disk_scans_directories.html) so it updates on every drill. #}
 
   <div class="card mb-3">
     <div class="card-body">

--- a/src/webapp/templates/dashboards/user/partials/_disk_scans_dir_filters.html
+++ b/src/webapp/templates/dashboards/user/partials/_disk_scans_dir_filters.html
@@ -30,6 +30,8 @@
   {% if fileset %}<input type="hidden" name="fileset" value="{{ fileset }}">{% endif %}
   <input type="hidden" name="target_id" value="{{ target_id }}">
   <input type="hidden" name="sort_by" value="{{ filters.sort_by }}">
+  {# Explorer-only panel → always file-browser mode (clickable rows + breadcrumb). #}
+  <input type="hidden" name="browse" value="1">
 
   <div class="d-flex flex-wrap align-items-end gap-3">
     <div>

--- a/src/webapp/templates/dashboards/user/partials/_disk_scans_dir_filters.html
+++ b/src/webapp/templates/dashboards/user/partials/_disk_scans_dir_filters.html
@@ -1,0 +1,77 @@
+{% from 'dashboards/fragments/form_fields.html' import fk_search_field %}
+{#
+  Reusable Large-directories filter panel (audit_filters house style),
+  mode-agnostic. Rendered above the table container on the standalone
+  explorer page; on submit it hx-get's *fragment_url* (the project- or
+  resource-mode directory fragment) into #target_id with all of its fields.
+
+  Args:
+    form_id         unique id for this form instance
+    fragment_url    the directory fragment to fetch (project or resource mode)
+    target_id       container the fragment swaps into
+    filters         the parsed _dir_filters() dict (current values)
+    user_search_url fk-picker search endpoint (admin_dashboard.htmx_search_users, fk)
+    resource_name / scope / fileset   scope context echoed back on submit
+    limit_options   row-count choices for the limit selector
+
+  The user picker stores a SAM user_id under ``owner_user_id``; the route
+  resolves it to the unix UID the scan data is keyed on (see _resolve_owner).
+#}
+{% macro dir_filters(form_id, fragment_url, target_id, filters, user_search_url,
+                     resource_name, scope, fileset, limit_options) %}
+<form id="{{ form_id }}"
+      hx-get="{{ fragment_url }}"
+      hx-target="#{{ target_id }}"
+      hx-swap="innerHTML"
+      hx-trigger="submit">
+  {# Scope context — submitted alongside the visible filter controls. #}
+  <input type="hidden" name="resource" value="{{ resource_name }}">
+  {% if scope %}<input type="hidden" name="scope" value="{{ scope }}">{% endif %}
+  {% if fileset %}<input type="hidden" name="fileset" value="{{ fileset }}">{% endif %}
+  <input type="hidden" name="target_id" value="{{ target_id }}">
+  <input type="hidden" name="sort_by" value="{{ filters.sort_by }}">
+
+  <div class="d-flex flex-wrap align-items-end gap-3">
+    <div>
+      <label class="form-label mb-1"><strong>Accessed after</strong></label>
+      <input type="date" class="form-control form-control-sm"
+             name="accessed_after" value="{{ filters.accessed_after_str }}"
+             style="width:160px;">
+    </div>
+    <div>
+      <label class="form-label mb-1"><strong>Accessed before</strong></label>
+      <input type="date" class="form-control form-control-sm"
+             name="accessed_before" value="{{ filters.accessed_before_str }}"
+             style="width:160px;">
+    </div>
+
+    <div style="min-width:240px;">
+      {{ fk_search_field('owner_user_id', 'User', user_search_url,
+                         placeholder='Search users…',
+                         selected_id=filters.owner_user_id or '',
+                         selected_label=filters.owner_label or '',
+                         label_class='form-label mb-1') }}
+    </div>
+
+    <div class="form-check form-switch mb-2">
+      <input class="form-check-input" type="checkbox" role="switch"
+             id="{{ form_id }}-leaves" name="leaves_only" value="1"
+             {% if filters.leaves_only %}checked{% endif %}>
+      <label class="form-check-label" for="{{ form_id }}-leaves">Leaves only</label>
+    </div>
+
+    <div>
+      <label class="form-label mb-1"><strong>Rows</strong></label>
+      <select class="form-select form-select-sm" name="limit" style="width:100px;">
+        {% for n in limit_options %}
+          <option value="{{ n }}" {% if filters.limit == n %}selected{% endif %}>{{ n }}</option>
+        {% endfor %}
+      </select>
+    </div>
+
+    <button type="submit" class="btn btn-primary mb-2">
+      <i class="fas fa-filter me-1"></i> Apply
+    </button>
+  </div>
+</form>
+{% endmacro %}

--- a/src/webapp/templates/dashboards/user/partials/_disk_scans_macros.html
+++ b/src/webapp/templates/dashboards/user/partials/_disk_scans_macros.html
@@ -1,0 +1,44 @@
+{#
+  Shared banners for the Filesystem Scans fragments. Mirrors the
+  disabled / error / empty shape of jobs_fragment.html so all three
+  scan tabs degrade identically.
+#}
+
+{# Plugin not loaded / no reachable collection — graceful "unavailable"
+   notice (the page may hx-get this unconditionally), never a 404. #}
+{% macro scans_disabled() %}
+  <div class="alert alert-secondary py-2 mb-0" role="status">
+    <small>
+      Filesystem-scan data is unavailable: the
+      <code>fs-scans</code> plugin is not loaded or has no reachable
+      collection for this resource.
+      <a href="/dashboards/admin/configuration"
+         target="_blank" rel="noopener">
+        Check the Database card on the Admin → Configuration page
+      </a>
+      for plugin/DB health.
+    </small>
+  </div>
+{% endmacro %}
+
+{# A scan query raised (transient plugin/DB issue) — warn inline. #}
+{% macro scans_error(error) %}
+  <div class="alert alert-warning py-2 mb-0" role="alert">
+    <small>Could not load filesystem-scan data: {{ error }}</small>
+  </div>
+{% endmacro %}
+
+{# Scope resolved but the scan returned nothing. #}
+{% macro scans_empty(message) %}
+  <p class="text-muted small mb-0">{{ message }}</p>
+{% endmacro %}
+
+{# A small "scoped to <fileset>" note shown when drilled into one fileset
+   (the slow on-the-fly path). #}
+{% macro scans_scope_note(fileset) %}
+  {% if fileset %}
+    <span class="badge bg-light text-dark border me-1">
+      <i class="fas fa-folder-open me-1"></i><code>{{ fileset }}</code>
+    </span>
+  {% endif %}
+{% endmacro %}

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_access_history.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_access_history.html
@@ -1,0 +1,64 @@
+{% from 'dashboards/user/partials/_disk_scans_macros.html'
+   import scans_disabled, scans_error, scans_empty, scans_scope_note %}
+{#
+  Access-time histogram fragment — embedded via hx-get from the Filesystem
+  Scans card. Context (set in webapp/disk_scans/routes.py):
+    hist (dict|None), chart_svg (str|None), enabled, error,
+    resource_name, scope, fileset, target_id
+  hist: bucket_labels, buckets{label:{data,files,owners}},
+        total_data, total_files, directory, fast_path, reference_scan_date.
+#}
+
+{% if not enabled %}
+  {{ scans_disabled() }}
+{% elif error %}
+  {{ scans_error(error) }}
+{% elif not hist %}
+  {{ scans_empty('No access-history data for this scope.') }}
+{% else %}
+  <div class="d-flex align-items-center flex-wrap gap-2 mb-2">
+    {{ scans_scope_note(fileset) }}
+    <span class="text-muted small">
+      Total: <strong>{{ hist.total_data | fmt_size }}</strong>
+      across <strong>{{ hist.total_files | fmt_number }}</strong> files
+    </span>
+    {% if hist.reference_scan_date %}
+      <span class="text-muted small">| as of {{ hist.reference_scan_date | fmt_date }}</span>
+    {% endif %}
+    {% if hist.fast_path %}
+      <span class="badge bg-success-subtle text-success-emphasis border border-success-subtle"
+            title="Read from pre-computed tables">fast path</span>
+    {% else %}
+      <span class="badge bg-warning-subtle text-warning-emphasis border border-warning-subtle"
+            title="Computed on the fly from directory stats">on-the-fly</span>
+    {% endif %}
+  </div>
+
+  <div class="chart-container">
+    {{ chart_svg | safe }}
+  </div>
+
+  <div class="table-responsive mt-3">
+    <table class="table table-sm table-hover align-middle mb-0">
+      <thead class="table-light">
+        <tr>
+          <th>Last accessed</th>
+          <th class="text-end">Data</th>
+          <th class="text-end">Files</th>
+          <th class="text-end">Owners</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for label in hist.bucket_labels %}
+          {% set b = hist.buckets.get(label, {}) %}
+          <tr>
+            <td>{{ label }}</td>
+            <td class="text-end font-monospace">{{ b.get('data', 0) | fmt_size }}</td>
+            <td class="text-end">{{ b.get('files', 0) | fmt_number }}</td>
+            <td class="text-end">{{ (b.get('owners') or {}) | length | fmt_number }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endif %}

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_access_history.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_access_history.html
@@ -38,10 +38,15 @@
     {{ chart_svg | safe }}
   </div>
 
+  {# Per-user breakdown lives inside each bucket's collapse detail row —
+     the owners dict (uid → {data, files}) is already on the histogram, so
+     this is a pure client-side expand, mirroring the jobs table pattern. #}
+  {% set umap = hist.username_map or {} %}
   <div class="table-responsive mt-3">
     <table class="table table-sm table-hover align-middle mb-0">
       <thead class="table-light">
         <tr>
+          <th style="width:1.5rem;" aria-label="Expand"></th>
           <th>Last accessed</th>
           <th class="text-end">Data</th>
           <th class="text-end">Files</th>
@@ -51,12 +56,67 @@
       <tbody>
         {% for label in hist.bucket_labels %}
           {% set b = hist.buckets.get(label, {}) %}
-          <tr>
+          {% set owners = b.get('owners') or {} %}
+          {% set b_data = b.get('data', 0) or 0 %}
+          {% set b_files = b.get('files', 0) or 0 %}
+          {% set rowid = (target_id or 'ah') ~ '-ah' ~ loop.index %}
+          <tr {% if owners %}class="cursor-pointer"
+                data-ah-bucket="{{ loop.index0 }}"
+                data-bs-toggle="collapse" data-bs-target="#{{ rowid }}"
+                aria-expanded="false" aria-controls="{{ rowid }}"
+                title="Show top users in this bucket"{% endif %}>
+            <td class="text-center p-0">
+              {% if owners %}
+                <i class="fas fa-chevron-right small collapse-icon text-muted"></i>
+              {% endif %}
+            </td>
             <td>{{ label }}</td>
-            <td class="text-end font-monospace">{{ b.get('data', 0) | fmt_size }}</td>
-            <td class="text-end">{{ b.get('files', 0) | fmt_number }}</td>
-            <td class="text-end">{{ (b.get('owners') or {}) | length | fmt_number }}</td>
+            <td class="text-end font-monospace">{{ b_data | fmt_size }}</td>
+            <td class="text-end">{{ b_files | fmt_number }}</td>
+            <td class="text-end">{{ owners | length | fmt_number }}</td>
           </tr>
+          {% if owners %}
+            {% set ranked = owners.items() | sort(attribute='1.data', reverse=true) %}
+            <tr class="collapse" id="{{ rowid }}">
+              <td colspan="5" class="bg-light">
+                <div class="small text-muted mb-1">
+                  Top users by data in <strong>{{ label }}</strong>
+                  ({{ owners | length | fmt_number }} total)
+                </div>
+                <table class="table table-sm align-middle mb-0">
+                  <thead>
+                    <tr>
+                      <th style="width:2rem;" class="text-end text-muted">#</th>
+                      <th>User</th>
+                      <th class="text-end">Data</th>
+                      <th class="text-end text-muted">% data</th>
+                      <th class="text-end">Files</th>
+                      <th class="text-end text-muted">% files</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for uid, stats in ranked[:10] %}
+                      {% set dpct = (100.0 * stats.get('data', 0) / b_data) if b_data else 0 %}
+                      {% set fpct = (100.0 * stats.get('files', 0) / b_files) if b_files else 0 %}
+                      <tr>
+                        <td class="text-end text-muted">{{ loop.index }}</td>
+                        <td class="font-monospace">{{ umap.get(uid) or umap.get(uid | string) or ('uid ' ~ uid) }}</td>
+                        <td class="text-end font-monospace">{{ stats.get('data', 0) | fmt_size }}</td>
+                        <td class="text-end text-muted">{{ dpct | fmt_pct }}</td>
+                        <td class="text-end">{{ stats.get('files', 0) | fmt_number }}</td>
+                        <td class="text-end text-muted">{{ fpct | fmt_pct }}</td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+                {% if owners | length > 10 %}
+                  <div class="small text-muted mt-1">
+                    … and {{ (owners | length - 10) | fmt_number }} more users
+                  </div>
+                {% endif %}
+              </td>
+            </tr>
+          {% endif %}
         {% endfor %}
       </tbody>
     </table>

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
@@ -7,6 +7,11 @@
     resource_name, scope, fileset, enabled, error
   Each row: path, depth, total_size_r, file_count_r, dir_count_r,
             max_atime_r, owner_uid, owner_gid, filesystem.
+
+  Server-side sorting (re-fetches the true top-N for the chosen key) — the
+  foundation for a future filter panel (search path / by user / leaves-only
+  / accessed-before), which are all DB-level filters applied before the
+  top-N limit. Mirrors the jobs_fragment pattern.
 #}
 
 {# (sort_key, label, row-attr, numeric?) — the facade fixes sort direction
@@ -14,9 +19,9 @@
 {% set _cols = [
   ('path',    'Path',        'path',         false),
   ('size',    'Size',        'total_size_r', true),
-  ('files',   'Files',       'file_count_r', true),
-  ('depth',   'Depth',       'depth',        true),
-  ('atime_r', 'Last Access', 'max_atime_r',  false),
+  ('files',   'Files',         'file_count_r', true),
+  ('dirs',    'Subdirectories', 'dir_count_r', true),
+  ('atime_r', 'Last Access',   'max_atime_r',  false),
 ] %}
 
 {% macro dir_sort_link(key, label) %}
@@ -74,7 +79,7 @@
               <td class="text-nowrap small"><code>{{ r.path }}</code></td>
               <td class="text-end font-monospace">{{ r.total_size_r | fmt_size }}</td>
               <td class="text-end">{{ r.file_count_r | fmt_number }}</td>
-              <td class="text-end">{{ r.depth | fmt_number }}</td>
+              <td class="text-end">{{ r.dir_count_r | fmt_number }}</td>
               <td class="text-end text-nowrap small">
                 {%- set a = r.max_atime_r -%}
                 {%- if a is none or a == '' -%}<span class="text-muted">—</span>

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
@@ -49,6 +49,10 @@
   ('files', '# Files',   'fa-hashtag'),
   ('dirs',  '# Subdirs', 'fa-folder-tree'),
 ] %}
+{# Recursive subdirectory count (dir_count_r) is 0 by definition for leaves,
+   so the Subdirectories column + its sort pill are meaningless (and would
+   degenerate the sort) under the leaves-only filter — drop both. #}
+{% set _show_dirs = not filters.leaves_only %}
 
 {% if not enabled %}
   {{ scans_disabled() }}
@@ -73,6 +77,7 @@
   <div class="d-flex align-items-center mb-2 flex-wrap gap-2">
     <div class="btn-group btn-group-sm" role="group" aria-label="Sort directories by">
       {% for key, label, icon in _pills %}
+        {% if key != 'dirs' or _show_dirs %}
         <button type="button"
                 class="btn btn-outline-secondary {% if sort.sort_by == key %}active{% endif %}"
                 hx-get="{{ fragment_url }}?sort_by={{ key }}"
@@ -81,6 +86,7 @@
                 hx-swap="innerHTML">
           <i class="fas {{ icon }} me-1"></i>{{ label }}
         </button>
+        {% endif %}
       {% endfor %}
     </div>
     {{ scans_scope_note(fileset) }}
@@ -108,7 +114,9 @@
         <thead class="table-light">
           <tr>
             {% for key, label, attr, numeric in _cols %}
+              {% if key != 'dirs' or _show_dirs %}
               <th class="{% if numeric %}text-end{% endif %}">{{ dir_sort_link(key, label) }}</th>
+              {% endif %}
             {% endfor %}
           </tr>
         </thead>
@@ -118,7 +126,7 @@
               <td class="text-nowrap small"><code>{{ r.path }}</code></td>
               <td class="text-end font-monospace">{{ r.total_size_r | fmt_size }}</td>
               <td class="text-end">{{ r.file_count_r | fmt_number }}</td>
-              <td class="text-end">{{ r.dir_count_r | fmt_number }}</td>
+              {% if _show_dirs %}<td class="text-end">{{ r.dir_count_r | fmt_number }}</td>{% endif %}
               <td class="text-end text-nowrap small">
                 {%- set a = r.max_atime_r -%}
                 {%- if a is none or a == '' -%}<span class="text-muted">—</span>

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
@@ -1,5 +1,6 @@
 {% from 'dashboards/user/partials/_disk_scans_macros.html'
    import scans_disabled, scans_error, scans_empty, scans_scope_note %}
+{% from 'dashboards/fragments/_breadcrumb.html' import breadcrumb %}
 {#
   Largest-directories fragment — embedded via hx-get from the Filesystem
   Scans card. Context (set in webapp/disk_scans/routes.py):
@@ -28,7 +29,7 @@
   {%- if key in sortable_columns -%}
     {%- set is_active = (sort.sort_by == key) -%}
     <a class="text-decoration-none" href="#"
-       hx-get="{{ fragment_url }}?sort_by={{ key }}"
+       hx-get="{{ fragment_url }}?sort_by={{ key }}{% if fileset %}&fileset={{ fileset | urlencode }}{% endif %}"
        hx-target="#{{ target_id }}"
        hx-include="#disk-scans-dir-params-{{ target_id }}"
        hx-swap="innerHTML">
@@ -62,11 +63,14 @@
   {# Round-trip the scope + active filters so every sort / pill re-fetch stays
      scoped AND keeps the current filter selection. ``owner_uid`` is the
      canonical (resolved) unix UID; the filter panel feeds it via owner_user_id. #}
+  {# NB: ``fileset`` is deliberately NOT in this form — every path-changing
+     control (sort links, pill, drill rows, breadcrumb) carries ``fileset`` in
+     its own URL, so keeping it here too would send it twice. #}
   <form id="disk-scans-dir-params-{{ target_id }}" class="d-none">
     <input type="hidden" name="resource" value="{{ resource_name }}">
     {% if scope %}<input type="hidden" name="scope" value="{{ scope }}">{% endif %}
-    {% if fileset %}<input type="hidden" name="fileset" value="{{ fileset }}">{% endif %}
     <input type="hidden" name="target_id" value="{{ target_id }}">
+    {% if browse %}<input type="hidden" name="browse" value="1">{% endif %}
     <input type="hidden" name="limit" value="{{ filters.limit }}">
     {% if filters.owner_uid is not none %}<input type="hidden" name="owner_uid" value="{{ filters.owner_uid }}">{% endif %}
     {% if filters.leaves_only %}<input type="hidden" name="leaves_only" value="1">{% endif %}
@@ -74,13 +78,19 @@
     {% if filters.accessed_after_str %}<input type="hidden" name="accessed_after" value="{{ filters.accessed_after_str }}">{% endif %}
   </form>
 
+  {# File-browser ancestry (explorer/browse mode only). Click a crumb to
+     re-anchor; Home clears the fileset back to the whole scope. #}
+  {% if breadcrumb_items %}
+    {{ breadcrumb(breadcrumb_items) }}
+  {% endif %}
+
   <div class="d-flex align-items-center mb-2 flex-wrap gap-2">
     <div class="btn-group btn-group-sm" role="group" aria-label="Sort directories by">
       {% for key, label, icon in _pills %}
         {% if key != 'dirs' or _show_dirs %}
         <button type="button"
                 class="btn btn-outline-secondary {% if sort.sort_by == key %}active{% endif %}"
-                hx-get="{{ fragment_url }}?sort_by={{ key }}"
+                hx-get="{{ fragment_url }}?sort_by={{ key }}{% if fileset %}&fileset={{ fileset | urlencode }}{% endif %}"
                 hx-target="#{{ target_id }}"
                 hx-include="#disk-scans-dir-params-{{ target_id }}"
                 hx-swap="innerHTML">
@@ -123,7 +133,22 @@
         <tbody>
           {% for r in rows %}
             <tr>
-              <td class="text-nowrap small"><code>{{ r.path }}</code></td>
+              <td class="text-nowrap small">
+                {%- if browse and not filters.leaves_only and r.dir_count_r -%}
+                  {# Drill into this directory's subtree, keeping the active
+                     filters (the params form). Leaves (dir_count_r == 0) and
+                     the static card tab render a plain path. #}
+                  <a class="text-decoration-none" href="#"
+                     hx-get="{{ fragment_url }}?fileset={{ r.path | urlencode }}&sort_by={{ sort.sort_by }}"
+                     hx-target="#{{ target_id }}"
+                     hx-include="#disk-scans-dir-params-{{ target_id }}"
+                     hx-swap="innerHTML">
+                    <i class="fas fa-folder me-1 text-muted"></i><code>{{ r.path }}</code>
+                  </a>
+                {%- else -%}
+                  <code>{{ r.path }}</code>
+                {%- endif -%}
+              </td>
               <td class="text-end font-monospace">{{ r.total_size_r | fmt_size }}</td>
               <td class="text-end">{{ r.file_count_r | fmt_number }}</td>
               {% if _show_dirs %}<td class="text-end">{{ r.dir_count_r | fmt_number }}</td>{% endif %}

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
@@ -1,0 +1,90 @@
+{% from 'dashboards/user/partials/_disk_scans_macros.html'
+   import scans_disabled, scans_error, scans_empty, scans_scope_note %}
+{#
+  Largest-directories fragment — embedded via hx-get from the Filesystem
+  Scans card. Context (set in webapp/disk_scans/routes.py):
+    rows, sort, sortable_columns, fragment_url, target_id,
+    resource_name, scope, fileset, enabled, error
+  Each row: path, depth, total_size_r, file_count_r, dir_count_r,
+            max_atime_r, owner_uid, owner_gid, filesystem.
+#}
+
+{# (sort_key, label, row-attr, numeric?) — the facade fixes sort direction
+   per key, so a header click only switches the active key. #}
+{% set _cols = [
+  ('path',    'Path',        'path',         false),
+  ('size',    'Size',        'total_size_r', true),
+  ('files',   'Files',       'file_count_r', true),
+  ('depth',   'Depth',       'depth',        true),
+  ('atime_r', 'Last Access', 'max_atime_r',  false),
+] %}
+
+{% macro dir_sort_link(key, label) %}
+  {%- if key in sortable_columns -%}
+    {%- set is_active = (sort.sort_by == key) -%}
+    <a class="text-decoration-none" href="#"
+       hx-get="{{ fragment_url }}?sort_by={{ key }}"
+       hx-target="#{{ target_id }}"
+       hx-include="#disk-scans-dir-params-{{ target_id }}"
+       hx-swap="innerHTML">
+      {{ label }}
+      {%- if is_active %} <i class="fas fa-caret-down ms-1"></i>
+      {%- else %} <i class="fas fa-sort text-muted small ms-1"></i>{% endif -%}
+    </a>
+  {%- else -%}
+    {{ label }}
+  {%- endif -%}
+{% endmacro %}
+
+{% if not enabled %}
+  {{ scans_disabled() }}
+{% elif error %}
+  {{ scans_error(error) }}
+{% else %}
+  {# Round-trip the scope params so every sort re-fetch stays scoped. #}
+  <form id="disk-scans-dir-params-{{ target_id }}" class="d-none">
+    <input type="hidden" name="resource" value="{{ resource_name }}">
+    <input type="hidden" name="scope" value="{{ scope }}">
+    {% if fileset %}<input type="hidden" name="fileset" value="{{ fileset }}">{% endif %}
+    <input type="hidden" name="target_id" value="{{ target_id }}">
+  </form>
+
+  <div class="d-flex align-items-center mb-2">
+    {{ scans_scope_note(fileset) }}
+    <span class="ms-auto text-muted small">
+      {{ rows | length | fmt_number }} director{{ 'y' if rows | length == 1 else 'ies' }}
+    </span>
+  </div>
+
+  {% if not rows %}
+    {{ scans_empty('No scanned directories for this scope.') }}
+  {% else %}
+    <div class="table-responsive">
+      <table class="table table-sm table-hover align-middle mb-0">
+        <thead class="table-light">
+          <tr>
+            {% for key, label, attr, numeric in _cols %}
+              <th class="{% if numeric %}text-end{% endif %}">{{ dir_sort_link(key, label) }}</th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for r in rows %}
+            <tr>
+              <td class="text-nowrap small"><code>{{ r.path }}</code></td>
+              <td class="text-end font-monospace">{{ r.total_size_r | fmt_size }}</td>
+              <td class="text-end">{{ r.file_count_r | fmt_number }}</td>
+              <td class="text-end">{{ r.depth | fmt_number }}</td>
+              <td class="text-end text-nowrap small">
+                {%- set a = r.max_atime_r -%}
+                {%- if a is none or a == '' -%}<span class="text-muted">—</span>
+                {%- elif a is string -%}{{ a[:10] }}
+                {%- else -%}{{ a | fmt_date }}{%- endif -%}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
+{% endif %}

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
@@ -41,21 +41,60 @@
   {%- endif -%}
 {% endmacro %}
 
+{# Sort pill — mirrors the File Sizes Data/Files pill. Each click re-queries
+   the server for the true top-N by that key (top-by-size ≠ top-by-files), so
+   it is NOT a client re-sort; the column headers remain available too. #}
+{% set _pills = [
+  ('size',  'Size',      'fa-hard-drive'),
+  ('files', '# Files',   'fa-hashtag'),
+  ('dirs',  '# Subdirs', 'fa-folder-tree'),
+] %}
+
 {% if not enabled %}
   {{ scans_disabled() }}
 {% elif error %}
   {{ scans_error(error) }}
 {% else %}
-  {# Round-trip the scope params so every sort re-fetch stays scoped. #}
+  {# Round-trip the scope + active filters so every sort / pill re-fetch stays
+     scoped AND keeps the current filter selection. ``owner_uid`` is the
+     canonical (resolved) unix UID; the filter panel feeds it via owner_user_id. #}
   <form id="disk-scans-dir-params-{{ target_id }}" class="d-none">
     <input type="hidden" name="resource" value="{{ resource_name }}">
-    <input type="hidden" name="scope" value="{{ scope }}">
+    {% if scope %}<input type="hidden" name="scope" value="{{ scope }}">{% endif %}
     {% if fileset %}<input type="hidden" name="fileset" value="{{ fileset }}">{% endif %}
     <input type="hidden" name="target_id" value="{{ target_id }}">
+    <input type="hidden" name="limit" value="{{ filters.limit }}">
+    {% if filters.owner_uid is not none %}<input type="hidden" name="owner_uid" value="{{ filters.owner_uid }}">{% endif %}
+    {% if filters.leaves_only %}<input type="hidden" name="leaves_only" value="1">{% endif %}
+    {% if filters.accessed_before_str %}<input type="hidden" name="accessed_before" value="{{ filters.accessed_before_str }}">{% endif %}
+    {% if filters.accessed_after_str %}<input type="hidden" name="accessed_after" value="{{ filters.accessed_after_str }}">{% endif %}
   </form>
 
-  <div class="d-flex align-items-center mb-2">
+  <div class="d-flex align-items-center mb-2 flex-wrap gap-2">
+    <div class="btn-group btn-group-sm" role="group" aria-label="Sort directories by">
+      {% for key, label, icon in _pills %}
+        <button type="button"
+                class="btn btn-outline-secondary {% if sort.sort_by == key %}active{% endif %}"
+                hx-get="{{ fragment_url }}?sort_by={{ key }}"
+                hx-target="#{{ target_id }}"
+                hx-include="#disk-scans-dir-params-{{ target_id }}"
+                hx-swap="innerHTML">
+          <i class="fas {{ icon }} me-1"></i>{{ label }}
+        </button>
+      {% endfor %}
+    </div>
     {{ scans_scope_note(fileset) }}
+    {% if filters.owner_uid is not none or filters.leaves_only
+          or filters.accessed_before_str or filters.accessed_after_str %}
+      <span class="badge bg-info-subtle text-dark border">
+        <i class="fas fa-filter me-1"></i>
+        {%- if filters.owner_label %}{{ filters.owner_label }}
+        {%- elif filters.owner_uid is not none %}uid {{ filters.owner_uid }}{% endif -%}
+        {%- if filters.leaves_only %} · leaves only{% endif -%}
+        {%- if filters.accessed_after_str %} · after {{ filters.accessed_after_str }}{% endif -%}
+        {%- if filters.accessed_before_str %} · before {{ filters.accessed_before_str }}{% endif -%}
+      </span>
+    {% endif %}
     <span class="ms-auto text-muted small">
       {{ rows | length | fmt_number }} director{{ 'y' if rows | length == 1 else 'ies' }}
     </span>

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
@@ -25,9 +25,9 @@
 {% elif not hist %}
   {{ scans_empty('No distribution data for this scope.') }}
 {% else %}
-  {% if metric_toggle %}
-    {# Carry scope/resource/fileset on the pill re-fetch — same hidden-form +
-       hx-include pattern as the owner↔group toggle. #}
+  {% if metric_toggle or log_toggle %}
+    {# Carry scope/resource/fileset on the pill / switch re-fetch — same
+       hidden-form + hx-include pattern as the owner↔group toggle. #}
     <form id="disk-scans-metric-params-{{ target_id }}" class="d-none">
       <input type="hidden" name="resource" value="{{ resource_name }}">
       <input type="hidden" name="scope" value="{{ scope }}">
@@ -36,13 +36,15 @@
     </form>
   {% endif %}
 
+  {% set _log_q = '&log=1' if log_on else '' %}
   <div class="d-flex align-items-center flex-wrap gap-2 mb-2">
     {% if metric_toggle %}
-      {# Data ↔ Files metric pill — re-fetches this same pane with ?metric=. #}
+      {# Data ↔ Files metric pill — re-fetches this same pane with ?metric=,
+         preserving the current log-scale state. #}
       <div class="btn-group btn-group-sm me-1" role="group" aria-label="Chart metric">
         <button type="button"
                 class="btn btn-outline-secondary {% if not _by_files %}active{% endif %}"
-                hx-get="{{ fragment_url }}?metric=data"
+                hx-get="{{ fragment_url }}?metric=data{{ _log_q }}"
                 hx-target="#{{ target_id }}"
                 hx-include="#disk-scans-metric-params-{{ target_id }}"
                 hx-swap="innerHTML">
@@ -50,12 +52,30 @@
         </button>
         <button type="button"
                 class="btn btn-outline-secondary {% if _by_files %}active{% endif %}"
-                hx-get="{{ fragment_url }}?metric=files"
+                hx-get="{{ fragment_url }}?metric=files{{ _log_q }}"
                 hx-target="#{{ target_id }}"
                 hx-include="#disk-scans-metric-params-{{ target_id }}"
                 hx-swap="innerHTML">
           <i class="fas fa-hashtag me-1"></i> Files
         </button>
+      </div>
+    {% endif %}
+    {% if log_toggle %}
+      {# Log-scale switch — re-fetches with ?log=, preserving the metric. A log
+         y-axis can't stack, so this trades the per-user gradient for legible
+         small bands (see disk_scans/routes.py). #}
+      <div class="form-check form-switch form-check-inline mb-0 me-1"
+           title="Log y-axis — reveals small bands but flattens the per-user breakdown">
+        <input class="form-check-input" type="checkbox" role="switch"
+               id="disk-scans-log-{{ target_id }}"
+               {% if log_on %}checked{% endif %}
+               hx-get="{{ fragment_url }}?metric={{ _metric }}&log={{ '0' if log_on else '1' }}"
+               hx-target="#{{ target_id }}"
+               hx-include="#disk-scans-metric-params-{{ target_id }}"
+               hx-swap="innerHTML">
+        <label class="form-check-label small text-muted" for="disk-scans-log-{{ target_id }}">
+          Log scale
+        </label>
       </div>
     {% endif %}
     {{ scans_scope_note(fileset) }}

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
@@ -1,22 +1,63 @@
 {% from 'dashboards/user/partials/_disk_scans_macros.html'
    import scans_disabled, scans_error, scans_empty, scans_scope_note %}
 {#
-  Access-time histogram fragment — embedded via hx-get from the Filesystem
-  Scans card. Context (set in webapp/disk_scans/routes.py):
+  Distribution-histogram fragment — shared by the Access-history and
+  File-size tabs (they have an identical hist shape). Embedded via hx-get
+  from the Filesystem Scans card. Context (set in webapp/disk_scans/routes.py):
     hist (dict|None), chart_svg (str|None), enabled, error,
-    resource_name, scope, fileset, target_id
+    resource_name, scope, fileset, target_id,
+    bucket_header (x-axis column label), metric ('data'|'files'),
+    metric_toggle (bool — show the Data↔Files pill), fragment_url.
   hist: bucket_labels, buckets{label:{data,files,owners}},
-        total_data, total_files, directory, fast_path, reference_scan_date.
+        total_data, total_files, directory, fast_path, reference_scan_date,
+        username_map.
+  The bar→row drill-down (#ah-bar-<i> / data-ah-bucket=<i>) is pane-scoped in
+  svg-chart-links.js, so both tabs can use the same anchor scheme.
 #}
+
+{% set _metric = metric or 'data' %}
+{% set _by_files = (_metric == 'files') %}
 
 {% if not enabled %}
   {{ scans_disabled() }}
 {% elif error %}
   {{ scans_error(error) }}
 {% elif not hist %}
-  {{ scans_empty('No access-history data for this scope.') }}
+  {{ scans_empty('No distribution data for this scope.') }}
 {% else %}
+  {% if metric_toggle %}
+    {# Carry scope/resource/fileset on the pill re-fetch — same hidden-form +
+       hx-include pattern as the owner↔group toggle. #}
+    <form id="disk-scans-metric-params-{{ target_id }}" class="d-none">
+      <input type="hidden" name="resource" value="{{ resource_name }}">
+      <input type="hidden" name="scope" value="{{ scope }}">
+      {% if fileset %}<input type="hidden" name="fileset" value="{{ fileset }}">{% endif %}
+      <input type="hidden" name="target_id" value="{{ target_id }}">
+    </form>
+  {% endif %}
+
   <div class="d-flex align-items-center flex-wrap gap-2 mb-2">
+    {% if metric_toggle %}
+      {# Data ↔ Files metric pill — re-fetches this same pane with ?metric=. #}
+      <div class="btn-group btn-group-sm me-1" role="group" aria-label="Chart metric">
+        <button type="button"
+                class="btn btn-outline-secondary {% if not _by_files %}active{% endif %}"
+                hx-get="{{ fragment_url }}?metric=data"
+                hx-target="#{{ target_id }}"
+                hx-include="#disk-scans-metric-params-{{ target_id }}"
+                hx-swap="innerHTML">
+          <i class="fas fa-hard-drive me-1"></i> Data
+        </button>
+        <button type="button"
+                class="btn btn-outline-secondary {% if _by_files %}active{% endif %}"
+                hx-get="{{ fragment_url }}?metric=files"
+                hx-target="#{{ target_id }}"
+                hx-include="#disk-scans-metric-params-{{ target_id }}"
+                hx-swap="innerHTML">
+          <i class="fas fa-hashtag me-1"></i> Files
+        </button>
+      </div>
+    {% endif %}
     {{ scans_scope_note(fileset) }}
     <span class="text-muted small">
       Total: <strong>{{ hist.total_data | fmt_size }}</strong>
@@ -47,7 +88,7 @@
       <thead class="table-light">
         <tr>
           <th style="width:1.5rem;" aria-label="Expand"></th>
-          <th>Last accessed</th>
+          <th>{{ bucket_header or 'Bucket' }}</th>
           <th class="text-end">Data</th>
           <th class="text-end">Files</th>
           <th class="text-end">Owners</th>
@@ -76,11 +117,13 @@
             <td class="text-end">{{ owners | length | fmt_number }}</td>
           </tr>
           {% if owners %}
-            {% set ranked = owners.items() | sort(attribute='1.data', reverse=true) %}
+            {# Sort the per-user breakdown by the active chart metric so the
+               table order matches the stacked bar. #}
+            {% set ranked = owners.items() | sort(attribute='1.' ~ _metric, reverse=true) %}
             <tr class="collapse" id="{{ rowid }}">
               <td colspan="5" class="bg-light">
                 <div class="small text-muted mb-1">
-                  Top users by data in <strong>{{ label }}</strong>
+                  Top users by {{ 'files' if _by_files else 'data' }} in <strong>{{ label }}</strong>
                   ({{ owners | length | fmt_number }} total)
                 </div>
                 <table class="table table-sm align-middle mb-0">

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_entities.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_entities.html
@@ -1,0 +1,86 @@
+{% from 'dashboards/user/partials/_disk_scans_macros.html'
+   import scans_disabled, scans_error, scans_empty, scans_scope_note %}
+{#
+  Owner/group rollup fragment — embedded via hx-get from the Filesystem
+  Scans card. Context (set in webapp/disk_scans/routes.py):
+    rows, kind ('owner'|'group'), fragment_url, target_id,
+    resource_name, scope, fileset, enabled, error
+  Owner rows: owner_uid, total_size, total_files, directory_count,
+              filesystem, username.
+  Group rows: owner_gid + groupname (same shape otherwise).
+#}
+
+{% set _is_owner = (kind == 'owner') %}
+{% set _id_attr = 'owner_uid' if _is_owner else 'owner_gid' %}
+{% set _name_attr = 'username' if _is_owner else 'groupname' %}
+
+{% if not enabled %}
+  {{ scans_disabled() }}
+{% elif error %}
+  {{ scans_error(error) }}
+{% else %}
+  <form id="disk-scans-ent-params-{{ target_id }}" class="d-none">
+    <input type="hidden" name="resource" value="{{ resource_name }}">
+    <input type="hidden" name="scope" value="{{ scope }}">
+    {% if fileset %}<input type="hidden" name="fileset" value="{{ fileset }}">{% endif %}
+    <input type="hidden" name="target_id" value="{{ target_id }}">
+  </form>
+
+  <div class="d-flex align-items-center mb-2">
+    {# Owner ↔ group sub-toggle — re-fetches this same pane with ?kind=. #}
+    <div class="btn-group btn-group-sm me-3" role="group" aria-label="Owner or group">
+      <button type="button"
+              class="btn btn-outline-secondary {% if _is_owner %}active{% endif %}"
+              hx-get="{{ fragment_url }}?kind=owner"
+              hx-target="#{{ target_id }}"
+              hx-include="#disk-scans-ent-params-{{ target_id }}"
+              hx-swap="innerHTML">
+        <i class="fas fa-user me-1"></i> By user
+      </button>
+      <button type="button"
+              class="btn btn-outline-secondary {% if not _is_owner %}active{% endif %}"
+              hx-get="{{ fragment_url }}?kind=group"
+              hx-target="#{{ target_id }}"
+              hx-include="#disk-scans-ent-params-{{ target_id }}"
+              hx-swap="innerHTML">
+        <i class="fas fa-users me-1"></i> By group
+      </button>
+    </div>
+    {{ scans_scope_note(fileset) }}
+    <span class="ms-auto text-muted small">
+      {{ rows | length | fmt_number }} {{ 'user' if _is_owner else 'group' }}{{ '' if rows | length == 1 else 's' }}
+    </span>
+  </div>
+
+  {% if not rows %}
+    {{ scans_empty('No ' ~ ('user' if _is_owner else 'group') ~ ' usage recorded for this scope.') }}
+  {% else %}
+    <div class="table-responsive">
+      <table class="table table-sm table-hover align-middle mb-0">
+        <thead class="table-light">
+          <tr>
+            <th>{{ 'User' if _is_owner else 'Group' }}</th>
+            <th class="text-end">Size</th>
+            <th class="text-end">Files</th>
+            <th class="text-end">Directories</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for r in rows %}
+            <tr>
+              <td>
+                {% set name = r[_name_attr] %}
+                {% if name %}<code>{{ name }}</code>
+                {% else %}<span class="text-muted" title="unresolved {{ 'UID' if _is_owner else 'GID' }}">
+                  {{ 'uid' if _is_owner else 'gid' }} {{ r[_id_attr] }}</span>{% endif %}
+              </td>
+              <td class="text-end font-monospace">{{ r.total_size | fmt_size }}</td>
+              <td class="text-end">{{ r.total_files | fmt_number }}</td>
+              <td class="text-end">{{ r.directory_count | fmt_number }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
+{% endif %}

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_entities.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_entities.html
@@ -55,28 +55,32 @@
   {% if not rows %}
     {{ scans_empty('No ' ~ ('user' if _is_owner else 'group') ~ ' usage recorded for this scope.') }}
   {% else %}
+    {# Client-side sortable (sortable_table.js, house style for small read-only
+       tables): sort by name (text), or Size/Files/Directories (numeric).
+       Size sorts by raw bytes via data-sort-value while rendering fmt_size.
+       Default order is Size desc, matching the facade's result order. #}
     <div class="table-responsive">
       <table class="table table-sm table-hover align-middle mb-0">
         <thead class="table-light">
           <tr>
-            <th>{{ 'User' if _is_owner else 'Group' }}</th>
-            <th class="text-end">Size</th>
-            <th class="text-end">Files</th>
-            <th class="text-end">Directories</th>
+            <th class="sortable-header" data-sort="text">{{ 'User' if _is_owner else 'Group' }}</th>
+            <th class="sortable-header text-end sort-desc" data-sort="numeric">Size</th>
+            <th class="sortable-header text-end" data-sort="numeric">Files</th>
+            <th class="sortable-header text-end" data-sort="numeric">Directories</th>
           </tr>
         </thead>
         <tbody>
           {% for r in rows %}
+            {% set name = r[_name_attr] %}
             <tr>
-              <td>
-                {% set name = r[_name_attr] %}
+              <td data-sort-value="{{ name if name else (r[_id_attr] | string) }}">
                 {% if name %}<code>{{ name }}</code>
                 {% else %}<span class="text-muted" title="unresolved {{ 'UID' if _is_owner else 'GID' }}">
                   {{ 'uid' if _is_owner else 'gid' }} {{ r[_id_attr] }}</span>{% endif %}
               </td>
-              <td class="text-end font-monospace">{{ r.total_size | fmt_size }}</td>
-              <td class="text-end">{{ r.total_files | fmt_number }}</td>
-              <td class="text-end">{{ r.directory_count | fmt_number }}</td>
+              <td class="text-end font-monospace" data-sort-value="{{ r.total_size }}">{{ r.total_size | fmt_size }}</td>
+              <td class="text-end" data-sort-value="{{ r.total_files }}">{{ r.total_files | fmt_number }}</td>
+              <td class="text-end" data-sort-value="{{ r.directory_count }}">{{ r.directory_count | fmt_number }}</td>
             </tr>
           {% endfor %}
         </tbody>

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_entities.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_entities.html
@@ -11,8 +11,6 @@
 #}
 
 {% set _is_owner = (kind == 'owner') %}
-{% set _id_attr = 'owner_uid' if _is_owner else 'owner_gid' %}
-{% set _name_attr = 'username' if _is_owner else 'groupname' %}
 
 {% if not enabled %}
   {{ scans_disabled() }}
@@ -55,10 +53,15 @@
   {% if not rows %}
     {{ scans_empty('No ' ~ ('user' if _is_owner else 'group') ~ ' usage recorded for this scope.') }}
   {% else %}
-    {# Client-side sortable (sortable_table.js, house style for small read-only
-       tables): sort by name (text), or Size/Files/Directories (numeric).
-       Size sorts by raw bytes via data-sort-value while rendering fmt_size.
-       Default order is Size desc, matching the facade's result order. #}
+    {# Client-side sortable (sortable_table.js): sort by name (text), or
+       Size/Files/Directories (numeric). Size sorts by raw bytes via
+       data-sort-value while rendering fmt_size. Default order is Size desc,
+       matching the facade's result order.
+
+       Owner mode uses MULTI-TBODY (``tbody.sortable-group``): each user's row
+       and its lazy drill-down detail row reorder together under client sort.
+       Group mode stays a single tbody (no per-group directory drill-down —
+       the facade filters directories by owner UID only). #}
     <div class="table-responsive">
       <table class="table table-sm table-hover align-middle mb-0">
         <thead class="table-light">
@@ -69,21 +72,62 @@
             <th class="sortable-header text-end" data-sort="numeric">Directories</th>
           </tr>
         </thead>
-        <tbody>
+        {% if _is_owner %}
           {% for r in rows %}
-            {% set name = r[_name_attr] %}
-            <tr>
-              <td data-sort-value="{{ name if name else (r[_id_attr] | string) }}">
-                {% if name %}<code>{{ name }}</code>
-                {% else %}<span class="text-muted" title="unresolved {{ 'UID' if _is_owner else 'GID' }}">
-                  {{ 'uid' if _is_owner else 'gid' }} {{ r[_id_attr] }}</span>{% endif %}
-              </td>
-              <td class="text-end font-monospace" data-sort-value="{{ r.total_size }}">{{ r.total_size | fmt_size }}</td>
-              <td class="text-end" data-sort-value="{{ r.total_files }}">{{ r.total_files | fmt_number }}</td>
-              <td class="text-end" data-sort-value="{{ r.directory_count }}">{{ r.directory_count | fmt_number }}</td>
-            </tr>
+            {% set name = r.username %}
+            {% set _oid = target_id ~ '-owner-' ~ r.owner_uid %}
+            <tbody class="sortable-group">
+              <tr>
+                <td data-sort-value="{{ name if name else (r.owner_uid | string) }}">
+                  <button class="btn btn-sm btn-link text-decoration-none p-0 me-1"
+                          type="button" data-bs-toggle="collapse"
+                          data-bs-target="#{{ _oid }}-row"
+                          aria-expanded="false" aria-controls="{{ _oid }}-row">
+                    <i class="fas fa-chevron-right collapse-icon small"></i>
+                  </button>
+                  {% if name %}<code>{{ name }}</code>
+                  {% else %}<span class="text-muted" title="unresolved UID">uid {{ r.owner_uid }}</span>{% endif %}
+                </td>
+                <td class="text-end font-monospace" data-sort-value="{{ r.total_size }}">{{ r.total_size | fmt_size }}</td>
+                <td class="text-end" data-sort-value="{{ r.total_files }}">{{ r.total_files | fmt_number }}</td>
+                <td class="text-end" data-sort-value="{{ r.directory_count }}">{{ r.directory_count | fmt_number }}</td>
+              </tr>
+              <tr class="collapse" id="{{ _oid }}-row">
+                <td colspan="4" class="p-0 border-0">
+                  {# Lazy-load this user's top directories on first expand
+                     (owner_uid filter → short-TTL 'filtered' cache bucket).
+                     Bind to shown.bs.collapse (not click) so it fires under
+                     nav-view-persistence restore too. #}
+                  <div class="p-2 bg-light"
+                       id="{{ _oid }}"
+                       hx-get="{{ url_for('disk_scans.directories_fragment', projcode=project.projcode) }}?owner_uid={{ r.owner_uid }}&resource={{ resource_name }}{% if scope %}&scope={{ scope }}{% endif %}{% if fileset %}&fileset={{ fileset }}{% endif %}&target_id={{ _oid }}&limit=20"
+                       hx-trigger="shown.bs.collapse from:closest tr.collapse once"
+                       hx-swap="innerHTML">
+                    <p class="text-muted small mb-0">
+                      <i class="fas fa-spinner fa-spin me-1"></i>
+                      Loading {{ name or ('uid ' ~ r.owner_uid) }}'s directories…
+                    </p>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
           {% endfor %}
-        </tbody>
+        {% else %}
+          <tbody>
+            {% for r in rows %}
+              {% set name = r.groupname %}
+              <tr>
+                <td data-sort-value="{{ name if name else (r.owner_gid | string) }}">
+                  {% if name %}<code>{{ name }}</code>
+                  {% else %}<span class="text-muted" title="unresolved GID">gid {{ r.owner_gid }}</span>{% endif %}
+                </td>
+                <td class="text-end font-monospace" data-sort-value="{{ r.total_size }}">{{ r.total_size | fmt_size }}</td>
+                <td class="text-end" data-sort-value="{{ r.total_files }}">{{ r.total_files | fmt_number }}</td>
+                <td class="text-end" data-sort-value="{{ r.directory_count }}">{{ r.directory_count | fmt_number }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        {% endif %}
       </table>
     </div>
   {% endif %}

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -333,10 +333,12 @@
 {# ── Filesystem Scans card ──────────────────────────────────────────── #}
 {# Shown only when the fs-scans plugin is loaded AND this resource maps to
    a live scan collection (show_scans, set in the route). Collapsed by
-   default + data-no-persist so the (potentially slow, 30-200s for a
-   fileset drill-down) scans only run when the user opts in by expanding.
-   Each tab lazy-loads its fragment once; the active tab fires on
-   card-open via htmx `from:#collapseDiskScans`. #}
+   default; once opened, the expanded state AND active tab persist across
+   reloads via nav-view-persistence.js (collapse:<id> + tab:<tablistId>).
+   On restore the active tab re-fires its lazy-load — fast for project-root
+   scope (pre-computed); a fileset drill-down re-runs its on-the-fly scan.
+   Each tab loads its fragment once; the active tab fires on card-open via
+   htmx `from:#collapseDiskScans`. #}
 {% if show_scans %}
 <div class="card mb-4">
     <div class="card-header cursor-pointer"
@@ -364,7 +366,7 @@
             <i class="fas fa-chevron-down float-end transition-smooth"></i>
         </h5>
     </div>
-    <div id="collapseDiskScans" class="collapse" data-no-persist>
+    <div id="collapseDiskScans" class="collapse">
         <div class="card-body">
             <ul class="nav nav-tabs mb-0" id="diskScansTabs" role="tablist">
                 <li class="nav-item" role="presentation">

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -324,6 +324,103 @@
     </div>
 </div>
 
+{# ── Filesystem Scans card ──────────────────────────────────────────── #}
+{# Shown only when the fs-scans plugin is loaded AND this resource maps to
+   a live scan collection (show_scans, set in the route). Collapsed by
+   default + data-no-persist so the (potentially slow, 30-200s for a
+   fileset drill-down) scans only run when the user opts in by expanding.
+   Each tab lazy-loads its fragment once; the active tab fires on
+   card-open via htmx `from:#collapseDiskScans`. #}
+{% if show_scans %}
+<div class="card mb-4">
+    <div class="card-header cursor-pointer"
+         data-bs-toggle="collapse" data-bs-target="#collapseDiskScans"
+         aria-expanded="false">
+        <h5 class="mb-0">
+            <i class="fas fa-magnifying-glass-chart"></i> Filesystem Scans
+            <small class="text-muted fw-normal ms-2">
+                large directories, user/group counts, and access-time history
+                {% if fileset %}— scoped to <code>{{ fileset }}</code>
+                {% elif scope != projcode %}under <code>{{ scope }}</code>{% endif %}
+            </small>
+            <i class="fas fa-chevron-down float-end transition-smooth"></i>
+        </h5>
+    </div>
+    <div id="collapseDiskScans" class="collapse" data-no-persist>
+        <div class="card-body">
+            <ul class="nav nav-tabs mb-0" id="diskScansTabs" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link active" id="disk-scans-dirs-tab"
+                            data-bs-toggle="tab" data-bs-target="#tab-disk-scans-dirs"
+                            type="button" role="tab"
+                            hx-get="{{ url_for('disk_scans.directories_fragment',
+                                               projcode=projcode, resource=resource_name,
+                                               scope=scope, fileset=fileset,
+                                               target_id='disk-scans-directories') }}"
+                            hx-target="#disk-scans-directories"
+                            hx-swap="innerHTML"
+                            hx-trigger="shown.bs.tab once, shown.bs.collapse once from:#collapseDiskScans">
+                        <i class="fas fa-folder-tree me-1"></i> Large directories
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="disk-scans-ent-tab"
+                            data-bs-toggle="tab" data-bs-target="#tab-disk-scans-ent"
+                            type="button" role="tab"
+                            hx-get="{{ url_for('disk_scans.entities_fragment',
+                                               projcode=projcode, resource=resource_name,
+                                               scope=scope, fileset=fileset,
+                                               target_id='disk-scans-entities') }}"
+                            hx-target="#disk-scans-entities"
+                            hx-swap="innerHTML"
+                            hx-trigger="shown.bs.tab once">
+                        <i class="fas fa-users me-1"></i> User / group counts
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="disk-scans-acc-tab"
+                            data-bs-toggle="tab" data-bs-target="#tab-disk-scans-acc"
+                            type="button" role="tab"
+                            hx-get="{{ url_for('disk_scans.access_history_fragment',
+                                               projcode=projcode, resource=resource_name,
+                                               scope=scope, fileset=fileset,
+                                               target_id='disk-scans-access') }}"
+                            hx-target="#disk-scans-access"
+                            hx-swap="innerHTML"
+                            hx-trigger="shown.bs.tab once">
+                        <i class="fas fa-clock-rotate-left me-1"></i> Access history
+                    </button>
+                </li>
+            </ul>
+            <div class="tab-content border border-top-0 rounded-bottom p-3"
+                 id="diskScansTabsContent">
+                <div class="tab-pane fade show active" id="tab-disk-scans-dirs" role="tabpanel">
+                    <div id="disk-scans-directories">
+                        <p class="text-muted small mb-0">
+                            <i class="fas fa-spinner fa-spin me-1"></i> Loading directories…
+                        </p>
+                    </div>
+                </div>
+                <div class="tab-pane fade" id="tab-disk-scans-ent" role="tabpanel">
+                    <div id="disk-scans-entities">
+                        <p class="text-muted small mb-0">
+                            <i class="fas fa-spinner fa-spin me-1"></i> Loading…
+                        </p>
+                    </div>
+                </div>
+                <div class="tab-pane fade" id="tab-disk-scans-acc" role="tabpanel">
+                    <div id="disk-scans-access">
+                        <p class="text-muted small mb-0">
+                            <i class="fas fa-spinner fa-spin me-1"></i> Loading access history…
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+
 {# Modal targeted by clickable username legend entries on the disk
    usage chart (see svg-chart-links.js). Only operators with
    VIEW_USERS see the legend wrapped as anchors; the modal container

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -429,6 +429,14 @@
             <div class="tab-content border border-top-0 rounded-bottom p-3"
                  id="diskScansTabsContent">
                 <div class="tab-pane fade show active" id="tab-disk-scans-dirs" role="tabpanel">
+                    <div class="d-flex justify-content-end mb-2">
+                        <a class="btn btn-sm btn-outline-primary"
+                           href="{{ url_for('disk_scans.directories_page', projcode=projcode,
+                                            resource=resource_name, scope=scope, fileset=fileset) }}"
+                           target="_blank" rel="noopener">
+                            Open full view <i class="fas fa-up-right-from-square ms-1"></i>
+                        </a>
+                    </div>
                     <div id="disk-scans-directories">
                         <p class="text-muted small mb-0">
                             <i class="fas fa-spinner fa-spin me-1"></i> Loading directories…

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -411,6 +411,20 @@
                         <i class="fas fa-clock-rotate-left me-1"></i> Access history
                     </button>
                 </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="disk-scans-files-tab"
+                            data-bs-toggle="tab" data-bs-target="#tab-disk-scans-files"
+                            type="button" role="tab"
+                            hx-get="{{ url_for('disk_scans.file_sizes_fragment',
+                                               projcode=projcode, resource=resource_name,
+                                               scope=scope, fileset=fileset,
+                                               target_id='disk-scans-files') }}"
+                            hx-target="#disk-scans-files"
+                            hx-swap="innerHTML"
+                            hx-trigger="shown.bs.tab once">
+                        <i class="fas fa-ruler me-1"></i> File sizes
+                    </button>
+                </li>
             </ul>
             <div class="tab-content border border-top-0 rounded-bottom p-3"
                  id="diskScansTabsContent">
@@ -432,6 +446,13 @@
                     <div id="disk-scans-access">
                         <p class="text-muted small mb-0">
                             <i class="fas fa-spinner fa-spin me-1"></i> Loading access history…
+                        </p>
+                    </div>
+                </div>
+                <div class="tab-pane fade" id="tab-disk-scans-files" role="tabpanel">
+                    <div id="disk-scans-files">
+                        <p class="text-muted small mb-0">
+                            <i class="fas fa-spinner fa-spin me-1"></i> Loading file sizes…
                         </p>
                     </div>
                 </div>

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -277,6 +277,11 @@
 </div>
 
 {# ── Per-user current-snapshot table ────────────────────────────────── #}
+{# Hidden when the Filesystem Scans card is shown — its "User / group counts"
+   tab covers the same per-user breakdown (and more) from the scan DB, so
+   this snapshot table would be redundant. Falls back to showing here
+   whenever scans aren't available for this resource. #}
+{% if not show_scans %}
 <div class="card mb-4">
     <div class="card-header cursor-pointer"
          data-bs-toggle="collapse" data-bs-target="#collapseDiskUsers"
@@ -323,6 +328,7 @@
         </div>
     </div>
 </div>
+{% endif %}
 
 {# ── Filesystem Scans card ──────────────────────────────────────────── #}
 {# Shown only when the fs-scans plugin is loaded AND this resource maps to
@@ -338,6 +344,18 @@
          aria-expanded="false">
         <h5 class="mb-0">
             <i class="fas fa-magnifying-glass-chart"></i> Filesystem Scans
+            {% if scan_info and scan_info.reference %}
+            {# Scan-freshness badge — mirrors the suppressed Per-User
+               Occupancy "snapshot <date>". When the project spans multiple
+               collections with differing scan dates, show the latest and
+               list each in the tooltip. #}
+            <small class="text-muted fw-normal ms-2"
+                   {%- if scan_info.scan_dates | length > 1 %}
+                   title="{% for c, d in scan_info.scan_dates.items() %}{{ c }}: {{ d | fmt_date }}{% if not loop.last %} · {% endif %}{% endfor %}"
+                   {%- endif %}>
+                <i class="far fa-calendar-check"></i> scanned {{ scan_info.reference | fmt_date }}
+            </small>
+            {% endif %}
             <small class="text-muted fw-normal ms-2">
                 large directories, user/group counts, and access-time history
                 {% if fileset %}— scoped to <code>{{ fileset }}</code>

--- a/src/webapp/utils/rbac.py
+++ b/src/webapp/utils/rbac.py
@@ -97,6 +97,18 @@ class Permission(Enum):
     MANAGE_CHARGE_SUMMARIES = "manage_charge_summaries"  # Write charge summary records
     EXPORT_DATA = "export_data"
 
+    # Filesystem scans (elevated)
+    # Browse all filesystem-scan data across a disk resource, UNSCOPED — every
+    # user's paths / sizes / owner UIDs, cross-project and cross-user. The
+    # project-scoped fs-scans card needs no permission (members see their own
+    # tree); this gates only the resource-wide explorer. Named ``view_*`` so
+    # it is auto-granted to the operator bundles via ``ALL_VIEW`` (today exactly
+    # nusd/csg/ssg) and NOT to the facility-scoped tier, which enumerates its
+    # VIEW_* grants explicitly. Campaign collections don't map onto
+    # UNIV/WNA/NCAR facilities, so this is intentionally global, not
+    # facility-scoped.
+    VIEW_ALL_FILESYSTEM_DATA = "view_all_filesystem_data"
+
     # System administration
     ACCESS_ADMIN_DASHBOARD = "access_admin_dashboard"  # Land on /admin/ and see the navbar tab
     MANAGE_ROLES = "manage_roles"

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -37,11 +37,10 @@ def _disable_fs_scans_cache():
     affected by the process-wide adapter singleton.
     """
     from webapp.disk_scans import cache as _c
-    _c._adapter = None
-    _c._disabled = True
+    # A stored None per bucket means "initialised but disabled".
+    _c._adapters = {b: None for b in _c._BUCKETS}
     yield
-    _c._adapter = None
-    _c._disabled = False
+    _c._adapters = {}   # clear → buckets re-init on next use
 
 
 # ---------------------------------------------------------------------------
@@ -478,8 +477,7 @@ class _FakeQ:
 def test_cached_scan_hit_miss_and_scan_date_invalidation(monkeypatch):
     from webapp.disk_scans import cache as c
     monkeypatch.delenv('CACHE_REDIS_URL', raising=False)
-    c._adapter = None
-    c._disabled = False  # re-enable (the autouse fixture disabled it)
+    c._adapters.clear()  # re-enable (the autouse fixture disabled all buckets)
 
     calls = {'n': 0}
     def compute():
@@ -512,8 +510,7 @@ def test_cached_scan_skips_when_no_scan_dates(monkeypatch):
     """Without a scan date there's no freshness to key on — never cache."""
     from webapp.disk_scans import cache as c
     monkeypatch.delenv('CACHE_REDIS_URL', raising=False)
-    c._adapter = None
-    c._disabled = False
+    c._adapters.clear()
 
     calls = {'n': 0}
     def compute():
@@ -531,8 +528,7 @@ def test_cached_scan_disabled_passes_through(monkeypatch):
     from webapp.disk_scans import cache as c
     monkeypatch.delenv('CACHE_REDIS_URL', raising=False)
     monkeypatch.setenv('FS_SCANS_CACHE_TTL', '0')
-    c._adapter = None
-    c._disabled = False  # force re-init under the TTL=0 env
+    c._adapters.clear()  # force re-init under the TTL=0 env
 
     calls = {'n': 0}
     def compute():
@@ -544,3 +540,248 @@ def test_cached_scan_disabled_passes_through(monkeypatch):
     c.cached_scan('directories', q, ['mmm'], ['/mmm'], {'limit': 50}, compute)
     assert calls['n'] == 2
     assert c.get_cache_adapter() is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — directory filters, two cache buckets, resource mode, drill-down
+# ---------------------------------------------------------------------------
+
+def test_scan_directories_forwards_filters(monkeypatch):
+    """The four new filters reach the facade with the right kwarg names."""
+    cap = {}
+    svc = _wire_service(
+        monkeypatch,
+        prefixes=['/glade/campaign/cisl/csg'],
+        collections=['cisl'], warmed=['cisl'],
+        collection_map={'/glade/campaign/cisl/csg': 'cisl'},
+        capture=cap,
+    )
+    svc.scan_directories(
+        None, object(), 'Campaign_Store',
+        owner_uid=4242, leaves_only=True,
+        accessed_before=datetime(2026, 1, 1), accessed_after=datetime(2025, 1, 1),
+    )
+    kw = cap['list_kwargs']
+    assert kw['owner_id'] == 4242            # facade param is owner_id
+    assert kw['leaves_only'] is True
+    assert kw['accessed_before'] == datetime(2026, 1, 1)
+    assert kw['accessed_after'] == datetime(2025, 1, 1)
+
+
+def test_directories_bucket_selection(monkeypatch):
+    """Any filter routes to the 'filtered' bucket; the bare query to 'default'."""
+    from webapp.disk_scans import service
+    _wire_service(
+        monkeypatch, prefixes=['/p'], collections=['c'], warmed=['c'],
+        collection_map={'/p': 'c'}, capture={},
+    )
+    seen = []
+
+    def fake_cached(qt, q, colls, pfx, opts, compute, bucket='default'):
+        seen.append(bucket)
+        return compute()
+
+    monkeypatch.setattr(service, 'cached_scan', fake_cached)
+    service.scan_directories(None, object(), 'R')                     # default
+    service.scan_directories(None, object(), 'R', owner_uid=5)        # filtered
+    service.scan_directories(None, object(), 'R', leaves_only=True)   # filtered
+    service.scan_directories(None, object(), 'R',
+                             accessed_before=datetime(2026, 1, 1))    # filtered
+    assert seen == ['default', 'filtered', 'filtered', 'filtered']
+
+
+def test_filtered_bucket_has_short_ttl(monkeypatch):
+    """The two buckets carry distinct TTLs (8 days vs 30 minutes)."""
+    from webapp.disk_scans import cache as c
+    monkeypatch.delenv('CACHE_REDIS_URL', raising=False)
+    c._adapters.clear()
+    assert c.get_cache_adapter('default').info()['ttl'] == 691200
+    assert c.get_cache_adapter('filtered').info()['ttl'] == 1800
+
+
+def test_fs_scans_cache_info_lists_both_buckets(monkeypatch):
+    """Admin card data: one info() dict per bucket, default first."""
+    from webapp.disk_scans import cache as c
+    monkeypatch.delenv('CACHE_REDIS_URL', raising=False)
+    c._adapters.clear()
+    infos = c.fs_scans_cache_info()
+    assert [i['name'] for i in infos] == ['fs_scans', 'fs_scans_filtered']
+
+
+# -- resource mode (service) -------------------------------------------------
+
+def _wire_resource_service(monkeypatch, *, collections, capture):
+    """Patch the service for resource mode: a fake module + collection map."""
+    from webapp.disk_scans import service
+
+    class _FakeQueries:
+        def __init__(self, filesystems):
+            capture['filesystems'] = list(filesystems)
+
+        def list_directories(self, **kw):
+            capture['list_kwargs'] = kw
+            return [{'path': 'X'}]
+
+    mod = types.SimpleNamespace(FsScanQueries=_FakeQueries)
+    monkeypatch.setattr(service, 'get_module', lambda: mod)
+    monkeypatch.setattr(service, 'collections_for_resource',
+                        lambda r: list(collections))
+    return service
+
+
+def test_scan_directories_resource_unscoped(monkeypatch):
+    """Resource mode queries the whole collection (path_prefixes=None)."""
+    cap = {}
+    svc = _wire_resource_service(monkeypatch, collections=['campaign'], capture=cap)
+    rows = svc.scan_directories_resource('Campaign_Store')
+    assert cap['filesystems'] == ['campaign']
+    assert cap['list_kwargs']['path_prefixes'] is None   # whole-collection fast path
+    assert rows == [{'path': 'X'}]
+
+
+def test_scan_directories_resource_subpath(monkeypatch):
+    """A fileset narrows resource mode to that single sub-path."""
+    cap = {}
+    svc = _wire_resource_service(monkeypatch, collections=['campaign'], capture=cap)
+    svc.scan_directories_resource('Campaign_Store', subpath='/glade/campaign/cisl')
+    assert cap['list_kwargs']['path_prefixes'] == ['/glade/campaign/cisl']
+
+
+def test_scan_directories_resource_empty_when_plugin_off(monkeypatch):
+    from webapp.disk_scans import service
+    monkeypatch.setattr(service, 'get_module', lambda: None)
+    assert service.scan_directories_resource('Campaign_Store') == []
+
+
+def test_collections_for_resource_delegates(monkeypatch):
+    """The resource→collections seam returns the warmed set (today)."""
+    from webapp.disk_scans import session as sess
+    monkeypatch.setattr(sess, 'get_collections', lambda app=None: ['campaign'])
+    assert sess.collections_for_resource('Campaign_Store') == ['campaign']
+    monkeypatch.setattr(sess, 'get_collections', lambda app=None: [])
+    assert sess.collections_for_resource('Campaign_Store') == []
+
+
+# -- routes: filters, explorer page, owner drill-down ------------------------
+
+def test_directories_owner_filter_and_form(app, auth_client, active_project, monkeypatch):
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    captured = {}
+
+    def fake_scan(session, project, resource_name, **kw):
+        captured.update(kw)
+        return [{
+            'path': '/glade/campaign/cisl/csg', 'depth': 4,
+            'total_size_r': 1024 ** 4, 'file_count_r': 1, 'dir_count_r': 1,
+            'max_atime_r': None, 'owner_uid': 4242, 'owner_gid': 1,
+            'filesystem': 'cisl',
+        }]
+    monkeypatch.setattr(service, 'scan_directories', fake_scan)
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/directories'
+        f'?resource={_RES}&owner_uid=4242&leaves_only=1&accessed_before=2026-01-01'
+    )
+    assert resp.status_code == 200
+    assert captured['owner_uid'] == 4242
+    assert captured['leaves_only'] is True
+    assert captured['accessed_before'] == datetime(2026, 1, 1)
+    body = resp.get_data(as_text=True)
+    # Hidden params form round-trips the active filters across sort re-fetches.
+    assert 'name="owner_uid" value="4242"' in body
+    assert 'name="leaves_only"' in body
+    assert 'name="accessed_before" value="2026-01-01"' in body
+
+
+def test_directories_page_renders(auth_client, active_project):
+    """The standalone explorer page shows the filters panel (project mode)."""
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/directories/explore'
+        f'?resource={_RES}'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'Accessed before' in body
+    assert 'disk-scans-filters-' in body      # the filter form id
+    assert 'Apply' in body
+
+
+def test_entities_owner_drilldown_markup(app, auth_client, active_project, monkeypatch):
+    """Owner rows are sortable-group tbodies with a lazy directory drill-down."""
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    monkeypatch.setattr(service, 'scan_owner_summary', lambda s, p, r, **kw: [{
+        'owner_uid': 4242, 'total_size': 1024 ** 4, 'total_files': 5,
+        'directory_count': 2, 'filesystem': 'cisl', 'username': 'alice',
+    }])
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/entities?resource={_RES}'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'sortable-group' in body
+    assert 'data-bs-toggle="collapse"' in body
+    assert 'owner_uid=4242' in body              # drill-down hx-get carries the uid
+    assert 'shown.bs.collapse' in body           # lazy-loads on expand
+
+
+def test_entities_group_no_drilldown(app, auth_client, active_project, monkeypatch):
+    """Group mode stays a single tbody — no per-group directory expansion."""
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    monkeypatch.setattr(service, 'scan_group_summary', lambda s, p, r, **kw: [{
+        'owner_gid': 2001, 'total_size': 1, 'total_files': 1,
+        'directory_count': 1, 'filesystem': 'cisl', 'groupname': 'csgteam',
+    }])
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/entities'
+        f'?resource={_RES}&kind=group'
+    )
+    assert resp.status_code == 200
+    assert 'sortable-group' not in resp.get_data(as_text=True)
+
+
+# -- resource mode (routes): RBAC gating -------------------------------------
+
+def test_resource_fragment_403_without_perm(non_admin_client):
+    resp = non_admin_client.get(
+        f'/dashboards/user/disk-scans/resource/{_RES}/directories'
+    )
+    assert resp.status_code == 403
+
+
+def test_resource_page_403_without_perm(non_admin_client):
+    resp = non_admin_client.get(
+        f'/dashboards/user/disk-scans/resource/{_RES}/explore'
+    )
+    assert resp.status_code == 403
+
+
+def test_resource_fragment_200_with_perm(auth_client):
+    """benkirk holds VIEW_ALL_FILESYSTEM_DATA → 200 (plugin off → banner)."""
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/resource/{_RES}/directories'
+    )
+    assert resp.status_code == 200
+
+
+def test_resource_page_200_with_perm(auth_client):
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/resource/{_RES}/explore'
+    )
+    assert resp.status_code == 200
+    assert 'Resource-wide' in resp.get_data(as_text=True)
+
+
+def test_view_all_filesystem_data_grants():
+    """Auto-granted to operator bundles via ALL_VIEW; NOT to facility tier."""
+    from webapp.utils.rbac import (
+        GROUP_PERMISSIONS, USER_FACILITY_PERMISSIONS, Permission,
+    )
+    p = Permission.VIEW_ALL_FILESYSTEM_DATA
+    for bundle in ('nusd', 'csg', 'ssg'):
+        assert p in GROUP_PERMISSIONS[bundle], bundle
+    assert p not in USER_FACILITY_PERMISSIONS['sureshm']['WNA']

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -27,6 +27,23 @@ from datetime import datetime
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _disable_fs_scans_cache():
+    """Disable the scan-result cache for these tests by default.
+
+    The scoping/route tests exercise the query path directly; the cache is
+    covered explicitly by the test_cached_scan_* cases (which re-enable it).
+    Reset to a clean, enabled state on teardown so other modules aren't
+    affected by the process-wide adapter singleton.
+    """
+    from webapp.disk_scans import cache as _c
+    _c._adapter = None
+    _c._disabled = True
+    yield
+    _c._adapter = None
+    _c._disabled = False
+
+
 # ---------------------------------------------------------------------------
 # service._scoped — project scoping + subpath narrowing
 # ---------------------------------------------------------------------------
@@ -338,7 +355,7 @@ def test_access_history_renders_svg(app, auth_client, active_project, monkeypatc
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
     assert '<svg' in body                 # matplotlib SVG actually rendered
-    assert '< 1 Month' in body            # bucket label in the table
+    assert '7+ Years' in body             # bucket label in the table (no HTML-escaping)
     assert 'fast path' in body            # fast_path badge
 
 
@@ -367,3 +384,87 @@ def test_fragment_missing_resource_is_graceful(app, auth_client, active_project,
     )
     assert resp.status_code == 200
     assert called['hit'] is False
+
+
+# ---------------------------------------------------------------------------
+# cache.cached_scan — scan-date-keyed get / miss / weekly invalidation
+# ---------------------------------------------------------------------------
+
+class _FakeQ:
+    """Minimal facade stand-in: only scan_dates() is needed for the cache key."""
+    def __init__(self, iso):
+        self.iso = iso
+
+    def scan_dates(self, filesystems=None):
+        return [datetime.fromisoformat(self.iso)] if self.iso else []
+
+
+def test_cached_scan_hit_miss_and_scan_date_invalidation(monkeypatch):
+    from webapp.disk_scans import cache as c
+    monkeypatch.delenv('CACHE_REDIS_URL', raising=False)
+    c._adapter = None
+    c._disabled = False  # re-enable (the autouse fixture disabled it)
+
+    calls = {'n': 0}
+    def compute():
+        calls['n'] += 1
+        return [{'v': calls['n']}]
+
+    q = _FakeQ('2026-06-14T00:00:00')
+    opts = {'sort_by': 'size', 'limit': 50}
+
+    r1 = c.cached_scan('directories', q, ['mmm'], ['/mmm'], opts, compute)
+    r2 = c.cached_scan('directories', q, ['mmm'], ['/mmm'], opts, compute)
+    assert r1 == r2 == [{'v': 1}]
+    assert calls['n'] == 1                               # 2nd call served from cache
+
+    # Different opts (a future filter selection) → distinct key → recompute.
+    c.cached_scan('directories', q, ['mmm'], ['/mmm'], {'sort_by': 'files', 'limit': 50}, compute)
+    assert calls['n'] == 2
+
+    # Different query type, same scope → its own entry.
+    c.cached_scan('owner', q, ['mmm'], ['/mmm'], {'limit': 50}, compute)
+    assert calls['n'] == 3
+
+    # A new weekly scan (later date) → key changes → recompute (auto-invalidation).
+    q2 = _FakeQ('2026-06-21T00:00:00')
+    c.cached_scan('directories', q2, ['mmm'], ['/mmm'], opts, compute)
+    assert calls['n'] == 4
+
+
+def test_cached_scan_skips_when_no_scan_dates(monkeypatch):
+    """Without a scan date there's no freshness to key on — never cache."""
+    from webapp.disk_scans import cache as c
+    monkeypatch.delenv('CACHE_REDIS_URL', raising=False)
+    c._adapter = None
+    c._disabled = False
+
+    calls = {'n': 0}
+    def compute():
+        calls['n'] += 1
+        return ['x']
+
+    q = _FakeQ(None)  # scan_dates() -> []
+    c.cached_scan('owner', q, ['mmm'], ['/mmm'], {'limit': 50}, compute)
+    c.cached_scan('owner', q, ['mmm'], ['/mmm'], {'limit': 50}, compute)
+    assert calls['n'] == 2
+
+
+def test_cached_scan_disabled_passes_through(monkeypatch):
+    """TTL/SIZE == 0 disables the cache; every call recomputes."""
+    from webapp.disk_scans import cache as c
+    monkeypatch.delenv('CACHE_REDIS_URL', raising=False)
+    monkeypatch.setenv('FS_SCANS_CACHE_TTL', '0')
+    c._adapter = None
+    c._disabled = False  # force re-init under the TTL=0 env
+
+    calls = {'n': 0}
+    def compute():
+        calls['n'] += 1
+        return ['x']
+
+    q = _FakeQ('2026-06-14T00:00:00')
+    c.cached_scan('directories', q, ['mmm'], ['/mmm'], {'limit': 50}, compute)
+    c.cached_scan('directories', q, ['mmm'], ['/mmm'], {'limit': 50}, compute)
+    assert calls['n'] == 2
+    assert c.get_cache_adapter() is None

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -1,0 +1,369 @@
+"""Tests for the fs-scans Flask integration (webapp/disk_scans/*).
+
+Covers two layers:
+
+1. ``service._scoped`` — the project-scoping + ``subpath`` (fileset
+   drill-down) narrowing, exercised through the public ``scan_directories``
+   wrapper with a fake plugin module. No app context / DB needed.
+
+2. ``routes`` — the three HTMX fragment endpoints (directories, entities,
+   access-history): disabled banner (not 404), 404 on unknown projcode,
+   param whitelisting, fileset→subpath plumbing, and the enabled happy
+   path. The service layer is monkeypatched so these stay independent of
+   real project-directory data and the fs-scans backend.
+
+The session-scoped ``app`` fixture (tests/conftest.py) uses
+``TestingConfig`` with ``FS_SCANS_ENABLED = False``, so the plugin starts
+disabled in every test; cases that need it enable it via
+``monkeypatch.setitem`` on ``app.extensions['fs_scans']`` (restored at
+teardown).
+"""
+
+from __future__ import annotations
+
+import types
+from datetime import datetime
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# service._scoped — project scoping + subpath narrowing
+# ---------------------------------------------------------------------------
+
+def _wire_service(monkeypatch, *, prefixes, collections, warmed,
+                  collection_map, capture):
+    """Patch the service module's scope/module/collection helpers + a fake
+    FsScanQueries that captures the kwargs it's called with."""
+    from webapp.disk_scans import service
+
+    class _FakeQueries:
+        def __init__(self, filesystems):
+            capture['filesystems'] = list(filesystems)
+
+        def list_directories(self, **kw):
+            capture['list_kwargs'] = kw
+            return [{'path': p} for p in (kw.get('path_prefixes') or [])]
+
+        def owner_summary(self, **kw):
+            capture['owner_kwargs'] = kw
+            return []
+
+        def resolve_usernames(self, uids):
+            return {}
+
+    mod = types.SimpleNamespace(
+        FsScanQueries=_FakeQueries,
+        collection_for_path=lambda p: collection_map.get(p),
+    )
+    monkeypatch.setattr(service, 'get_module', lambda: mod)
+    monkeypatch.setattr(service, 'get_collections', lambda: list(warmed))
+    monkeypatch.setattr(
+        service, 'resolve_scan_scope',
+        lambda session, project, resource_name: (list(prefixes), list(collections)),
+    )
+    return service
+
+
+def test_scoped_no_subpath_keeps_all_prefixes(monkeypatch):
+    """Without a subpath, every resolved prefix is handed to the facade."""
+    cap = {}
+    svc = _wire_service(
+        monkeypatch,
+        prefixes=['/glade/campaign/cisl/csg', '/glade/campaign/cisl/other'],
+        collections=['cisl'], warmed=['cisl'],
+        collection_map={
+            '/glade/campaign/cisl/csg': 'cisl',
+            '/glade/campaign/cisl/other': 'cisl',
+        },
+        capture=cap,
+    )
+    rows = svc.scan_directories(None, object(), 'Campaign_Store')
+    assert cap['filesystems'] == ['cisl']
+    assert sorted(cap['list_kwargs']['path_prefixes']) == [
+        '/glade/campaign/cisl/csg', '/glade/campaign/cisl/other',
+    ]
+    assert len(rows) == 2
+
+
+def test_scoped_subpath_narrows_to_fileset(monkeypatch):
+    """A subpath keeps only that prefix (and descendants) — the drill-down."""
+    cap = {}
+    svc = _wire_service(
+        monkeypatch,
+        prefixes=['/glade/campaign/cisl/csg', '/glade/campaign/cisl/other'],
+        collections=['cisl'], warmed=['cisl'],
+        collection_map={
+            '/glade/campaign/cisl/csg': 'cisl',
+            '/glade/campaign/cisl/other': 'cisl',
+        },
+        capture=cap,
+    )
+    svc.scan_directories(None, object(), 'Campaign_Store',
+                         subpath='/glade/campaign/cisl/csg')
+    assert cap['list_kwargs']['path_prefixes'] == ['/glade/campaign/cisl/csg']
+
+
+def test_scoped_unknown_subpath_yields_no_query(monkeypatch):
+    """A subpath outside the project's resolved set returns [] (never widens)."""
+    cap = {}
+    svc = _wire_service(
+        monkeypatch,
+        prefixes=['/glade/campaign/cisl/csg'],
+        collections=['cisl'], warmed=['cisl'],
+        collection_map={'/glade/campaign/cisl/csg': 'cisl'},
+        capture=cap,
+    )
+    rows = svc.scan_directories(None, object(), 'Campaign_Store',
+                                subpath='/glade/campaign/other/elsewhere')
+    assert rows == []
+    # Facade must not have been constructed/queried for an unscoped path.
+    assert 'list_kwargs' not in cap
+
+
+def test_scoped_drops_unwarmed_collections(monkeypatch):
+    """Collections not in the warmed set are dropped → no results."""
+    cap = {}
+    svc = _wire_service(
+        monkeypatch,
+        prefixes=['/glade/campaign/aiml/proj'],
+        collections=['aiml'], warmed=['cisl'],   # aiml not reachable
+        collection_map={'/glade/campaign/aiml/proj': 'aiml'},
+        capture=cap,
+    )
+    assert svc.scan_directories(None, object(), 'Campaign_Store') == []
+    assert 'list_kwargs' not in cap
+
+
+def test_scoped_returns_empty_when_module_missing(monkeypatch):
+    from webapp.disk_scans import service
+    monkeypatch.setattr(service, 'get_module', lambda: None)
+    assert service.scan_directories(None, object(), 'Campaign_Store') == []
+    assert service.scan_access_history(None, object(), 'Campaign_Store') is None
+
+
+# ---------------------------------------------------------------------------
+# routes — HTMX fragment endpoints
+# ---------------------------------------------------------------------------
+
+def _enable_fs_scans(app, monkeypatch, collections=('cisl',)):
+    """Mark the plugin enabled on app.extensions for is_enabled() checks."""
+    state = {
+        'module':      object(),
+        'collections': list(collections),
+        'engines':     {c: object() for c in collections},
+        'enabled':     True,
+    }
+    monkeypatch.setitem(app.extensions, 'fs_scans', state)
+
+
+_RES = 'Campaign_Store'
+
+
+# -- directories ------------------------------------------------------------
+
+def test_directories_disabled_banner(auth_client, active_project):
+    """Plugin off → 200 with the 'unavailable' alert, not a 404."""
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/directories?resource={_RES}'
+    )
+    assert resp.status_code == 200
+    assert 'Filesystem-scan data is unavailable' in resp.get_data(as_text=True)
+
+
+def test_directories_404_on_unknown_projcode(auth_client):
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/NOPE9999/directories?resource={_RES}'
+    )
+    assert resp.status_code == 404
+
+
+def test_directories_renders_rows(app, auth_client, active_project, monkeypatch):
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    captured = {}
+
+    def fake_scan(session, project, resource_name, **kw):
+        captured.update(kw)
+        return [{
+            'path': '/glade/campaign/cisl/csg', 'depth': 4,
+            'total_size_r': 2 * 1024 ** 4, 'file_count_r': 12345,
+            'dir_count_r': 50, 'max_atime_r': '2026-05-01 10:00:00',
+            'owner_uid': 1001, 'owner_gid': 2001, 'filesystem': 'cisl',
+        }]
+    monkeypatch.setattr(service, 'scan_directories', fake_scan)
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/directories?resource={_RES}'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert '/glade/campaign/cisl/csg' in body
+    assert 'TiB' in body                       # 2 TiB rendered via fmt_size
+    assert 'Filesystem-scan data is unavailable' not in body
+    assert captured['sort_by'] == 'size'       # default
+    assert captured['subpath'] is None         # no fileset
+
+
+def test_directories_sort_by_whitelisted(app, auth_client, active_project, monkeypatch):
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    captured = {}
+    monkeypatch.setattr(service, 'scan_directories',
+                        lambda s, p, r, **kw: captured.update(kw) or [])
+
+    auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/directories'
+        f'?resource={_RES}&sort_by=bogus'
+    )
+    assert captured['sort_by'] == 'size'       # bogus coerced to default
+
+    auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/directories'
+        f'?resource={_RES}&sort_by=files'
+    )
+    assert captured['sort_by'] == 'files'
+
+
+def test_directories_fileset_becomes_subpath(app, auth_client, active_project, monkeypatch):
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    captured = {}
+    monkeypatch.setattr(service, 'scan_directories',
+                        lambda s, p, r, **kw: captured.update(kw) or [])
+
+    auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/directories'
+        f'?resource={_RES}&fileset=/glade/campaign/cisl/csg'
+    )
+    assert captured['subpath'] == '/glade/campaign/cisl/csg'
+
+
+def test_directories_error_banner_on_exception(app, auth_client, active_project, monkeypatch):
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+
+    def boom(*a, **k):
+        raise RuntimeError('backend down')
+    monkeypatch.setattr(service, 'scan_directories', boom)
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/directories?resource={_RES}'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'Could not load filesystem-scan data' in body
+    assert 'backend down' in body
+
+
+# -- entities ---------------------------------------------------------------
+
+def test_entities_owner_renders(app, auth_client, active_project, monkeypatch):
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    monkeypatch.setattr(service, 'scan_owner_summary', lambda s, p, r, **kw: [{
+        'owner_uid': 1001, 'total_size': 1024 ** 4, 'total_files': 500,
+        'directory_count': 10, 'filesystem': 'cisl', 'username': 'benkirk',
+    }])
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/entities?resource={_RES}'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'benkirk' in body
+    assert 'By group' in body          # the owner↔group toggle is present
+
+
+def test_entities_group_renders(app, auth_client, active_project, monkeypatch):
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    captured = {}
+
+    def fake_group(s, p, r, **kw):
+        captured.update(kw)
+        return [{
+            'owner_gid': 2001, 'total_size': 1024 ** 4, 'total_files': 500,
+            'directory_count': 10, 'filesystem': 'cisl', 'groupname': 'csgteam',
+        }]
+    monkeypatch.setattr(service, 'scan_group_summary', fake_group)
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/entities'
+        f'?resource={_RES}&kind=group'
+    )
+    assert resp.status_code == 200
+    assert 'csgteam' in resp.get_data(as_text=True)
+
+
+def test_entities_kind_whitelisted(app, auth_client, active_project, monkeypatch):
+    """A bogus kind falls back to owner (scan_owner_summary is used)."""
+    from webapp.disk_scans import service
+    called = {'owner': False, 'group': False}
+    _enable_fs_scans(app, monkeypatch)
+    monkeypatch.setattr(service, 'scan_owner_summary',
+                        lambda *a, **k: called.update(owner=True) or [])
+    monkeypatch.setattr(service, 'scan_group_summary',
+                        lambda *a, **k: called.update(group=True) or [])
+
+    auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/entities'
+        f'?resource={_RES}&kind=bogus'
+    )
+    assert called['owner'] is True
+    assert called['group'] is False
+
+
+# -- access history ---------------------------------------------------------
+
+def test_access_history_renders_svg(app, auth_client, active_project, monkeypatch):
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    hist = {
+        'bucket_labels': ['< 1 Month', '1-3 Months', '7+ Years'],
+        'buckets': {
+            '< 1 Month':   {'data': 2 * 1024 ** 4, 'files': 100, 'owners': {1001: {}}},
+            '1-3 Months':  {'data': 1024 ** 4, 'files': 50, 'owners': {1001: {}, 1002: {}}},
+            '7+ Years':    {'data': 512 * 1024 ** 3, 'files': 10, 'owners': {}},
+        },
+        'total_data': 3 * 1024 ** 4 + 512 * 1024 ** 3, 'total_files': 160,
+        'directory': '/glade/campaign/cisl', 'fast_path': True,
+        'reference_scan_date': datetime(2026, 6, 1),
+    }
+    monkeypatch.setattr(service, 'scan_access_history', lambda s, p, r, **kw: hist)
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/access-history?resource={_RES}'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert '<svg' in body                 # matplotlib SVG actually rendered
+    assert '< 1 Month' in body            # bucket label in the table
+    assert 'fast path' in body            # fast_path badge
+
+
+def test_access_history_empty_when_none(app, auth_client, active_project, monkeypatch):
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    monkeypatch.setattr(service, 'scan_access_history', lambda s, p, r, **kw: None)
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/access-history?resource={_RES}'
+    )
+    assert resp.status_code == 200
+    assert 'No access-history data' in resp.get_data(as_text=True)
+
+
+def test_fragment_missing_resource_is_graceful(app, auth_client, active_project, monkeypatch):
+    """No ?resource= → treated like disabled (no unscoped query)."""
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    called = {'hit': False}
+    monkeypatch.setattr(service, 'scan_directories',
+                        lambda *a, **k: called.update(hit=True) or [])
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/directories'
+    )
+    assert resp.status_code == 200
+    assert called['hit'] is False

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -157,6 +157,7 @@ def test_scoped_returns_empty_when_module_missing(monkeypatch):
     monkeypatch.setattr(service, 'get_module', lambda: None)
     assert service.scan_directories(None, object(), 'Campaign_Store') == []
     assert service.scan_access_history(None, object(), 'Campaign_Store') is None
+    assert service.scan_file_sizes(None, object(), 'Campaign_Store') is None
 
 
 # ---------------------------------------------------------------------------
@@ -380,7 +381,54 @@ def test_access_history_empty_when_none(app, auth_client, active_project, monkey
         f'/dashboards/user/disk-scans/{active_project.projcode}/access-history?resource={_RES}'
     )
     assert resp.status_code == 200
-    assert 'No access-history data' in resp.get_data(as_text=True)
+    assert 'No distribution data' in resp.get_data(as_text=True)
+
+
+def test_file_sizes_renders_svg(app, auth_client, active_project, monkeypatch):
+    """File-size tab is the access-history tab's twin: same shape, same
+    template/chart, different service query (scan_file_sizes)."""
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    hist = {
+        'bucket_labels': ['0 - 1 KiB', '1 KiB - 10 KiB', '100 GiB+'],
+        'buckets': {
+            '0 - 1 KiB':     {'data': 127 * 1024 ** 3, 'files': 4 * 10 ** 8,
+                              'owners': {1001: {'data': 64 * 1024 ** 3, 'files': 3 * 10 ** 8},
+                                         1002: {'data': 63 * 1024 ** 3, 'files': 10 ** 8}}},
+            '1 KiB - 10 KiB': {'data': 693 * 1024 ** 3, 'files': 3 * 10 ** 8,
+                               'owners': {1001: {'data': 693 * 1024 ** 3, 'files': 3 * 10 ** 8}}},
+            '100 GiB+':      {'data': 8 * 1024 ** 5, 'files': 35000, 'owners': {}},
+        },
+        'total_data': 8 * 1024 ** 5, 'total_files': 7 * 10 ** 8,
+        'directory': '/glade/campaign/cisl', 'fast_path': True,
+        'reference_scan_date': datetime(2026, 6, 1),
+        'username_map': {1001: 'fasullo', 1002: 'schwartz'},
+    }
+    monkeypatch.setattr(service, 'scan_file_sizes', lambda s, p, r, **kw: hist)
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/file-sizes?resource={_RES}'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert '<svg' in body                 # matplotlib SVG rendered
+    assert '100 GiB+' in body             # file-size bucket label in the table
+    assert 'fasullo' in body              # per-user breakdown resolved
+    assert '#ah-bar-0' in body            # bar→row drill-down anchor (shared scheme)
+    assert 'data-ah-bucket="0"' in body
+    # Data ↔ Files metric pill present (file-sizes only) and defaults to Data.
+    assert 'metric=files' in body
+    assert 'Top users by data' in body
+
+    # Switching the pill re-renders the same fragment by file count.
+    resp2 = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}'
+        f'/file-sizes?resource={_RES}&metric=files'
+    )
+    assert resp2.status_code == 200
+    body2 = resp2.get_data(as_text=True)
+    assert '<svg' in body2
+    assert 'Top users by files' in body2   # per-user table re-sorted by metric
 
 
 def test_fragment_missing_resource_is_graceful(app, auth_client, active_project, monkeypatch):

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -419,6 +419,10 @@ def test_file_sizes_renders_svg(app, auth_client, active_project, monkeypatch):
     # Data ↔ Files metric pill present (file-sizes only) and defaults to Data.
     assert 'metric=files' in body
     assert 'Top users by data' in body
+    # Log-scale switch present and off by default.
+    assert 'Log scale' in body
+    assert 'disk-scans-log-' in body
+    assert 'checked' not in body
 
     # Switching the pill re-renders the same fragment by file count.
     resp2 = auth_client.get(
@@ -429,6 +433,18 @@ def test_file_sizes_renders_svg(app, auth_client, active_project, monkeypatch):
     body2 = resp2.get_data(as_text=True)
     assert '<svg' in body2
     assert 'Top users by files' in body2   # per-user table re-sorted by metric
+
+    # Log scale on → still renders (solid bars), switch reflects checked state,
+    # and the bar→row drill-down anchor survives.
+    resp3 = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}'
+        f'/file-sizes?resource={_RES}&log=1'
+    )
+    assert resp3.status_code == 200
+    body3 = resp3.get_data(as_text=True)
+    assert '<svg' in body3
+    assert 'checked' in body3              # switch reflects log_on
+    assert '#ah-bar-0' in body3            # drill-down preserved under log
 
 
 def test_fragment_missing_resource_is_graceful(app, auth_client, active_project, monkeypatch):

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -694,6 +694,28 @@ def test_directories_owner_filter_and_form(app, auth_client, active_project, mon
     assert 'name="accessed_before" value="2026-01-01"' in body
 
 
+def test_directories_subdirs_column_hidden_under_leaves_only(
+        app, auth_client, active_project, monkeypatch):
+    """Recursive subdir count is 0 for leaves — hide the column + its pill."""
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    monkeypatch.setattr(service, 'scan_directories', lambda s, p, r, **kw: [{
+        'path': '/glade/campaign/cisl/csg/leaf', 'depth': 5,
+        'total_size_r': 1024 ** 4, 'file_count_r': 3, 'dir_count_r': 0,
+        'max_atime_r': None, 'owner_uid': 1, 'owner_gid': 1, 'filesystem': 'cisl',
+    }])
+
+    base = f'/dashboards/user/disk-scans/{active_project.projcode}/directories?resource={_RES}'
+    # Without the filter the Subdirectories column + # Subdirs pill are present.
+    on = auth_client.get(base).get_data(as_text=True)
+    assert 'Subdirectories' in on
+    assert '# Subdirs' in on
+    # With leaves-only, both are suppressed.
+    off = auth_client.get(base + '&leaves_only=1').get_data(as_text=True)
+    assert 'Subdirectories' not in off
+    assert '# Subdirs' not in off
+
+
 def test_directories_page_renders(auth_client, active_project):
     """The standalone explorer page shows the filters panel (project mode)."""
     resp = auth_client.get(

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -27,6 +27,26 @@ from datetime import datetime
 import pytest
 
 
+# Mirror the plugin's normalize_path / collection_for_path lexical helpers so the
+# fake module behaves like the real one for scope matching (see
+# project_fs_scans_paths_normalized).
+_FAKE_MOUNTS = ('/glade/campaign', '/gpfs/csfs1', '/glade/derecho/scratch', '/lustre/desc1')
+
+
+def _fake_normalize(p):
+    p = (p or '').rstrip('/')
+    for pre in _FAKE_MOUNTS:
+        if p.startswith(pre):
+            s = p[len(pre):]
+            return s if s.startswith('/') else '/' + s
+    return p
+
+
+def _fake_collection_for_path(p):
+    n = _fake_normalize(p).strip('/')
+    return n.split('/', 1)[0].lower() if n else None
+
+
 @pytest.fixture(autouse=True)
 def _disable_fs_scans_cache():
     """Disable the scan-result cache for these tests by default.
@@ -70,7 +90,10 @@ def _wire_service(monkeypatch, *, prefixes, collections, warmed,
 
     mod = types.SimpleNamespace(
         FsScanQueries=_FakeQueries,
-        collection_for_path=lambda p: collection_map.get(p),
+        # Explicit map wins; fall back to the computed (normalize + first
+        # segment) form so normalized descent paths (/cisl/csg/sub) resolve too.
+        collection_for_path=lambda p: collection_map.get(p) or _fake_collection_for_path(p),
+        normalize_path=_fake_normalize,
     )
     monkeypatch.setattr(service, 'get_module', lambda: mod)
     monkeypatch.setattr(service, 'get_collections', lambda: list(warmed))
@@ -807,3 +830,163 @@ def test_view_all_filesystem_data_grants():
     for bundle in ('nusd', 'csg', 'ssg'):
         assert p in GROUP_PERMISSIONS[bundle], bundle
     assert p not in USER_FACILITY_PERMISSIONS['sureshm']['WNA']
+
+
+# ---------------------------------------------------------------------------
+# File-browser drill-down — _scoped descent/normalized matching, browse rows,
+# breadcrumb, shared macro
+# ---------------------------------------------------------------------------
+
+def test_scoped_normalized_subpath_selects_fileset(monkeypatch):
+    """A normalized subpath selects the matching absolute project fileset."""
+    cap = {}
+    svc = _wire_service(
+        monkeypatch,
+        prefixes=['/glade/campaign/cisl/csg', '/glade/campaign/cisl/other'],
+        collections=['cisl'], warmed=['cisl'],
+        collection_map={'/glade/campaign/cisl/csg': 'cisl',
+                        '/glade/campaign/cisl/other': 'cisl'},
+        capture=cap,
+    )
+    svc.scan_directories(None, object(), 'Campaign_Store', subpath='/cisl/csg')
+    assert cap['list_kwargs']['path_prefixes'] == ['/glade/campaign/cisl/csg']
+
+
+def test_scoped_descent_into_subdir(monkeypatch):
+    """A subpath BELOW a registered fileset queries that deeper subtree."""
+    cap = {}
+    svc = _wire_service(
+        monkeypatch,
+        prefixes=['/glade/campaign/cisl/csg'],
+        collections=['cisl'], warmed=['cisl'],
+        collection_map={'/glade/campaign/cisl/csg': 'cisl'},
+        capture=cap,
+    )
+    svc.scan_directories(None, object(), 'Campaign_Store', subpath='/cisl/csg/sub')
+    assert cap['list_kwargs']['path_prefixes'] == ['/cisl/csg/sub']
+
+
+def test_scoped_out_of_scope_subpath_empty(monkeypatch):
+    """A subpath neither ancestor nor descendant of a project prefix → []."""
+    cap = {}
+    svc = _wire_service(
+        monkeypatch,
+        prefixes=['/glade/campaign/cisl/csg'],
+        collections=['cisl'], warmed=['cisl'],
+        collection_map={'/glade/campaign/cisl/csg': 'cisl'},
+        capture=cap,
+    )
+    assert svc.scan_directories(None, object(), 'Campaign_Store',
+                                subpath='/mmm/foo') == []
+    assert 'list_kwargs' not in cap
+
+
+_DRILL_ROW = {
+    'path': '/cisl/csg/sub', 'depth': 5, 'total_size_r': 1024 ** 4,
+    'file_count_r': 1, 'dir_count_r': 3, 'max_atime_r': None,
+    'owner_uid': 1, 'owner_gid': 1, 'filesystem': 'cisl',
+}
+_DRILL_MARKER = 'fa-folder me-1'   # unique to a drillable row's link
+
+
+def test_directories_browse_rows_drillable(app, auth_client, active_project, monkeypatch):
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    monkeypatch.setattr(service, 'scan_directories', lambda s, p, r, **kw: [_DRILL_ROW])
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/directories'
+        f'?resource={_RES}&browse=1'
+    )
+    body = resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    assert _DRILL_MARKER in body                       # row is a drill link
+    # The drill link carries the row path as the new fileset (Jinja's urlencode
+    # may or may not %-escape slashes depending on version).
+    assert ('fileset=/cisl/csg/sub' in body
+            or 'fileset=%2Fcisl%2Fcsg%2Fsub' in body)
+
+
+def test_directories_card_tab_rows_not_drillable(app, auth_client, active_project, monkeypatch):
+    """Without browse (the resource-details card tab) rows stay plain text."""
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    monkeypatch.setattr(service, 'scan_directories', lambda s, p, r, **kw: [_DRILL_ROW])
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/directories?resource={_RES}'
+    )
+    body = resp.get_data(as_text=True)
+    assert _DRILL_MARKER not in body
+    assert '/cisl/csg/sub' in body                      # path still shown
+
+
+def test_directories_leaves_only_not_drillable(app, auth_client, active_project, monkeypatch):
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    monkeypatch.setattr(service, 'scan_directories', lambda s, p, r, **kw: [_DRILL_ROW])
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/directories'
+        f'?resource={_RES}&browse=1&leaves_only=1'
+    )
+    assert _DRILL_MARKER not in resp.get_data(as_text=True)
+
+
+def test_resource_browse_breadcrumb_and_pill_fileset(app, auth_client, monkeypatch):
+    """Resource-mode drill: breadcrumb (Home=resource + segments) + sort pill
+    carries the active fileset."""
+    from webapp.disk_scans import routes, service
+    _enable_fs_scans(app, monkeypatch)
+    monkeypatch.setattr(service, 'scan_directories_resource', lambda r, **kw: [])
+    monkeypatch.setattr(routes, 'get_module',
+                        lambda: types.SimpleNamespace(normalize_path=lambda p: p))
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/resource/{_RES}/directories'
+        f'?browse=1&fileset=/cisl/csg'
+    )
+    body = resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    assert 'aria-label="breadcrumb"' in body
+    assert _RES in body                                # Home crumb = resource name
+    assert '>cisl<' in body and '>csg<' in body        # path segments
+    assert ('fileset=/cisl/csg' in body
+            or 'fileset=%2Fcisl%2Fcsg' in body)        # sort pill keeps the anchor
+
+
+def test_project_breadcrumb_bounded_at_scan_root(app, auth_client, active_project, monkeypatch):
+    """Project-mode breadcrumb collapses everything up to the project prefix:
+    All / csg / sub — NOT All / cisl / csg / sub."""
+    from webapp.disk_scans import routes, service
+    _enable_fs_scans(app, monkeypatch)
+    monkeypatch.setattr(service, 'scan_directories', lambda s, p, r, **kw: [])
+    monkeypatch.setattr(routes, 'get_module',
+                        lambda: types.SimpleNamespace(normalize_path=lambda p: p))
+    monkeypatch.setattr(routes, 'resolve_scan_scope',
+                        lambda s, proj, res: (['/cisl/csg'], ['cisl']))
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/directories'
+        f'?resource={_RES}&browse=1&fileset=/cisl/csg/sub'
+    )
+    body = resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    assert body.count('breadcrumb-item') == 3          # All, csg, sub (bounded)
+
+
+def test_breadcrumb_macro_renders_href_and_htmx(app):
+    """The shared macro renders href items, htmx items, and a plain active item."""
+    from flask import render_template_string
+    with app.test_request_context():
+        out = render_template_string(
+            "{% from 'dashboards/fragments/_breadcrumb.html' import breadcrumb %}"
+            "{{ breadcrumb(["
+            "{'label':'Admin','attrs':{'href':'/admin'}},"
+            "{'label':'Go','attrs':{'hx-get':'/x','hx-target':'#t'}},"
+            "{'label':'Here','active':True}]) }}"
+        )
+    assert 'href="/admin"' in out
+    assert 'hx-get="/x"' in out
+    assert 'aria-current="page"' in out
+    assert '>Here<' in out

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -339,13 +339,17 @@ def test_access_history_renders_svg(app, auth_client, active_project, monkeypatc
     hist = {
         'bucket_labels': ['< 1 Month', '1-3 Months', '7+ Years'],
         'buckets': {
-            '< 1 Month':   {'data': 2 * 1024 ** 4, 'files': 100, 'owners': {1001: {}}},
-            '1-3 Months':  {'data': 1024 ** 4, 'files': 50, 'owners': {1001: {}, 1002: {}}},
+            '< 1 Month':   {'data': 2 * 1024 ** 4, 'files': 100,
+                            'owners': {1001: {'data': 1024 ** 4, 'files': 60},
+                                       1002: {'data': 1024 ** 4, 'files': 40}}},
+            '1-3 Months':  {'data': 1024 ** 4, 'files': 50,
+                            'owners': {1001: {'data': 1024 ** 4, 'files': 50}}},
             '7+ Years':    {'data': 512 * 1024 ** 3, 'files': 10, 'owners': {}},
         },
         'total_data': 3 * 1024 ** 4 + 512 * 1024 ** 3, 'total_files': 160,
         'directory': '/glade/campaign/cisl', 'fast_path': True,
         'reference_scan_date': datetime(2026, 6, 1),
+        'username_map': {1001: 'alice', 1002: 'bob'},
     }
     monkeypatch.setattr(service, 'scan_access_history', lambda s, p, r, **kw: hist)
 
@@ -357,6 +361,14 @@ def test_access_history_renders_svg(app, auth_client, active_project, monkeypatc
     assert '<svg' in body                 # matplotlib SVG actually rendered
     assert '7+ Years' in body             # bucket label in the table (no HTML-escaping)
     assert 'fast path' in body            # fast_path badge
+    # Per-user breakdown rendered inside the bucket's collapse detail row.
+    assert 'alice' in body                # username resolved via username_map
+    assert 'bob' in body
+    assert 'data-bs-toggle="collapse"' in body   # bucket rows are expandable
+    # Chart bar → row drill-down wiring (svg-chart-links.js #ah-bar- branch):
+    # buckets with owners get an SVG anchor and a matching row lookup attr.
+    assert '#ah-bar-0' in body            # bar anchor for the first owned bucket
+    assert 'data-ah-bucket="0"' in body   # row the anchor expands
 
 
 def test_access_history_empty_when_none(app, auth_client, active_project, monkeypatch):


### PR DESCRIPTION
> **Stacked on #321** (fs-scans Phase 1 — plugin wire-up). Base branch is
> `fs_scans_plugin`. Review/merge #321 first; this PR re-targets once it lands.
>
> **Companion plugin PR: benkirk/hpc-usage-queries#77** — the per-collection
> fast-path that makes whole-collection-root scans read pre-computed tables.

This PR bundles **Phase 2** (the Filesystem Scans card + tabs) and **Phase 3**
(a reusable, filterable directory explorer with an elevated resource-wide mode).
Phase 3 is conceptually a follow-on but lands here in lockstep.

---

# Phase 2 — Filesystem Scans card

A **Filesystem Scans** card on the disk resource-details page surfacing the
Phase-1 service layer — lazy-loaded HTMX tabs, scoped to the project's
directories and following the page's `?scope=`/`?fileset=` selection.
Campaign_Store today; Destor slots in later.

### Tabs
1. **Large directories** → `scan_directories` (server-side sortable; **Subdirectories** column = recursive `dir_count_r`).
2. **User / group counts** → owner/group rollups with a sub-toggle; client-side sortable.
3. **Access history** → server-rendered matplotlib SVG histogram over the 10 access-time buckets.
4. **File sizes** → file-size histogram with a Data/Files metric pill + log-scale switch.

### UX
- Card **collapsed by default**; expanded state + active tab persist across reloads via `nav-view-persistence.js`.
- **Scan-freshness badge** in the header (per-collection in the tooltip).
- Native **Per-User Occupancy** card hidden when scans are available.

### Caching (Phase 2)
Scan-date-keyed result cache (`webapp/disk_scans/cache.py`) — content-addressed
weekly invalidation (a new scan changes the key; no flush, no stale window).
Redis-backed + shared across workers when `CACHE_REDIS_URL` is set. Verified
(P43713000): cold **11.4s → warm 0.09s**.

---

# Phase 3 — Reusable directory explorer (filters, drill-down, resource mode)

The plugin facade (`list_directories`) already supports `sort_by` (size/files/dirs),
`accessed_before`, `accessed_after`, `leaves_only`, and `owner_id` — Phase 3
surfaces them. **No plugin change.**

### Tab
- Server-side **sort pill** (Size / # Files / # Subdirs) — each re-queries the
  *true* top-N for that key (top-by-size ≠ top-by-files), mirroring the File
  Sizes metric pill; column-header sort links stay too.
- **"Open full view ↗"** link to the standalone explorer.

### Standalone explorer page (project + resource modes, one template)
- **Filters panel** above a lazy-loaded table: accessed-after / accessed-before
  dates, a leaves-only switch, a user picker, and a row-count selector
  (50/100/250/500).
- **Project mode** (`@require_project_access`): scoped to the project's
  `path_prefixes`. Members explore within their tree.
- **Resource mode** (NEW, **elevated**): browses the *entire* resource's
  collections unscoped (whole-collection fast path), with a fileset breadcrumb —
  the file-browser entry point.

### Per-user drill-down
- User/group tab: owner rows become `tbody.sortable-group` blocks; expanding one
  lazy-loads that user's top directories (`owner_uid` filter). Group rows are
  unchanged (the facade filters directories by UID only).

### Caching — two Redis buckets
`cache.py` is now a per-name adapter registry:
- **`fs_scans`** (default, 8-day TTL): passive/landing + the sort pill. High
  reuse, long-lived, cross-worker.
- **`fs_scans_filtered`** (30-min TTL): any owner/date/leaves-only permutation
  and the drill-down. Short TTL keeps the volatile explorer footprint small and
  self-expiring, so it doesn't crowd the long-lived default entries (a *soft*
  protection — `allkeys-lru` is instance-global). Both Redis-shared.

Admin → Configuration lists both buckets with their TTLs.

### Security
Resource mode exposes every user's paths/sizes/owner UIDs across an entire disk
resource. It is gated by a **global** `Permission.VIEW_ALL_FILESYSTEM_DATA`
**at the route** (not just the template link). Named `view_*` so `ALL_VIEW`
auto-grants it to the operator bundles (nusd/csg/ssg) and **not** to the
facility-scoped tier (which enumerates its `VIEW_*` grants explicitly).
Project-mode's unscoped-refusal safety invariant is left fully intact; resource
mode reaches the unscoped facade path only through its own permission-gated
wrapper. `collections_for_resource()` is the single resource→collections seam
where a future Destor DB-map plugs in.

---

### File-browser drill-down (Phase 3, follow-on)
The explorer is now navigable like a file browser:
- **Click a directory row** to re-anchor the table to that path's subtree, with
  the active filters preserved (drill links appear only when a row has subdirs
  and leaves-only is off; the card tab stays static).
- **Ancestry breadcrumb** rendered live inside the fragment (updates each drill):
  Home clears the anchor; project mode bounds at the project prefix, resource
  mode at the collection-root segment.
- `service._scoped` now matches subpaths in **normalized** path space and gains a
  **descent** branch so you can navigate *below* a registered fileset; out-of-scope
  paths still return nothing. No plugin change — scan paths are mount-stripped and
  a collection's absolute mount isn't recoverable (Campaign Store has moved
  mounts), so normalized space keeps this SAM-only and mount-move-proof.
- New shared `dashboards/fragments/_breadcrumb.html` `breadcrumb()` macro (href- and
  htmx-capable); `admin/edit_project.html` migrated onto it.

## Tests
`tests/unit/test_webapp_disk_scans.py` — Phase 2 scoping/route/cache coverage,
plus Phase 3: filter forwarding, bucket selection + distinct TTLs, two-bucket
info list, resource-mode service (unscoped / subpath / plugin-off), owner-filter
route + hidden-form round-trip, explorer page render, owner drill-down markup,
group no-drill-down, resource-mode RBAC 403/200, and the permission-grant
assertion. Existing cache tests updated for the bucket registry.

**The full test suite passes** (`pytest`, ~1400 tests).

## Verification
- `docker compose up webdev --watch`.
- Disk page → Large directories: toggle the Size/#Files/#Subdirs pill (each a
  different top-N), click **Open full view ↗**.
- Explorer page: set dates, toggle leaves-only, pick a user; table re-queries.
- User/group counts → expand a user → that user's top directories.
- Resource mode: as an operator open
  `/dashboards/user/disk-scans/resource/Campaign_Store/explore`; as a plain
  member confirm the entry point is hidden **and** the route returns 403.
- Admin → Configuration: both `fs_scans` and `fs_scans_filtered` buckets appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


