### PR TITLE
Disk-scans UX polish: Dirs column + explorer Scope panel

### DIFF
--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -43,7 +43,7 @@ from webapp.dashboards.charts import (
     generate_distribution_histogram,
 )
 from webapp.disk_scans import service
-from webapp.disk_scans.scope import resolve_scan_scope
+from webapp.disk_scans.scope import resolve_scan_scope, resolve_scan_scope_grouped
 from webapp.disk_scans.session import get_module, is_enabled
 from webapp.extensions import db
 from webapp.utils.rbac import Permission, require_permission
@@ -446,12 +446,19 @@ def directories_page(project):
     flt = _dir_filters()
     fragment_url = url_for('disk_scans.directories_fragment',
                            projcode=project.projcode)
+    # The directories that *define* this scope (the scoped project + its active
+    # descendants on this resource), grouped by owning project — surfaced in the
+    # page's "Scope" panel. Same subtree walk the fragment scan runs.
+    scope_groups = resolve_scan_scope_grouped(
+        db.session, ctx['scoped_project'], ctx['resource_name'])
+    scope_dir_count = sum(len(g['paths']) for g in scope_groups)
     return render_template(
         'dashboards/user/disk_scans_directories_page.html',
         mode='project', fragment_url=fragment_url,
         initial_url=_initial_fragment_url(fragment_url, ctx, flt, browse=True),
         filters=flt, user_search_url=_user_search_url(),
-        limit_options=_LIMIT_OPTIONS, browse=True, **ctx,
+        limit_options=_LIMIT_OPTIONS, browse=True,
+        scope_groups=scope_groups, scope_dir_count=scope_dir_count, **ctx,
     )
 
 

--- a/src/webapp/disk_scans/scope.py
+++ b/src/webapp/disk_scans/scope.py
@@ -36,6 +36,36 @@ def _collect_fileset_paths(node) -> List[str]:
     return paths
 
 
