### PR TITLE
UX polish: status inodes fix, disk-scans filter restyle, clickable usage pie charts

### DIFF
--- a/docs/plans/K8S_HAMMER_HANDOFF.md
+++ b/docs/plans/K8S_HAMMER_HANDOFF.md
@@ -1,0 +1,227 @@
+# Handoff: Hammer k8s (fs-scans load + protection-chain verification)
+
+**Purpose.** Reproduce, from a fresh session, the load-pressure test we ran against
+the live `samuel` deploy on nwc1 — exercise the gthread worker model, the fs-scans
+`statement_timeout`, and the route-level graceful-degradation, under deliberately
+heavy concurrency. Use this AFTER peer `hpc-usage-queries` DB-query optimization to
+re-baseline and confirm the protection chain still holds (and that scans got faster).
+
+> Context: this verifies SAM PR #323 (gthread + `statement_timeout`) and the
+> `csg-postgres-ro` replica repoint. See `docs/plans/K8S_DEPLOYMENT_HARDENING.md`
+> for the design + the original findings. Peer CNPG hardening = hpc-usage-queries #78.
+
+---
+
+## 0. Preconditions (ask the user / confirm)
+
+- **VPN up** (needed to reach `samuel.k8s.ucar.edu` and the nwc1 ingress).
+- `kubectl` context is **nwc1**, namespace **sam-queries** (`kubectl config current-context`).
+- **Peer is watching CNPG** before you apply load — confirm with the user first; this
+  hits the production `campaign` DB **replica** (`csg-postgres-ro`). Coordinate.
+- **Playwright MCP** available for an authenticated browser session (routes are
+  `@login_required`). The user does the 2FA step.
+- Re-baseline mindset: peer query optimization may have made the slow path **faster**,
+  so you may need **harder** load (more concurrency / bigger scopes) to trip the 100s cap.
+
+---
+
+## 1. Structural verification (in-pod — no browser needed)
+
+```bash
+POD=$(kubectl -n sam-queries get pod -l app=samuel -o jsonpath='{.items[0].metadata.name}')
+echo "pod=$POD image=$(kubectl -n sam-queries get pod $POD -o jsonpath='{.spec.containers[0].image}')"
+# gthread env + replica host + worker count (expect ~10 = master + 9; class=gthread)
+kubectl -n sam-queries exec "$POD" -- sh -c 'echo "CLASS=$GUNICORN_WORKER_CLASS WORKERS=$GUNICORN_WORKERS THREADS=$GUNICORN_THREADS"; echo "FS_SCAN_PG_HOST=$FS_SCAN_PG_HOST"'
+kubectl -n sam-queries exec "$POD" -- sh -c 'ps -e -o cmd | grep -c "[g]unicorn"'
+```
+
+**Definitive `statement_timeout` + replica routing** (uses the app's *own* init-warmed
+engine — a bare `FS_SCANS.load()` probe does NOT attach the listener, so it would show
+`statement_timeout=0`; you MUST go through `create_app`):
+
+```bash
+kubectl -n sam-queries exec -i "$POD" -- python - <<'PY' 2>&1 | grep -vE '^(INFO|WARNING|\[20|pguser:)'
+from webapp.run import create_app
+from sqlalchemy import text
+app=create_app()
+with app.app_context():
+    from webapp.disk_scans.session import get_engines
+    print("FS_SCAN_STATEMENT_TIMEOUT_MS =", app.config.get('FS_SCAN_STATEMENT_TIMEOUT_MS'))
+    e=get_engines(app); coll=sorted(e)[0]
+    with e[coll].connect() as c:
+        print("statement_timeout =", c.execute(text("SHOW statement_timeout")).scalar())   # expect '100s'
+        print("pg_is_in_recovery =", c.execute(text("SELECT pg_is_in_recovery()")).scalar()) # expect True (replica)
+PY
+```
+
+Baseline healthcheck: `./scripts/cirrus_healthcheck.sh` (expect 0 FAIL; benign WARNs =
+rollout startup-probe race + unrelated `baotoken`).
+
+---
+
+## 2. Re-baseline the slow path (DB vs Python split)
+
+This is the measurement that justified gthread (DB-bound → threads help). Re-run it to
+see how much the peer optimization shaved off. Goes through the real service `_scoped`.
+
+```bash
+kubectl -n sam-queries exec -i "$POD" -- python - <<'PY' 2>&1 | grep -vE '^(INFO|WARNING|\[20|pguser:)'
+import time
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+db=[0.0]; qn=[0]
+@event.listens_for(Engine,"before_cursor_execute")
+def _b(c,cur,s,p,ctx,m): ctx._t=time.perf_counter()
+@event.listens_for(Engine,"after_cursor_execute")
+def _a(c,cur,s,p,ctx,m): db[0]+=time.perf_counter()-ctx._t; qn[0]+=1
+from webapp.run import create_app
+app=create_app()
+with app.app_context():
+    from webapp.extensions import db as fdb
+    from sam import Project
+    from webapp.disk_scans import service
+    proj=Project.get_by_projcode(fdb.session,"NRAL0002")
+    mod,prefixes,collections=service._scoped(fdb.session,proj,"Campaign_Store",None)
+    q=mod.FsScanQueries(filesystems=collections)
+    for label,call in (("file_size_histogram",lambda:q.file_size_histogram(path_prefixes=prefixes)),
+                       ("access_history",lambda:q.access_history(path_prefixes=prefixes))):
+        db[0]=0.0; qn[0]=0
+        t0=time.perf_counter(); r=call(); wall=time.perf_counter()-t0
+        print("%s: wall=%.1fs db=%.1fs(%.0f%%) python=%.1fs queries=%d fast_path=%s"
+              %(label,wall,db[0],100*db[0]/wall,wall-db[0],qn[0],(r or {}).get("fast_path")))
+PY
+```
+
+**Pre-optimization baseline (2026-06-19):** `file_size_histogram` wall 61s / db 52s (85%) ·
+`access_history` wall 70s / db 53s (76%); 12 queries each; `fast_path=False`. If the new
+numbers are much lower, the on-the-fly cost dropped — note it and scale load up.
+
+---
+
+## 3. Authenticated browser (Playwright) — for load generation
+
+Drive load from **inside** the browser context (in-page `fetch`). **Do NOT extract the
+session cookie** (HttpOnly; the user declined cookie exfiltration). All load rides the
+browser's existing session; only status/timings come back.
+
+Auth flow: `browser_navigate https://samuel.k8s.ucar.edu/` → click **Login** →
+Microsoft OIDC (`login.microsoftonline.com`) → **hand off to the user for password + 2FA**
+→ they land authenticated. Confirm with a `browser_snapshot` (should show the dashboard,
+build footer in `contentinfo`).
+
+The disk resource-details page (fs-scans tabs live here):
+`/user/resource-details/<projcode>?resource=Campaign_Store` — expand the **Filesystem
+Scans** card to lazy-load the 4 tabs (Large directories / User-group / Access history /
+File sizes).
+
+---
+
+## 4. Load generation (Playwright `browser_run_code_unsafe` → `page.evaluate`)
+
+**Pattern:** fire-and-forget concurrent `fetch`es (the browser MCP caps tool calls at
+~30s, but scans run 60–100s+), keep refs on `window.__x` so they aren't GC'd, return
+quickly, then read outcomes from **server logs** (§5). Measure fast-route latency in the
+same call to prove gthread non-blocking.
+
+**Cache awareness (critical):** results are cached scan-date-keyed, 8-day TTL
+(`webapp/disk_scans/cache.py`). To generate *real* DB load you need **cold keys**:
+- distinct **child scopes** (each a different `scope=`), or
+- distinct **`owner_uid=`** values on the same scope (distinct cache key, still a full scan), or
+- **resource-wide** (`/resource/Campaign_Store/directories`) = whole filesystem, heaviest.
+There is **no single-flight** — N concurrent misses on the *same* key all compute (herd).
+
+**Wave A — gthread non-blocking** (12 slow distinct-child + fast probe interleaved):
+```js
+async (page) => { return await page.evaluate(async () => {
+  const base=location.origin, now=()=>performance.now();
+  const get=async(p,l)=>{const s=now();try{const r=await fetch(base+p,{credentials:'include',headers:{'HX-Request':'true'}});const t=await r.text();return{l,status:r.status,ms:Math.round(now()-s),bytes:t.length};}catch(e){return{l,status:'ERR',ms:Math.round(now()-s)};}};
+  const kids=['NSAP0003','P48500028','P48500047','NWSA0002','NWCA0002','NRIS0001','P48503002','NRAL0003'];
+  const mk=(s,k)=>`/dashboards/user/disk-scans/NRAL0002/${k}?resource=Campaign_Store&scope=${s}&target_id=t`;
+  const slow=[]; kids.forEach(c=>slow.push(get(mk(c,'file-sizes'),`slow:${c}`)));
+  kids.slice(0,4).forEach(c=>slow.push(get(mk(c,'access-history'),`ah:${c}`)));
+  window.__A=slow; await new Promise(r=>setTimeout(r,2000));
+  const fast=[]; for(let i=0;i<6;i++){fast.push(await get(`/dashboards/user/disk-scans/NMMM0003/directories?resource=Campaign_Store&scope=NMMM0003&target_id=d`,`fast#${i}`)); await new Promise(r=>setTimeout(r,800));}
+  const fm=fast.map(f=>f.ms).sort((a,b)=>a-b);
+  return {dispatched_slow:slow.length, fast:fast.map(f=>`${f.l}:${f.status}:${f.ms}ms`), fast_p50:fm[3], fast_max:fm[5]};
+});}
+```
+PASS: fast probes stay ~100–400ms (200) while 12 slow scans run.
+
+**Wave B — brutal cold-key, trip `statement_timeout`** (resource-wide + owner-varied parent):
+```js
+async (page) => { return await page.evaluate(async () => {
+  const base=location.origin, fire=p=>fetch(base+p,{credentials:'include',headers:{'HX-Request':'true'}}).then(r=>r.text()).catch(e=>String(e));
+  const w=[];
+  for(let i=0;i<4;i++) w.push(fire(`/dashboards/user/disk-scans/resource/Campaign_Store/directories?target_id=t&_=${i}`));
+  for(let u=9000;u<9008;u++) w.push(fire(`/dashboards/user/disk-scans/NRAL0002/access-history?resource=Campaign_Store&scope=NRAL0002&owner_uid=${u}&target_id=t`));
+  for(let u=9008;u<9016;u++) w.push(fire(`/dashboards/user/disk-scans/NRAL0002/file-sizes?resource=Campaign_Store&scope=NRAL0002&owner_uid=${u}&target_id=t`));
+  window.__B=w; await new Promise(r=>setTimeout(r,1500)); return {dispatched:w.length};
+});}
+```
+If peer optimization made these too fast to trip 100s, escalate: raise concurrency
+(e.g. 16→32), add more resource-wide copies, or widen the `owner_uid` range.
+
+---
+
+## 5. Monitoring (run in BACKGROUND after firing a wave; ~3 min)
+
+```bash
+POD=$(kubectl -n sam-queries get pod -l app=samuel -o jsonpath='{.items[0].metadata.name}')
+probe(){ kubectl -n sam-queries exec -i "$POD" -- python - <<'PY' 2>/dev/null
+from sam.plugins import FS_SCANS
+from sqlalchemy import text
+m=FS_SCANS.load(); eng=m.get_engine(sorted(m.list_pg_schemas())[0])
+with eng.connect() as c:
+    r=c.execute(text("SELECT count(*) FILTER (WHERE state='active'), coalesce(round(max(extract(epoch from (now()-query_start))) FILTER (WHERE state='active')),0) FROM pg_stat_activity WHERE application_name LIKE 'sam-webapp%fs_scans%'")).fetchone()
+    print(f"active={r[0]} oldest={int(r[1])}s")
+PY
+}
+for i in $(seq 1 9); do printf "t+%03ds: " $((i*20-20)); probe|grep active=||echo "?"; [ $i -lt 9 ] && sleep 20; done
+echo "--- route-level scan failures (statement_timeout surfaces here) ---"
+kubectl -n sam-queries logs -l app=samuel --since=6m --tail=-1 2>&1 | grep -iE 'scan failed|canceling statement|QueryCanceled|statement timeout' | tail -15
+echo "--- duration histogram (seconds, app-log) ---"
+kubectl -n sam-queries logs -l app=samuel --since=6m --tail=-1 2>&1 | grep -E 'webapp.run — GET /dashboards/user/disk-scans' | grep -oE '\([0-9.]+ ms\)' | tr -dc '0-9.\n' | awk '{printf "%.0f\n",$1/1000}' | sort -n | uniq -c
+echo "--- 5xx / worker-timeout / restarts ---"
+kubectl -n sam-queries logs -l app=samuel --since=6m --tail=-1 2>&1 | grep -ciE '→ 50[0-9]|HTTP/1.1" 50[0-9]|WORKER TIMEOUT' | xargs echo "  5xx/timeout lines:"
+kubectl -n sam-queries get pods -l app=samuel -o 'custom-columns=NAME:.metadata.name,RESTARTS:.status.containerStatuses[0].restartCount'
+```
+
+---
+
+## 6. Pass criteria (what "healthy under load" looks like)
+
+- Worker count stable (master + 9); **zero pod/worker restarts** across the run.
+- gthread non-blocking: fast routes stay sub-second while many slow scans run.
+- `statement_timeout` fires on queries >100s → `QueryCanceled`/`OperationalError`
+  caught by the route's `except Exception` → **HTTP 200 + error banner, ZERO 5xx**
+  (`disk_scans/routes.py` `_render_*`; `error=str(exc)`).
+- Active query age never exceeds ~100s; max request ~100s for single-dominant-query scans.
+- Connections recover after cancellation (no cascade; `pool_pre_ping` covers it).
+
+**Pre-optimization baseline result (2026-06-19):** 12 concurrent slow → all 200, fast
+route 114–205ms throughout. Brutal wave → ~20 `statement_timeout` cancels, **0 5xx**,
+max 100.4s, 0 restarts. Route degrades gracefully. If a fresh run shows 5xx, hangs, or
+restarts → regression, investigate.
+
+---
+
+## 7. Pitfalls / lessons (don't repeat these)
+
+- **Don't exfiltrate the session cookie** — drive load via in-browser `page.evaluate`. (User declined cookie extraction.)
+- **µs vs ms:** gunicorn access-log durations end in `…µs` (micro). `196866µs` = 0.2s, NOT 196s. Use the app-log `webapp.run — … (NNN ms)` lines for human-readable durations.
+- A bare in-pod `FS_SCANS.load()` engine has **no** `statement_timeout`/`application_name` (the listener is attached only inside `init_fs_scans`). Verify via `create_app` (§1).
+- `statement_timeout` is **per-query**, not per-request: a request issuing several sub-100s queries can sum past 100s (saw 115s once), bounded then by the 120s gunicorn worker timeout. The >120s-under-gthread path was never reached.
+- Browser MCP tool calls cap ~30s → fire-and-forget, monitor server-side.
+- The cache has **no single-flight** → identical-key concurrency stampedes (proposed follow-up; see §6 of K8S_DEPLOYMENT_HARDENING.md). For load you generally WANT cold keys anyway.
+
+---
+
+## 8. Key facts
+
+- Resource: **Campaign_Store** (disk). Disk-details page: `/user/resource-details/<projcode>?resource=Campaign_Store`.
+- **Fast** scope (fast-path, sub-second): **NMMM0003** (`/gpfs/csfs1/mmm`).
+- **Slow** on-the-fly scope (spans `ncar`+`ral` collections): **NRAL0002**.
+- NRAL0002 child scopes (distinct cold keys): `NSAP0003 P48500028 P48500047 NWSA0002 NWCA0002 NRIS0001 P48503002 NRAL0003` (P48500028 = `/ral/hap`, biggest ~4PB).
+- Fragment endpoints: `/dashboards/user/disk-scans/<projcode>/{directories,entities,access-history,file-sizes}?resource=Campaign_Store&scope=<scope>[&owner_uid=<uid>]&target_id=t`
+- Resource-wide (needs `VIEW_ALL_FILESYSTEM_DATA`; Ben has it): `/dashboards/user/disk-scans/resource/Campaign_Store/directories`
+- 13 collections: acom asp cesm cgd cisl collections eol hao mmm ncar ral univ uwyo.

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -932,6 +932,127 @@ def generate_allocation_type_pie_chart_matplotlib(type_data: List[Dict]) -> str:
 
 
 # ---------------------------------------------------------------------------
+# 5b. Disk-scans entity pie chart (By User / By Group tab)
+#
+# Distribution of scanned bytes across the top owners/groups. Unlike the
+# allocation pies (fixed top-10 cap), this keeps the largest entities up to a
+# ~90% cumulative share and lumps the rest into one "Other" slice. Each kept
+# wedge + its legend entry is clickable: matplotlib set_url() emits an
+# <a xlink:href="#disk-ent-{kind}-{id}"> sentinel that svg-chart-links.js
+# routes to expanding that entity's row in the table below. The "Other" slice
+# is inert. Sentinels are keyed by uid/gid (part of the hashed input), so the
+# cached SVG is independent of any per-render container id.
+# ---------------------------------------------------------------------------
+
+_PIE_CUM_SHARE = 0.90      # show entities up to ~90% cumulative share
+_PIE_HARD_CAP = 9          # never exceed 9 named slices (palette has 10; keep "Other" distinct)
+
+
+def _pie_cumulative_keep(values_desc: list) -> int:
+    """How many leading (descending) entries to show individually.
+
+    The fewest whose cumulative share reaches ``_PIE_CUM_SHARE``, capped at
+    ``_PIE_HARD_CAP``. The remainder (if any) is meant to collapse into one
+    'Other' slice. Returns ``len(values_desc)`` when everything fits (no Other).
+    """
+    total = sum(values_desc)
+    if total <= 0:
+        return min(len(values_desc), _PIE_HARD_CAP)
+    cum = 0.0
+    for i, v in enumerate(values_desc):
+        cum += v
+        if i + 1 >= _PIE_HARD_CAP:
+            return i + 1
+        if cum / total >= _PIE_CUM_SHARE:
+            return i + 1
+    return len(values_desc)
+
+
+def _disk_entity_pie_cache_key(entity_data, kind):
+    # kind is NOT in the default content_hash(args[0]) key, but it drives the
+    # clickable-sentinel prefix — include it so owner/group never alias.
+    return _content_hash([entity_data, kind])
+
+
+@caching.chart_cached(name='disk_entity_pie_chart', maxsize=64,
+                      key_fn=_disk_entity_pie_cache_key)
+def generate_disk_entity_pie_chart(entity_data: List[Dict], kind: str) -> str:
+    """Pie of scanned bytes by owner (kind='owner') or group (kind='group').
+
+    Args:
+        entity_data: list of {'id': uid|gid, 'name': str|None, 'value': bytes}
+        kind: 'owner' or 'group' — selects the click sentinel prefix and the
+              numeric fallback label.
+
+    Returns:
+        SVG string ready for template rendering.
+    """
+    if not entity_data:
+        return '<div class="text-center text-muted">No usage data available</div>'
+
+    prefix = '#disk-ent-owner-' if kind == 'owner' else '#disk-ent-group-'
+    numeric_label = 'uid ' if kind == 'owner' else 'gid '
+
+    # Coerce to float at the single entry point: scan rollups arrive as
+    # decimal.Decimal from Postgres, and Decimal/float don't mix in arithmetic
+    # (cum += v) or matplotlib. Everything downstream is then plain float.
+    data = sorted(entity_data, key=lambda d: float(d['value']), reverse=True)
+    values_desc = [float(d['value']) for d in data]
+    keep = _pie_cumulative_keep(values_desc)
+
+    ids = [d['id'] for d in data[:keep]]
+    labels = [d['name'] or f'{numeric_label}{d["id"]}' for d in data[:keep]]
+    values = list(values_desc[:keep])
+    colors = list(UNITY_PALETTE_10[:keep])
+
+    n_others = len(data) - keep
+    if n_others > 0:
+        ids.append(None)                       # inert slice — no set_url
+        labels.append(f'Other ({n_others})')
+        values.append(sum(values_desc[keep:]))
+        colors.append(UNITY_NCAR_GRAY_LIGHT)
+
+    legend_labels = [f'{n} ({fmt.size(v)})' for n, v in zip(labels, values)]
+
+    fig, ax = plt.subplots(figsize=(7, 4))
+    wedges, _texts, autotexts = ax.pie(
+        values,
+        labels=None,
+        autopct=lambda p: fmt.pct(p, decimals=1) if p >= 5 else '',
+        startangle=_PIE_START_ANGLE,
+        counterclock=False,
+        colors=colors,
+        pctdistance=0.85,
+    )
+    for at, wedge_color in zip(autotexts, colors):
+        at.set_color(_autopct_color_for(wedge_color))
+        at.set_fontweight('bold')
+        at.set_fontsize(8)
+
+    legend = ax.legend(wedges, legend_labels, loc='center left',
+                       bbox_to_anchor=(1.0, 0.5), fontsize=9)
+
+    # Clickable wedges + legend entries → expand the matching table row.
+    # Skip the "Other" slice (id is None). svg-chart-links.js intercepts these.
+    leg_patches = legend.get_patches()
+    leg_texts = legend.get_texts()
+    for i, ent_id in enumerate(ids):
+        if ent_id is None:
+            continue
+        url = f'{prefix}{ent_id}'
+        wedges[i].set_url(url)
+        if i < len(leg_patches):
+            leg_patches[i].set_url(url)
+        if i < len(leg_texts):
+            leg_texts[i].set_url(url)
+
+    svg_io = StringIO()
+    fig.savefig(svg_io, format='svg', bbox_inches='tight', transparent=True)
+    plt.close(fig)
+    return svg_io.getvalue()
+
+
+# ---------------------------------------------------------------------------
 # 6. Allocation pace chart (allocations dashboard)
 #
 # Stacked-area chart where each allocation is one band with a step at

--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -38,7 +38,10 @@ from flask_login import login_required
 from sam.core.users import User
 from sam.projects.projects import Project
 from webapp.api.access_control import require_project_access
-from webapp.dashboards.charts import generate_distribution_histogram
+from webapp.dashboards.charts import (
+    generate_disk_entity_pie_chart,
+    generate_distribution_histogram,
+)
 from webapp.disk_scans import service
 from webapp.disk_scans.scope import resolve_scan_scope
 from webapp.disk_scans.session import get_module, is_enabled
@@ -140,6 +143,7 @@ def _dir_filters() -> dict:
         sort_by = _DEFAULT_DIR_SORT
 
     owner_uid, owner_user_id, owner_label = _resolve_owner()
+    owner_gid, group_label = _resolve_group()
 
     return {
         'sort_by': sort_by,
@@ -147,6 +151,8 @@ def _dir_filters() -> dict:
         'owner_uid': owner_uid,
         'owner_user_id': owner_user_id,
         'owner_label': owner_label,
+        'owner_gid': owner_gid,
+        'group_label': group_label,
         'accessed_before': _query_date('accessed_before'),
         'accessed_after': _query_date('accessed_after'),
         'accessed_before_str': (request.args.get('accessed_before') or '').strip(),
@@ -179,6 +185,23 @@ def _resolve_owner() -> Tuple[Optional[int], Optional[int], str]:
     return owner_uid, owner_user_id, label
 
 
+def _resolve_group() -> Tuple[Optional[int], str]:
+    """Resolve the group filter to ``(owner_gid, label)``.
+
+    The 'By group' drill-down passes a unix ``?owner_gid=`` (the canonical wire
+    param echoed across re-fetches) plus an optional ``?group_label=`` carrying
+    the group name the entities row already resolved — SAM has no gid→name table
+    of its own (names come from the scan plugin's ``resolve_groupnames``), so the
+    row hands the label down rather than re-resolving it here. Falls back to a
+    numeric ``gid N`` label.
+    """
+    owner_gid = request.args.get('owner_gid', type=int)
+    if owner_gid is None:
+        return None, ''
+    label = (request.args.get('group_label') or '').strip() or f'gid {owner_gid}'
+    return owner_gid, label
+
+
 def _user_search_url() -> str:
     """The fk-picker search endpoint for the owner user picker (context='fk')."""
     return url_for('admin_dashboard.htmx_search_users', context='fk')
@@ -207,6 +230,10 @@ def _initial_fragment_url(fragment_url: str, ctx: dict, flt: dict,
         params['fileset'] = ctx['fileset']
     if flt['owner_uid'] is not None:
         params['owner_uid'] = flt['owner_uid']
+    if flt.get('owner_gid') is not None:
+        params['owner_gid'] = flt['owner_gid']
+        if flt.get('group_label'):
+            params['group_label'] = flt['group_label']
     if flt['leaves_only']:
         params['leaves_only'] = '1'
     if flt['accessed_before_str']:
@@ -359,6 +386,7 @@ def directories_fragment(project):
             db.session, ctx['scoped_project'], ctx['resource_name'],
             sort_by=flt['sort_by'], limit=flt['limit'],
             owner_uid=flt['owner_uid'],
+            owner_gid=flt['owner_gid'],
             accessed_before=flt['accessed_before'],
             accessed_after=flt['accessed_after'],
             leaves_only=flt['leaves_only'],
@@ -463,7 +491,7 @@ def entities_fragment(project):
     if not is_enabled() or not ctx['resource_name']:
         return render_template(
             'dashboards/user/partials/disk_scans_entities.html',
-            rows=[], kind=kind,
+            rows=[], kind=kind, pie_chart=None,
             fragment_url=url_for('disk_scans.entities_fragment',
                                  projcode=project.projcode),
             enabled=is_enabled(), error=None, **ctx,
@@ -483,9 +511,22 @@ def entities_fragment(project):
         )
         error = str(exc)
 
+    # Distribution pie of scanned bytes by entity (clickable wedges → row drill).
+    # id/name keys differ by kind; value is bytes (matches the table's Size sort).
+    pie_chart = None
+    if rows:
+        id_key = 'owner_uid' if kind == 'owner' else 'owner_gid'
+        name_key = 'username' if kind == 'owner' else 'groupname'
+        entity_data = [
+            {'id': r[id_key], 'name': r.get(name_key), 'value': r['total_size']}
+            for r in rows if r.get(id_key) is not None
+        ]
+        if entity_data:
+            pie_chart = generate_disk_entity_pie_chart(entity_data, kind)
+
     return render_template(
         'dashboards/user/partials/disk_scans_entities.html',
-        rows=rows, kind=kind,
+        rows=rows, kind=kind, pie_chart=pie_chart,
         fragment_url=url_for('disk_scans.entities_fragment',
                              projcode=project.projcode),
         enabled=True, error=error, **ctx,

--- a/src/webapp/disk_scans/service.py
+++ b/src/webapp/disk_scans/service.py
@@ -139,6 +139,7 @@ def _scan_directories(
     sort_by: str = 'size',
     limit: Optional[int] = 50,
     owner_uid: Optional[int] = None,
+    owner_gid: Optional[int] = None,
     accessed_before: Optional[datetime] = None,
     accessed_after: Optional[datetime] = None,
     leaves_only: bool = False,
@@ -157,11 +158,12 @@ def _scan_directories(
     interactive exploration can't crowd the hot default-path entries.
     """
     q = mod.FsScanQueries(filesystems=collections)
-    filtered = bool(owner_uid is not None or accessed_before or accessed_after
-                    or leaves_only)
+    filtered = bool(owner_uid is not None or owner_gid is not None
+                    or accessed_before or accessed_after or leaves_only)
     opts = {
         'sort_by': sort_by, 'limit': limit,
         'owner_uid': owner_uid,
+        'owner_gid': owner_gid,
         'accessed_before': accessed_before.isoformat() if accessed_before else None,
         'accessed_after': accessed_after.isoformat() if accessed_after else None,
         'leaves_only': leaves_only,
@@ -177,6 +179,7 @@ def _scan_directories(
             sort_by=sort_by,
             limit=limit,
             owner_id=owner_uid,
+            group_id=owner_gid,
             accessed_before=accessed_before,
             accessed_after=accessed_after,
             leaves_only=leaves_only,
@@ -196,6 +199,7 @@ def scan_directories(
     sort_by: str = 'size',
     limit: Optional[int] = 50,
     owner_uid: Optional[int] = None,
+    owner_gid: Optional[int] = None,
     accessed_before: Optional[datetime] = None,
     accessed_after: Optional[datetime] = None,
     leaves_only: bool = False,
@@ -219,7 +223,7 @@ def scan_directories(
     return _scan_directories(
         mod, collections, path_prefixes,
         sort_by=sort_by, limit=limit,
-        owner_uid=owner_uid, accessed_before=accessed_before,
+        owner_uid=owner_uid, owner_gid=owner_gid, accessed_before=accessed_before,
         accessed_after=accessed_after, leaves_only=leaves_only,
         single_owner=single_owner, min_depth=min_depth, max_depth=max_depth,
     )

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -1273,6 +1273,15 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     height: auto;
 }
 
+/* Disk-scans entity pie (By User / By Group tab). matplotlib renders it at a
+   ~670px native width (≈ half the card); scale it up to read better without
+   going full width. Centered by the wrapper's flex justify-content. */
+.disk-entity-pie svg {
+    width: 100%;
+    max-width: 880px;
+    height: auto;
+}
+
 /* ============================================================================
    MUTED BADGE PALETTE — saturated Bootstrap defaults (bg-primary/info/success/
    warning/danger) read as aggressive next to the flat Unity surfaces, especially

--- a/src/webapp/static/js/fk-picker.js
+++ b/src/webapp/static/js/fk-picker.js
@@ -90,4 +90,19 @@
             picker2.dispatchEvent(new CustomEvent('fk:cleared', {bubbles: true}));
         }
     });
+
+    // ── Native form reset ───────────────────────────────────────────────
+    // A "Clear filters" control (form-reset-submit in actions.js) calls
+    // form.reset(). The browser clears the picker's hidden input but never
+    // restores the badge / selected UI, so clear it explicitly. The reset
+    // event bubbles, so a delegated listener catches every form.
+    document.body.addEventListener('reset', function (e) {
+        var form = e.target;
+        if (!form || form.tagName !== 'FORM') return;
+        var pickers = form.querySelectorAll('.fk-picker');
+        for (var i = 0; i < pickers.length; i++) {
+            reset(pickers[i]);
+            pickers[i].dispatchEvent(new CustomEvent('fk:cleared', {bubbles: true}));
+        }
+    });
 })();

--- a/src/webapp/static/js/svg-chart-links.js
+++ b/src/webapp/static/js/svg-chart-links.js
@@ -16,6 +16,10 @@
  *   - Bar href starts with #ah-bar-<index> (Access-history histogram on
  *     the disk resource-details page) → expand the matching bucket's
  *     per-user detail row in the table below the chart.
+ *   - Pie wedge/legend href starts with #disk-ent-owner-<uid> or
+ *     #disk-ent-group-<gid> (disk-scans By User / By Group tab) → expand
+ *     that entity's row in the table below (found via data-owner-uid /
+ *     data-group-gid), which lazy-loads its directories.
  *
  * Safe on pages where the target containers aren't included — each
  * branch checks for its targets and silently no-ops.
@@ -36,6 +40,11 @@
 
     var BAR_DAY_PREFIX = '#day-bar-';
     var BAR_AH_PREFIX = '#ah-bar-';
+    // Disk-scans entity pie (By User / By Group tab): a wedge/legend click
+    // expands the matching entity's table row, found by data-owner-uid /
+    // data-group-gid (see disk_scans_entities.html).
+    var ENT_OWNER_PREFIX = '#disk-ent-owner-';
+    var ENT_GROUP_PREFIX = '#disk-ent-group-';
 
     // Distribution histogram (Access-history / File-size tabs) → expand the
     // matching bucket's per-user detail row. The bucket <tr> carries
@@ -50,6 +59,23 @@
         var targetSel = row.getAttribute('data-bs-target');
         if (!targetSel) return;
         var el = document.querySelector(targetSel);
+        if (!el) return;
+        bootstrap.Collapse.getOrCreateInstance(el, {toggle: false}).show();
+        setTimeout(function () {
+            row.scrollIntoView({behavior: 'smooth', block: 'center'});
+        }, 60);
+    }
+
+    // Pie wedge/legend → expand the entity's table row. The row carries the
+    // collapse target in data-bs-target (same attribute the chevron toggles),
+    // keyed by attr (data-owner-uid / data-group-gid). Scoped to the clicked
+    // chart's tab pane so other panes' identical sentinels never cross-fire.
+    function openEntityRow(attr, id, scopeEl) {
+        var root = scopeEl || document;
+        var row = root.querySelector('tr[' + attr + '="' + id + '"]');
+        if (!row || !window.bootstrap) return;
+        var sel = row.getAttribute('data-bs-target');
+        var el = sel && document.querySelector(sel);
         if (!el) return;
         bootstrap.Collapse.getOrCreateInstance(el, {toggle: false}).show();
         setTimeout(function () {
@@ -118,6 +144,24 @@
             if (idx === '') return;
             e.preventDefault();
             openBucketRow(idx, a.closest('.tab-pane'));
+            return;
+        }
+
+        // Pie wedge/legend → expand the owner row
+        if (href.indexOf(ENT_OWNER_PREFIX) === 0) {
+            var uid = href.slice(ENT_OWNER_PREFIX.length);
+            if (uid === '') return;
+            e.preventDefault();
+            openEntityRow('data-owner-uid', uid, a.closest('.tab-pane'));
+            return;
+        }
+
+        // Pie wedge/legend → expand the group row
+        if (href.indexOf(ENT_GROUP_PREFIX) === 0) {
+            var gid = href.slice(ENT_GROUP_PREFIX.length);
+            if (gid === '') return;
+            e.preventDefault();
+            openEntityRow('data-group-gid', gid, a.closest('.tab-pane'));
             return;
         }
 

--- a/src/webapp/templates/dashboards/status/casper.html
+++ b/src/webapp/templates/dashboards/status/casper.html
@@ -147,7 +147,7 @@
         <!-- Filesystems -->
         {% if casper_filesystems %}
         <h6 class="mb-3 mt-4"><i class="fas fa-database"></i> Filesystem Status</h6>
-        {{ fs.filesystem_table(casper_filesystems) }}
+        {{ fs.filesystem_table(casper_filesystems, 'casper') }}
         {% endif %}
     </div>
 </div>

--- a/src/webapp/templates/dashboards/status/derecho.html
+++ b/src/webapp/templates/dashboards/status/derecho.html
@@ -110,7 +110,7 @@
         <!-- Filesystems -->
         {% if derecho_filesystems %}
         <h6 class="mb-3 mt-4"><i class="fas fa-database"></i> Filesystem Status</h6>
-        {{ fs.filesystem_table(derecho_filesystems) }}
+        {{ fs.filesystem_table(derecho_filesystems, 'derecho') }}
         {% endif %}
     </div>
 </div>

--- a/src/webapp/templates/dashboards/status/partials/filesystem_table.html
+++ b/src/webapp/templates/dashboards/status/partials/filesystem_table.html
@@ -1,19 +1,25 @@
-{% macro filesystem_table(filesystems) %}
+{% macro filesystem_table(filesystems, id_prefix='fs') %}
+{# id_prefix namespaces all tab element IDs so this macro can be rendered more
+   than once on the same page (e.g. Derecho + Casper in dashboard.html) without
+   duplicate IDs. Bootstrap resolves a tab's href target with
+   document.querySelector(), which returns the FIRST match — so without unique
+   IDs the second table's Inodes tab targets the first table's pane and never
+   activates its own, leaving its Capacity pane showing. #}
 <div class="table-responsive">
     <!-- Tab navigation -->
-    <ul class="nav nav-tabs" id="filesystemTabs" role="tablist">
+    <ul class="nav nav-tabs" id="{{ id_prefix }}-filesystemTabs" role="tablist">
         <li class="nav-item">
-            <a class="nav-link active" id="capacity-tab" data-bs-toggle="tab" href="#capacity" role="tab" aria-controls="capacity" aria-selected="true">Capacity</a>
+            <a class="nav-link active" id="{{ id_prefix }}-capacity-tab" data-bs-toggle="tab" href="#{{ id_prefix }}-capacity" role="tab" aria-controls="{{ id_prefix }}-capacity" aria-selected="true">Capacity</a>
         </li>
         <li class="nav-item">
-            <a class="nav-link" id="inodes-tab" data-bs-toggle="tab" href="#inodes" role="tab" aria-controls="inodes" aria-selected="false">Inodes</a>
+            <a class="nav-link" id="{{ id_prefix }}-inodes-tab" data-bs-toggle="tab" href="#{{ id_prefix }}-inodes" role="tab" aria-controls="{{ id_prefix }}-inodes" aria-selected="false">Inodes</a>
         </li>
     </ul>
 
     <!-- Tab content -->
-    <div class="tab-content" id="filesystemTabContent">
+    <div class="tab-content" id="{{ id_prefix }}-filesystemTabContent">
         <!-- Capacity Tab Pane -->
-        <div class="tab-pane fade show active" id="capacity" role="tabpanel" aria-labelledby="capacity-tab">
+        <div class="tab-pane fade show active" id="{{ id_prefix }}-capacity" role="tabpanel" aria-labelledby="{{ id_prefix }}-capacity-tab">
             <table class="table table-sm table-bordered filesystem-table">
                 <thead class="thead-light">
                     <tr>
@@ -72,7 +78,7 @@
         </div>
 
         <!-- Inodes Tab Pane -->
-        <div class="tab-pane fade" id="inodes" role="tabpanel" aria-labelledby="inodes-tab">
+        <div class="tab-pane fade" id="{{ id_prefix }}-inodes" role="tabpanel" aria-labelledby="{{ id_prefix }}-inodes-tab">
             <table class="table table-sm table-bordered filesystem-table">
                 <thead class="thead-light">
                     <tr>

--- a/src/webapp/templates/dashboards/user/disk_scans_directories_page.html
+++ b/src/webapp/templates/dashboards/user/disk_scans_directories_page.html
@@ -40,12 +40,12 @@
   {# The live, drill-aware ancestry breadcrumb is rendered inside the table
      fragment (disk_scans_directories.html) so it updates on every drill. #}
 
-  <div class="card mb-3">
-    <div class="card-body">
-      {{ dir_filters('disk-scans-filters-' ~ target_id, fragment_url, target_id,
-                     filters, user_search_url, resource_name, scope, fileset,
-                     limit_options) }}
-    </div>
+  {# Unity NCAR navy panel — same .filter-sidebar tokens as the allocations
+     and audit filters, so this explorer matches the rest of the dashboard. #}
+  <div class="filter-sidebar mb-3">
+    {{ dir_filters('disk-scans-filters-' ~ target_id, fragment_url, target_id,
+                   filters, user_search_url, resource_name, scope, fileset,
+                   limit_options) }}
   </div>
 
   <div class="card">

--- a/src/webapp/templates/dashboards/user/partials/_disk_scans_dir_filters.html
+++ b/src/webapp/templates/dashboards/user/partials/_disk_scans_dir_filters.html
@@ -1,9 +1,12 @@
 {% from 'dashboards/fragments/form_fields.html' import fk_search_field %}
 {#
-  Reusable Large-directories filter panel (audit_filters house style),
-  mode-agnostic. Rendered above the table container on the standalone
-  explorer page; on submit it hx-get's *fragment_url* (the project- or
-  resource-mode directory fragment) into #target_id with all of its fields.
+  Reusable Large-directories filter panel in the Unity .filter-sidebar house
+  style (navy panel + gold title + white controls + "Clear filters"), matching
+  audit_filters / the allocations dashboard. The caller wraps this macro in a
+  <div class="filter-sidebar">. Mode-agnostic. Rendered above the table
+  container on the standalone explorer page; on submit it hx-get's
+  *fragment_url* (the project- or resource-mode directory fragment) into
+  #target_id with all of its fields.
 
   Args:
     form_id         unique id for this form instance
@@ -24,6 +27,15 @@
       hx-target="#{{ target_id }}"
       hx-swap="innerHTML"
       hx-trigger="submit">
+  <div class="filter-sidebar-header">
+    <h2 class="filter-sidebar-title">Filters</h2>
+    {# CSP-clean reset: form-reset-submit (static/js/actions.js) resets the form
+       and re-triggers its htmx submit. fk-picker.js also clears its badge on
+       the native reset event, so the user picker clears too. #}
+    <a class="filter-sidebar-clear" style="cursor: pointer;"
+       data-action="form-reset-submit" data-form-id="{{ form_id }}">Clear filters</a>
+  </div>
+
   {# Scope context — submitted alongside the visible filter controls. #}
   <input type="hidden" name="resource" value="{{ resource_name }}">
   {% if scope %}<input type="hidden" name="scope" value="{{ scope }}">{% endif %}
@@ -35,27 +47,30 @@
 
   <div class="d-flex flex-wrap align-items-end gap-3">
     <div>
-      <label class="form-label mb-1"><strong>Accessed after</strong></label>
-      <input type="date" class="form-control form-control-sm"
+      <label class="form-label"><strong>Accessed after</strong></label>
+      <input type="date" class="form-control"
              name="accessed_after" value="{{ filters.accessed_after_str }}"
              style="width:160px;">
     </div>
     <div>
-      <label class="form-label mb-1"><strong>Accessed before</strong></label>
-      <input type="date" class="form-control form-control-sm"
+      <label class="form-label"><strong>Accessed before</strong></label>
+      <input type="date" class="form-control"
              name="accessed_before" value="{{ filters.accessed_before_str }}"
              style="width:160px;">
     </div>
 
     <div style="min-width:240px;">
+      {# optional_text='' — drops the muted "(optional)" hint, which is both
+         redundant on a filter and low-contrast on the navy panel. #}
       {{ fk_search_field('owner_user_id', 'User', user_search_url,
                          placeholder='Search users…',
+                         optional_text='',
                          selected_id=filters.owner_user_id or '',
                          selected_label=filters.owner_label or '',
-                         label_class='form-label mb-1') }}
+                         label_class='form-label') }}
     </div>
 
-    <div class="form-check form-switch mb-2">
+    <div class="form-check form-switch align-self-center mb-2">
       <input class="form-check-input" type="checkbox" role="switch"
              id="{{ form_id }}-leaves" name="leaves_only" value="1"
              {% if filters.leaves_only %}checked{% endif %}>
@@ -63,15 +78,15 @@
     </div>
 
     <div>
-      <label class="form-label mb-1"><strong>Rows</strong></label>
-      <select class="form-select form-select-sm" name="limit" style="width:100px;">
+      <label class="form-label"><strong>Rows</strong></label>
+      <select class="form-select" name="limit" style="width:100px;">
         {% for n in limit_options %}
           <option value="{{ n }}" {% if filters.limit == n %}selected{% endif %}>{{ n }}</option>
         {% endfor %}
       </select>
     </div>
 
-    <button type="submit" class="btn btn-primary mb-2">
+    <button type="submit" class="btn btn-outline-white mb-2">
       <i class="fas fa-filter me-1"></i> Apply
     </button>
   </div>

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
@@ -73,6 +73,8 @@
     {% if browse %}<input type="hidden" name="browse" value="1">{% endif %}
     <input type="hidden" name="limit" value="{{ filters.limit }}">
     {% if filters.owner_uid is not none %}<input type="hidden" name="owner_uid" value="{{ filters.owner_uid }}">{% endif %}
+    {% if filters.owner_gid is not none %}<input type="hidden" name="owner_gid" value="{{ filters.owner_gid }}">{% endif %}
+    {% if filters.group_label %}<input type="hidden" name="group_label" value="{{ filters.group_label }}">{% endif %}
     {% if filters.leaves_only %}<input type="hidden" name="leaves_only" value="1">{% endif %}
     {% if filters.accessed_before_str %}<input type="hidden" name="accessed_before" value="{{ filters.accessed_before_str }}">{% endif %}
     {% if filters.accessed_after_str %}<input type="hidden" name="accessed_after" value="{{ filters.accessed_after_str }}">{% endif %}
@@ -100,12 +102,14 @@
       {% endfor %}
     </div>
     {{ scans_scope_note(fileset) }}
-    {% if filters.owner_uid is not none or filters.leaves_only
+    {% if filters.owner_uid is not none or filters.owner_gid is not none or filters.leaves_only
           or filters.accessed_before_str or filters.accessed_after_str %}
       <span class="badge bg-info-subtle text-dark border">
         <i class="fas fa-filter me-1"></i>
         {%- if filters.owner_label %}{{ filters.owner_label }}
-        {%- elif filters.owner_uid is not none %}uid {{ filters.owner_uid }}{% endif -%}
+        {%- elif filters.owner_uid is not none %}uid {{ filters.owner_uid }}
+        {%- elif filters.group_label %}{{ filters.group_label }}
+        {%- elif filters.owner_gid is not none %}gid {{ filters.owner_gid }}{% endif -%}
         {%- if filters.leaves_only %} · leaves only{% endif -%}
         {%- if filters.accessed_after_str %} · after {{ filters.accessed_after_str }}{% endif -%}
         {%- if filters.accessed_before_str %} · before {{ filters.accessed_before_str }}{% endif -%}

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_entities.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_entities.html
@@ -53,15 +53,25 @@
   {% if not rows %}
     {{ scans_empty('No ' ~ ('user' if _is_owner else 'group') ~ ' usage recorded for this scope.') }}
   {% else %}
+    {# Distribution pie of scanned bytes (top ~90% + one "Other"). Wedges and
+       legend entries are clickable (set_url sentinels → svg-chart-links.js)
+       and expand the matching entity's row below. Swaps with the kind toggle
+       since the whole fragment re-renders. #}
+    {% if pie_chart %}
+    <div class="d-flex justify-content-center mb-3 disk-entity-pie">
+      {{ pie_chart | safe }}
+    </div>
+    {% endif %}
+
     {# Client-side sortable (sortable_table.js): sort by name (text), or
        Size/Files/Directories (numeric). Size sorts by raw bytes via
        data-sort-value while rendering fmt_size. Default order is Size desc,
        matching the facade's result order.
 
-       Owner mode uses MULTI-TBODY (``tbody.sortable-group``): each user's row
-       and its lazy drill-down detail row reorder together under client sort.
-       Group mode stays a single tbody (no per-group directory drill-down —
-       the facade filters directories by owner UID only). #}
+       Both owner and group modes use MULTI-TBODY (``tbody.sortable-group``):
+       each entity's row and its lazy drill-down detail row reorder together
+       under client sort. Owner rows filter directories by UID, group rows by
+       GID (fs_scans plugin ``group_id`` filter). #}
     <div class="table-responsive">
       <table class="table table-sm table-hover align-middle mb-0">
         <thead class="table-light">
@@ -77,7 +87,9 @@
             {% set name = r.username %}
             {% set _oid = target_id ~ '-owner-' ~ r.owner_uid %}
             <tbody class="sortable-group">
-              <tr>
+              {# data-owner-uid + data-bs-target let a pie-wedge click open this
+                 row's collapse (svg-chart-links.js), same as the chevron. #}
+              <tr data-owner-uid="{{ r.owner_uid }}" data-bs-target="#{{ _oid }}-row">
                 <td data-sort-value="{{ name if name else (r.owner_uid | string) }}">
                   <button class="btn btn-sm btn-link text-decoration-none p-0 me-1"
                           type="button" data-bs-toggle="collapse"
@@ -113,11 +125,20 @@
             </tbody>
           {% endfor %}
         {% else %}
-          <tbody>
-            {% for r in rows %}
-              {% set name = r.groupname %}
-              <tr>
+          {% for r in rows %}
+            {% set name = r.groupname %}
+            {% set _gid = target_id ~ '-group-' ~ r.owner_gid %}
+            <tbody class="sortable-group">
+              {# data-group-gid + data-bs-target let a pie-wedge click open this
+                 row's collapse (svg-chart-links.js), same as the chevron. #}
+              <tr data-group-gid="{{ r.owner_gid }}" data-bs-target="#{{ _gid }}-row">
                 <td data-sort-value="{{ name if name else (r.owner_gid | string) }}">
+                  <button class="btn btn-sm btn-link text-decoration-none p-0 me-1"
+                          type="button" data-bs-toggle="collapse"
+                          data-bs-target="#{{ _gid }}-row"
+                          aria-expanded="false" aria-controls="{{ _gid }}-row">
+                    <i class="fas fa-chevron-right collapse-icon small"></i>
+                  </button>
                   {% if name %}<code>{{ name }}</code>
                   {% else %}<span class="text-muted" title="unresolved GID">gid {{ r.owner_gid }}</span>{% endif %}
                 </td>
@@ -125,8 +146,25 @@
                 <td class="text-end" data-sort-value="{{ r.total_files }}">{{ r.total_files | fmt_number }}</td>
                 <td class="text-end" data-sort-value="{{ r.directory_count }}">{{ r.directory_count | fmt_number }}</td>
               </tr>
-            {% endfor %}
-          </tbody>
+              <tr class="collapse" id="{{ _gid }}-row">
+                <td colspan="4" class="p-0 border-0">
+                  {# Lazy-load this group's top directories on first expand
+                     (owner_gid filter → fs_scans plugin group_id). group_label
+                     carries the resolved name for the filter badge. #}
+                  <div class="p-2 bg-light"
+                       id="{{ _gid }}"
+                       hx-get="{{ url_for('disk_scans.directories_fragment', projcode=project.projcode) }}?owner_gid={{ r.owner_gid }}{% if name %}&group_label={{ name | urlencode }}{% endif %}&resource={{ resource_name }}{% if scope %}&scope={{ scope }}{% endif %}{% if fileset %}&fileset={{ fileset }}{% endif %}&target_id={{ _gid }}&limit=20"
+                       hx-trigger="shown.bs.collapse from:closest tr.collapse once"
+                       hx-swap="innerHTML">
+                    <p class="text-muted small mb-0">
+                      <i class="fas fa-spinner fa-spin me-1"></i>
+                      Loading {{ name or ('gid ' ~ r.owner_gid) }}'s directories…
+                    </p>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          {% endfor %}
         {% endif %}
       </table>
     </div>

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -336,6 +336,26 @@ def test_entities_group_renders(app, auth_client, active_project, monkeypatch):
     assert 'csgteam' in resp.get_data(as_text=True)
 
 
+def test_entities_group_drilldown_and_pie(app, auth_client, active_project, monkeypatch):
+    """By-group rows are now expandable (GID drill-down) and a clickable pie renders."""
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    monkeypatch.setattr(service, 'scan_group_summary', lambda s, p, r, **kw: [{
+        'owner_gid': 2001, 'total_size': 1024 ** 4, 'total_files': 500,
+        'directory_count': 10, 'filesystem': 'cisl', 'groupname': 'csgteam',
+    }])
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/entities'
+        f'?resource={_RES}&kind=group'
+    )
+    body = resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    assert 'data-group-gid="2001"' in body     # row addressable from a pie wedge
+    assert 'owner_gid=2001' in body            # collapse lazy-loads directories by GID
+    assert '#disk-ent-group-2001' in body      # pie wedge/legend sentinel
+
+
 def test_entities_kind_whitelisted(app, auth_client, active_project, monkeypatch):
     """A bogus kind falls back to owner (scan_owner_summary is used)."""
     from webapp.disk_scans import service
@@ -591,6 +611,22 @@ def test_scan_directories_forwards_filters(monkeypatch):
     assert kw['accessed_after'] == datetime(2025, 1, 1)
 
 
+def test_scan_directories_forwards_group_id(monkeypatch):
+    """A 'By group' drill-down reaches the facade as group_id (not owner_id)."""
+    cap = {}
+    svc = _wire_service(
+        monkeypatch,
+        prefixes=['/glade/campaign/cisl/csg'],
+        collections=['cisl'], warmed=['cisl'],
+        collection_map={'/glade/campaign/cisl/csg': 'cisl'},
+        capture=cap,
+    )
+    svc.scan_directories(None, object(), 'Campaign_Store', owner_gid=2001)
+    kw = cap['list_kwargs']
+    assert kw['group_id'] == 2001            # facade param is group_id
+    assert kw['owner_id'] is None            # mutually exclusive with owner
+
+
 def test_directories_bucket_selection(monkeypatch):
     """Any filter routes to the 'filtered' bucket; the bare query to 'default'."""
     from webapp.disk_scans import service
@@ -607,10 +643,11 @@ def test_directories_bucket_selection(monkeypatch):
     monkeypatch.setattr(service, 'cached_scan', fake_cached)
     service.scan_directories(None, object(), 'R')                     # default
     service.scan_directories(None, object(), 'R', owner_uid=5)        # filtered
+    service.scan_directories(None, object(), 'R', owner_gid=7)        # filtered
     service.scan_directories(None, object(), 'R', leaves_only=True)   # filtered
     service.scan_directories(None, object(), 'R',
                              accessed_before=datetime(2026, 1, 1))    # filtered
-    assert seen == ['default', 'filtered', 'filtered', 'filtered']
+    assert seen == ['default', 'filtered', 'filtered', 'filtered', 'filtered']
 
 
 def test_filtered_bucket_has_short_ttl(monkeypatch):
@@ -772,21 +809,9 @@ def test_entities_owner_drilldown_markup(app, auth_client, active_project, monke
     assert 'shown.bs.collapse' in body           # lazy-loads on expand
 
 
-def test_entities_group_no_drilldown(app, auth_client, active_project, monkeypatch):
-    """Group mode stays a single tbody — no per-group directory expansion."""
-    from webapp.disk_scans import service
-    _enable_fs_scans(app, monkeypatch)
-    monkeypatch.setattr(service, 'scan_group_summary', lambda s, p, r, **kw: [{
-        'owner_gid': 2001, 'total_size': 1, 'total_files': 1,
-        'directory_count': 1, 'filesystem': 'cisl', 'groupname': 'csgteam',
-    }])
-
-    resp = auth_client.get(
-        f'/dashboards/user/disk-scans/{active_project.projcode}/entities'
-        f'?resource={_RES}&kind=group'
-    )
-    assert resp.status_code == 200
-    assert 'sortable-group' not in resp.get_data(as_text=True)
+# NB: group drill-down is now SUPPORTED (fs_scans plugin group_id filter) —
+# see test_entities_group_drilldown_and_pie above, which replaces the former
+# test_entities_group_no_drilldown that asserted the single-tbody contract.
 
 
 # -- resource mode (routes): RBAC gating -------------------------------------
@@ -990,3 +1015,47 @@ def test_breadcrumb_macro_renders_href_and_htmx(app):
     assert 'hx-get="/x"' in out
     assert 'aria-current="page"' in out
     assert '>Here<' in out
+
+
+# -- disk-scans entity pie chart (By User / By Group) -----------------------
+
+class TestDiskEntityPie:
+    """charts.generate_disk_entity_pie_chart — cumulative ~90% trim + clickable
+    wedge/legend sentinels that svg-chart-links.js routes to row expansion."""
+
+    def test_cumulative_keep(self):
+        from webapp.dashboards.charts import _pie_cumulative_keep
+        assert _pie_cumulative_keep([90, 5, 3, 2]) == 1   # one dominant slice
+        assert _pie_cumulative_keep([1] * 20) == 9        # hard cap (palette = 10)
+        assert _pie_cumulative_keep([5, 4, 3]) == 3       # all fit → no "Other"
+        assert _pie_cumulative_keep([0, 0]) == 2          # zero total, no crash
+
+    def test_owner_wedges_clickable_other_inert(self):
+        from webapp.dashboards.charts import generate_disk_entity_pie_chart
+        data = [{'id': 1000 + i, 'name': f'u{i}', 'value': v}
+                for i, v in enumerate([50, 20, 10, 6, 5, 3, 2, 1, 1, 1, 0.5, 0.5])]
+        svg = generate_disk_entity_pie_chart(data, 'owner')
+        assert '#disk-ent-owner-1000' in svg     # top kept entity is clickable
+        assert 'Other (' in svg                  # long tail lumped into one slice
+        assert '#disk-ent-owner-None' not in svg  # the Other slice has no sentinel
+
+    def test_group_uses_group_prefix(self):
+        from webapp.dashboards.charts import generate_disk_entity_pie_chart
+        svg = generate_disk_entity_pie_chart(
+            [{'id': 500, 'name': 'csg', 'value': 10},
+             {'id': 501, 'name': None, 'value': 1}], 'group')
+        assert '#disk-ent-group-500' in svg
+
+    def test_empty_returns_placeholder(self):
+        from webapp.dashboards.charts import generate_disk_entity_pie_chart
+        assert 'No usage data' in generate_disk_entity_pie_chart([], 'owner')
+
+    def test_decimal_values_do_not_crash(self):
+        # Scan rollups arrive as decimal.Decimal from Postgres; the chart must
+        # coerce to float (Decimal/float don't mix in cum += v / matplotlib).
+        from decimal import Decimal
+        from webapp.dashboards.charts import generate_disk_entity_pie_chart
+        data = [{'id': 7, 'name': 'g7', 'value': Decimal('10')},
+                {'id': 8, 'name': 'g8', 'value': Decimal('3')}]
+        svg = generate_disk_entity_pie_chart(data, 'group')
+        assert '#disk-ent-group-7' in svg


### PR DESCRIPTION
This session's UX-polish work on the disk-scans dashboard and system-status page. Four commits, smallest → largest.

## 1. Fix Casper status page Inodes tab showing Capacity data
`dashboard.html` includes both `derecho.html` and `casper.html` into one DOM, and both rendered the shared `filesystem_table` macro with **hardcoded** Bootstrap tab IDs (`#capacity`/`#inodes`). Bootstrap resolves a tab target via `querySelector` (first match = Derecho's), so Casper's Inodes tab never activated and showed Capacity. Fixed by namespacing the macro's IDs with an `id_prefix` per system. (Data/model/query were correct.)

