### PR TITLE
k8s deployment hardening: gthread workers + fs-scans statement_timeout

### DIFF
--- a/containers/webapp/gunicorn_config.py
+++ b/containers/webapp/gunicorn_config.py
@@ -31,9 +31,46 @@ def post_fork(server, worker):
 bind = '0.0.0.0:5050'
 backlog = 2048
 
-# Worker processes: (2 × cores) + 1, overridable via env
-workers = int(os.environ.get('GUNICORN_WORKERS', multiprocessing.cpu_count() * 2 + 1))
-worker_class = os.environ.get('GUNICORN_WORKER_CLASS', 'sync')
+def _effective_cpus():
+    """CPUs available to THIS container, not the node.
+
+    multiprocessing.cpu_count() returns the host's core count (e.g. 64 on the
+    nwc1 nodes), which over-provisions workers and OOMs the pod. Read the
+    cgroup CPU quota instead — cgroup v2 (``cpu.max``) then v1
+    (``cfs_quota_us`` / ``cfs_period_us``) — and fall back to cpu_count()
+    only when unconstrained or unreadable.
+    """
+    try:  # cgroup v2
+        with open('/sys/fs/cgroup/cpu.max') as fh:
+            quota, period = fh.read().split()
+        if quota != 'max':
+            return max(1, round(int(quota) / int(period)))
+    except (OSError, ValueError):
+        pass
+    try:  # cgroup v1
+        with open('/sys/fs/cgroup/cpu/cpu.cfs_quota_us') as fh:
+            quota = int(fh.read())
+        with open('/sys/fs/cgroup/cpu/cpu.cfs_period_us') as fh:
+            period = int(fh.read())
+        if quota > 0:
+            return max(1, round(quota / period))
+    except (OSError, ValueError):
+        pass
+    return multiprocessing.cpu_count()
+
+
+# Concurrency model — gthread (threaded), not sync. SAM routes are I/O-bound
+# (DB waits); the heaviest — fs-scans on-the-fly scans — measured ~76-85%
+# blocked in Postgres, where psycopg2 releases the GIL, so threads overlap
+# those waits and a slow scan ties up a THREAD, not a whole process. This runs
+# far fewer processes than the old sync model for the same (or higher)
+# concurrency → lower memory and a smaller DB-connection fan-out. All knobs are
+# env-overridable; helm sets them explicitly (see deployment.yaml).
+worker_class = os.environ.get('GUNICORN_WORKER_CLASS', 'gthread')
+# Default workers track the cgroup CPU quota, NOT the node's core count, so the
+# default is safe even if GUNICORN_WORKERS is unset. helm pins it explicitly.
+workers = int(os.environ.get('GUNICORN_WORKERS', _effective_cpus() * 2 + 1))
+threads = int(os.environ.get('GUNICORN_THREADS', 4))
 worker_connections = 1000
 
 # Worker lifecycle (prevents memory leaks)

