### PR TITLE
Filesystem Scans: whole-FS view as a gated Status dashboard tab

### DIFF
--- a/docs/plans/FS_SCANS_STATUS_TAB.md
+++ b/docs/plans/FS_SCANS_STATUS_TAB.md
@@ -1,0 +1,201 @@
+# Filesystem Scans — whole-FS view as a Status dashboard tab
+
+**Status:** planned, not started. Its own PR vs `staging`. **SAM-only — no
+plugin change** (every plugin endpoint this needs already exists).
+
+**Sequencing:** land PR #328 (`fs_scans_ux_polish`: Dirs column + explorer
+Scope panel) first; this is orthogonal and starts from a fresh branch off
+`staging`.
+
+---
+
+## Goal
+
+Surface the **unrestricted, whole-filesystem** scan rollup that already exists
+behind `VIEW_ALL_FILESYSTEM_DATA` but has **no UX route** today (reachable only
+by hand-typing `…/disk-scans/resource/<resource>/explore`).
+
+Make it a **conditional "Filesystem Scans" tab on the Status dashboard**
+(`/status`), visible only with `VIEW_ALL_FILESYSTEM_DATA`. The tab holds **one
+subtab per scan-capable disk resource** (Campaign_Store today, Destor soon).
+Each subtab renders the *same card* we show on a project's disk
+resource-details page — **Large Directories + User/Group entities + Access /
+File-size histograms** — but **rooted over the whole filesystem** instead of a
+project. The card's "Large Directories" detail opens the existing unscoped
+explorer, which is how the whole-FS view finally becomes *findable*.
+
+---
+
+## Why Status is the right home
+
+- Status already surfaces filesystems: `templates/dashboards/status/partials/
+  filesystem_table.html` (capacity/health per system).
+- The tab shell (`templates/dashboards/status/dashboard.html`) already has both
+  patterns we need:
+  - **conditional tab** — Reservations is `{% if reservations or
+    google_calendar_embed_url %}`.
+  - **RBAC gating** — `{% if has_permission(Permission.EDIT_SYSTEM_STATUS) %}`
+    wraps the outage controls. (`has_permission` + `Permission` are template
+    globals.)
+- The multi-FS seam is already designed: `disk_scans/session.py:
+  collections_for_resource()` is documented as *"the seam where a future
+  resource→database map plugs in… once a second resource (e.g. Destor)
+  ships"*.
+
+## Decisions locked in
+
+- **Subtab enumeration: a config list** of scan-capable disk resources (explicit;
+  Destor is a one-line add) — NOT derived from the `Resource` table.
+- **No blueprint move.** Keep `disk_scans` at `/dashboards/user/disk-scans`.
+  The URL prefix is cosmetic; resource-mode routes already live under it and the
+  Status tab `hx-get`s them regardless. Renaming = route churn + bookmark
+  breakage + collision with the just-shipped scoped explorer, for zero
+  functional gain.
+- **The real refactor** is extracting the scans **card** into a
+  mode-parameterized partial shared by the project disk page and the Status tab.
+
+---
+
+## What already exists vs. what's missing
+
+| Card piece | Whole-FS (resource-mode) state |
+|---|---|
+| **Large Directories** | ✅ Built: `service.scan_directories_resource` + routes `directories_resource_fragment` (`/resource/<r>/directories`) & `directories_resource_page` (`/resource/<r>/explore`), both `VIEW_ALL_FILESYSTEM_DATA`-gated. `_resource_ctx()` + `_render_directories_fragment(mode='resource')` already exist. |
+| **User / Group entities** | ❌ project-scoped only (`entities_fragment` → `scan_owner_summary`/`scan_group_summary` via `_scoped(...)`). |
+| **Access-history histogram** | ❌ project-scoped only (`access_history_fragment` → `_render_distribution` → `scan_access_history`). |
+| **File-sizes histogram** | ❌ project-scoped only (`file_sizes_fragment` → `_render_distribution` → `scan_file_sizes`). |
+
+**Perf bonus:** unscoped histograms/entities run with `path_prefixes=None`,
+which is the plugin's **whole-collection-root fast path** (pre-computed
+`access_histogram`/`size_histogram` tables) — so the whole-FS card is *cheaper*
+to render than the scoped one, not more expensive.
+
+---
+
+## Implementation steps
+
+### 1. Service — three `*_resource` siblings
+`src/webapp/disk_scans/service.py`. Mirror the existing `scan_directories_resource`
+(which uses `collections_for_resource(resource_name)` + `path_prefixes=None`
+instead of `_scoped(...)`). Add:
+
+- `scan_owner_summary_resource(resource_name, *, limit, subpath=None)`
+- `scan_group_summary_resource(resource_name, *, limit, subpath=None)`
+- `scan_access_history_resource(resource_name, *, owner_uid=None, subpath=None)`
+- `scan_file_sizes_resource(resource_name, *, owner_uid=None, subpath=None)`
+
+(4 fns — owner + group are separate today.) Each: `mod = get_module()` guard →
+`collections = collections_for_resource(resource_name)` → empty-guard →
+`FsScanQueries(filesystems=collections)` → same `_compute()` body + `cached_scan`
+key as the scoped version, but `path_prefixes = [subpath] if subpath else None`.
+The histogram band-enrichment (`_atime_band_bounds` / `_size_band_bounds`) is
+scope-independent — reuse verbatim.
+
+**Refactor option:** extract the shared `_compute` bodies so scoped and resource
+fns differ only in how they obtain `(collections, path_prefixes)`. Nice-to-have,
+not required.
+
+### 2. Routes — three resource-mode fragments
+`src/webapp/disk_scans/routes.py`, all `@login_required` +
+`@require_permission(Permission.VIEW_ALL_FILESYSTEM_DATA)`, using `_resource_ctx`:
+
+- `GET /resource/<resource>/entities` → `entities_resource_fragment`
+- `GET /resource/<resource>/access-history` → `access_history_resource_fragment`
+- `GET /resource/<resource>/file-sizes` → `file_sizes_resource_fragment`
+
+Refactor `entities_fragment` and `_render_distribution` to take **mode +
+ctx-builder + service-fn** the way `_render_directories_fragment(mode=...)`
+already does, so the project and resource routes share one body each. Key point:
+`_render_distribution` currently hardcodes `ctx['scoped_project']` and
+`url_for(endpoint, projcode=...)` — parameterize both (resource mode passes
+`resource=` and calls the `*_resource` service fn). The shared
+`disk_scans_distribution.html` / `disk_scans_entities.html` partials already
+treat `project`/`scope` as optional (drill-down links are guarded by
+`{% if project %}` — in resource mode they degrade to non-clickable, which is
+correct: the per-user→directories drill needs a projcode; the whole-FS card's
+drill path is via Large Directories → unscoped explorer instead).
+
+### 3. Config list of scan-capable disk resources
+`src/webapp/config.py` (near the other `FS_SCAN_*` vars). Add e.g.
+`FS_SCAN_RESOURCES = [...]` — list of disk **resource names** that have scans
+(`['Campaign_Store']` today; append `'Destor'` when it ships). Pair with the
+`collections_for_resource` seam (which is where the resource→DB branch will go).
+Expose a tiny helper (e.g. `service.scan_capable_resources()` or a status
+blueprint local) that returns the configured names, optionally intersected with
+"has warmed collections" so a misconfigured entry doesn't render an empty subtab.
+**No hardcoded resource IDs** (see `feedback_no_duplicate_db_ids`).
+
+### 4. Extract the scans **card** into a shared partial
+Today the card is assembled inline in
+`templates/dashboards/user/resource_details_disk.html` (the tabs: Large Dirs /
+entities / histograms, each lazy-loading a `disk_scans.*_fragment` via hx-get).
+Extract into e.g. `templates/dashboards/user/partials/disk_scans_card.html`
+parameterized by:
+- `mode` (`'project'` | `'resource'`)
+- the set of fragment endpoints to hit (project: `*_fragment` with `projcode`;
+  resource: `*_resource_fragment` with `resource`)
+- `target_id` prefix (so multiple cards/subtabs on one page don't collide)
+
+Re-include it from `resource_details_disk.html` (project mode) to prove parity,
+then include it in the Status tab (resource mode). The "Open full view ↗" button
+points at `directories_page` (project) or `directories_resource_page` (resource).
+
+### 5. Status tab + per-FS subtabs
+- `templates/dashboards/status/dashboard.html`: add
+  `{% if has_permission(Permission.VIEW_ALL_FILESYSTEM_DATA) %}` nav-tab
+  "Filesystem Scans" + a `tab-pane`. (Mirror the Reservations conditional-tab
+  markup.)
+- New partial e.g. `status/partials/filesystem_scans.html`: a subtab strip (one
+  `nav-link` per configured resource) + a `tab-pane` per resource that
+  lazy-loads `disk_scans_card.html` in `mode='resource'` on
+  `shown.bs.tab once` (see `feedback_persisted_collapse_htmx` — bind to the
+  shown event, not click; lazy so closed subtabs cost nothing).
+- `dashboards/status/blueprint.py index()`: pass
+  `fs_scan_resources=service.scan_capable_resources()` (guarded so the tab is
+  empty/hidden when the plugin is off) and ensure `has_permission`/`Permission`
+  are in the template context (they're globals already).
+
+### 6. Tests (`tests/unit/test_webapp_disk_scans.py` + status tests)
+- Each `*_resource` service fn forwards `path_prefixes=None`, uses
+  `collections_for_resource`, and keys the cache distinctly (monkeypatch a fake
+  `mod`, as the existing resource tests do).
+- Each resource-mode route is **403 without** `VIEW_ALL_FILESYSTEM_DATA` and
+  **200 with** it (mirror `directories_resource_*` gating tests).
+- Status `index()` shows the "Filesystem Scans" tab only with the permission,
+  and renders one subtab per configured resource.
+- Card partial renders in both modes (project link vs resource link present).
+
+---
+
+## Gotchas / notes
+
+- **Drill-down in resource mode:** the histogram band→user→directories drill and
+  the entities row→directories drill both build `url_for('…directories_fragment',
+  projcode=project.projcode)` — they need a projcode and are correctly
+  **suppressed when `project` is None** (templates already guard on `project`).
+  The whole-FS card's drill story is **Large Directories → unscoped explorer**
+  (already built), not the per-user drill. Confirm the guards hold; don't try to
+  synthesize a projcode.
+- **`VIEW_ALL_FILESYSTEM_DATA` audience:** its enum value starts with `view_`, so
+  it's swept into `ALL_VIEW` → the `nusd`, `csg`, `ssg` group bundles all hold it
+  (plus `benkirk`). Real operator audience, gate is meaningful.
+- **No new plugin endpoints** — `FsScanQueries` already supports
+  `path_prefixes=None`; this is pure SAM wiring.
+- **Webdev watch-sync** gotcha unchanged: after any `webdev` restart, re-`touch`
+  edited files to force `develop.watch` sync (no source bind-mount).
+
+## Key files
+
+- `src/webapp/disk_scans/service.py` — `scan_*_resource` siblings.
+- `src/webapp/disk_scans/routes.py` — 3 gated resource-mode routes; parameterize
+  `entities_fragment` + `_render_distribution` on mode.
+- `src/webapp/disk_scans/session.py` — `collections_for_resource` (the
+  resource→DB seam; already present).
+- `src/webapp/config.py` — `FS_SCAN_RESOURCES` config list.
+- `templates/dashboards/user/partials/disk_scans_card.html` — extracted shared
+  card (new).
+- `templates/dashboards/user/resource_details_disk.html` — include the extracted
+  card (project mode).
+- `templates/dashboards/status/dashboard.html` + `status/partials/
+  filesystem_scans.html` — gated tab + per-FS subtabs.
+- `src/webapp/dashboards/status/blueprint.py` — pass the resource list.

--- a/src/webapp/config.py
+++ b/src/webapp/config.py
@@ -151,6 +151,20 @@ class SAMWebappConfig(SAMConfig):
         os.getenv('FS_SCAN_STATEMENT_TIMEOUT_MS', '100000')
     )
 
+    # Disk resources that have filesystem-scan collections, surfaced as
+    # subtabs on the Status dashboard's gated "Filesystem Scans" tab. An
+    # explicit list (NOT derived from the Resource table) — append 'Destor'
+    # when it ships. Resource NAMES, not IDs (see feedback_no_duplicate_db_ids);
+    # the resource→collections mapping lives in the
+    # disk_scans.session.collections_for_resource seam. A configured resource
+    # with no warmed collections is filtered out at render time
+    # (service.scan_capable_resources), so the tab/subtab never shows empty.
+    FS_SCAN_RESOURCES = [
+        s.strip()
+        for s in os.getenv('FS_SCAN_RESOURCES', 'Campaign_Store').split(',')
+        if s.strip()
+    ]
+
     # Session cookies (common defaults; subclasses tighten for prod)
     SESSION_COOKIE_HTTPONLY    = True
     SESSION_COOKIE_SAMESITE    = 'Lax'

--- a/src/webapp/dashboards/status/blueprint.py
+++ b/src/webapp/dashboards/status/blueprint.py
@@ -16,6 +16,7 @@ from ..charts import (
 )
 
 from system_status import queries as status_queries
+from webapp.disk_scans import service as disk_scans_service
 
 bp = Blueprint('status_dashboard', __name__, url_prefix='/status')
 logger = logging.getLogger(__name__)
@@ -108,6 +109,12 @@ def index():
         now=datetime.now(),
         selected_hours=selected_hours,
         chart_hours=chart_hours,
+        # Scan-capable disk resources for the gated "Filesystem Scans" tab.
+        # Empty (→ tab hidden) when the fs-scans plugin is off or no configured
+        # resource has warmed collections. Tab visibility is additionally gated
+        # in-template on VIEW_ALL_FILESYSTEM_DATA. has_permission/Permission are
+        # template globals (rbac_context_processor).
+        fs_scan_resources=disk_scans_service.scan_capable_resources(),
     )
 
 