## 2. Add K8s stress-test plan
Docs-only (`docs/plans/K8S_HAMMER_HANDOFF.md`).

## 3. Restyle disk-scans directory-explorer filters to Unity house style
The explorer filter panel was a plain white card; brought it onto the Unity `.filter-sidebar` pattern from #302 (navy panel, gold title, white controls, "Clear filters", `btn-outline-white`). Also taught `fk-picker.js` to clear on a native form `reset` so "Clear filters" drops the user-picker badge (fixes every `form-reset-submit` + fk-picker combo).

## 4. Clickable usage pie charts on the By User / By Group tab ⭐
A distribution pie above the counts table (largest entities to ~90% cumulative + one "Other"). Wedges **and** legend entries are clickable — the first pie drill-down in the app — and expand the matching entity's row, lazily loading its directories. Reuses the matplotlib/`UNITY_PALETTE_10`/`@caching.chart_cached`/`set_url`→`svg-chart-links.js` stack.

This also enables **group** drill-down: "By group" rows are now expandable (filter by GID), backed by the new `group_id` directory filter in **hpc-usage-queries#83** (merged to main). Owner + group both verified live.

## Testing
- Unit: 54 disk_scans + 129 allocations/chart-font pass. New coverage for the cumulative trim, wedge-sentinel emission ("Other" inert), group prefix, **Decimal** inputs (Postgres rollups), `scan_directories(owner_gid=…)` → facade `group_id`, filtered-bucket selection, and the group drill-down + pie fragment. Removed the obsolete `test_entities_group_no_drilldown`.
- Live: verified across three scopes (whole/aiml/asap → 50/14/8 entities, distinct + scope-correct, no cache cross-contamination); owner and group wedge-clicks expand the right row and load scope-correct directories.

## Dependency
The pie/group-drill work depends on **hpc-usage-queries#83** being in the plugin build (default `HPC_USAGE_QUERIES_REF=main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)