### PR TITLE
Disk-scans histogram drill-downs: access-history (by date) + file-sizes (by avg file size)

### DIFF
--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -54,8 +54,11 @@ bp = Blueprint('disk_scans', __name__)
 # fs_scans/queries/facade.py:_DIR_SORT_KEYS). The facade fixes the sort
 # direction per key (size/files/atime/dirs descending, path ascending),
 # so the UI only switches the active key, not a direction. 'dirs' maps to
-# the recursive subdirectory count (dir_count_r).
-_DIR_SORT_WHITELIST = {'size', 'files', 'atime_r', 'path', 'dirs'}
+# the recursive subdirectory count (dir_count_r). The ``_nr`` keys sort on the
+# non-recursive (own-files) columns — used by the access-history drill-down's
+# non-recursive view, which shows a directory's own cold data.
+_DIR_SORT_WHITELIST = {'size', 'files', 'atime_r', 'path', 'dirs',
+                       'size_nr', 'files_nr'}
 _DEFAULT_DIR_SORT = 'size'
 
 _DEFAULT_LIMIT = 50
@@ -114,6 +117,18 @@ def _truthy(v) -> bool:
     return (v or '').strip().lower() in ('1', 'true', 'on', 'yes')
 
 
+def _atime_recursive_flag() -> bool:
+    """Read ``?recursive=`` for the access-date filter, defaulting to True.
+
+    True (default, and what every existing caller gets) compares the
+    accessed-before/after filters against the recursive subtree atime; the
+    access-history drill-down passes ``recursive=0`` for its non-recursive
+    (own-files) default view, matching the histogram bar.
+    """
+    raw = request.args.get('recursive')
+    return True if raw is None else _truthy(raw)
+
+
 def _query_date(name: str) -> Optional[datetime]:
     """Parse a ``?<name>=YYYY-MM-DD`` query arg to a datetime (or ``None``).
 
@@ -157,6 +172,8 @@ def _dir_filters() -> dict:
         'accessed_after': _query_date('accessed_after'),
         'accessed_before_str': (request.args.get('accessed_before') or '').strip(),
         'accessed_after_str': (request.args.get('accessed_after') or '').strip(),
+        'atime_recursive': _atime_recursive_flag(),
+        'outermost': _truthy(request.args.get('outermost')),
         'leaves_only': _truthy(request.args.get('leaves_only')),
     }
 
@@ -240,6 +257,10 @@ def _initial_fragment_url(fragment_url: str, ctx: dict, flt: dict,
         params['accessed_before'] = flt['accessed_before_str']
     if flt['accessed_after_str']:
         params['accessed_after'] = flt['accessed_after_str']
+    if not flt.get('atime_recursive', True):
+        params['recursive'] = '0'
+    if flt.get('outermost'):
+        params['outermost'] = '1'
     return f'{fragment_url}?{urlencode(params)}'
 
 
@@ -389,6 +410,8 @@ def directories_fragment(project):
             owner_gid=flt['owner_gid'],
             accessed_before=flt['accessed_before'],
             accessed_after=flt['accessed_after'],
+            atime_recursive=flt['atime_recursive'],
+            outermost_only=flt['outermost'],
             leaves_only=flt['leaves_only'],
             subpath=ctx['fileset'],
         )

--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -174,6 +174,8 @@ def _dir_filters() -> dict:
         'accessed_after_str': (request.args.get('accessed_after') or '').strip(),
         'atime_recursive': _atime_recursive_flag(),
         'outermost': _truthy(request.args.get('outermost')),
+        'min_avg_size': request.args.get('min_avg_size', type=int),
+        'max_avg_size': request.args.get('max_avg_size', type=int),
         'leaves_only': _truthy(request.args.get('leaves_only')),
     }
 
@@ -261,6 +263,10 @@ def _initial_fragment_url(fragment_url: str, ctx: dict, flt: dict,
         params['recursive'] = '0'
     if flt.get('outermost'):
         params['outermost'] = '1'
+    if flt.get('min_avg_size') is not None:
+        params['min_avg_size'] = flt['min_avg_size']
+    if flt.get('max_avg_size') is not None:
+        params['max_avg_size'] = flt['max_avg_size']
     return f'{fragment_url}?{urlencode(params)}'
 
 
@@ -411,6 +417,8 @@ def directories_fragment(project):
             accessed_before=flt['accessed_before'],
             accessed_after=flt['accessed_after'],
             atime_recursive=flt['atime_recursive'],
+            min_avg_size=flt['min_avg_size'],
+            max_avg_size=flt['max_avg_size'],
             outermost_only=flt['outermost'],
             leaves_only=flt['leaves_only'],
             subpath=ctx['fileset'],

--- a/src/webapp/disk_scans/service.py
+++ b/src/webapp/disk_scans/service.py
@@ -189,6 +189,29 @@ def _atime_band_bounds(reference_scan_date, bucket_labels) -> Dict[str, Dict[str
     return out
 
 
+def _size_band_bounds(bucket_labels) -> Dict[str, Dict[str, Optional[int]]]:
+    """Map each file-size band to its ``(size_min, size_max)`` average-file-size
+    bounds (bytes), so the band → user → directories drill-down can filter
+    directories by average own-file size.
+
+    Bounds come from the plugin's ``SIZE_BUCKETS`` (label, min, max) — the single
+    source of truth — mapped by label. The largest band's ``max`` is ``None``
+    (open-ended). Returns ``{}`` if the plugin is unavailable.
+    """
+    try:
+        from fs_scans.core.models import SIZE_BUCKETS
+    except Exception:
+        return {}
+    if not bucket_labels:
+        return {}
+    wanted = set(bucket_labels)
+    return {
+        label: {'size_min': mn, 'size_max': mx}
+        for label, mn, mx in SIZE_BUCKETS
+        if label in wanted
+    }
+
+
 def _scan_directories(
     mod,
     collections: List[str],
@@ -201,6 +224,8 @@ def _scan_directories(
     accessed_before: Optional[datetime] = None,
     accessed_after: Optional[datetime] = None,
     atime_recursive: bool = True,
+    min_avg_size: Optional[int] = None,
+    max_avg_size: Optional[int] = None,
     leaves_only: bool = False,
     single_owner: bool = False,
     min_depth: Optional[int] = None,
@@ -218,7 +243,8 @@ def _scan_directories(
     """
     q = mod.FsScanQueries(filesystems=collections)
     filtered = bool(owner_uid is not None or owner_gid is not None
-                    or accessed_before or accessed_after or leaves_only)
+                    or accessed_before or accessed_after or leaves_only
+                    or min_avg_size is not None or max_avg_size is not None)
     opts = {
         'sort_by': sort_by, 'limit': limit,
         'owner_uid': owner_uid,
@@ -226,6 +252,8 @@ def _scan_directories(
         'accessed_before': accessed_before.isoformat() if accessed_before else None,
         'accessed_after': accessed_after.isoformat() if accessed_after else None,
         'atime_recursive': atime_recursive,
+        'min_avg_size': min_avg_size,
+        'max_avg_size': max_avg_size,
         'leaves_only': leaves_only,
         'single_owner': single_owner,
         'min_depth': min_depth, 'max_depth': max_depth,
@@ -243,6 +271,8 @@ def _scan_directories(
             accessed_before=accessed_before,
             accessed_after=accessed_after,
             atime_recursive=atime_recursive,
+            min_avg_size=min_avg_size,
+            max_avg_size=max_avg_size,
             leaves_only=leaves_only,
             single_owner=single_owner,
             min_depth=min_depth,
@@ -264,6 +294,8 @@ def scan_directories(
     accessed_before: Optional[datetime] = None,
     accessed_after: Optional[datetime] = None,
     atime_recursive: bool = True,
+    min_avg_size: Optional[int] = None,
+    max_avg_size: Optional[int] = None,
     outermost_only: bool = False,
     leaves_only: bool = False,
     single_owner: bool = False,
@@ -295,6 +327,7 @@ def scan_directories(
         sort_by=sort_by, limit=limit,
         owner_uid=owner_uid, owner_gid=owner_gid, accessed_before=accessed_before,
         accessed_after=accessed_after, atime_recursive=atime_recursive,
+        min_avg_size=min_avg_size, max_avg_size=max_avg_size,
         leaves_only=leaves_only,
         single_owner=single_owner, min_depth=min_depth, max_depth=max_depth,
     )
@@ -461,7 +494,20 @@ def scan_file_sizes(
     if not collections:
         return None
     q = mod.FsScanQueries(filesystems=collections)
+
+    def _compute():
+        hist = q.file_size_histogram(path_prefixes=path_prefixes, owner_uid=owner_uid)
+        if hist:
+            # Tag each band with its average-file-size window so the per-user
+            # drill-down can list that band's directories (see _size_band_bounds).
+            bounds = _size_band_bounds(hist.get('bucket_labels'))
+            for label, b in (hist.get('buckets') or {}).items():
+                if label in bounds:
+                    b['size_min'] = bounds[label]['size_min']
+                    b['size_max'] = bounds[label]['size_max']
+        return hist
+
     return cached_scan(
         'file_sizes', q, collections, path_prefixes, {'owner_uid': owner_uid},
-        lambda: q.file_size_histogram(path_prefixes=path_prefixes, owner_uid=owner_uid),
+        _compute,
     )

--- a/src/webapp/disk_scans/service.py
+++ b/src/webapp/disk_scans/service.py
@@ -18,7 +18,7 @@ so there is no session context manager here — we just construct
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
 from webapp.disk_scans.cache import cached_scan
@@ -131,6 +131,64 @@ def scan_overview(session, project, resource_name: str) -> Dict[str, Any]:
     return {'collections': collections, 'scan_dates': scan_dates, 'reference': reference}
 
 
+def _drop_nested(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Keep only the outermost directories — drop any row whose ancestor path
+    is also present.
+
+    Used by the access-history *recursive* drill-down, where the question is
+    "which whole trees are entirely stale?": listing both ``/foo`` and
+    ``/foo/bar`` is redundant — you'd reclaim the tree by deleting ``/foo``.
+    Rows arrive sorted by recursive size, and an ancestor's subtree is always
+    larger than its descendant's, so an ancestor always precedes its children;
+    a single forward pass keeping the first-seen prefix is therefore exact.
+    """
+    kept: List[Dict[str, Any]] = []
+    kept_paths: List[str] = []
+    for r in rows:
+        p = (r.get('path') or '').rstrip('/')
+        if any(p == kp or p.startswith(kp + '/') for kp in kept_paths):
+            continue
+        kept.append(r)
+        kept_paths.append(p)
+    return kept
+
+
+def _atime_band_bounds(reference_scan_date, bucket_labels) -> Dict[str, Dict[str, Optional[str]]]:
+    """Map each access-history band to ``(accessed_after, accessed_before)``
+    ``YYYY-MM-DD`` date strings, so the band → user → directories drill-down can
+    filter directories to exactly the clicked band's date window.
+
+    Bounds come from the plugin's ``ATIME_BUCKETS`` day thresholds (the single
+    source of truth, imported here) relative to the scan date. A directory is
+    in band ``i`` when its last-access *age* (days from the scan) is in
+    ``[lower, upper)``; since access-time = scan − age, that maps to
+    ``accessed_after = scan − upper`` (older edge; ``None`` for the open-ended
+    oldest band) and ``accessed_before = scan − lower`` (newer edge; the scan
+    date itself for band 0). Returns ``{}`` if the plugin or scan date is
+    unavailable.
+    """
+    try:
+        from fs_scans.core.models import ATIME_BUCKETS
+    except Exception:
+        return {}
+    if not reference_scan_date or not bucket_labels:
+        return {}
+    wanted = set(bucket_labels)
+    out: Dict[str, Dict[str, Optional[str]]] = {}
+    prev = 0  # cumulative lower threshold (days) carried across bands in order
+    for label, upper in ATIME_BUCKETS:
+        lower = prev
+        if upper is not None:
+            prev = upper
+        if label not in wanted:
+            continue
+        before = (reference_scan_date - timedelta(days=lower)).strftime('%Y-%m-%d')
+        after = (None if upper is None
+                 else (reference_scan_date - timedelta(days=upper)).strftime('%Y-%m-%d'))
+        out[label] = {'accessed_after': after, 'accessed_before': before}
+    return out
+
+
 def _scan_directories(
     mod,
     collections: List[str],
@@ -142,6 +200,7 @@ def _scan_directories(
     owner_gid: Optional[int] = None,
     accessed_before: Optional[datetime] = None,
     accessed_after: Optional[datetime] = None,
+    atime_recursive: bool = True,
     leaves_only: bool = False,
     single_owner: bool = False,
     min_depth: Optional[int] = None,
@@ -166,6 +225,7 @@ def _scan_directories(
         'owner_gid': owner_gid,
         'accessed_before': accessed_before.isoformat() if accessed_before else None,
         'accessed_after': accessed_after.isoformat() if accessed_after else None,
+        'atime_recursive': atime_recursive,
         'leaves_only': leaves_only,
         'single_owner': single_owner,
         'min_depth': min_depth, 'max_depth': max_depth,
@@ -182,6 +242,7 @@ def _scan_directories(
             group_id=owner_gid,
             accessed_before=accessed_before,
             accessed_after=accessed_after,
+            atime_recursive=atime_recursive,
             leaves_only=leaves_only,
             single_owner=single_owner,
             min_depth=min_depth,
@@ -202,6 +263,8 @@ def scan_directories(
     owner_gid: Optional[int] = None,
     accessed_before: Optional[datetime] = None,
     accessed_after: Optional[datetime] = None,
+    atime_recursive: bool = True,
+    outermost_only: bool = False,
     leaves_only: bool = False,
     single_owner: bool = False,
     min_depth: Optional[int] = None,
@@ -216,17 +279,26 @@ def scan_directories(
     directories or the plugin is unavailable. Filters
     (``owner_uid / accessed_before / accessed_after / leaves_only``) narrow
     within that scope.
+
+    ``atime_recursive`` selects which access-time column the date filters
+    compare against — the subtree max (``True``, default) or the directory's own
+    files (``False``). ``outermost_only`` collapses the result to the topmost
+    directories (drops any whose ancestor is also listed) — used by the
+    recursive access-history drill-down to surface removable trees, not every
+    nested match.
     """
     mod, path_prefixes, collections = _scoped(session, project, resource_name, subpath)
     if not collections:
         return []
-    return _scan_directories(
+    rows = _scan_directories(
         mod, collections, path_prefixes,
         sort_by=sort_by, limit=limit,
         owner_uid=owner_uid, owner_gid=owner_gid, accessed_before=accessed_before,
-        accessed_after=accessed_after, leaves_only=leaves_only,
+        accessed_after=accessed_after, atime_recursive=atime_recursive,
+        leaves_only=leaves_only,
         single_owner=single_owner, min_depth=min_depth, max_depth=max_depth,
     )
+    return _drop_nested(rows) if outermost_only else rows
 
 
 def scan_directories_resource(
@@ -346,9 +418,23 @@ def scan_access_history(
     if not collections:
         return None
     q = mod.FsScanQueries(filesystems=collections)
+
+    def _compute():
+        hist = q.access_history(path_prefixes=path_prefixes, owner_uid=owner_uid)
+        if hist:
+            # Tag each band with the date window it represents so the per-user
+            # drill-down can list that band's directories (see _atime_band_bounds).
+            bounds = _atime_band_bounds(hist.get('reference_scan_date'),
+                                        hist.get('bucket_labels'))
+            for label, b in (hist.get('buckets') or {}).items():
+                if label in bounds:
+                    b['accessed_after'] = bounds[label]['accessed_after']
+                    b['accessed_before'] = bounds[label]['accessed_before']
+        return hist
+
     return cached_scan(
         'access_history', q, collections, path_prefixes, {'owner_uid': owner_uid},
-        lambda: q.access_history(path_prefixes=path_prefixes, owner_uid=owner_uid),
+        _compute,
     )
 
 

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
@@ -96,6 +96,8 @@
     {% if filters.leaves_only %}<input type="hidden" name="leaves_only" value="1">{% endif %}
     {% if filters.accessed_before_str %}<input type="hidden" name="accessed_before" value="{{ filters.accessed_before_str }}">{% endif %}
     {% if filters.accessed_after_str %}<input type="hidden" name="accessed_after" value="{{ filters.accessed_after_str }}">{% endif %}
+    {% if filters.min_avg_size is not none %}<input type="hidden" name="min_avg_size" value="{{ filters.min_avg_size }}">{% endif %}
+    {% if filters.max_avg_size is not none %}<input type="hidden" name="max_avg_size" value="{{ filters.max_avg_size }}">{% endif %}
   </form>
 
   {# File-browser ancestry (explorer/browse mode only). Click a crumb to
@@ -140,7 +142,8 @@
     {% endif %}
     {{ scans_scope_note(fileset) }}
     {% if filters.owner_uid is not none or filters.owner_gid is not none or filters.leaves_only
-          or filters.accessed_before_str or filters.accessed_after_str %}
+          or filters.accessed_before_str or filters.accessed_after_str
+          or filters.min_avg_size is not none or filters.max_avg_size is not none %}
       <span class="badge bg-info-subtle text-dark border">
         <i class="fas fa-filter me-1"></i>
         {%- if filters.owner_label %}{{ filters.owner_label }}
@@ -151,6 +154,8 @@
         {%- if filters.accessed_after_str %} · after {{ filters.accessed_after_str }}{% endif -%}
         {%- if filters.accessed_before_str %} · before {{ filters.accessed_before_str }}{% endif -%}
         {%- if (filters.accessed_after_str or filters.accessed_before_str) %} · {{ 'subtree' if _rec else 'own files' }}{% endif -%}
+        {%- if filters.min_avg_size is not none or filters.max_avg_size is not none %} · avg
+          {{ filters.min_avg_size | fmt_size if filters.min_avg_size is not none else '0' }}–{{ filters.max_avg_size | fmt_size if filters.max_avg_size is not none else '∞' }}{% endif -%}
       </span>
     {% endif %}
     <span class="ms-auto text-muted small">

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
@@ -15,21 +15,39 @@
   top-N limit. Mirrors the jobs_fragment pattern.
 #}
 
+{# Recursive (default) vs non-recursive view. The access-history drill-down
+   passes ``recursive=0`` to show a directory's OWN cold data (matching the
+   histogram bar); the rest of the app uses the recursive subtree columns.
+   This switches the displayed size/files/atime columns AND the sort keys. #}
+{% set _rec = (filters.atime_recursive if filters.atime_recursive is not none else true) %}
+{% set _size_field  = 'total_size_r' if _rec else 'total_size_nr' %}
+{% set _files_field = 'file_count_r' if _rec else 'file_count_nr' %}
+{% set _atime_field = 'max_atime_r'  if _rec else 'max_atime_nr' %}
+{% set _size_key  = 'size'  if _rec else 'size_nr' %}
+{% set _files_key = 'files' if _rec else 'files_nr' %}
+{# atime_nr has no sort key in the facade, so the Last-Access header is only
+   clickable in recursive mode (atime_r); non-recursive renders a plain label. #}
+{% set _atime_key = 'atime_r' if _rec else 'atime_nr' %}
+{# Preserve the non-recursive / outermost state across sort/pill re-fetches,
+   the same per-URL way ``sort_by`` and ``fileset`` are carried (NOT the form). #}
+{% set _rec_q = ('' if _rec else '&recursive=0') ~ ('&outermost=1' if filters.outermost else '') %}
+
 {# (sort_key, label, row-attr, numeric?) — the facade fixes sort direction
    per key, so a header click only switches the active key. #}
 {% set _cols = [
-  ('path',    'Path',        'path',         false),
-  ('size',    'Size',        'total_size_r', true),
-  ('files',   'Files',         'file_count_r', true),
-  ('dirs',    'Subdirectories', 'dir_count_r', true),
-  ('atime_r', 'Last Access',   'max_atime_r',  false),
+  ('path',      'Path',           'path',        false),
+  (_size_key,   'Size',           _size_field,   true),
+  (_files_key,  'Files',          _files_field,  true),
+  ('dirs',      'Subdirectories', 'dir_count_r', true),
+  (_atime_key,  'Last Access',    _atime_field,  false),
 ] %}
 
 {% macro dir_sort_link(key, label) %}
   {%- if key in sortable_columns -%}
     {%- set is_active = (sort.sort_by == key) -%}
+    {%- set _rec_q = ('' if (filters.atime_recursive if filters.atime_recursive is not none else true) else '&recursive=0') ~ ('&outermost=1' if filters.outermost else '') -%}
     <a class="text-decoration-none" href="#"
-       hx-get="{{ fragment_url }}?sort_by={{ key }}{% if fileset %}&fileset={{ fileset | urlencode }}{% endif %}"
+       hx-get="{{ fragment_url }}?sort_by={{ key }}{% if fileset %}&fileset={{ fileset | urlencode }}{% endif %}{{ _rec_q }}"
        hx-target="#{{ target_id }}"
        hx-include="#disk-scans-dir-params-{{ target_id }}"
        hx-swap="innerHTML">
@@ -46,9 +64,9 @@
    the server for the true top-N by that key (top-by-size ≠ top-by-files), so
    it is NOT a client re-sort; the column headers remain available too. #}
 {% set _pills = [
-  ('size',  'Size',      'fa-hard-drive'),
-  ('files', '# Files',   'fa-hashtag'),
-  ('dirs',  '# Subdirs', 'fa-folder-tree'),
+  (_size_key,  'Size',      'fa-hard-drive'),
+  (_files_key, '# Files',   'fa-hashtag'),
+  ('dirs',     '# Subdirs', 'fa-folder-tree'),
 ] %}
 {# Recursive subdirectory count (dir_count_r) is 0 by definition for leaves,
    so the Subdirectories column + its sort pill are meaningless (and would
@@ -92,7 +110,7 @@
         {% if key != 'dirs' or _show_dirs %}
         <button type="button"
                 class="btn btn-outline-secondary {% if sort.sort_by == key %}active{% endif %}"
-                hx-get="{{ fragment_url }}?sort_by={{ key }}{% if fileset %}&fileset={{ fileset | urlencode }}{% endif %}"
+                hx-get="{{ fragment_url }}?sort_by={{ key }}{% if fileset %}&fileset={{ fileset | urlencode }}{% endif %}{{ _rec_q }}"
                 hx-target="#{{ target_id }}"
                 hx-include="#disk-scans-dir-params-{{ target_id }}"
                 hx-swap="innerHTML">
@@ -101,6 +119,25 @@
         {% endif %}
       {% endfor %}
     </div>
+    {# Recursive toggle — only meaningful when a last-access date window is
+       active (the access-history band drill-down, or a manual date filter).
+       On: outermost stale TREES sized by reclaimable subtree bytes. Off
+       (default): directories whose OWN files are stale, matching the bar. #}
+    {% if filters.accessed_before_str or filters.accessed_after_str %}
+      <div class="form-check form-switch form-check-inline mb-0"
+           title="On: list the outermost directory trees whose entire subtree is stale — size is the space reclaimed by deleting the tree. Off: directories whose own files are stale (matches the histogram bar).">
+        <input class="form-check-input" type="checkbox" role="switch"
+               id="disk-scans-recursive-{{ target_id }}"
+               {% if _rec %}checked{% endif %}
+               hx-get="{{ fragment_url }}?sort_by={{ 'size_nr' if _rec else 'size' }}&recursive={{ '0' if _rec else '1' }}{% if not _rec %}&outermost=1{% endif %}{% if fileset %}&fileset={{ fileset | urlencode }}{% endif %}"
+               hx-target="#{{ target_id }}"
+               hx-include="#disk-scans-dir-params-{{ target_id }}"
+               hx-swap="innerHTML">
+        <label class="form-check-label small text-muted" for="disk-scans-recursive-{{ target_id }}">
+          Recursive (whole trees)
+        </label>
+      </div>
+    {% endif %}
     {{ scans_scope_note(fileset) }}
     {% if filters.owner_uid is not none or filters.owner_gid is not none or filters.leaves_only
           or filters.accessed_before_str or filters.accessed_after_str %}
@@ -113,6 +150,7 @@
         {%- if filters.leaves_only %} · leaves only{% endif -%}
         {%- if filters.accessed_after_str %} · after {{ filters.accessed_after_str }}{% endif -%}
         {%- if filters.accessed_before_str %} · before {{ filters.accessed_before_str }}{% endif -%}
+        {%- if (filters.accessed_after_str or filters.accessed_before_str) %} · {{ 'subtree' if _rec else 'own files' }}{% endif -%}
       </span>
     {% endif %}
     <span class="ms-auto text-muted small">
@@ -143,7 +181,7 @@
                      filters (the params form). Leaves (dir_count_r == 0) and
                      the static card tab render a plain path. #}
                   <a class="text-decoration-none" href="#"
-                     hx-get="{{ fragment_url }}?fileset={{ r.path | urlencode }}&sort_by={{ sort.sort_by }}"
+                     hx-get="{{ fragment_url }}?fileset={{ r.path | urlencode }}&sort_by={{ sort.sort_by }}{{ _rec_q }}"
                      hx-target="#{{ target_id }}"
                      hx-include="#disk-scans-dir-params-{{ target_id }}"
                      hx-swap="innerHTML">
@@ -153,11 +191,11 @@
                   <code>{{ r.path }}</code>
                 {%- endif -%}
               </td>
-              <td class="text-end font-monospace">{{ r.total_size_r | fmt_size }}</td>
-              <td class="text-end">{{ r.file_count_r | fmt_number }}</td>
+              <td class="text-end font-monospace">{{ r[_size_field] | fmt_size }}</td>
+              <td class="text-end">{{ r[_files_field] | fmt_number }}</td>
               {% if _show_dirs %}<td class="text-end">{{ r.dir_count_r | fmt_number }}</td>{% endif %}
               <td class="text-end text-nowrap small">
-                {%- set a = r.max_atime_r -%}
+                {%- set a = r[_atime_field] -%}
                 {%- if a is none or a == '' -%}<span class="text-muted">—</span>
                 {%- elif a is string -%}{{ a[:10] }}
                 {%- else -%}{{ a | fmt_date }}{%- endif -%}

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
@@ -161,14 +161,48 @@
                     {% for uid, stats in ranked[:10] %}
                       {% set dpct = (100.0 * stats.get('data', 0) / b_data) if b_data else 0 %}
                       {% set fpct = (100.0 * stats.get('files', 0) / b_files) if b_files else 0 %}
-                      <tr>
+                      {# Drill one level deeper: this user's directories in this
+                         band. Only the access-history histogram tags bands with a
+                         date window (b.accessed_before, set in the service), so
+                         file-size bands stay flat — exactly right, since there's
+                         no date range to filter directories by there. #}
+                      {% set _uname = umap.get(uid) or umap.get(uid | string) or ('uid ' ~ uid) %}
+                      {% set _has_dd = b.get('accessed_before') and project %}
+                      {% set _urow = rowid ~ '-u' ~ loop.index %}
+                      {% set _dt = rowid ~ '-d' ~ loop.index %}
+                      <tr {% if _has_dd %}class="cursor-pointer" data-bs-toggle="collapse"
+                            data-bs-target="#{{ _urow }}" aria-expanded="false"
+                            aria-controls="{{ _urow }}"
+                            title="Show this user's directories last accessed in this band"{% endif %}>
                         <td class="text-end text-muted">{{ loop.index }}</td>
-                        <td class="font-monospace">{{ umap.get(uid) or umap.get(uid | string) or ('uid ' ~ uid) }}</td>
+                        <td class="font-monospace">
+                          {%- if _has_dd %}<i class="fas fa-chevron-right small collapse-icon text-muted me-1"></i>{% endif -%}
+                          {{ _uname }}
+                        </td>
                         <td class="text-end font-monospace">{{ stats.get('data', 0) | fmt_size }}</td>
                         <td class="text-end text-muted">{{ dpct | fmt_pct }}</td>
                         <td class="text-end">{{ stats.get('files', 0) | fmt_number }}</td>
                         <td class="text-end text-muted">{{ fpct | fmt_pct }}</td>
                       </tr>
+                      {% if _has_dd %}
+                        <tr class="collapse" id="{{ _urow }}">
+                          <td colspan="6" class="p-0 border-0">
+                            {# Lazy-load on first expand. Non-recursive (own cold
+                               files) by default to match the bar; the fragment's
+                               Recursive toggle switches to removable trees. Bind
+                               to shown.bs.collapse so it fires under nav restore. #}
+                            <div class="p-2 bg-light" id="{{ _dt }}"
+                                 hx-get="{{ url_for('disk_scans.directories_fragment', projcode=project.projcode) }}?owner_uid={{ uid }}&resource={{ resource_name }}{% if scope %}&scope={{ scope }}{% endif %}{% if b.get('accessed_after') %}&accessed_after={{ b.accessed_after }}{% endif %}&accessed_before={{ b.accessed_before }}&recursive=0&sort_by=size_nr&limit=25&target_id={{ _dt }}"
+                                 hx-trigger="shown.bs.collapse from:closest tr.collapse once"
+                                 hx-swap="innerHTML">
+                              <p class="text-muted small mb-0">
+                                <i class="fas fa-spinner fa-spin me-1"></i>
+                                Loading {{ _uname }}'s directories…
+                              </p>
+                            </div>
+                          </td>
+                        </tr>
+                      {% endif %}
                     {% endfor %}
                   </tbody>
                 </table>

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
@@ -162,18 +162,21 @@
                       {% set dpct = (100.0 * stats.get('data', 0) / b_data) if b_data else 0 %}
                       {% set fpct = (100.0 * stats.get('files', 0) / b_files) if b_files else 0 %}
                       {# Drill one level deeper: this user's directories in this
-                         band. Only the access-history histogram tags bands with a
-                         date window (b.accessed_before, set in the service), so
-                         file-size bands stay flat — exactly right, since there's
-                         no date range to filter directories by there. #}
+                         band. The service tags access-history bands with a date
+                         window (accessed_before) and file-size bands with an
+                         avg-size window (size_min/size_max); either makes the row
+                         expandable, filtering directories by the matching
+                         dimension (date range vs average own-file size). #}
                       {% set _uname = umap.get(uid) or umap.get(uid | string) or ('uid ' ~ uid) %}
-                      {% set _has_dd = b.get('accessed_before') and project %}
+                      {% set _date_band = b.get('accessed_before') %}
+                      {% set _size_band = (b.get('size_min') is not none) or (b.get('size_max') is not none) %}
+                      {% set _has_dd = (_date_band or _size_band) and project %}
                       {% set _urow = rowid ~ '-u' ~ loop.index %}
                       {% set _dt = rowid ~ '-d' ~ loop.index %}
                       <tr {% if _has_dd %}class="cursor-pointer" data-bs-toggle="collapse"
                             data-bs-target="#{{ _urow }}" aria-expanded="false"
                             aria-controls="{{ _urow }}"
-                            title="Show this user's directories last accessed in this band"{% endif %}>
+                            title="Show this user's directories in this band"{% endif %}>
                         <td class="text-end text-muted">{{ loop.index }}</td>
                         <td class="font-monospace">
                           {%- if _has_dd %}<i class="fas fa-chevron-right small collapse-icon text-muted me-1"></i>{% endif -%}
@@ -187,12 +190,14 @@
                       {% if _has_dd %}
                         <tr class="collapse" id="{{ _urow }}">
                           <td colspan="6" class="p-0 border-0">
-                            {# Lazy-load on first expand. Non-recursive (own cold
-                               files) by default to match the bar; the fragment's
-                               Recursive toggle switches to removable trees. Bind
-                               to shown.bs.collapse so it fires under nav restore. #}
+                            {# Lazy-load on first expand, non-recursive (own files)
+                               to match the bar. Access-history bands filter by the
+                               date window; file-size bands filter by average
+                               own-file size (min_avg_size/max_avg_size, the last
+                               band has no upper bound). Bind to shown.bs.collapse
+                               so it fires under nav restore. #}
                             <div class="p-2 bg-light" id="{{ _dt }}"
-                                 hx-get="{{ url_for('disk_scans.directories_fragment', projcode=project.projcode) }}?owner_uid={{ uid }}&resource={{ resource_name }}{% if scope %}&scope={{ scope }}{% endif %}{% if b.get('accessed_after') %}&accessed_after={{ b.accessed_after }}{% endif %}&accessed_before={{ b.accessed_before }}&recursive=0&sort_by=size_nr&limit=25&target_id={{ _dt }}"
+                                 hx-get="{{ url_for('disk_scans.directories_fragment', projcode=project.projcode) }}?owner_uid={{ uid }}&resource={{ resource_name }}{% if scope %}&scope={{ scope }}{% endif %}{% if _date_band %}{% if b.get('accessed_after') %}&accessed_after={{ b.accessed_after }}{% endif %}&accessed_before={{ b.accessed_before }}{% else %}&min_avg_size={{ b.size_min }}{% if b.get('size_max') is not none %}&max_avg_size={{ b.size_max }}{% endif %}{% endif %}&recursive=0&sort_by=size_nr&limit=25&target_id={{ _dt }}"
                                  hx-trigger="shown.bs.collapse from:closest tr.collapse once"
                                  hx-swap="innerHTML">
                               <p class="text-muted small mb-0">

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -279,6 +279,26 @@ def test_directories_fileset_becomes_subpath(app, auth_client, active_project, m
     assert captured['subpath'] == '/glade/campaign/cisl/csg'
 
 
+def test_directories_recursive_flag(app, auth_client, active_project, monkeypatch):
+    """?recursive defaults True; recursive=0 + outermost=1 reach the service."""
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    captured = {}
+    monkeypatch.setattr(service, 'scan_directories',
+                        lambda s, p, r, **kw: captured.update(kw) or [])
+
+    base = (f'/dashboards/user/disk-scans/{active_project.projcode}/directories'
+            f'?resource={_RES}')
+    auth_client.get(base)
+    assert captured['atime_recursive'] is True       # default — existing callers
+    assert captured['outermost_only'] is False
+
+    auth_client.get(base + '&recursive=0&outermost=1&sort_by=size_nr')
+    assert captured['atime_recursive'] is False
+    assert captured['outermost_only'] is True
+    assert captured['sort_by'] == 'size_nr'          # _nr sort key whitelisted
+
+
 def test_directories_error_banner_on_exception(app, auth_client, active_project, monkeypatch):
     from webapp.disk_scans import service
     _enable_fs_scans(app, monkeypatch)
@@ -412,6 +432,67 @@ def test_access_history_renders_svg(app, auth_client, active_project, monkeypatc
     # buckets with owners get an SVG anchor and a matching row lookup attr.
     assert '#ah-bar-0' in body            # bar anchor for the first owned bucket
     assert 'data-ah-bucket="0"' in body   # row the anchor expands
+
+
+def test_access_history_user_drilldown_rows(app, auth_client, active_project, monkeypatch):
+    """Bands carrying a date window render expandable per-user rows whose
+    collapse lazy-loads that user's directories scoped to the band (owner_uid
+    + date window + recursive=0 by default)."""
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    hist = {
+        'bucket_labels': ['1-2 Years'],
+        'buckets': {
+            '1-2 Years': {
+                'data': 1024 ** 4, 'files': 100,
+                'owners': {1001: {'data': 1024 ** 4, 'files': 100}},
+                # date window stamped by the service (_atime_band_bounds)
+                'accessed_after': '2024-06-01', 'accessed_before': '2025-06-01',
+            },
+        },
+        'total_data': 1024 ** 4, 'total_files': 100,
+        'directory': '/glade/campaign/cisl', 'fast_path': True,
+        'reference_scan_date': datetime(2026, 6, 1),
+        'username_map': {1001: 'alice'},
+    }
+    monkeypatch.setattr(service, 'scan_access_history', lambda s, p, r, **kw: hist)
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/access-history?resource={_RES}'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # The user row is expandable and lazy-loads the directories fragment for
+    # that user, scoped to the band's date window, non-recursive by default.
+    assert 'owner_uid=1001' in body
+    assert 'accessed_after=2024-06-01' in body
+    assert 'accessed_before=2025-06-01' in body
+    assert 'recursive=0' in body
+    assert 'sort_by=size_nr' in body
+    assert 'shown.bs.collapse' in body            # lazy-load trigger
+
+
+def test_access_history_no_drilldown_without_bounds(app, auth_client, active_project, monkeypatch):
+    """A band with no date window (e.g. the file-size histogram shape) does not
+    sprout a per-user drill-down — there's no range to scope directories by."""
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    hist = {
+        'bucket_labels': ['1-2 Years'],
+        'buckets': {'1-2 Years': {'data': 1, 'files': 1,
+                                  'owners': {1001: {'data': 1, 'files': 1}}}},
+        'total_data': 1, 'total_files': 1, 'fast_path': True,
+        'reference_scan_date': datetime(2026, 6, 1),
+        'username_map': {1001: 'alice'},
+    }
+    monkeypatch.setattr(service, 'scan_access_history', lambda s, p, r, **kw: hist)
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/access-history?resource={_RES}'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'alice' in body                        # user still listed
+    assert 'owner_uid=1001' not in body           # but not expandable to dirs
 
 
 def test_access_history_empty_when_none(app, auth_client, active_project, monkeypatch):
@@ -625,6 +706,112 @@ def test_scan_directories_forwards_group_id(monkeypatch):
     kw = cap['list_kwargs']
     assert kw['group_id'] == 2001            # facade param is group_id
     assert kw['owner_id'] is None            # mutually exclusive with owner
+
+
+def test_scan_directories_forwards_atime_recursive(monkeypatch):
+    """The recursive/non-recursive atime choice reaches the facade verbatim."""
+    cap = {}
+    svc = _wire_service(
+        monkeypatch,
+        prefixes=['/glade/campaign/cisl/csg'],
+        collections=['cisl'], warmed=['cisl'],
+        collection_map={'/glade/campaign/cisl/csg': 'cisl'},
+        capture=cap,
+    )
+    svc.scan_directories(None, object(), 'Campaign_Store')          # default
+    assert cap['list_kwargs']['atime_recursive'] is True
+    svc.scan_directories(None, object(), 'Campaign_Store', atime_recursive=False)
+    assert cap['list_kwargs']['atime_recursive'] is False
+
+
+def test_scan_directories_outermost_drops_nested(monkeypatch):
+    """outermost_only keeps the topmost tree, dropping nested descendants.
+
+    Rows arrive size-sorted (ancestor first); the recursive drill-down wants
+    the removable tree, not every directory inside it.
+    """
+    from webapp.disk_scans import service
+
+    rows = [
+        {'path': '/glade/campaign/cisl/csg'},
+        {'path': '/glade/campaign/cisl/csg/sub'},      # nested under the above
+        {'path': '/glade/campaign/cisl/csg/sub/deep'}, # nested deeper
+        {'path': '/glade/campaign/cisl/other'},        # sibling — kept
+    ]
+    monkeypatch.setattr(service, '_scan_directories', lambda *a, **k: list(rows))
+    monkeypatch.setattr(
+        service, '_scoped',
+        lambda s, p, r, subpath=None: (object(), ['/glade/campaign/cisl'], ['cisl']),
+    )
+    kept = service.scan_directories(None, object(), 'Campaign_Store',
+                                    outermost_only=True)
+    assert [r['path'] for r in kept] == [
+        '/glade/campaign/cisl/csg', '/glade/campaign/cisl/other',
+    ]
+    # Without the flag, every directory is returned untouched.
+    allrows = service.scan_directories(None, object(), 'Campaign_Store')
+    assert len(allrows) == 4
+
+
+def test_atime_band_bounds_maps_bands_to_dates():
+    """Each band maps to (accessed_after, accessed_before) by its ATIME_BUCKETS
+    day window, relative to the scan date; the open-ended oldest band has no
+    lower (after) bound. Mapping is by label, not list position."""
+    from webapp.disk_scans.service import _atime_band_bounds
+
+    scan = datetime(2026, 6, 1)
+    bounds = _atime_band_bounds(scan, ['< 1 Month', '7+ Years'])
+    # Band 0: ages [0, 30) days → before = scan, after = scan - 30 days.
+    assert bounds['< 1 Month']['accessed_before'] == '2026-06-01'
+    assert bounds['< 1 Month']['accessed_after'] == '2026-05-02'
+    # Oldest band: open-ended → no after bound, before = scan - 2555 days.
+    assert bounds['7+ Years']['accessed_after'] is None
+    assert bounds['7+ Years']['accessed_before'] == (
+        (scan - timedelta(days=2555)).strftime('%Y-%m-%d'))
+
+
+def test_atime_band_bounds_empty_without_scan_date():
+    from webapp.disk_scans.service import _atime_band_bounds
+    assert _atime_band_bounds(None, ['< 1 Month']) == {}
+
+
+def test_scan_access_history_tags_band_bounds(monkeypatch):
+    """scan_access_history stamps each band with its date window so the
+    drill-down can scope directories to the clicked band."""
+    from webapp.disk_scans import service
+
+    hist = {
+        'bucket_labels': ['< 1 Month', '7+ Years'],
+        'buckets': {
+            '< 1 Month': {'data': 1, 'files': 1, 'owners': {1001: {'data': 1, 'files': 1}}},
+            '7+ Years':  {'data': 1, 'files': 1, 'owners': {}},
+        },
+        'reference_scan_date': datetime(2026, 6, 1),
+    }
+
+    class _Q:
+        def __init__(self, filesystems):
+            pass
+
+        def access_history(self, **kw):
+            return hist
+
+    mod = types.SimpleNamespace(FsScanQueries=_Q,
+                                collection_for_path=lambda p: 'cisl',
+                                normalize_path=lambda p: p)
+    monkeypatch.setattr(service, 'get_module', lambda: mod)
+    monkeypatch.setattr(service, 'get_collections', lambda: ['cisl'])
+    monkeypatch.setattr(service, 'resolve_scan_scope',
+                        lambda s, p, r: (['/glade/campaign/cisl/csg'], ['cisl']))
+    monkeypatch.setattr(
+        service, 'cached_scan',
+        lambda qt, q, colls, pfx, opts, compute, bucket='default': compute(),
+    )
+
+    out = service.scan_access_history(None, object(), 'Campaign_Store')
+    assert out['buckets']['< 1 Month']['accessed_before'] == '2026-06-01'
+    assert out['buckets']['< 1 Month']['accessed_after'] == '2026-05-02'
+    assert out['buckets']['7+ Years']['accessed_after'] is None
 
 
 def test_directories_bucket_selection(monkeypatch):

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -22,7 +22,7 @@ teardown).
 from __future__ import annotations
 
 import types
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -495,6 +495,56 @@ def test_access_history_no_drilldown_without_bounds(app, auth_client, active_pro
     assert 'owner_uid=1001' not in body           # but not expandable to dirs
 
 
+def test_file_sizes_user_drilldown_rows(app, auth_client, active_project, monkeypatch):
+    """File-size bands carrying an avg-size window render expandable per-user
+    rows whose collapse lazy-loads that user's directories filtered by average
+    own-file size (owner_uid + min/max_avg_size + recursive=0)."""
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    hist = {
+        'bucket_labels': ['1 MiB - 10 MiB'],
+        'buckets': {
+            '1 MiB - 10 MiB': {
+                'data': 1024 ** 3, 'files': 100,
+                'owners': {1001: {'data': 1024 ** 3, 'files': 100}},
+                'size_min': 1048576, 'size_max': 10485760,
+            },
+        },
+        'total_data': 1024 ** 3, 'total_files': 100,
+        'directory': '/glade/campaign/cisl', 'fast_path': True,
+        'reference_scan_date': datetime(2026, 6, 1),
+        'username_map': {1001: 'alice'},
+    }
+    monkeypatch.setattr(service, 'scan_file_sizes', lambda s, p, r, **kw: hist)
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/file-sizes?resource={_RES}'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'owner_uid=1001' in body
+    assert 'min_avg_size=1048576' in body
+    assert 'max_avg_size=10485760' in body
+    assert 'recursive=0' in body
+    assert 'shown.bs.collapse' in body
+
+
+def test_directories_avg_size_flag(app, auth_client, active_project, monkeypatch):
+    """?min_avg_size/max_avg_size reach the service as ints for the size drill."""
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    captured = {}
+    monkeypatch.setattr(service, 'scan_directories',
+                        lambda s, p, r, **kw: captured.update(kw) or [])
+
+    auth_client.get(
+        f'/dashboards/user/disk-scans/{active_project.projcode}/directories'
+        f'?resource={_RES}&min_avg_size=1048576&max_avg_size=10485760&recursive=0&sort_by=size_nr'
+    )
+    assert captured['min_avg_size'] == 1048576
+    assert captured['max_avg_size'] == 10485760
+
+
 def test_access_history_empty_when_none(app, auth_client, active_project, monkeypatch):
     from webapp.disk_scans import service
     _enable_fs_scans(app, monkeypatch)
@@ -812,6 +862,72 @@ def test_scan_access_history_tags_band_bounds(monkeypatch):
     assert out['buckets']['< 1 Month']['accessed_before'] == '2026-06-01'
     assert out['buckets']['< 1 Month']['accessed_after'] == '2026-05-02'
     assert out['buckets']['7+ Years']['accessed_after'] is None
+
+
+def test_size_band_bounds_maps_bands_to_byte_ranges():
+    """Each file-size band maps to its (size_min, size_max) byte range; the
+    largest band is open-ended (max None)."""
+    from webapp.disk_scans.service import _size_band_bounds
+
+    b = _size_band_bounds(['0 - 1 KiB', '100 GiB+'])
+    assert b['0 - 1 KiB'] == {'size_min': 0, 'size_max': 1024}
+    assert b['100 GiB+']['size_min'] == 100 * 1024 ** 3
+    assert b['100 GiB+']['size_max'] is None
+
+
+def test_scan_directories_forwards_avg_size(monkeypatch):
+    """The average-file-size band reaches the facade as min/max_avg_size."""
+    cap = {}
+    svc = _wire_service(
+        monkeypatch,
+        prefixes=['/glade/campaign/cisl/csg'],
+        collections=['cisl'], warmed=['cisl'],
+        collection_map={'/glade/campaign/cisl/csg': 'cisl'},
+        capture=cap,
+    )
+    svc.scan_directories(None, object(), 'Campaign_Store',
+                         min_avg_size=1024, max_avg_size=10240)
+    kw = cap['list_kwargs']
+    assert kw['min_avg_size'] == 1024
+    assert kw['max_avg_size'] == 10240
+
+
+def test_scan_file_sizes_tags_band_bounds(monkeypatch):
+    """scan_file_sizes stamps each band with its avg-file-size window so the
+    drill-down can scope directories to the clicked size band."""
+    from webapp.disk_scans import service
+
+    hist = {
+        'bucket_labels': ['0 - 1 KiB', '100 GiB+'],
+        'buckets': {
+            '0 - 1 KiB': {'data': 1, 'files': 1, 'owners': {1001: {'data': 1, 'files': 1}}},
+            '100 GiB+':  {'data': 1, 'files': 1, 'owners': {}},
+        },
+    }
+
+    class _Q:
+        def __init__(self, filesystems):
+            pass
+
+        def file_size_histogram(self, **kw):
+            return hist
+
+    mod = types.SimpleNamespace(FsScanQueries=_Q,
+                                collection_for_path=lambda p: 'cisl',
+                                normalize_path=lambda p: p)
+    monkeypatch.setattr(service, 'get_module', lambda: mod)
+    monkeypatch.setattr(service, 'get_collections', lambda: ['cisl'])
+    monkeypatch.setattr(service, 'resolve_scan_scope',
+                        lambda s, p, r: (['/glade/campaign/cisl/csg'], ['cisl']))
+    monkeypatch.setattr(
+        service, 'cached_scan',
+        lambda qt, q, colls, pfx, opts, compute, bucket='default': compute(),
+    )
+
+    out = service.scan_file_sizes(None, object(), 'Campaign_Store')
+    assert out['buckets']['0 - 1 KiB']['size_min'] == 0
+    assert out['buckets']['0 - 1 KiB']['size_max'] == 1024
+    assert out['buckets']['100 GiB+']['size_max'] is None
 
 
 def test_directories_bucket_selection(monkeypatch):


### PR DESCRIPTION
## Summary

Adds a **third drill level** to *both* disk-scans distribution histograms. Each band already lists its top users; now each *user* expands to that user's directories that fed the bar — reusing the existing `disk_scans_directories.html` fragment, lazy-loaded on `shown.bs.collapse`, non-recursive (own files) to match the bar.

- **Access history** → directories whose access falls in the band's **date window**. A **Recursive** toggle switches own-files (`*_nr`, matches the bar) ↔ subtree (`*_r`, reclaimable space, outermost-tree dedup).
- **File sizes** → directories whose **average own-file size** (`total_size_nr/file_count_nr`) falls in the band. No recursive toggle (there's no recursive file-size histogram).

The *shared* distribution template expands a user row on EITHER a date window (access) OR an avg-size window (file-sizes), stamped per-band by the service from `ATIME_BUCKETS` / `SIZE_BUCKETS`. Bars are unchanged — non-recursive, the accurate additive "how much data is X" view.

### Service / routes
- `service`: `_atime_band_bounds` / `_size_band_bounds` stamp each band; `scan_directories(atime_recursive, outermost_only, min_avg_size, max_avg_size)` threads the plugin filters + `_drop_nested` outermost dedup; all in the cache key.
- `routes`: `?recursive`/`?outermost`/`?min_avg_size`/`?max_avg_size` parsed + round-tripped; `size_nr`/`files_nr` sort keys whitelisted.

## Plugin dependencies (all merged)

- **hpc-usage-queries#87** — `atime_recursive` flag.
- **hpc-usage-queries#88** — access-history slow path aggregated in SQL (fixes `QueryCanceled` on large scopes; `SUM()` Decimal→int).
- **hpc-usage-queries#90** — file-size slow path aggregated in SQL **+** the `with_avg_file_size_range` (`min_avg_size`/`max_avg_size`) drill-down filter.

## Test Results

Disk-scans unit module: **67 passed**. Covers band-bounds mapping (date + size), filter forwarding (`atime_recursive`/`outermost`/`min_avg_size`/`max_avg_size`), bucket stamping, per-user drill render for both modes (present with bounds, absent without), and the route flags.

**Verified live** (Campaign_Store, after #88/#90 merge + rebuild):
- **NRAL0002** (15.8 PiB / 717M, large slow path — previously timed out): both histograms load fast; access-history drill (date window; Recursive toggle → subtree + outermost dedup) and file-sizes drill both correct.
- **NCGD0006** (15.3 PiB / 699M): File-sizes drill checked rigorously — for the "1 KiB–10 KiB", "1 MiB–10 MiB" and open-ended "100 GiB+" bands, **every** returned directory's average file size fell strictly inside the band (e.g. fasullo's multi-GB dirs of ~7–10 KiB files; macarew's 134–138 GiB-avg dirs). Access-history drill still uses the date filter — no regression to the shared template.
- **NCIS0001** (fast path): histogram + drill unaffected.

No timeouts, Decimal errors, or console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)