--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -481,8 +481,13 @@ def directories_resource_fragment(resource):
             ctx['resource_name'], subpath=ctx['fileset'],
             sort_by=flt['sort_by'], limit=flt['limit'],
             owner_uid=flt['owner_uid'],
+            owner_gid=flt['owner_gid'],
             accessed_before=flt['accessed_before'],
             accessed_after=flt['accessed_after'],
+            atime_recursive=flt['atime_recursive'],
+            min_avg_size=flt['min_avg_size'],
+            max_avg_size=flt['max_avg_size'],
+            outermost_only=flt['outermost'],
             leaves_only=flt['leaves_only'],
         )
 
@@ -516,15 +521,16 @@ def directories_resource_page(resource):
     )
 
 
-def _render_entities(ctx, fragment_url, *, scan_call, log_label):
+def _render_entities(ctx, fragment_url, *, scan_call, log_label, dir_fragment_url):
     """Shared body for the project + resource entity (owner|group) fragments.
 
     Both render the *same* ``disk_scans_entities.html`` partial; they differ
     only in scope context, which fragment URL the owner↔group toggle re-fetches,
-    and the (already scope-resolved) ``scan_call(kind, limit, subpath)``. In
-    resource mode ``ctx['project']`` is ``None`` so the partial's per-user row
-    drill-down (which needs a projcode) degrades to non-clickable — the whole-FS
-    drill path is Large Directories → unscoped explorer instead.
+    and the (already scope-resolved) ``scan_call(kind, limit, subpath)``. The
+    per-entity row drill-down re-targets ``dir_fragment_url`` — the directories
+    fragment for *this mode* (project ``directories_fragment`` or resource
+    ``directories_resource_fragment``), both of which accept the owner/group
+    filters — so the drill works in both modes.
     """
     kind = (request.args.get('kind') or 'owner').strip().lower()
     if kind not in ('owner', 'group'):
@@ -534,6 +540,7 @@ def _render_entities(ctx, fragment_url, *, scan_call, log_label):
         return render_template(
             'dashboards/user/partials/disk_scans_entities.html',
             rows=[], kind=kind, pie_chart=None, fragment_url=fragment_url,
+            dir_fragment_url=dir_fragment_url,
             enabled=is_enabled(), error=None, **ctx,
         )
 
@@ -563,6 +570,7 @@ def _render_entities(ctx, fragment_url, *, scan_call, log_label):
     return render_template(
         'dashboards/user/partials/disk_scans_entities.html',
         rows=rows, kind=kind, pie_chart=pie_chart, fragment_url=fragment_url,
+        dir_fragment_url=dir_fragment_url,
         enabled=True, error=error, **ctx,
     )
 
@@ -584,6 +592,8 @@ def entities_fragment(project):
     return _render_entities(
         ctx, fragment_url, scan_call=_scan,
         log_label=f"project={ctx['scoped_project'].projcode}",
+        dir_fragment_url=url_for('disk_scans.directories_fragment',
+                                 projcode=project.projcode),
     )
 
 
@@ -605,16 +615,19 @@ def entities_resource_fragment(resource):
               else service.scan_group_summary_resource)
         return fn(ctx['resource_name'], limit=limit, subpath=subpath)
 
-    return _render_entities(ctx, fragment_url, scan_call=_scan,
-                            log_label='resource-wide')
+    return _render_entities(
+        ctx, fragment_url, scan_call=_scan, log_label='resource-wide',
+        dir_fragment_url=url_for('disk_scans.directories_resource_fragment',
+                                 resource=resource),
+    )
 
 
 _METRIC_WHITELIST = {'data', 'files'}
 
 
 def _render_distribution(ctx, fragment_url, *, scan_call, kind,
-                         bucket_header, log_label, metric_toggle=False,
-                         log_toggle=False):
+                         bucket_header, log_label, dir_fragment_url,
+                         metric_toggle=False, log_toggle=False):
     """Shared body for the two distribution histogram fragments (both modes).
 
     The Access-history and File-size tabs are identical end to end — same
@@ -639,7 +652,8 @@ def _render_distribution(ctx, fragment_url, *, scan_call, kind,
     log_on = log_toggle and _truthy(request.args.get('log'))
     extra = dict(metric=metric, metric_toggle=metric_toggle,
                  log_on=log_on, log_toggle=log_toggle,
-                 bucket_header=bucket_header, fragment_url=fragment_url)
+                 bucket_header=bucket_header, fragment_url=fragment_url,
+                 dir_fragment_url=dir_fragment_url)
 
     if not is_enabled() or not ctx['resource_name']:
         return render_template(
@@ -687,6 +701,8 @@ def access_history_fragment(project):
         ctx, fragment_url, scan_call=_scan, kind='access_history',
         bucket_header='Last accessed',
         log_label=f"project={ctx['scoped_project'].projcode}",
+        dir_fragment_url=url_for('disk_scans.directories_fragment',
+                                 projcode=project.projcode),
     )
 
 
@@ -714,6 +730,8 @@ def file_sizes_fragment(project):
         ctx, fragment_url, scan_call=_scan, kind='file_sizes',
         bucket_header='File size',
         log_label=f"project={ctx['scoped_project'].projcode}",
+        dir_fragment_url=url_for('disk_scans.directories_fragment',
+                                 projcode=project.projcode),
         metric_toggle=True, log_toggle=True,
     )
 
@@ -737,6 +755,8 @@ def access_history_resource_fragment(resource):
     return _render_distribution(
         ctx, fragment_url, scan_call=_scan, kind='access_history',
         bucket_header='Last accessed', log_label='resource-wide',
+        dir_fragment_url=url_for('disk_scans.directories_resource_fragment',
+                                 resource=resource),
     )
 
 
@@ -760,5 +780,7 @@ def file_sizes_resource_fragment(resource):
     return _render_distribution(
         ctx, fragment_url, scan_call=_scan, kind='file_sizes',
         bucket_header='File size', log_label='resource-wide',
+        dir_fragment_url=url_for('disk_scans.directories_resource_fragment',
+                                 resource=resource),
         metric_toggle=True, log_toggle=True,
     )

--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -516,12 +516,16 @@ def directories_resource_page(resource):
     )
 
 
-@bp.route('/<projcode>/entities')
-@login_required
-@require_project_access
-def entities_fragment(project):
-    """HTMX fragment: per-owner or per-group rollup (``?kind=owner|group``)."""
-    ctx = _common_ctx(project)
+def _render_entities(ctx, fragment_url, *, scan_call, log_label):
+    """Shared body for the project + resource entity (owner|group) fragments.
+
+    Both render the *same* ``disk_scans_entities.html`` partial; they differ
+    only in scope context, which fragment URL the owner↔group toggle re-fetches,
+    and the (already scope-resolved) ``scan_call(kind, limit, subpath)``. In
+    resource mode ``ctx['project']`` is ``None`` so the partial's per-user row
+    drill-down (which needs a projcode) degrades to non-clickable — the whole-FS
+    drill path is Large Directories → unscoped explorer instead.
+    """
     kind = (request.args.get('kind') or 'owner').strip().lower()
     if kind not in ('owner', 'group'):
         kind = 'owner'
@@ -529,23 +533,17 @@ def entities_fragment(project):
     if not is_enabled() or not ctx['resource_name']:
         return render_template(
             'dashboards/user/partials/disk_scans_entities.html',
-            rows=[], kind=kind, pie_chart=None,
-            fragment_url=url_for('disk_scans.entities_fragment',
-                                 projcode=project.projcode),
+            rows=[], kind=kind, pie_chart=None, fragment_url=fragment_url,
             enabled=is_enabled(), error=None, **ctx,
         )
 
     rows, error = [], None
     try:
-        fn = service.scan_owner_summary if kind == 'owner' else service.scan_group_summary
-        rows = fn(
-            db.session, ctx['scoped_project'], ctx['resource_name'],
-            limit=_limit(), subpath=ctx['fileset'],
-        )
+        rows = scan_call(kind, _limit(), ctx['fileset'])
     except Exception as exc:
         current_app.logger.exception(
-            'disk_scans.entities: %s scan failed for project=%s resource=%s',
-            kind, ctx['scoped_project'].projcode, ctx['resource_name'],
+            'disk_scans.entities: %s scan failed for %s resource=%s',
+            kind, log_label, ctx['resource_name'],
         )
         error = str(exc)
 
@@ -564,19 +562,60 @@ def entities_fragment(project):
 
     return render_template(
         'dashboards/user/partials/disk_scans_entities.html',
-        rows=rows, kind=kind, pie_chart=pie_chart,
-        fragment_url=url_for('disk_scans.entities_fragment',
-                             projcode=project.projcode),
+        rows=rows, kind=kind, pie_chart=pie_chart, fragment_url=fragment_url,
         enabled=True, error=error, **ctx,
     )
+
+
+@bp.route('/<projcode>/entities')
+@login_required
+@require_project_access
+def entities_fragment(project):
+    """HTMX fragment: per-owner or per-group rollup (``?kind=owner|group``)."""
+    ctx = _common_ctx(project)
+    fragment_url = url_for('disk_scans.entities_fragment', projcode=project.projcode)
+
+    def _scan(kind, limit, subpath):
+        fn = (service.scan_owner_summary if kind == 'owner'
+              else service.scan_group_summary)
+        return fn(db.session, ctx['scoped_project'], ctx['resource_name'],
+                  limit=limit, subpath=subpath)
+
+    return _render_entities(
+        ctx, fragment_url, scan_call=_scan,
+        log_label=f"project={ctx['scoped_project'].projcode}",
+    )
+
+
+@bp.route('/resource/<resource>/entities')
+@login_required
+@require_permission(Permission.VIEW_ALL_FILESYSTEM_DATA)
+def entities_resource_fragment(resource):
+    """HTMX fragment: owner|group rollup across an ENTIRE disk resource.
+
+    Resource mode — unscoped, elevated (``VIEW_ALL_FILESYSTEM_DATA``). Same
+    partial as project mode; the per-user drill-down degrades to non-clickable
+    since there is no project to scope it to.
+    """
+    ctx = _resource_ctx(resource)
+    fragment_url = url_for('disk_scans.entities_resource_fragment', resource=resource)
+
+    def _scan(kind, limit, subpath):
+        fn = (service.scan_owner_summary_resource if kind == 'owner'
+              else service.scan_group_summary_resource)
+        return fn(ctx['resource_name'], limit=limit, subpath=subpath)
+
+    return _render_entities(ctx, fragment_url, scan_call=_scan,
+                            log_label='resource-wide')
 
 
 _METRIC_WHITELIST = {'data', 'files'}
 
 
-def _render_distribution(project, *, service_fn, endpoint, kind,
-                         bucket_header, metric_toggle=False, log_toggle=False):
-    """Shared body for the two distribution histogram fragments.
+def _render_distribution(ctx, fragment_url, *, scan_call, kind,
+                         bucket_header, log_label, metric_toggle=False,
+                         log_toggle=False):
+    """Shared body for the two distribution histogram fragments (both modes).
 
     The Access-history and File-size tabs are identical end to end — same
     ``{bucket_labels, buckets{...}, owners, username_map}`` shape, same
@@ -585,19 +624,19 @@ def _render_distribution(project, *, service_fn, endpoint, kind,
     Log-scale switch, both of which re-fetch the pane via ``?metric=`` /
     ``?log=``. ``kind`` is used only for logging.
 
+    Project vs resource mode differ only in the prebuilt ``ctx`` /
+    ``fragment_url`` and the (already scope-resolved) ``scan_call(owner_uid,
+    subpath)``. In resource mode ``ctx['project']`` is ``None`` so the band →
+    user → directories drill degrades to non-clickable (it needs a projcode).
+
     A log y-axis can't represent a stack, so ``log_y`` renders solid bars
     (no per-user gradient); it's offered only where the metric is skewed
     enough to need it (file-sizes), hence gated on *log_toggle*.
     """