+def resolve_scan_scope_grouped(session, project, resource_name: str) -> List[dict]:
+    """Return the scope's defining directories grouped by owning project.
+
+    A list of ``{'projcode': str, 'is_root': bool, 'paths': [str, ...]}`` dicts,
+    pre-order from *project* (the scan root) through its active descendant
+    projects, each carrying its sorted ``ProjectDirectory.directory_name``
+    values. Only nodes that actually own a fileset appear. Empty list when the
+    project has no scannable directories.
+
+    Powers the explorer's "Scope" panel so a user can see exactly which
+    directories — and which descendant projects — bound the listing. Mirrors
+    :func:`resolve_scan_scope` (same ``build_disk_subtree`` walk), but keeps the
+    per-project grouping instead of flattening to a path set.
+    """
+    full = build_disk_subtree(session, project, resource_name)
+    groups: List[dict] = []
+    _collect_scope_groups(full['tree'], project.projcode, groups)
+    return groups
+
+
+def _collect_scope_groups(node, root_projcode: str, out: List[dict]) -> None:
+    """Pre-order walk collecting one group per fileset-owning node."""
+    paths = sorted(node.get('fileset_paths', []))
+    if paths:
+        pc = node.get('projcode')
+        out.append({'projcode': pc, 'is_root': pc == root_projcode, 'paths': paths})
+    for child in node.get('children', []):
+        _collect_scope_groups(child, root_projcode, out)
+
+
 def resolve_scan_scope(session, project, resource_name: str) -> Tuple[List[str], List[str]]:
     """Return ``(path_prefixes, collections)`` for *project* on a disk resource.
 

--- a/src/webapp/templates/dashboards/user/disk_scans_directories_page.html
+++ b/src/webapp/templates/dashboards/user/disk_scans_directories_page.html
@@ -37,6 +37,50 @@
     {% endif %}
   </div>
 
+  {# Scope panel — the directories that DEFINE this view (the scoped project +
+     its active descendants on this resource), grouped by owning project. Each
+     path click-drills the table into that fileset (same hx mechanism as the
+     breadcrumb). Collapsed by default when more than 5 directories. Project
+     mode only; resource mode is "all directories", which has no project scope. #}
+  {% if mode == 'project' and scope_groups %}
+    {% set _scope_collapsed = scope_dir_count > 5 %}
+    <div class="alert alert-light border py-2 px-3 mb-3 small">
+      <div class="d-flex align-items-center flex-wrap gap-2">
+        <span class="text-muted">
+          <i class="fas fa-folder-open me-1"></i>
+          <strong>Scope</strong> —
+          {{ scope_dir_count }} director{{ 'y' if scope_dir_count == 1 else 'ies' }}
+          {% if scope_groups | length > 1 %}across {{ scope_groups | length }} projects{% endif %}
+        </span>
+        {% if _scope_collapsed %}
+          <button class="btn btn-sm btn-link p-0 text-decoration-none" type="button"
+                  data-bs-toggle="collapse" data-bs-target="#scope-dirs-{{ target_id }}"
+                  aria-expanded="false" aria-controls="scope-dirs-{{ target_id }}">
+            <i class="fas fa-chevron-right small collapse-icon me-1"></i>show directories
+          </button>
+        {% endif %}
+      </div>
+      <div class="{% if _scope_collapsed %}collapse{% endif %} mt-2"
+           id="scope-dirs-{{ target_id }}">
+        {% for g in scope_groups %}
+          <div class="d-flex flex-wrap align-items-baseline gap-2 mb-1">
+            <span class="badge {{ 'bg-primary-subtle' if g.is_root else 'bg-secondary-subtle' }} text-dark border">
+              {{ g.projcode }}{% if g.is_root %} <span class="text-muted fw-normal">· root</span>{% endif %}
+            </span>
+            {% for p in g.paths %}
+              <a class="font-monospace text-decoration-none" href="#"
+                 hx-get="{{ fragment_url }}?fileset={{ p | urlencode }}&resource={{ resource_name | urlencode }}{% if scope %}&scope={{ scope | urlencode }}{% endif %}&sort_by={{ filters.sort_by }}"
+                 hx-target="#{{ target_id }}"
+                 hx-include="#disk-scans-dir-params-{{ target_id }}"
+                 hx-swap="innerHTML"
+                 title="Drill the table into this directory">{{ p }}</a>
+            {% endfor %}
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
+
   {# The live, drill-aware ancestry breadcrumb is rendered inside the table
      fragment (disk_scans_directories.html) so it updates on every drill. #}
 

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
@@ -69,9 +69,13 @@
   ('dirs',     '# Subdirs', 'fa-folder-tree'),
 ] %}
 {# Recursive subdirectory count (dir_count_r) is 0 by definition for leaves,
-   so the Subdirectories column + its sort pill are meaningless (and would
-   degenerate the sort) under the leaves-only filter — drop both. #}
-{% set _show_dirs = not filters.leaves_only %}
+   so the Dirs column + its sort pill are meaningless (and would degenerate
+   the sort) under the leaves-only filter — drop both. Also fold the column
+   when every row in THIS view has a zero/empty count (common in the
+   non-recursive access-history / file-size drill-downs, where the listed
+   directories are frequently leaves) — an all-zero column is just noise. #}
+{% set _has_dirs = (rows | selectattr('dir_count_r') | list | length) > 0 %}
+{% set _show_dirs = (not filters.leaves_only) and _has_dirs %}
 
 {% if not enabled %}
   {{ scans_disabled() }}

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
@@ -38,7 +38,7 @@
   ('path',      'Path',           'path',        false),
   (_size_key,   'Size',           _size_field,   true),
   (_files_key,  'Files',          _files_field,  true),
-  ('dirs',      'Subdirectories', 'dir_count_r', true),
+  ('dirs',      'Dirs',           'dir_count_r', true),
   (_atime_key,  'Last Access',    _atime_field,  false),
 ] %}
 

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -183,6 +183,58 @@ def test_scoped_returns_empty_when_module_missing(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# scope grouping — resolve_scan_scope_grouped
+# ---------------------------------------------------------------------------
+
+def test_resolve_scan_scope_grouped_orders_root_first_and_groups(monkeypatch):
+    """Pre-order from the scan root, one group per fileset-owning node."""
+    from webapp.disk_scans import scope
+
+    tree = {
+        'projcode': 'ROOT0001',
+        'fileset_paths': ['/glade/campaign/root/b', '/glade/campaign/root/a'],
+        'children': [
+            {'projcode': 'CHILD002', 'fileset_paths': ['/glade/campaign/child2'],
+             'children': []},
+            # a node that owns nothing is skipped entirely
+            {'projcode': 'EMPTY003', 'fileset_paths': [], 'children': [
+                {'projcode': 'GRAND004', 'fileset_paths': ['/glade/campaign/gc'],
+                 'children': []},
+            ]},
+        ],
+    }
+
+    class _Proj:
+        projcode = 'ROOT0001'
+
+    monkeypatch.setattr(scope, 'build_disk_subtree',
+                        lambda s, p, r: {'tree': tree})
+    groups = scope.resolve_scan_scope_grouped(None, _Proj(), 'Campaign_Store')
+
+    assert [g['projcode'] for g in groups] == ['ROOT0001', 'CHILD002', 'GRAND004']
+    root = groups[0]
+    assert root['is_root'] is True
+    # paths sorted within a group
+    assert root['paths'] == ['/glade/campaign/root/a', '/glade/campaign/root/b']
+    assert all(g['is_root'] is False for g in groups[1:])
+    # EMPTY003 (no filesets) contributes no group
+    assert 'EMPTY003' not in [g['projcode'] for g in groups]
+
+
+def test_resolve_scan_scope_grouped_empty_when_no_dirs(monkeypatch):
+    from webapp.disk_scans import scope
+
+    class _Proj:
+        projcode = 'NONE0001'
+
+    monkeypatch.setattr(
+        scope, 'build_disk_subtree',
+        lambda s, p, r: {'tree': {'projcode': 'NONE0001',
+                                  'fileset_paths': [], 'children': []}})
+    assert scope.resolve_scan_scope_grouped(None, _Proj(), 'Campaign_Store') == []
+
+
+# ---------------------------------------------------------------------------
 # routes — HTMX fragment endpoints
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -1111,24 +1111,45 @@ def test_directories_owner_filter_and_form(app, auth_client, active_project, mon
 
 def test_directories_subdirs_column_hidden_under_leaves_only(
         app, auth_client, active_project, monkeypatch):
-    """Recursive subdir count is 0 for leaves — hide the column + its pill."""
+    """Recursive subdir count is 0 for leaves — hide the Dirs column + its pill."""
     from webapp.disk_scans import service
     _enable_fs_scans(app, monkeypatch)
     monkeypatch.setattr(service, 'scan_directories', lambda s, p, r, **kw: [{
         'path': '/glade/campaign/cisl/csg/leaf', 'depth': 5,
-        'total_size_r': 1024 ** 4, 'file_count_r': 3, 'dir_count_r': 0,
+        'total_size_r': 1024 ** 4, 'file_count_r': 3, 'dir_count_r': 7,
         'max_atime_r': None, 'owner_uid': 1, 'owner_gid': 1, 'filesystem': 'cisl',
     }])
 
     base = f'/dashboards/user/disk-scans/{active_project.projcode}/directories?resource={_RES}'
-    # Without the filter the Subdirectories column + # Subdirs pill are present.
+    # Without the filter the Dirs column + # Subdirs pill are present (the row
+    # has a non-zero dir_count_r).
     on = auth_client.get(base).get_data(as_text=True)
-    assert 'Subdirectories' in on
+    assert 'Dirs' in on
     assert '# Subdirs' in on
     # With leaves-only, both are suppressed.
     off = auth_client.get(base + '&leaves_only=1').get_data(as_text=True)
-    assert 'Subdirectories' not in off
+    assert 'Dirs' not in off
     assert '# Subdirs' not in off
+
+
+def test_directories_dirs_column_hidden_when_uniformly_zero(
+        app, auth_client, active_project, monkeypatch):
+    """All rows have dir_count_r == 0 (common in nr drill-downs) — fold the column."""
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    monkeypatch.setattr(service, 'scan_directories', lambda s, p, r, **kw: [{
+        'path': '/glade/campaign/cisl/csg/a', 'depth': 5,
+        'total_size_nr': 1024 ** 3, 'file_count_nr': 9, 'dir_count_r': 0,
+        'max_atime_nr': None, 'owner_uid': 1, 'owner_gid': 1, 'filesystem': 'cisl',
+    }])
+
+    # Non-recursive drill-down view: single row, dir_count_r 0 → column folded
+    # even though leaves_only is NOT set.
+    base = (f'/dashboards/user/disk-scans/{active_project.projcode}'
+            f'/directories?resource={_RES}&recursive=0')
+    body = auth_client.get(base).get_data(as_text=True)
+    assert 'Dirs' not in body
+    assert '# Subdirs' not in body
 
 
 def test_directories_page_renders(auth_client, active_project):


### PR DESCRIPTION
## Summary

Targeted UX tweaks for the filesystem-scans (`fs_scans`) directory views and
the access-history / file-size drill-downs added in #326. No plugin changes —
pure SAM webapp + tests.

### 1. `Subdirectories` → `Dirs` column header
The wide `Subdirectories` header stole horizontal space in the drill-down
directory tables. Renamed the column header to `Dirs` (the sort pill keeps its
`# Subdirs` label).

### 2. Fold the `Dirs` column when uniformly zero
In the non-recursive access-history / file-size drill-downs the listed
directories are frequently leaves, so the `dir_count_r` column is uniformly
`0` — pure noise. The column (header, sort pill, and cells) now folds whenever
**every row in the current view** has a zero/empty count, on top of the
existing `leaves_only` suppression. It's view-scoped, so a re-sort or filter
that surfaces non-leaf directories brings it back.

### 3. "Scope" panel on the full-page directory explorer
The explorer header (`…/directories/explore?resource=…&scope=…`) named the
project + resource but never showed **which** directories bound the listing —
opaque when a project owns several non-contiguous dirs or folds in active
descendant projects.

A new **Scope** panel sits between the header and the filter sidebar:
- `resolve_scan_scope_grouped()` walks the same `build_disk_subtree` the
  fragment scan uses, grouping the defining `ProjectDirectory` paths by owning
  project (root project flagged), pre-order from the scan root.
- Each path **click-drills** the table into that fileset (same hx-get /
  params-form mechanism as the ancestry breadcrumb).
- **Collapsed by default when more than 5 directories.**
- Project mode only (resource mode is "all directories", which has no project
  scope).

## Test Results

`tests/unit/test_webapp_disk_scans.py` — **70 passed**. Added:
- `test_resolve_scan_scope_grouped_orders_root_first_and_groups` /
  `…_empty_when_no_dirs` — the grouping walker (root-first order, per-project
  grouping, empty-node skipping, in-group path sort).
- `test_directories_dirs_column_hidden_when_uniformly_zero` — the all-zero fold.
- Updated `test_directories_subdirs_column_hidden_under_leaves_only` for the
  `Dirs` rename + a non-zero `dir_count_r` so it isolates the `leaves_only` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)