--- a/docs/plans/K8S_DEPLOYMENT_HARDENING.md
+++ b/docs/plans/K8S_DEPLOYMENT_HARDENING.md
@@ -1,0 +1,80 @@
+# k8s Deployment Hardening — gunicorn worker model + fs-scans query bound
+
+**Branch:** `k8s_deployment_hardening` · **PR base:** `staging` · **Deploy:** manual
+`workflow_dispatch` of the CIRRUS deploy on this branch → deploy-probe-test iterate.
+
+## Why
+
+The fs-scans Phase 2/3 UI (PR #322) added the first **interactive, long-running,
+connection-holding** routes. The deployment config was tuned for an era of
+sub-second DB reads, so the numbers were inherited/arbitrary and a poor fit:
+
+- `gunicorn_config.py`: `worker_class=sync` — one slow request pins a whole
+  process. `workers` defaulted to `multiprocessing.cpu_count()*2+1`, where
+  `cpu_count()` returns the **node's 64 cores**, so the helm template pinned it
+  to `2×limits.cpu+1 = 33`. But that tracks the **burst limit (16)** while only
+  **4 cores are guaranteed** (requests) → 33 processes contend for 4 cores.
+- The fs-scans CNPG engine had **`statement_timeout = 0`** — a runaway scope
+  rides a worker to the 120s gunicorn SIGKILL with no clean failure.
+
+## Measurement that grounded the worker model
+
+In-pod probe (build c9250db) of NRAL0002 whole-parent scans (on-the-fly path,
+collections ncar+ral, 10 path_prefixes), splitting Postgres `execute` time from
+Python time via SQLAlchemy cursor events:
+
+| Scan | Wall | DB (Postgres) | Python |
+|---|---|---|---|
+| file_size_histogram | 61.4s | **52.3s (85%)** | 9.1s (15%) |
+| access_history | 70.6s | **53.5s (76%)** | 17.2s (24%) |
+
+→ **76–85% DB-bound.** psycopg2 releases the GIL during `execute`, so threads
+overlap those waits → **gthread is the right model.** (Both authoritative numbers
+are in-cluster — the in-pod probe and the gunicorn `%(D)s` request duration —
+pod↔CNPG colocated, so the local laptop+VPN hop does not inflate them.)
+
+Cutting the 52s of DB work itself is **plugin-side** (precompute more collection
+roots / push aggregation into SQL) and is explicitly out of scope here.
+
+## Changes in this PR (all SAM-side, no peer/plugin dependency)
+
+1. **`containers/webapp/gunicorn_config.py`**
+   - `worker_class` default `sync` → **`gthread`**; add `threads` (env `GUNICORN_THREADS`, default 4).
+   - New `_effective_cpus()` reads the **cgroup** CPU quota (v2 `cpu.max`, then
+     v1) instead of the node core count, so the default worker count is safe
+     even if `GUNICORN_WORKERS` is unset.
+2. **`helm/templates/deployment.yaml`** + **`helm/values.yaml`**
+   - `GUNICORN_WORKER_CLASS=gthread`, `GUNICORN_THREADS=8`.
+   - `GUNICORN_WORKERS` now derives from **`requests.cpu` (guaranteed)**:
+     `2×4+1 = 9` (was 33). Tunable via `webapp.gunicorn.{workerClass,workers,threads}`.
+   - Net: **9 processes × 8 threads = 72 concurrency** (was 33 sync / 33 procs)
+     → lower memory, smaller CNPG connection fan-out, more concurrency.
+3. **`src/webapp/config.py`** + **`src/webapp/disk_scans/session.py`**
+   - `FS_SCAN_STATEMENT_TIMEOUT_MS` (default 100000 = 100s; below the 120s
+     gunicorn `timeout`, above the ~70s legit-scan worst case). 0 disables.
+   - The existing connect listener (`_attach_application_name` →
+     `_apply_connection_settings`) now also issues `SET statement_timeout`. Value
+     read once at init (warm pool runs in threads where `current_app` isn't bound).
+
+`helm lint` clean; template renders class=gthread workers=9 threads=8.
+
+## Deploy-probe-test checklist (iterate on this branch)
+
+- [ ] `cirrus_healthcheck.sh` — 0 FAIL; confirm pod env shows class/workers/threads.
+- [ ] `ps -e -o cmd | grep -c gunicorn` in-pod ≈ 9 workers (+ master), not 33.
+- [ ] Re-walk fs-scans tabs for NMMM0003 (fast) + NRAL0002 (on-the-fly); confirm
+      no thread-safety regressions (gthread is the main risk — watch for
+      cross-request state bleed, session/engine sharing).
+- [ ] Concurrency: fire a few simultaneous NRAL0002 scans; fast routes must stay
+      responsive while a thread is parked on the 60s query.
+- [ ] Verify a deliberately huge scope now fails at ~100s with a clean
+      statement_timeout error (catchable), not a 120s SIGKill.
+- [ ] Observe per-pod memory under gthread → then right-size `limits.memory`
+      (currently 12G, sized for the old 33-process model) in a follow-up commit.
+
+## Open follow-ups (NOT this PR)
+
+- Plugin-side: precompute more collection roots so whole-lab-parent scopes hit
+  the fast path instead of the 52s on-the-fly aggregation.
+- Memory limit right-sizing (pending the observation above).
+- Revisit cpu requests/limits coherence once worker count is validated.

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -59,12 +59,19 @@ spec:
           - name: {{ $key }}
             value: {{ $value | quote }}
           {{- end }}
-          # Gunicorn workers sized from the cgroup CPU limit (2·cpu + 1).
-          # multiprocessing.cpu_count() inside the pod returns the node's CPU
-          # count, not the cgroup quota — without this, gunicorn_config.py would
-          # spawn ~129 workers on a 64-core node and OOM the pod.
+          # Concurrency model: gthread (threaded workers). fs-scans on-the-fly
+          # scans measured ~76-85% blocked in Postgres and psycopg2 frees the
+          # GIL, so threads absorb the waits — a slow scan holds a thread, not a
+          # process. Workers track the GUARANTEED cpu (requests), NOT the burst
+          # limit, so we no longer run 33 processes against 4 reserved cores.
+          # The cgroup-aware default in gunicorn_config.py is the backstop if
+          # these are unset. Tunable via .Values.webapp.gunicorn for deploy-probe.
+          - name: GUNICORN_WORKER_CLASS
+            value: {{ .Values.webapp.gunicorn.workerClass | default "gthread" | quote }}
           - name: GUNICORN_WORKERS
-            value: {{ mul (.Values.webapp.container.limits.cpu | int) 2 | add 1 | quote }}
+            value: {{ .Values.webapp.gunicorn.workers | default (mul (.Values.webapp.container.requests.cpu | int) 2 | add 1) | quote }}
+          - name: GUNICORN_THREADS
+            value: {{ .Values.webapp.gunicorn.threads | default 8 | quote }}
           # Number of trusted proxy hops for ProxyFix (X-Forwarded-For depth).
           # Must match the real proxy chain exactly — too high allows client IP
           # spoofing. Confirm from the gunicorn access log's xff="…" field.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -183,7 +183,7 @@ webapp:
     # JOB_HISTORY_PG_USER / JOB_HISTORY_PG_PASSWORD are injected below
     # from the jhDbCredentials ExternalSecret.
     JOB_HISTORY_DB_BACKEND: "postgres"
-    JOB_HISTORY_PG_HOST: "csg-postgres.k8s.ucar.edu"
+    JOB_HISTORY_PG_HOST: "csg-postgres-ro.k8s.ucar.edu"
     JOB_HISTORY_PG_PORT: "5432"
     JOB_HISTORY_MACHINES: "derecho,casper"
     # fs-scans plugin (filesystem-scan analytics on disk resource-details pages).
@@ -197,7 +197,7 @@ webapp:
     # Campaign_Store (campaign) is scanned.
     FS_SCANS_ENABLED: "1"
     FS_SCAN_DB_BACKEND: "postgres"
-    FS_SCAN_PG_HOST: "csg-postgres.k8s.ucar.edu"
+    FS_SCAN_PG_HOST: "csg-postgres-ro.k8s.ucar.edu"
     FS_SCAN_PG_PORT: "5432"
     FS_SCAN_PG_DB: "campaign"
     # disable creating projects until ID system transition & GID pool
@@ -235,7 +235,7 @@ webapp:
     passwordKey: password                 # Key in OpenBao for password
 
   # hpc-usage-queries plugin's per-machine job_history Postgres
-  # (derecho_jobs / casper_jobs on csg-postgres.k8s.ucar.edu).
+  # (derecho_jobs / casper_jobs on csg-postgres-ro.k8s.ucar.edu).
   # Read-only application user — distinct from dbCredentials' pg-superuser
   # since the plugin only needs SELECT on the job_history tables.
   jhDbCredentials:
@@ -247,7 +247,7 @@ webapp:
     passwordKey: password                 # Key in OpenBao for password
 
   # fs-scans plugin's filesystem-scan Postgres (campaign DB / per-collection
-  # schemas on csg-postgres.k8s.ucar.edu). Reuses the SAME csg/pg-appuser role
+  # schemas on csg-postgres-ro.k8s.ucar.edu). Reuses the SAME csg/pg-appuser role
   # as jhDbCredentials above (read-only application user, SELECT on the scan
   # tables) — kept as a distinct block so the integration can be toggled and
   # rotated independently. Injected as FS_SCAN_PG_USER / FS_SCAN_PG_PASSWORD.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -137,6 +137,16 @@ webapp:
     limits:
       memory: 12G                         # Maximum memory allowed
       cpu: 16                             # Maximum CPU allowed
+  # Gunicorn concurrency (see deployment.yaml env block + gunicorn_config.py).
+  # Threaded workers: a slow fs-scans scan holds a thread, not a process. The
+  # 12G memory limit above is a candidate to lower once gthread per-pod usage
+  # is observed — the old 33-process sync model drove that ceiling.
+  # Empty workers/threads fall back to the template/config defaults.
+  gunicorn:
+    workerClass: gthread
+    workers: ""                           # "" → 2×requests.cpu+1 (=9 at cpu request 4),
+                                          # tracking GUARANTEED cores not the burst limit
+    threads: 8                            # I/O concurrency per worker; scans are ~80% DB-bound
   env:
     DISABLE_AUTH: "0"                     # Explicitly disabled — must remain 0 in production
     FLASK_ADMIN_ENABLED: "0"              # Flask-Admin /database browser stays unmounted on the public deploy

--- a/src/webapp/config.py
+++ b/src/webapp/config.py
@@ -141,6 +141,16 @@ class SAMWebappConfig(SAMConfig):
         '0', 'false', 'no', '',
     )
 
+    # Server-side Postgres statement_timeout (ms) applied to every fs-scans
+    # connection. A runaway scope can otherwise hold a CNPG connection (and a
+    # gthread thread) until the gunicorn worker timeout kills it; this caps the
+    # query server-side so it fails cleanly first. Set comfortably below
+    # gunicorn `timeout` (120s) but above legit lab-parent scans (measured
+    # ~70s). 0 disables.
+    FS_SCAN_STATEMENT_TIMEOUT_MS = int(
+        os.getenv('FS_SCAN_STATEMENT_TIMEOUT_MS', '100000')
+    )
+
     # Session cookies (common defaults; subclasses tighten for prod)
     SESSION_COOKIE_HTTPONLY    = True
     SESSION_COOKIE_SAMESITE    = 'Lax'

--- a/src/webapp/disk_scans/session.py
+++ b/src/webapp/disk_scans/session.py
@@ -107,6 +107,11 @@ def init_fs_scans(app: Flask) -> None:
     # rather than threading our own connect_args through.
     pod_id = os.environ.get('HOSTNAME') or socket.gethostname()
 
+    # Read once here (main thread) and close over it — the warm pool runs in
+    # worker threads where ``current_app`` isn't bound, so we can't read config
+    # from inside the connect listener.
+    stmt_timeout_ms = int(app.config.get('FS_SCAN_STATEMENT_TIMEOUT_MS', 0) or 0)
+
     def _warm(collection: str):
         """Create + tag + health-check one collection's engine.
 
@@ -116,8 +121,9 @@ def init_fs_scans(app: Flask) -> None:
         try:
             engine = mod.get_engine(collection)
             if engine.url.drivername.startswith('postgresql'):
-                _attach_application_name(
-                    engine, f'sam-webapp:{pod_id}:fs_scans:{collection}'
+                _apply_connection_settings(
+                    engine, f'sam-webapp:{pod_id}:fs_scans:{collection}',
+                    statement_timeout_ms=stmt_timeout_ms,
                 )
             # Health check — also forces the pool to open one connection
             # so the application_name listener fires before first query.
@@ -154,27 +160,40 @@ def init_fs_scans(app: Flask) -> None:
     state['enabled'] = bool(engines)
 
 
-def _attach_application_name(engine, app_name: str) -> None:
-    """Run ``SET application_name`` on every new DBAPI connection for this engine.
+def _apply_connection_settings(
+    engine, app_name: str, *, statement_timeout_ms: int = 0
+) -> None:
+    """Apply per-connection postgres settings on every new DBAPI connection.
+
+    Sets ``application_name`` (for ``pg_stat_activity`` attribution) and, when
+    ``statement_timeout_ms`` > 0, a server-side ``statement_timeout`` so a
+    runaway fs-scans query fails cleanly instead of holding a CNPG connection
+    (and a gthread thread) until the gunicorn worker timeout.
 
     The ``connect`` event fires once per fresh postgres connection (not on
-    pool checkout), so this is the cheap, correct hook to tag connections
-    when the engine's ``connect_args`` are owned by the plugin and can't
-    be amended in-place. Mirrors ``webapp/jobs/session.py``.
+    pool checkout), so this is the cheap, correct hook when the engine's
+    ``connect_args`` are owned by the plugin and can't be amended in-place.
+    Mirrors ``webapp/jobs/session.py``.
 
-    Toggles autocommit around the ``SET`` because postgres documents that
+    Toggles autocommit around the ``SET``s because postgres documents that
     ``application_name`` changes made via ``SET`` "will not appear in
     pg_stat_activity until after a commit or rollback" — and psycopg2's
     default is ``autocommit=False``.
     """
     @event.listens_for(engine, 'connect')
-    def _set_app_name(dbapi_conn, _conn_record):
+    def _on_connect(dbapi_conn, _conn_record):
         saved = dbapi_conn.autocommit
         dbapi_conn.autocommit = True
         try:
             cur = dbapi_conn.cursor()
             try:
                 cur.execute("SET application_name = %s", (app_name,))
+                if statement_timeout_ms and statement_timeout_ms > 0:
+                    # statement_timeout accepts an integer number of ms.
+                    cur.execute(
+                        "SET statement_timeout = %s",
+                        (str(int(statement_timeout_ms)),),
+                    )
             finally:
                 cur.close()
         finally:


### PR DESCRIPTION
## Summary

Re-derives the gunicorn deployment config for the **interactive, long-running, connection-holding** fs-scans workload introduced in #322, and bounds runaway scan queries server-side. The prior numbers were tuned for sub-second DB-read routes and are a poor fit. **All SAM-side — no `hpc-usage-queries` change.** Verified live on nwc1 under deliberately brutal load (see *Verification*).

## Problems addressed
- `worker_class=sync` → one slow scan pins a whole worker **process** for ~60–115s.
- `GUNICORN_WORKERS=33` = `2×limits.cpu+1` (burst **limit** 16) while only **4 cores are guaranteed** (requests) → 33 processes contending for 4 reserved cores. The default also used `multiprocessing.cpu_count()`, which returns the **node's 64 cores** (latent footgun the pin papered over).
- fs-scans CNPG engine had **`statement_timeout = 0`** → a runaway query rode a worker to the 120s gunicorn SIGKILL with no clean failure.

## Measurement that picked the worker model
In-pod probe of NRAL0002 whole-parent on-the-fly scans, splitting Postgres `execute` time from Python time:

| Scan | Wall | DB (Postgres) | Python |
|---|---|---|---|
| `file_size_histogram` | 61.4s | **52.3s (85%)** | 9.1s (15%) |
| `access_history` | 70.6s | **53.5s (76%)** | 17.2s (24%) |

76–85% DB-bound; psycopg2 frees the GIL during `execute`, so **gthread** lets threads overlap the waits — a slow scan holds a *thread*, not a process.

## Changes
- **`containers/webapp/gunicorn_config.py`** — default `worker_class=gthread`; add `GUNICORN_THREADS`; new `_effective_cpus()` reads the **cgroup** CPU quota (v2 `cpu.max`, then v1) so the default worker count is container-correct even if unset.
- **`helm` (`deployment.yaml` + `values.yaml`)** — `GUNICORN_WORKER_CLASS=gthread`, `GUNICORN_THREADS=8`, and `GUNICORN_WORKERS` now from **`requests.cpu`**: `2×4+1 = 9` (was 33). Net **9 procs × 8 threads = 72 concurrency** (was 33 sync / 33 procs) → less memory, smaller CNPG connection fan-out. Tunable via `webapp.gunicorn.*`.
- **`config.py` + `disk_scans/session.py`** — `FS_SCAN_STATEMENT_TIMEOUT_MS` (default **100s**, below the 120s worker timeout, above the ~70s legit-scan worst case). The connect listener (`_attach_application_name` → `_apply_connection_settings`) now also issues `SET statement_timeout`, read once at init (the warm pool runs in threads where `current_app` isn't bound).

`helm lint` clean; template renders `class=gthread workers=9 threads=8`.

## Verification (live, nwc1, build `sha-4222d31`)

**Structural**
- gthread live: **10 processes** (master + 9 workers), down from 34. `GUNICORN_WORKER_CLASS=gthread WORKERS=9 THREADS=8`.
- Reads land on the **CNPG replica** (`csg-postgres-ro`, peer hpc-usage-queries #78): `pg_is_in_recovery() = true`.
- `statement_timeout = 100s` confirmed applied on the app's own init-warmed engine; `application_name` attribution intact (`sam-webapp:<pod>:fs_scans:<collection>`).

**Concurrency — gthread non-blocking**
- 12 concurrent cache-missing slow scans (5–23s each): all 200, and an interleaved fast route held **114–205ms throughout**. A thread parked on a slow CNPG query does not block other requests.

**Brutal wave — protection chain end-to-end** (20 concurrent: whole-Campaign_Store resource scans + 16 cold-key heavy parent scans, sustained 8–16 active queries for ~160s)
- **`statement_timeout` fired** under contention: `psycopg2.errors.QueryCanceled: canceling statement due to statement timeout` → `sqlalchemy.exc.OperationalError`, caught by the route's `except Exception`.
- **Zero 5xx** — every cancelled scan returned **HTTP 200 with an error banner** (the `except → error=str(exc) → render_template` path). Graceful, not a crash.
- **Max request 100.4s** — `statement_timeout` bounded the dominant-query case to ~100s, keeping requests under the 120s worker timeout; query age never exceeded ~99s.
- **Zero pod/worker restarts** throughout; cancelled connections recovered cleanly (pool discard + `pool_pre_ping`).

**Known edge (low severity):** `statement_timeout` is per-*query*, not per-*request* — a request issuing several sub-100s queries can sum past 100s (observed one at 115s), bounded then only by the 120s worker timeout. The >120s-under-gthread path was not reached (max 100.4s). The real fix is plugin-side fast-path (below), which removes the slow query entirely.

## Out of scope (follow-ups)
- **Single-flight in `cached_scan`** (SAM, separate PR) — coalesce concurrent cold-key misses so a herd (e.g. scan-date rollover re-warm) doesn't run the same expensive query N times.
- **Plugin-side fast-path** for whole-lab-parent scopes (`hpc-usage-queries`) — turns the 100s on-the-fly aggregation sub-second; the real fix for the cost itself.
- **Memory-limit right-sizing** — `limits.memory` 12G was sized for the old 33-process model; revisit once gthread per-pod usage is observed.

Deploy-probe checklist + findings: `docs/plans/K8S_DEPLOYMENT_HARDENING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)