-    ctx = _common_ctx(project)
-
     metric = (request.args.get('metric') or 'data').strip().lower()
     if not metric_toggle or metric not in _METRIC_WHITELIST:
         metric = 'data'
     log_on = log_toggle and _truthy(request.args.get('log'))
-    # urls the pill / switch re-fetch (carry scope/resource/fileset via the
-    # pane's hidden form + hx-include, exactly like the owner↔group toggle).
-    fragment_url = url_for(endpoint, projcode=project.projcode)
     extra = dict(metric=metric, metric_toggle=metric_toggle,
                  log_on=log_on, log_toggle=log_toggle,
                  bucket_header=bucket_header, fragment_url=fragment_url)
@@ -612,17 +651,14 @@ def _render_distribution(project, *, service_fn, endpoint, kind,
     owner_uid = request.args.get('owner_uid', type=int)
     hist, chart_svg, error = None, None, None
     try:
-        hist = service_fn(
-            db.session, ctx['scoped_project'], ctx['resource_name'],
-            owner_uid=owner_uid, subpath=ctx['fileset'],
-        )
+        hist = scan_call(owner_uid, ctx['fileset'])
         if hist:
             chart_svg = generate_distribution_histogram(
                 hist, log_y=log_on, metric=metric)
     except Exception as exc:
         current_app.logger.exception(
-            'disk_scans.%s: scan failed for project=%s resource=%s',
-            kind, ctx['scoped_project'].projcode, ctx['resource_name'],
+            'disk_scans.%s: scan failed for %s resource=%s',
+            kind, log_label, ctx['resource_name'],
         )
         error = str(exc)
 
@@ -638,10 +674,19 @@ def _render_distribution(project, *, service_fn, endpoint, kind,
 @require_project_access
 def access_history_fragment(project):
     """HTMX fragment: access-time distribution histogram (server-rendered SVG)."""
+    ctx = _common_ctx(project)
+    fragment_url = url_for('disk_scans.access_history_fragment',
+                           projcode=project.projcode)
+
+    def _scan(owner_uid, subpath):
+        return service.scan_access_history(
+            db.session, ctx['scoped_project'], ctx['resource_name'],
+            owner_uid=owner_uid, subpath=subpath)
+
     return _render_distribution(
-        project, service_fn=service.scan_access_history,
-        endpoint='disk_scans.access_history_fragment', kind='access_history',
+        ctx, fragment_url, scan_call=_scan, kind='access_history',
         bucket_header='Last accessed',
+        log_label=f"project={ctx['scoped_project'].projcode}",
     )
 
 
@@ -656,8 +701,64 @@ def file_sizes_fragment(project):
     Log-scale switch (``?log=``) because file-size *data* spans many orders
     of magnitude — at the cost of the per-user stack gradient.
     """
+    ctx = _common_ctx(project)
+    fragment_url = url_for('disk_scans.file_sizes_fragment',
+                           projcode=project.projcode)
+
+    def _scan(owner_uid, subpath):
+        return service.scan_file_sizes(
+            db.session, ctx['scoped_project'], ctx['resource_name'],
+            owner_uid=owner_uid, subpath=subpath)
+
     return _render_distribution(
-        project, service_fn=service.scan_file_sizes,
-        endpoint='disk_scans.file_sizes_fragment', kind='file_sizes',
-        bucket_header='File size', metric_toggle=True, log_toggle=True,
+        ctx, fragment_url, scan_call=_scan, kind='file_sizes',
+        bucket_header='File size',
+        log_label=f"project={ctx['scoped_project'].projcode}",
+        metric_toggle=True, log_toggle=True,
+    )
+
+
+@bp.route('/resource/<resource>/access-history')
+@login_required
+@require_permission(Permission.VIEW_ALL_FILESYSTEM_DATA)
+def access_history_resource_fragment(resource):
+    """HTMX fragment: access-time histogram across an ENTIRE disk resource.
+
+    Resource mode — unscoped, elevated (``VIEW_ALL_FILESYSTEM_DATA``).
+    """
+    ctx = _resource_ctx(resource)
+    fragment_url = url_for('disk_scans.access_history_resource_fragment',
+                           resource=resource)
+
+    def _scan(owner_uid, subpath):
+        return service.scan_access_history_resource(
+            ctx['resource_name'], owner_uid=owner_uid, subpath=subpath)
+
+    return _render_distribution(
+        ctx, fragment_url, scan_call=_scan, kind='access_history',
+        bucket_header='Last accessed', log_label='resource-wide',
+    )
+
+
+@bp.route('/resource/<resource>/file-sizes')
+@login_required
+@require_permission(Permission.VIEW_ALL_FILESYSTEM_DATA)
+def file_sizes_resource_fragment(resource):
+    """HTMX fragment: file-size histogram across an ENTIRE disk resource.
+
+    Resource mode — unscoped, elevated (``VIEW_ALL_FILESYSTEM_DATA``). Same
+    Data ↔ Files metric pill + Log-scale switch as project mode.
+    """
+    ctx = _resource_ctx(resource)
+    fragment_url = url_for('disk_scans.file_sizes_resource_fragment',
+                           resource=resource)
+
+    def _scan(owner_uid, subpath):
+        return service.scan_file_sizes_resource(
+            ctx['resource_name'], owner_uid=owner_uid, subpath=subpath)
+
+    return _render_distribution(
+        ctx, fragment_url, scan_call=_scan, kind='file_sizes',
+        bucket_header='File size', log_label='resource-wide',
+        metric_toggle=True, log_toggle=True,
     )

--- a/src/webapp/disk_scans/service.py
+++ b/src/webapp/disk_scans/service.py
@@ -344,8 +344,13 @@ def scan_directories_resource(
     sort_by: str = 'size',
     limit: Optional[int] = 50,
     owner_uid: Optional[int] = None,
+    owner_gid: Optional[int] = None,
     accessed_before: Optional[datetime] = None,
     accessed_after: Optional[datetime] = None,
+    atime_recursive: bool = True,
+    min_avg_size: Optional[int] = None,
+    max_avg_size: Optional[int] = None,
+    outermost_only: bool = False,
     leaves_only: bool = False,
 ) -> List[Dict[str, Any]]:
     """Largest directories across an **entire disk resource**, unscoped.
@@ -358,6 +363,11 @@ def scan_directories_resource(
     project-scoping safety invariant by design, so it is only ever reachable
     behind the ``VIEW_ALL_FILESYSTEM_DATA``-gated route. Returns ``[]`` when the
     plugin is unavailable or the resource maps to no reachable collections.
+
+    Accepts the same filter set as the project-scoped :func:`scan_directories`
+    so the whole-FS card's per-user / per-group / histogram-band drill-downs
+    (which re-target this fragment with ``owner_uid`` / ``owner_gid`` /
+    ``min_avg_size`` / ``recursive`` etc.) filter identically.
     """
     mod = get_module()
     if mod is None:
@@ -366,12 +376,16 @@ def scan_directories_resource(
     if not collections:
         return []
     path_prefixes = [subpath] if subpath else None
-    return _scan_directories(
+    rows = _scan_directories(
         mod, collections, path_prefixes,
         sort_by=sort_by, limit=limit,
-        owner_uid=owner_uid, accessed_before=accessed_before,
-        accessed_after=accessed_after, leaves_only=leaves_only,
+        owner_uid=owner_uid, owner_gid=owner_gid,
+        accessed_before=accessed_before, accessed_after=accessed_after,
+        atime_recursive=atime_recursive,
+        min_avg_size=min_avg_size, max_avg_size=max_avg_size,
+        leaves_only=leaves_only,
     )
+    return _drop_nested(rows) if outermost_only else rows
 
 
 def _owner_summary(

--- a/src/webapp/disk_scans/service.py
+++ b/src/webapp/disk_scans/service.py
@@ -21,12 +21,15 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
+from flask import current_app
+
 from webapp.disk_scans.cache import cached_scan
 from webapp.disk_scans.scope import resolve_scan_scope
 from webapp.disk_scans.session import (
     collections_for_resource,
     get_collections,
     get_module,
+    is_enabled,
 )
 
 
@@ -371,6 +374,117 @@ def scan_directories_resource(
     )
 
 
+def _owner_summary(
+    mod, collections: List[str], path_prefixes: Optional[List[str]],
+    *, limit: Optional[int],
+) -> List[Dict[str, Any]]:
+    """Mode-agnostic per-owner (UID) rollup core, usernames resolved.
+
+    Callers resolve ``(mod, collections, path_prefixes)`` first — project mode
+    via :func:`_scoped` (always scoped), resource mode via
+    :func:`collections_for_resource` (``path_prefixes=None`` → whole-collection
+    fast path). Each row gains a ``username`` key (``None`` if unresolvable).
+    """
+    q = mod.FsScanQueries(filesystems=collections)
+
+    def _compute():
+        rows = q.owner_summary(path_prefixes=path_prefixes, limit=limit)
+        uids = {r['owner_uid'] for r in rows if r.get('owner_uid') is not None}
+        names = q.resolve_usernames(uids) if uids else {}
+        for r in rows:
+            r['username'] = names.get(r.get('owner_uid'))
+        return rows
+
+    # cache key tolerates an unscoped (None) prefix list — normalise to [].
+    return cached_scan('owner', q, collections, path_prefixes or [],
+                       {'limit': limit}, _compute)
+
+
+def _group_summary(
+    mod, collections: List[str], path_prefixes: Optional[List[str]],
+    *, limit: Optional[int],
+) -> List[Dict[str, Any]]:
+    """Mode-agnostic per-group (GID) rollup core, group names resolved."""
+    q = mod.FsScanQueries(filesystems=collections)
+
+    def _compute():
+        rows = q.group_summary(path_prefixes=path_prefixes, limit=limit)
+        gids = {r['owner_gid'] for r in rows if r.get('owner_gid') is not None}
+        names = q.resolve_groupnames(gids) if gids else {}
+        for r in rows:
+            r['groupname'] = names.get(r.get('owner_gid'))
+        return rows
+
+    return cached_scan('group', q, collections, path_prefixes or [],
+                       {'limit': limit}, _compute)
+
+
+def _access_history(
+    mod, collections: List[str], path_prefixes: Optional[List[str]],
+    *, owner_uid: Optional[int],
+) -> Optional[Dict[str, Any]]:
+    """Mode-agnostic access-time histogram core (band date windows tagged)."""
+    q = mod.FsScanQueries(filesystems=collections)
+
+    def _compute():
+        hist = q.access_history(path_prefixes=path_prefixes, owner_uid=owner_uid)
+        if hist:
+            # Tag each band with the date window it represents so the per-user
+            # drill-down can list that band's directories (see _atime_band_bounds).
+            bounds = _atime_band_bounds(hist.get('reference_scan_date'),
+                                        hist.get('bucket_labels'))
+            for label, b in (hist.get('buckets') or {}).items():
+                if label in bounds:
+                    b['accessed_after'] = bounds[label]['accessed_after']
+                    b['accessed_before'] = bounds[label]['accessed_before']
+        return hist
+
+    return cached_scan(
+        'access_history', q, collections, path_prefixes or [],
+        {'owner_uid': owner_uid}, _compute,
+    )
+
+
+def _file_sizes(
+    mod, collections: List[str], path_prefixes: Optional[List[str]],
+    *, owner_uid: Optional[int],
+) -> Optional[Dict[str, Any]]:
+    """Mode-agnostic file-size histogram core (avg-size windows tagged)."""
+    q = mod.FsScanQueries(filesystems=collections)
+
+    def _compute():
+        hist = q.file_size_histogram(path_prefixes=path_prefixes, owner_uid=owner_uid)
+        if hist:
+            # Tag each band with its average-file-size window so the per-user
+            # drill-down can list that band's directories (see _size_band_bounds).
+            bounds = _size_band_bounds(hist.get('bucket_labels'))
+            for label, b in (hist.get('buckets') or {}).items():
+                if label in bounds:
+                    b['size_min'] = bounds[label]['size_min']
+                    b['size_max'] = bounds[label]['size_max']
+        return hist
+
+    return cached_scan(
+        'file_sizes', q, collections, path_prefixes or [],
+        {'owner_uid': owner_uid}, _compute,
+    )
+
+
+def _resource_collections(resource_name: str):
+    """Resolve ``(mod, collections, path_prefixes)`` for resource mode.
+
+    The unscoped analogue of :func:`_scoped`: ``collections`` come from the
+    whole resource (:func:`collections_for_resource`) and ``path_prefixes`` is
+    ``None`` (whole-collection fast path) unless *subpath* drills in. Returns
+    ``(mod, [])`` whenever the plugin is unavailable or the resource maps to no
+    reachable collections; callers MUST treat an empty list as "no results".
+    """
+    mod = get_module()
+    if mod is None:
+        return None, []
+    return mod, collections_for_resource(resource_name)
+
+
 def scan_owner_summary(
     session,
     project,
@@ -388,17 +502,7 @@ def scan_owner_summary(
     mod, path_prefixes, collections = _scoped(session, project, resource_name, subpath)
     if not collections:
         return []
-    q = mod.FsScanQueries(filesystems=collections)
-
-    def _compute():
-        rows = q.owner_summary(path_prefixes=path_prefixes, limit=limit)
-        uids = {r['owner_uid'] for r in rows if r.get('owner_uid') is not None}
-        names = q.resolve_usernames(uids) if uids else {}
-        for r in rows:
-            r['username'] = names.get(r.get('owner_uid'))
-        return rows
-
-    return cached_scan('owner', q, collections, path_prefixes, {'limit': limit}, _compute)
+    return _owner_summary(mod, collections, path_prefixes, limit=limit)
 
 
 def scan_group_summary(
@@ -418,17 +522,7 @@ def scan_group_summary(
     mod, path_prefixes, collections = _scoped(session, project, resource_name, subpath)
     if not collections:
         return []
-    q = mod.FsScanQueries(filesystems=collections)
-
-    def _compute():
-        rows = q.group_summary(path_prefixes=path_prefixes, limit=limit)
-        gids = {r['owner_gid'] for r in rows if r.get('owner_gid') is not None}
-        names = q.resolve_groupnames(gids) if gids else {}
-        for r in rows:
-            r['groupname'] = names.get(r.get('owner_gid'))
-        return rows
-
-    return cached_scan('group', q, collections, path_prefixes, {'limit': limit}, _compute)
+    return _group_summary(mod, collections, path_prefixes, limit=limit)
 
 
 def scan_access_history(
@@ -450,25 +544,7 @@ def scan_access_history(
     mod, path_prefixes, collections = _scoped(session, project, resource_name, subpath)
     if not collections:
         return None
-    q = mod.FsScanQueries(filesystems=collections)
-
-    def _compute():
-        hist = q.access_history(path_prefixes=path_prefixes, owner_uid=owner_uid)
-        if hist:
-            # Tag each band with the date window it represents so the per-user
-            # drill-down can list that band's directories (see _atime_band_bounds).
-            bounds = _atime_band_bounds(hist.get('reference_scan_date'),
-                                        hist.get('bucket_labels'))
-            for label, b in (hist.get('buckets') or {}).items():
-                if label in bounds:
-                    b['accessed_after'] = bounds[label]['accessed_after']
-                    b['accessed_before'] = bounds[label]['accessed_before']
-        return hist
-
-    return cached_scan(
-        'access_history', q, collections, path_prefixes, {'owner_uid': owner_uid},
-        _compute,
-    )
+    return _access_history(mod, collections, path_prefixes, owner_uid=owner_uid)
 
 
 def scan_file_sizes(
@@ -493,21 +569,82 @@ def scan_file_sizes(
     mod, path_prefixes, collections = _scoped(session, project, resource_name, subpath)
     if not collections:
         return None
-    q = mod.FsScanQueries(filesystems=collections)
+    return _file_sizes(mod, collections, path_prefixes, owner_uid=owner_uid)
 
-    def _compute():
-        hist = q.file_size_histogram(path_prefixes=path_prefixes, owner_uid=owner_uid)
-        if hist:
-            # Tag each band with its average-file-size window so the per-user
-            # drill-down can list that band's directories (see _size_band_bounds).
-            bounds = _size_band_bounds(hist.get('bucket_labels'))
-            for label, b in (hist.get('buckets') or {}).items():
-                if label in bounds:
-                    b['size_min'] = bounds[label]['size_min']
-                    b['size_max'] = bounds[label]['size_max']
-        return hist
 
-    return cached_scan(
-        'file_sizes', q, collections, path_prefixes, {'owner_uid': owner_uid},
-        _compute,
-    )
+# ── Resource-mode (whole-filesystem) siblings ──────────────────────────────
+# Unscoped, elevated analogues of the project-scoped functions above. Each
+# obtains its collections from the whole resource and runs ``path_prefixes=None``
+# (the plugin's whole-collection fast path) unless a *subpath* drills in. Only
+# ever reachable behind the ``VIEW_ALL_FILESYSTEM_DATA``-gated resource routes;
+# return empty when the plugin is unavailable or the resource has no collections.
+
+def scan_owner_summary_resource(
+    resource_name: str,
+    *,
+    limit: Optional[int] = 50,
+    subpath: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Per-owner (UID) rollup across an **entire disk resource**, unscoped."""
+    mod, collections = _resource_collections(resource_name)
+    if not collections:
+        return []
+    path_prefixes = [subpath] if subpath else None
+    return _owner_summary(mod, collections, path_prefixes, limit=limit)
+
+
+def scan_group_summary_resource(
+    resource_name: str,
+    *,
+    limit: Optional[int] = 50,
+    subpath: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Per-group (GID) rollup across an **entire disk resource**, unscoped."""
+    mod, collections = _resource_collections(resource_name)
+    if not collections:
+        return []
+    path_prefixes = [subpath] if subpath else None
+    return _group_summary(mod, collections, path_prefixes, limit=limit)
+
+
+def scan_access_history_resource(
+    resource_name: str,
+    *,
+    owner_uid: Optional[int] = None,
+    subpath: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Access-time histogram across an **entire disk resource**, unscoped."""
+    mod, collections = _resource_collections(resource_name)
+    if not collections:
+        return None
+    path_prefixes = [subpath] if subpath else None
+    return _access_history(mod, collections, path_prefixes, owner_uid=owner_uid)
+
+
+def scan_file_sizes_resource(
+    resource_name: str,
+    *,
+    owner_uid: Optional[int] = None,
+    subpath: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """File-size histogram across an **entire disk resource**, unscoped."""
+    mod, collections = _resource_collections(resource_name)
+    if not collections:
+        return None
+    path_prefixes = [subpath] if subpath else None
+    return _file_sizes(mod, collections, path_prefixes, owner_uid=owner_uid)
+
+
+def scan_capable_resources(app=None) -> List[str]:
+    """Configured disk resources that currently have warmed scan collections.
+
+    Reads the explicit ``FS_SCAN_RESOURCES`` config list (resource *names*,
+    not IDs) and keeps only those the plugin can actually serve right now —
+    so a misconfigured entry (or the whole plugin being off) never renders an
+    empty Status subtab. Returns ``[]`` when the plugin is disabled. This is
+    what gates the Status "Filesystem Scans" tab's visibility + subtab set.
+    """
+    if not is_enabled(app):
+        return []
+    names = (app or current_app).config.get('FS_SCAN_RESOURCES') or []
+    return [n for n in names if collections_for_resource(n, app)]

--- a/src/webapp/templates/dashboards/status/dashboard.html
+++ b/src/webapp/templates/dashboards/status/dashboard.html
@@ -123,6 +123,13 @@
         </a>
     </li>
     {% endif %}
+    {% if fs_scan_resources and has_permission(Permission.VIEW_ALL_FILESYSTEM_DATA) %}
+    <li class="nav-item">
+        <a class="nav-link" id="filesystem-scans-tab" data-bs-toggle="tab" href="#filesystem-scans" role="tab">
+            <i class="fas fa-magnifying-glass-chart"></i> Filesystem Scans
+        </a>
+    </li>
+    {% endif %}
 </ul>
 
 <!-- Tab Content -->
@@ -139,6 +146,11 @@
     {% if reservations or google_calendar_embed_url %}
     <div class="tab-pane fade" id="reservations" role="tabpanel">
         {% include 'dashboards/status/fragments/reservations.html' %}
+    </div>
+    {% endif %}
+    {% if fs_scan_resources and has_permission(Permission.VIEW_ALL_FILESYSTEM_DATA) %}
+    <div class="tab-pane fade" id="filesystem-scans" role="tabpanel">
+        {% include 'dashboards/status/partials/filesystem_scans.html' %}
     </div>
     {% endif %}
 </div>

--- a/src/webapp/templates/dashboards/status/partials/filesystem_scans.html
+++ b/src/webapp/templates/dashboards/status/partials/filesystem_scans.html
@@ -1,0 +1,46 @@
+{# ── Filesystem Scans tab body (Status dashboard) ───────────────────────
+   One subtab per scan-capable disk resource (fs_scan_resources, from
+   service.scan_capable_resources()). Each subtab hosts the SAME scans card
+   the project disk page shows, but in resource mode — rooted over the whole
+   filesystem (VIEW_ALL_FILESYSTEM_DATA-gated routes).
+
+   Lazy-load: the active first subtab gets no shown.bs.tab when the parent
+   "Filesystem Scans" tab opens, so its card's first inner tab listens to the
+   parent tab (#filesystem-scans-tab). Other subtabs load when their own
+   subtab nav-link is shown. Bind to the shown event, not click
+   (feedback_persisted_collapse_htmx). Closed subtabs cost nothing.
+
+   This partial is only included when fs_scan_resources is non-empty AND the
+   viewer holds VIEW_ALL_FILESYSTEM_DATA (gated in dashboard.html), so it never
+   needs its own empty/disabled state.
+#}
+<ul class="nav nav-pills mb-3" id="fsScanSubtabs" role="tablist">
+    {% for res in fs_scan_resources %}
+    <li class="nav-item" role="presentation">
+        <a class="nav-link {% if loop.first %}active{% endif %}"
+           id="fs-scan-subtab-{{ loop.index }}"
+           data-bs-toggle="tab" href="#fs-scan-pane-{{ loop.index }}" role="tab">
+            <i class="fas fa-hard-drive me-1"></i> {{ res }}
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+<div class="tab-content" id="fsScanSubtabContent">
+    {% for res in fs_scan_resources %}
+    <div class="tab-pane fade {% if loop.first %}show active{% endif %}"
+         id="fs-scan-pane-{{ loop.index }}" role="tabpanel">
+        {% if loop.first %}
+            {% set _trigger = 'shown.bs.tab once from:#filesystem-scans-tab' %}
+        {% else %}
+            {% set _trigger = 'shown.bs.tab once from:#fs-scan-subtab-' ~ loop.index %}
+        {% endif %}
+        {% with mode='resource',
+                cid='disk-scans-r' ~ loop.index,
+                tablist_id='fsScanCardTabs' ~ loop.index,
+                resource_name=res,
+                load_trigger=_trigger %}
+            {% include 'dashboards/user/partials/disk_scans_card.html' %}
+        {% endwith %}
+    </div>
+    {% endfor %}
+</div>

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_card.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_card.html
@@ -1,0 +1,121 @@
+{# ── Filesystem Scans card (shared, mode-parameterized) ─────────────────
+   The Large directories / User-group counts / Access-history + File-sizes
+   tab strip, each lazy-loading its disk_scans.* fragment via hx-get. Shared
+   by the project disk resource-details page (mode='project') and the Status
+   dashboard's whole-FS subtabs (mode='resource').
+
+   Params:
+     mode        'project' | 'resource'
+     cid         element-id prefix; namespaces every id so multiple cards on
+                 one page (the Status subtabs) don't collide. Project default
+                 'disk-scans' reproduces the historical ids byte-for-byte.
+     tablist_id  id for the <ul class="nav-tabs"> (drives nav-view-persistence's
+                 tab:<id> key; keep stable per card).
+     resource_name, and project-only projcode / scope / fileset
+     load_trigger  hx-trigger for the first (Large directories) tab — the only
+                   bit of lazy-load wiring that differs by host: project mode
+                   fires on card-open (collapse) + tab show; resource mode fires
+                   when its subtab (and, for the first subtab, the parent tab)
+                   is shown. See feedback_persisted_collapse_htmx.
+
+   In resource mode project/scope/fileset are absent; the fragment templates
+   treat them as optional and suppress the per-user drill-downs (which need a
+   projcode) — the whole-FS drill path is Large Directories → unscoped explorer.
+#}
+{% if mode == 'resource' %}
+    {% set _dirs_url  = url_for('disk_scans.directories_resource_fragment',   resource=resource_name, target_id=cid ~ '-directories') %}
+    {% set _ent_url   = url_for('disk_scans.entities_resource_fragment',      resource=resource_name, target_id=cid ~ '-entities') %}
+    {% set _acc_url   = url_for('disk_scans.access_history_resource_fragment', resource=resource_name, target_id=cid ~ '-access') %}
+    {% set _files_url = url_for('disk_scans.file_sizes_resource_fragment',    resource=resource_name, target_id=cid ~ '-files') %}
+    {% set _full_url  = url_for('disk_scans.directories_resource_page',       resource=resource_name) %}
+{% else %}
+    {% set _dirs_url  = url_for('disk_scans.directories_fragment',     projcode=projcode, resource=resource_name, scope=scope, fileset=fileset, target_id=cid ~ '-directories') %}
+    {% set _ent_url   = url_for('disk_scans.entities_fragment',        projcode=projcode, resource=resource_name, scope=scope, fileset=fileset, target_id=cid ~ '-entities') %}
+    {% set _acc_url   = url_for('disk_scans.access_history_fragment',  projcode=projcode, resource=resource_name, scope=scope, fileset=fileset, target_id=cid ~ '-access') %}
+    {% set _files_url = url_for('disk_scans.file_sizes_fragment',      projcode=projcode, resource=resource_name, scope=scope, fileset=fileset, target_id=cid ~ '-files') %}
+    {% set _full_url  = url_for('disk_scans.directories_page',         projcode=projcode, resource=resource_name, scope=scope, fileset=fileset) %}
+{% endif %}
+<ul class="nav nav-tabs mb-0" id="{{ tablist_id }}" role="tablist">
+    <li class="nav-item" role="presentation">
+        <button class="nav-link active" id="{{ cid }}-dirs-tab"
+                data-bs-toggle="tab" data-bs-target="#tab-{{ cid }}-dirs"
+                type="button" role="tab"
+                hx-get="{{ _dirs_url }}"
+                hx-target="#{{ cid }}-directories"
+                hx-swap="innerHTML"
+                hx-trigger="{{ load_trigger }}">
+            <i class="fas fa-folder-tree me-1"></i> Large directories
+        </button>
+    </li>
+    <li class="nav-item" role="presentation">
+        <button class="nav-link" id="{{ cid }}-ent-tab"
+                data-bs-toggle="tab" data-bs-target="#tab-{{ cid }}-ent"
+                type="button" role="tab"
+                hx-get="{{ _ent_url }}"
+                hx-target="#{{ cid }}-entities"
+                hx-swap="innerHTML"
+                hx-trigger="shown.bs.tab once">
+            <i class="fas fa-users me-1"></i> User / group counts
+        </button>
+    </li>
+    <li class="nav-item" role="presentation">
+        <button class="nav-link" id="{{ cid }}-acc-tab"
+                data-bs-toggle="tab" data-bs-target="#tab-{{ cid }}-acc"
+                type="button" role="tab"
+                hx-get="{{ _acc_url }}"
+                hx-target="#{{ cid }}-access"
+                hx-swap="innerHTML"
+                hx-trigger="shown.bs.tab once">
+            <i class="fas fa-clock-rotate-left me-1"></i> Access history
+        </button>
+    </li>
+    <li class="nav-item" role="presentation">
+        <button class="nav-link" id="{{ cid }}-files-tab"
+                data-bs-toggle="tab" data-bs-target="#tab-{{ cid }}-files"
+                type="button" role="tab"
+                hx-get="{{ _files_url }}"
+                hx-target="#{{ cid }}-files"
+                hx-swap="innerHTML"
+                hx-trigger="shown.bs.tab once">
+            <i class="fas fa-ruler me-1"></i> File sizes
+        </button>
+    </li>
+</ul>
+<div class="tab-content border border-top-0 rounded-bottom p-3"
+     id="{{ tablist_id }}Content">
+    <div class="tab-pane fade show active" id="tab-{{ cid }}-dirs" role="tabpanel">
+        <div class="d-flex justify-content-end mb-2">
+            <a class="btn btn-sm btn-outline-primary"
+               href="{{ _full_url }}"
+               target="_blank" rel="noopener">
+                Open full view <i class="fas fa-up-right-from-square ms-1"></i>
+            </a>
+        </div>
+        <div id="{{ cid }}-directories">
+            <p class="text-muted small mb-0">
+                <i class="fas fa-spinner fa-spin me-1"></i> Loading directories…
+            </p>
+        </div>
+    </div>
+    <div class="tab-pane fade" id="tab-{{ cid }}-ent" role="tabpanel">
+        <div id="{{ cid }}-entities">
+            <p class="text-muted small mb-0">
+                <i class="fas fa-spinner fa-spin me-1"></i> Loading…
+            </p>
+        </div>
+    </div>
+    <div class="tab-pane fade" id="tab-{{ cid }}-acc" role="tabpanel">
+        <div id="{{ cid }}-access">
+            <p class="text-muted small mb-0">
+                <i class="fas fa-spinner fa-spin me-1"></i> Loading access history…
+            </p>
+        </div>
+    </div>
+    <div class="tab-pane fade" id="tab-{{ cid }}-files" role="tabpanel">
+        <div id="{{ cid }}-files">
+            <p class="text-muted small mb-0">
+                <i class="fas fa-spinner fa-spin me-1"></i> Loading file sizes…
+            </p>
+        </div>
+    </div>
+</div>

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
@@ -170,7 +170,7 @@
                       {% set _uname = umap.get(uid) or umap.get(uid | string) or ('uid ' ~ uid) %}
                       {% set _date_band = b.get('accessed_before') %}
                       {% set _size_band = (b.get('size_min') is not none) or (b.get('size_max') is not none) %}
-                      {% set _has_dd = (_date_band or _size_band) and project %}
+                      {% set _has_dd = (_date_band or _size_band) and dir_fragment_url %}
                       {% set _urow = rowid ~ '-u' ~ loop.index %}
                       {% set _dt = rowid ~ '-d' ~ loop.index %}
                       <tr {% if _has_dd %}class="cursor-pointer" data-bs-toggle="collapse"
@@ -197,7 +197,7 @@
                                band has no upper bound). Bind to shown.bs.collapse
                                so it fires under nav restore. #}
                             <div class="p-2 bg-light" id="{{ _dt }}"
-                                 hx-get="{{ url_for('disk_scans.directories_fragment', projcode=project.projcode) }}?owner_uid={{ uid }}&resource={{ resource_name }}{% if scope %}&scope={{ scope }}{% endif %}{% if _date_band %}{% if b.get('accessed_after') %}&accessed_after={{ b.accessed_after }}{% endif %}&accessed_before={{ b.accessed_before }}{% else %}&min_avg_size={{ b.size_min }}{% if b.get('size_max') is not none %}&max_avg_size={{ b.size_max }}{% endif %}{% endif %}&recursive=0&sort_by=size_nr&limit=25&target_id={{ _dt }}"
+                                 hx-get="{{ dir_fragment_url }}?owner_uid={{ uid }}&resource={{ resource_name }}{% if scope %}&scope={{ scope }}{% endif %}{% if _date_band %}{% if b.get('accessed_after') %}&accessed_after={{ b.accessed_after }}{% endif %}&accessed_before={{ b.accessed_before }}{% else %}&min_avg_size={{ b.size_min }}{% if b.get('size_max') is not none %}&max_avg_size={{ b.size_max }}{% endif %}{% endif %}&recursive=0&sort_by=size_nr&limit=25&target_id={{ _dt }}"
                                  hx-trigger="shown.bs.collapse from:closest tr.collapse once"
                                  hx-swap="innerHTML">
                               <p class="text-muted small mb-0">

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_entities.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_entities.html
@@ -3,8 +3,10 @@
 {#
   Owner/group rollup fragment — embedded via hx-get from the Filesystem
   Scans card. Context (set in webapp/disk_scans/routes.py):
-    rows, kind ('owner'|'group'), fragment_url, target_id,
+    rows, kind ('owner'|'group'), fragment_url, dir_fragment_url, target_id,
     resource_name, scope, fileset, enabled, error
+  dir_fragment_url is the directories fragment for the current mode (project
+  or resource) that the per-entity row drill-down re-targets.
   Owner rows: owner_uid, total_size, total_files, directory_count,
               filesystem, username.
   Group rows: owner_gid + groupname (same shape otherwise).
@@ -91,9 +93,10 @@
                  row's collapse (svg-chart-links.js), same as the chevron. #}
               <tr data-owner-uid="{{ r.owner_uid }}" data-bs-target="#{{ _oid }}-row">
                 <td data-sort-value="{{ name if name else (r.owner_uid | string) }}">
-                  {# Per-user directory drill needs a projcode; suppressed in
-                     resource (whole-FS) mode — drill via Large directories. #}
-                  {% if project %}
+                  {# Drill into this user's directories — targets the directories
+                     fragment for the current mode (dir_fragment_url): project
+                     (scope-rooted) or resource (whole-FS). #}
+                  {% if dir_fragment_url %}
                   <button class="btn btn-sm btn-link text-decoration-none p-0 me-1"
                           type="button" data-bs-toggle="collapse"
                           data-bs-target="#{{ _oid }}-row"
@@ -108,7 +111,7 @@
                 <td class="text-end" data-sort-value="{{ r.total_files }}">{{ r.total_files | fmt_number }}</td>
                 <td class="text-end" data-sort-value="{{ r.directory_count }}">{{ r.directory_count | fmt_number }}</td>
               </tr>
-              {% if project %}
+              {% if dir_fragment_url %}
               <tr class="collapse" id="{{ _oid }}-row">
                 <td colspan="4" class="p-0 border-0">
                   {# Lazy-load this user's top directories on first expand
@@ -117,7 +120,7 @@
                      nav-view-persistence restore too. #}
                   <div class="p-2 bg-light"
                        id="{{ _oid }}"
-                       hx-get="{{ url_for('disk_scans.directories_fragment', projcode=project.projcode) }}?owner_uid={{ r.owner_uid }}&resource={{ resource_name }}{% if scope %}&scope={{ scope }}{% endif %}{% if fileset %}&fileset={{ fileset }}{% endif %}&target_id={{ _oid }}&limit=20"
+                       hx-get="{{ dir_fragment_url }}?owner_uid={{ r.owner_uid }}&resource={{ resource_name }}{% if scope %}&scope={{ scope }}{% endif %}{% if fileset %}&fileset={{ fileset }}{% endif %}&target_id={{ _oid }}&limit=20"
                        hx-trigger="shown.bs.collapse from:closest tr.collapse once"
                        hx-swap="innerHTML">
                     <p class="text-muted small mb-0">
@@ -139,9 +142,9 @@
                  row's collapse (svg-chart-links.js), same as the chevron. #}
               <tr data-group-gid="{{ r.owner_gid }}" data-bs-target="#{{ _gid }}-row">
                 <td data-sort-value="{{ name if name else (r.owner_gid | string) }}">
-                  {# Per-group directory drill needs a projcode; suppressed in
-                     resource (whole-FS) mode — drill via Large directories. #}
-                  {% if project %}
+                  {# Drill into this group's directories — targets the directories
+                     fragment for the current mode (dir_fragment_url). #}
+                  {% if dir_fragment_url %}
                   <button class="btn btn-sm btn-link text-decoration-none p-0 me-1"
                           type="button" data-bs-toggle="collapse"
                           data-bs-target="#{{ _gid }}-row"
@@ -156,7 +159,7 @@
                 <td class="text-end" data-sort-value="{{ r.total_files }}">{{ r.total_files | fmt_number }}</td>
                 <td class="text-end" data-sort-value="{{ r.directory_count }}">{{ r.directory_count | fmt_number }}</td>
               </tr>
-              {% if project %}
+              {% if dir_fragment_url %}
               <tr class="collapse" id="{{ _gid }}-row">
                 <td colspan="4" class="p-0 border-0">
                   {# Lazy-load this group's top directories on first expand
@@ -164,7 +167,7 @@
                      carries the resolved name for the filter badge. #}
                   <div class="p-2 bg-light"
                        id="{{ _gid }}"
-                       hx-get="{{ url_for('disk_scans.directories_fragment', projcode=project.projcode) }}?owner_gid={{ r.owner_gid }}{% if name %}&group_label={{ name | urlencode }}{% endif %}&resource={{ resource_name }}{% if scope %}&scope={{ scope }}{% endif %}{% if fileset %}&fileset={{ fileset }}{% endif %}&target_id={{ _gid }}&limit=20"
+                       hx-get="{{ dir_fragment_url }}?owner_gid={{ r.owner_gid }}{% if name %}&group_label={{ name | urlencode }}{% endif %}&resource={{ resource_name }}{% if scope %}&scope={{ scope }}{% endif %}{% if fileset %}&fileset={{ fileset }}{% endif %}&target_id={{ _gid }}&limit=20"
                        hx-trigger="shown.bs.collapse from:closest tr.collapse once"
                        hx-swap="innerHTML">
                     <p class="text-muted small mb-0">

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_entities.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_entities.html
@@ -91,12 +91,16 @@
                  row's collapse (svg-chart-links.js), same as the chevron. #}
               <tr data-owner-uid="{{ r.owner_uid }}" data-bs-target="#{{ _oid }}-row">
                 <td data-sort-value="{{ name if name else (r.owner_uid | string) }}">
+                  {# Per-user directory drill needs a projcode; suppressed in
+                     resource (whole-FS) mode — drill via Large directories. #}
+                  {% if project %}
                   <button class="btn btn-sm btn-link text-decoration-none p-0 me-1"
                           type="button" data-bs-toggle="collapse"
                           data-bs-target="#{{ _oid }}-row"
                           aria-expanded="false" aria-controls="{{ _oid }}-row">
                     <i class="fas fa-chevron-right collapse-icon small"></i>
                   </button>
+                  {% endif %}
                   {% if name %}<code>{{ name }}</code>
                   {% else %}<span class="text-muted" title="unresolved UID">uid {{ r.owner_uid }}</span>{% endif %}
                 </td>
@@ -104,6 +108,7 @@
                 <td class="text-end" data-sort-value="{{ r.total_files }}">{{ r.total_files | fmt_number }}</td>
                 <td class="text-end" data-sort-value="{{ r.directory_count }}">{{ r.directory_count | fmt_number }}</td>
               </tr>
+              {% if project %}
               <tr class="collapse" id="{{ _oid }}-row">
                 <td colspan="4" class="p-0 border-0">
                   {# Lazy-load this user's top directories on first expand
@@ -122,6 +127,7 @@
                   </div>
                 </td>
               </tr>
+              {% endif %}
             </tbody>
           {% endfor %}
         {% else %}
@@ -133,12 +139,16 @@
                  row's collapse (svg-chart-links.js), same as the chevron. #}
               <tr data-group-gid="{{ r.owner_gid }}" data-bs-target="#{{ _gid }}-row">
                 <td data-sort-value="{{ name if name else (r.owner_gid | string) }}">
+                  {# Per-group directory drill needs a projcode; suppressed in
+                     resource (whole-FS) mode — drill via Large directories. #}
+                  {% if project %}
                   <button class="btn btn-sm btn-link text-decoration-none p-0 me-1"
                           type="button" data-bs-toggle="collapse"
                           data-bs-target="#{{ _gid }}-row"
                           aria-expanded="false" aria-controls="{{ _gid }}-row">
                     <i class="fas fa-chevron-right collapse-icon small"></i>
                   </button>
+                  {% endif %}
                   {% if name %}<code>{{ name }}</code>
                   {% else %}<span class="text-muted" title="unresolved GID">gid {{ r.owner_gid }}</span>{% endif %}
                 </td>
@@ -146,6 +156,7 @@
                 <td class="text-end" data-sort-value="{{ r.total_files }}">{{ r.total_files | fmt_number }}</td>
                 <td class="text-end" data-sort-value="{{ r.directory_count }}">{{ r.directory_count | fmt_number }}</td>
               </tr>
+              {% if project %}
               <tr class="collapse" id="{{ _gid }}-row">
                 <td colspan="4" class="p-0 border-0">
                   {# Lazy-load this group's top directories on first expand
@@ -163,6 +174,7 @@
                   </div>
                 </td>
               </tr>
+              {% endif %}
             </tbody>
           {% endfor %}
         {% endif %}

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -368,103 +368,13 @@
     </div>
     <div id="collapseDiskScans" class="collapse">
         <div class="card-body">
-            <ul class="nav nav-tabs mb-0" id="diskScansTabs" role="tablist">
-                <li class="nav-item" role="presentation">
-                    <button class="nav-link active" id="disk-scans-dirs-tab"
-                            data-bs-toggle="tab" data-bs-target="#tab-disk-scans-dirs"
-                            type="button" role="tab"
-                            hx-get="{{ url_for('disk_scans.directories_fragment',
-                                               projcode=projcode, resource=resource_name,
-                                               scope=scope, fileset=fileset,
-                                               target_id='disk-scans-directories') }}"
-                            hx-target="#disk-scans-directories"
-                            hx-swap="innerHTML"
-                            hx-trigger="shown.bs.tab once, shown.bs.collapse once from:#collapseDiskScans">
-                        <i class="fas fa-folder-tree me-1"></i> Large directories
-                    </button>
-                </li>
-                <li class="nav-item" role="presentation">
-                    <button class="nav-link" id="disk-scans-ent-tab"
-                            data-bs-toggle="tab" data-bs-target="#tab-disk-scans-ent"
-                            type="button" role="tab"
-                            hx-get="{{ url_for('disk_scans.entities_fragment',
-                                               projcode=projcode, resource=resource_name,
-                                               scope=scope, fileset=fileset,
-                                               target_id='disk-scans-entities') }}"
-                            hx-target="#disk-scans-entities"
-                            hx-swap="innerHTML"
-                            hx-trigger="shown.bs.tab once">
-                        <i class="fas fa-users me-1"></i> User / group counts
-                    </button>
-                </li>
-                <li class="nav-item" role="presentation">
-                    <button class="nav-link" id="disk-scans-acc-tab"
-                            data-bs-toggle="tab" data-bs-target="#tab-disk-scans-acc"
-                            type="button" role="tab"
-                            hx-get="{{ url_for('disk_scans.access_history_fragment',
-                                               projcode=projcode, resource=resource_name,
-                                               scope=scope, fileset=fileset,
-                                               target_id='disk-scans-access') }}"
-                            hx-target="#disk-scans-access"
-                            hx-swap="innerHTML"
-                            hx-trigger="shown.bs.tab once">
-                        <i class="fas fa-clock-rotate-left me-1"></i> Access history
-                    </button>
-                </li>
-                <li class="nav-item" role="presentation">
-                    <button class="nav-link" id="disk-scans-files-tab"
-                            data-bs-toggle="tab" data-bs-target="#tab-disk-scans-files"
-                            type="button" role="tab"
-                            hx-get="{{ url_for('disk_scans.file_sizes_fragment',
-                                               projcode=projcode, resource=resource_name,
-                                               scope=scope, fileset=fileset,
-                                               target_id='disk-scans-files') }}"
-                            hx-target="#disk-scans-files"
-                            hx-swap="innerHTML"
-                            hx-trigger="shown.bs.tab once">
-                        <i class="fas fa-ruler me-1"></i> File sizes
-                    </button>
-                </li>
-            </ul>
-            <div class="tab-content border border-top-0 rounded-bottom p-3"
-                 id="diskScansTabsContent">
-                <div class="tab-pane fade show active" id="tab-disk-scans-dirs" role="tabpanel">
-                    <div class="d-flex justify-content-end mb-2">
-                        <a class="btn btn-sm btn-outline-primary"
-                           href="{{ url_for('disk_scans.directories_page', projcode=projcode,
-                                            resource=resource_name, scope=scope, fileset=fileset) }}"
-                           target="_blank" rel="noopener">
-                            Open full view <i class="fas fa-up-right-from-square ms-1"></i>
-                        </a>
-                    </div>
-                    <div id="disk-scans-directories">
-                        <p class="text-muted small mb-0">
-                            <i class="fas fa-spinner fa-spin me-1"></i> Loading directories…
-                        </p>
-                    </div>
-                </div>
-                <div class="tab-pane fade" id="tab-disk-scans-ent" role="tabpanel">
-                    <div id="disk-scans-entities">
-                        <p class="text-muted small mb-0">
-                            <i class="fas fa-spinner fa-spin me-1"></i> Loading…
-                        </p>
-                    </div>
-                </div>
-                <div class="tab-pane fade" id="tab-disk-scans-acc" role="tabpanel">
-                    <div id="disk-scans-access">
-                        <p class="text-muted small mb-0">
-                            <i class="fas fa-spinner fa-spin me-1"></i> Loading access history…
-                        </p>
-                    </div>
-                </div>
-                <div class="tab-pane fade" id="tab-disk-scans-files" role="tabpanel">
-                    <div id="disk-scans-files">
-                        <p class="text-muted small mb-0">
-                            <i class="fas fa-spinner fa-spin me-1"></i> Loading file sizes…
-                        </p>
-                    </div>
-                </div>
-            </div>
+            {# Project mode: ids match the historical 'disk-scans-*' scheme, the
+               tablist keeps its 'diskScansTabs' persistence key, and the first
+               tab lazy-loads on card-open (collapse) as well as tab show. #}
+            {% with mode='project', cid='disk-scans', tablist_id='diskScansTabs',
+                    load_trigger='shown.bs.tab once, shown.bs.collapse once from:#collapseDiskScans' %}
+                {% include 'dashboards/user/partials/disk_scans_card.html' %}
+            {% endwith %}
         </div>
     </div>
 </div>

--- a/tests/integration/test_status_dashboard.py
+++ b/tests/integration/test_status_dashboard.py
@@ -150,6 +150,43 @@ class TestStatusDashboard:
         assert response.status_code == 200
         assert b'System Status' in response.data
 
+    # ------------------------------------------------------------------
+    # "Filesystem Scans" tab — gated on VIEW_ALL_FILESYSTEM_DATA AND a
+    # non-empty scan-capable resource list (plugin on + warmed collections).
+    # The plugin is off in tests, so scan_capable_resources() returns [] by
+    # default; patch it to exercise the visible path.
+    # ------------------------------------------------------------------
+
+    def test_fs_scans_tab_shown_with_perm(self, auth_client, status_session, monkeypatch):
+        """benkirk holds the perm → tab + one subtab per configured resource."""
+        seed_data(status_session)
+        monkeypatch.setattr('webapp.disk_scans.service.scan_capable_resources',
+                            lambda app=None: ['Campaign_Store'])
+        response = auth_client.get('/status/')
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        assert 'id="filesystem-scans-tab"' in body
+        assert 'Filesystem Scans' in body
+        assert 'Campaign_Store' in body          # subtab rendered
+
+    def test_fs_scans_tab_hidden_when_no_resources(self, auth_client, status_session, monkeypatch):
+        """No scan-capable resource (plugin off / unwarmed) → no tab even with perm."""
+        seed_data(status_session)
+        monkeypatch.setattr('webapp.disk_scans.service.scan_capable_resources',
+                            lambda app=None: [])
+        response = auth_client.get('/status/')
+        assert response.status_code == 200
+        assert 'id="filesystem-scans-tab"' not in response.get_data(as_text=True)
+
+    def test_fs_scans_tab_hidden_without_perm(self, non_admin_client, status_session, monkeypatch):
+        """A user lacking VIEW_ALL_FILESYSTEM_DATA never sees the tab."""
+        seed_data(status_session)
+        monkeypatch.setattr('webapp.disk_scans.service.scan_capable_resources',
+                            lambda app=None: ['Campaign_Store'])
+        response = non_admin_client.get('/status/')
+        assert response.status_code == 200
+        assert 'id="filesystem-scans-tab"' not in response.get_data(as_text=True)
+
     def test_nodetype_history(self, auth_client, status_session):
         """Test GET /status/nodetype-history/casper/cpu returns 200."""
         seed_data(status_session)

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -1077,6 +1077,129 @@ def test_collections_for_resource_delegates(monkeypatch):
     assert sess.collections_for_resource('Campaign_Store') == []
 
 
+# -- resource mode (service): entity + histogram siblings --------------------
+
+def _wire_resource_entities(monkeypatch, *, collections, capture):
+    """Patch the service for resource-mode owner/group/histogram queries.
+
+    Mirrors ``_wire_resource_service`` but the fake ``FsScanQueries`` captures
+    the kwargs of the four facade methods the entity/histogram cores call, and
+    resolves names so the enrichment paths run.
+    """
+    from webapp.disk_scans import service
+
+    class _FakeQueries:
+        def __init__(self, filesystems):
+            capture['filesystems'] = list(filesystems)
+
+        def owner_summary(self, **kw):
+            capture['owner_kwargs'] = kw
+            return [{'owner_uid': 1001, 'total_size': 5,
+                     'total_files': 2, 'directory_count': 1}]
+
+        def group_summary(self, **kw):
+            capture['group_kwargs'] = kw
+            return [{'owner_gid': 2001, 'total_size': 5,
+                     'total_files': 2, 'directory_count': 1}]
+
+        def access_history(self, **kw):
+            capture['access_kwargs'] = kw
+            return {'bucket_labels': [], 'buckets': {}}
+
+        def file_size_histogram(self, **kw):
+            capture['files_kwargs'] = kw
+            return {'bucket_labels': [], 'buckets': {}}
+
+        def resolve_usernames(self, uids):
+            return {u: f'user{u}' for u in uids}
+
+        def resolve_groupnames(self, gids):
+            return {g: f'grp{g}' for g in gids}
+
+    mod = types.SimpleNamespace(FsScanQueries=_FakeQueries)
+    monkeypatch.setattr(service, 'get_module', lambda: mod)
+    monkeypatch.setattr(service, 'collections_for_resource',
+                        lambda r, app=None: list(collections))
+    return service
+
+
+def test_scan_owner_summary_resource_unscoped(monkeypatch):
+    """Resource mode queries the whole collection (path_prefixes=None)."""
+    cap = {}
+    svc = _wire_resource_entities(monkeypatch, collections=['campaign'], capture=cap)
+    rows = svc.scan_owner_summary_resource('Campaign_Store', limit=10)
+    assert cap['filesystems'] == ['campaign']
+    assert cap['owner_kwargs']['path_prefixes'] is None   # whole-collection fast path
+    assert cap['owner_kwargs']['limit'] == 10
+    assert rows[0]['username'] == 'user1001'              # enrichment ran
+
+
+def test_scan_group_summary_resource_subpath(monkeypatch):
+    """A fileset narrows resource mode to that single sub-path."""
+    cap = {}
+    svc = _wire_resource_entities(monkeypatch, collections=['campaign'], capture=cap)
+    rows = svc.scan_group_summary_resource('Campaign_Store',
+                                           subpath='/glade/campaign/cisl')
+    assert cap['group_kwargs']['path_prefixes'] == ['/glade/campaign/cisl']
+    assert rows[0]['groupname'] == 'grp2001'
+
+
+def test_scan_access_history_resource_unscoped(monkeypatch):
+    cap = {}
+    svc = _wire_resource_entities(monkeypatch, collections=['campaign'], capture=cap)
+    hist = svc.scan_access_history_resource('Campaign_Store')
+    assert cap['access_kwargs']['path_prefixes'] is None
+    assert cap['access_kwargs']['owner_uid'] is None
+    assert hist == {'bucket_labels': [], 'buckets': {}}
+
+
+def test_scan_file_sizes_resource_owner_uid(monkeypatch):
+    cap = {}
+    svc = _wire_resource_entities(monkeypatch, collections=['campaign'], capture=cap)
+    svc.scan_file_sizes_resource('Campaign_Store', owner_uid=4242)
+    assert cap['files_kwargs']['path_prefixes'] is None   # whole-collection fast path
+    assert cap['files_kwargs']['owner_uid'] == 4242
+
+
+def test_resource_entity_fns_empty_when_plugin_off(monkeypatch):
+    from webapp.disk_scans import service
+    monkeypatch.setattr(service, 'get_module', lambda: None)
+    assert service.scan_owner_summary_resource('Campaign_Store') == []
+    assert service.scan_group_summary_resource('Campaign_Store') == []
+    assert service.scan_access_history_resource('Campaign_Store') is None
+    assert service.scan_file_sizes_resource('Campaign_Store') is None
+
+
+def test_resource_entity_fns_empty_when_no_collections(monkeypatch):
+    """An off-map / unwarmed resource yields no results (never unscoped)."""
+    cap = {}
+    svc = _wire_resource_entities(monkeypatch, collections=[], capture=cap)
+    assert svc.scan_owner_summary_resource('Campaign_Store') == []
+    assert svc.scan_access_history_resource('Campaign_Store') is None
+
+
+# -- scan_capable_resources (Status tab gating) ------------------------------
+
+def test_scan_capable_resources_filters_unwarmed(app, monkeypatch):
+    """Keeps only configured resources that currently have warmed collections."""
+    from webapp.disk_scans import service
+    monkeypatch.setattr(service, 'is_enabled', lambda a=None: True)
+    monkeypatch.setattr(
+        service, 'collections_for_resource',
+        lambda n, app=None: ['campaign'] if n == 'Campaign_Store' else [])
+    monkeypatch.setitem(app.config, 'FS_SCAN_RESOURCES', ['Campaign_Store', 'Destor'])
+    with app.app_context():
+        assert service.scan_capable_resources() == ['Campaign_Store']
+
+
+def test_scan_capable_resources_empty_when_disabled(app, monkeypatch):
+    from webapp.disk_scans import service
+    monkeypatch.setattr(service, 'is_enabled', lambda a=None: False)
+    monkeypatch.setitem(app.config, 'FS_SCAN_RESOURCES', ['Campaign_Store'])
+    with app.app_context():
+        assert service.scan_capable_resources() == []
+
+
 # -- routes: filters, explorer page, owner drill-down ------------------------
 
 def test_directories_owner_filter_and_form(app, auth_client, active_project, monkeypatch):
@@ -1220,6 +1343,23 @@ def test_resource_page_200_with_perm(auth_client):
     )
     assert resp.status_code == 200
     assert 'Resource-wide' in resp.get_data(as_text=True)
+
+
+@pytest.mark.parametrize('endpoint', ['entities', 'access-history', 'file-sizes'])
+def test_resource_card_fragments_403_without_perm(non_admin_client, endpoint):
+    resp = non_admin_client.get(
+        f'/dashboards/user/disk-scans/resource/{_RES}/{endpoint}'
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.parametrize('endpoint', ['entities', 'access-history', 'file-sizes'])
+def test_resource_card_fragments_200_with_perm(auth_client, endpoint):
+    """benkirk holds VIEW_ALL_FILESYSTEM_DATA → 200 (plugin off → banner)."""
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/resource/{_RES}/{endpoint}'
+    )
+    assert resp.status_code == 200
 
 
 def test_view_all_filesystem_data_grants():

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -1062,6 +1062,22 @@ def test_scan_directories_resource_subpath(monkeypatch):
     assert cap['list_kwargs']['path_prefixes'] == ['/glade/campaign/cisl']
 
 
+def test_scan_directories_resource_forwards_full_filters(monkeypatch):
+    """Resource mode accepts the same filters as project mode — so the card's
+    per-user/group + histogram-band drill-downs filter identically."""
+    cap = {}
+    svc = _wire_resource_service(monkeypatch, collections=['campaign'], capture=cap)
+    svc.scan_directories_resource(
+        'Campaign_Store', owner_gid=2001, atime_recursive=False,
+        min_avg_size=10, max_avg_size=20, sort_by='size_nr')
+    kw = cap['list_kwargs']
+    assert kw['group_id'] == 2001
+    assert kw['atime_recursive'] is False
+    assert kw['min_avg_size'] == 10
+    assert kw['max_avg_size'] == 20
+    assert kw['sort_by'] == 'size_nr'
+
+
 def test_scan_directories_resource_empty_when_plugin_off(monkeypatch):
     from webapp.disk_scans import service
     monkeypatch.setattr(service, 'get_module', lambda: None)
@@ -1343,6 +1359,24 @@ def test_resource_page_200_with_perm(auth_client):
     )
     assert resp.status_code == 200
     assert 'Resource-wide' in resp.get_data(as_text=True)
+
+
+def test_resource_entities_drilldown_targets_resource_fragment(app, auth_client, monkeypatch):
+    """Whole-FS owner rows drill into the *resource* directories fragment
+    (regression: the drill must not be suppressed in resource mode)."""
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    monkeypatch.setattr(service, 'scan_owner_summary_resource', lambda r, **kw: [{
+        'owner_uid': 4242, 'total_size': 1024 ** 4, 'total_files': 5,
+        'directory_count': 2, 'filesystem': 'cisl', 'username': 'alice',
+    }])
+
+    resp = auth_client.get(f'/dashboards/user/disk-scans/resource/{_RES}/entities')
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'data-bs-toggle="collapse"' in body          # drill chevron present
+    assert 'owner_uid=4242' in body                      # carries the uid
+    assert f'/disk-scans/resource/{_RES}/directories' in body   # → resource fragment
 
 
 @pytest.mark.parametrize('endpoint', ['entities', 'access-history', 'file-sizes'])


### PR DESCRIPTION
## Summary

Surfaces the unrestricted, **whole-filesystem** scan rollup (gated by
`VIEW_ALL_FILESYSTEM_DATA`) — previously reachable only by hand-typing
`…/disk-scans/resource/<r>/explore` — as a conditional **Filesystem Scans**
tab on the Status dashboard (`/status`). One subtab per scan-capable disk
resource (Campaign_Store today; Destor is a one-line config add). Each
subtab renders the *same* card the project disk page shows — Large
Directories + User/Group entities + Access-history / File-size histograms —
but rooted over the whole filesystem, with fully working drill-downs.

Implements `docs/plans/FS_SCANS_STATUS_TAB.md`. **SAM-only — no plugin
change** (the plugin already supports `path_prefixes=None`, which is also the
cheaper whole-collection fast path).

## Graceful plugin degradation

The fs-scans backend is an optional plugin, so the whole feature degrades
cleanly when it's unavailable: `scan_capable_resources()` returns `[]` (the
tab and its subtabs disappear), and every resource route reuses the existing
`is_enabled()` guard to render the "unavailable" banner instead of erroring.

## What changed

**Service** (`disk_scans/service.py`)
- Extract mode-agnostic cores (`_owner_summary` / `_group_summary` /
  `_access_history` / `_file_sizes`); scoped wrappers + new `*_resource`
  siblings differ only in how they resolve `(mod, collections, path_prefixes)`.
- `scan_directories_resource` accepts the same full filter set as the
  project path (`owner_uid/owner_gid/atime_recursive/min_avg_size/
  max_avg_size/outermost_only`) so the whole-FS drill-downs filter identically.
- `scan_capable_resources()` — configured resources ∩ warmed collections;
  `[]` when the plugin is off. Gates the tab.

**Routes** (`disk_scans/routes.py`)
- Parameterize `entities` + `_render_distribution` on a prebuilt ctx +
  `scan_call` (mirrors the existing `_render_directories_fragment`).
- 3 new `VIEW_ALL_FILESYSTEM_DATA`-gated fragments:
  `/resource/<r>/{entities,access-history,file-sizes}`.
- Thread a mode-aware `dir_fragment_url` into the entities/distribution
  partials so the per-user / per-group / histogram-band drill-downs target
  the correct directories fragment in **both** modes.

**Templates**
- Extract the scans card into `partials/disk_scans_card.html`
  (mode-parameterized, id-namespaced); re-included from the project disk page
  (parity) and the new Status subtabs.
- Conditional tab in `status/dashboard.html` + `status/partials/filesystem_scans.html`
  (lazy `shown.bs.tab` loading).
- Entities/distribution drill-downs gate on `dir_fragment_url` (mode-aware)
  rather than `project`, so they work whole-FS as well as project-scoped.

**Config / blueprint** — `FS_SCAN_RESOURCES` list; Status `index()` passes
`fs_scan_resources`.

## Test plan

Full suite passes locally (CI runs it on this PR). New coverage:
- resource-mode service siblings forward `path_prefixes=None` (fast path) /
  `[subpath]`, enrich names, return empty when plugin off / no collections
- `scan_directories_resource` forwards the full filter set (drill-down parity)
- resource-mode entities drill targets `/resource/<r>/directories`
- `scan_capable_resources` filters unwarmed entries; `[]` when disabled
- 3× resource-route RBAC gating (403 without / 200 with the permission)
- Status tab visible only with perm AND non-empty resource list

Manual: as benkirk on `/status`, the tab shows a subtab per `FS_SCAN_RESOURCES`,
each lazy-loading the card; per-user/group and histogram-band drill-downs work;
"Open full view ↗" opens the unscoped explorer; a non-privileged user sees no
tab; project disk card behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)