### PR TITLE
Add "My Data" per-user filesystem-scan tab to the User Dashboard

### DIFF
--- a/docs/plans/MY_DATA_TAB.md
+++ b/docs/plans/MY_DATA_TAB.md
@@ -1,0 +1,311 @@
+# "My Data" — per-user filesystem-scan view on the User Dashboard
+
+## Context
+
+PR #329 (`fs_scans_status_tab`, → `staging`) added a **whole-filesystem** scans
+view as a `VIEW_ALL_FILESYSTEM_DATA`-gated "Filesystem Scans" tab on the Status
+dashboard (`/status`), one subtab per scan-capable disk resource, each rendering
+the shared `disk_scans_card.html` in `mode='resource'` (rooted over the whole
+collection, `path_prefixes=None`).
+
+This follow-up surfaces the **same card scoped to the logged-in user's own
+files** — a **"My Data"** tab on the **User Dashboard** (`/user`,
+`templates/dashboards/user/dashboard.html`), available to **every authenticated
+user** (no special permission), showing Large Directories + the Access-history
+and File-size histograms filtered to files **the user owns**. The "User / group
+counts" tab is dropped (single user). No project scoping — it cuts across all of
+the user's projects + scratch/home, i.e. their total footprint, filtered by
+ownership.
+
+**This is the recommended sequencing: merge PR #329 first, then build this on
+top of its plumbing.** It is a small, SAM-only PR. **No plugin change is
+required for v1** — owner filtering is already wired end-to-end (see below).
+
+---
+
+## Why no plugin change is needed
+
+The whole-FS PR already built owner-filterable resource service functions, and
+they are exercised today by the admin per-user drill-down. A "My Data" view is
+just **resource mode with `owner_uid` pinned to the current user and the
+entities tab hidden**:
+
+| Service fn (`disk_scans/service.py`) | owner filter | line |
+|---|---|---|
+| `scan_directories_resource(resource, owner_uid=…)` | ✓ (`owner_id=owner_uid` → facade) | ~340 |
+| `scan_access_history_resource(resource, owner_uid=…)` | ✓ | ~624 |
+| `scan_file_sizes_resource(resource, owner_uid=…)` | ✓ | ~638 |
+
+So **the service layer needs nothing new.** Cache keys already include
+`owner_uid` (`{'owner_uid': owner_uid}` in `_access_history` / `_file_sizes`;
+the directories opts dict carries it too), so each user's view caches
+independently.
+
+`User.unix_uid` exists; the routes already resolve `User ↔ unix_uid` both ways
+(`_resolve_owner`, `routes.py:194-204`).
+
+When a plugin change *would* be needed (out of scope for v1):
+- group-membership "files I can **access**" semantics (vs "files I **own**");
+- a per-owner materialized rollup, only if the on-the-fly owner-filtered
+  whole-collection scan proves too hot at login scale (cache + lazy-load should
+  prevent this).
+
+---
+
+## ⚠️ The one security-critical requirement
+
+The existing resource routes are `VIEW_ALL_FILESYSTEM_DATA`-gated **and trust
+`?owner_uid=` / `?owner_user_id=` from the query string** (`_resolve_owner`,
+`routes.py:183`; `_render_distribution` reads `request.args.get('owner_uid')`
+directly at `routes.py:665`; `_dir_filters` → `flt['owner_uid']` likewise comes
+from request args).
+
+The "My Data" routes are gated only by `@login_required`, so they **must pin
+`owner_uid = current_user.unix_uid` server-side and ignore any client-supplied
+owner param.** Otherwise any logged-in user could pass `?owner_uid=<someone
+else>` and read another person's footprint — a data leak that bypasses the
+VIEW_ALL gate.
+
+**This is the single must-get-right item, and it needs a dedicated test**
+(user A cannot read user B's data even with `?owner_uid=<B>` / `?owner_user_id=<B>`).
+
+Because the three render helpers source the owner from `request.args`, pinning
+must happen *inside* them when in user mode — see Step 2.
+
+---
+
+## Step 1 — Service (`src/webapp/disk_scans/service.py`)
+
+**No new functions.** "My Data" reuses the existing `*_resource(…, owner_uid=…)`
+fns. (Optional nicety: a one-line `scan_capable_resources()` is already present
+and reused as-is to enumerate which resources to show.)
+
+---
+
+## Step 2 — Routes (`src/webapp/disk_scans/routes.py`)
+
+Add a hardened owner source and three thin user-scoped routes. Import
+`current_user` from `flask_login` (already imports `login_required`).
+
+### 2a. `_user_ctx(resource_name)` — `_resource_ctx` analogue, owner pinned
+
+```python
+def _user_ctx(resource_name: str) -> dict:
+    """`_resource_ctx` for user mode: whole-collection, owner pinned to me.
+
+    `forced_owner_uid` is the authenticated user's unix_uid; the render
+    helpers MUST use it and ignore any ?owner_uid / ?owner_user_id. None when
+    the account has no unix_uid (caller renders the no-identity empty state).
+    """
+    ctx = _resource_ctx(resource_name)        # project=None, scope='', fileset, target_id
+    ctx['mode'] = 'user'
+    ctx['forced_owner_uid'] = getattr(current_user, 'unix_uid', None)
+    return ctx
+```
+
+### 2b. Thread `forced_owner_uid` into the three render helpers
+
+This is the hardening. Each helper currently reads owner from `request.args`;
+when `ctx.get('forced_owner_uid')` is set (or pass it explicitly), override it
+**before** scan + render, and drop `owner_user_id` so it can't re-enter:
+
+- `_render_directories_fragment`: after `flt = _dir_filters()`, if a forced uid
+  is present, `flt['owner_uid'] = forced; flt['owner_user_id'] = None`. The
+  `_scan(flt)` closure then forwards the pinned uid unchanged.
+- `_render_distribution`: replace `owner_uid = request.args.get('owner_uid', type=int)`
+  (line 665) with `owner_uid = forced if forced is not None else request.args.get('owner_uid', type=int)`.
+- `_render_entities`: not used by the card (entities tab hidden in user mode),
+  but harden it the same way for defense-in-depth if you wire it at all.
+
+Prefer an explicit `forced_owner_uid=None` kwarg on each helper over reading it
+out of `ctx` implicitly — it makes the security contract visible at every call
+site. The project/resource routes pass nothing (unchanged behavior).
+
+### 2c. Three new routes — `@login_required` ONLY (no `require_permission`)
+
+Mirror the `*_resource_fragment` routes but: ctx via `_user_ctx`, `_scan`
+closes over the `*_resource(…, owner_uid=current_user.unix_uid)` fns, and the
+`dir_fragment_url` points at the **user** directories fragment.
+
+```
+GET /user/directories           → directories_user_fragment
+GET /user/access-history         → access_history_user_fragment
+GET /user/file-sizes             → file_sizes_user_fragment
+GET /user/explore                → directories_user_page   (full view)
+```
+
+(URL stems are suggestions; the blueprint `url_prefix` is
+`/dashboards/user/disk-scans`. Avoid colliding with the existing
+`/<projcode>/…` project routes — `/user/…` and `/resource/…` are both safe
+static prefixes since a projcode is matched as `<projcode>`. Double-check Flask
+route ordering / converter ambiguity vs `/<projcode>/directories`; if it
+collides, use a distinct stem like `/me/directories`.)
+
+Empty-state: when `forced_owner_uid is None` (account has no unix_uid), short-
+circuit each fragment to render the partial's disabled/empty branch with a
+"No filesystem identity on record" message rather than running an unfiltered
+scan.
+
+### 2d. User explorer "full view" page
+
+`directories_user_page` mirrors `directories_resource_page` BUT:
+- ctx via `_user_ctx`; force `flt['owner_uid']` before `_initial_fragment_url`
+  so the initial table load is owner-pinned;
+- **hide the owner user-picker** in the filter panel (a user can't filter by a
+  different owner). The page template (`disk_scans_directories_page.html`)
+  needs a `mode='user'` branch that omits the `user_search_url` picker. Confirm
+  no other filter-panel control lets the owner be changed.
+
+---
+
+## Step 3 — Card template (`templates/dashboards/user/partials/disk_scans_card.html`)
+
+Add `mode == 'user'` to the existing `project`/`resource` branch (top of file,
+the `{% set _*_url %}` block):
+
+```jinja
+{% elif mode == 'user' %}
+    {% set _dirs_url  = url_for('disk_scans.directories_user_fragment',   target_id=cid ~ '-directories') %}
+    {% set _acc_url   = url_for('disk_scans.access_history_user_fragment', target_id=cid ~ '-access') %}
+    {% set _files_url = url_for('disk_scans.file_sizes_user_fragment',    target_id=cid ~ '-files') %}
+    {% set _full_url  = url_for('disk_scans.directories_user_page') %}
+    {# no _ent_url — entities tab hidden #}
+```
+
+Wrap the **"User / group counts"** `<li>` (lines ~50-60) and its pane (lines
+~100-106) in `{% if mode != 'user' %}…{% endif %}`. The remaining 3 tabs are
+unchanged. (`resource_name` is irrelevant in user mode — the routes take no
+resource — but the card's other params still apply.)
+
+Card params in user mode: `mode='user'`, `cid`, `tablist_id`, `load_trigger`.
+No `projcode`/`scope`/`fileset`/`resource_name` needed.
+
+---
+
+## Step 4 — "My Data" tab on the User Dashboard
+
+`templates/dashboards/user/dashboard.html` currently has two tabs (`dashboardTabs`):
+*My Accounts* (active) and *User Information* (`#user-info-tab`, lines 25-29 /
+pane 72-80). Add **after User Information**:
+
+```jinja
+<li class="nav-item">
+    <a class="nav-link" id="my-data-tab" data-bs-toggle="tab" href="#my-data" role="tab">
+        <i class="fas fa-hard-drive"></i> My Data
+    </a>
+</li>
+```
+and the pane (after the User Information pane, before `</div><!-- End Tab Content -->`):
+
+```jinja
+<div class="tab-pane fade" id="my-data" role="tabpanel">
+    {% if my_data_available %}
+        {% with mode='user', cid='my-data', tablist_id='myDataTabs',
+                load_trigger='shown.bs.tab once from:#my-data-tab' %}
+            {% include 'dashboards/user/partials/disk_scans_card.html' %}
+        {% endwith %}
+    {% else %}
+        <div class="alert alert-info"><i class="fas fa-info-circle"></i>
+            Filesystem-scan data is unavailable for your account.</div>
+    {% endif %}
+</div>
+```
+
+`load_trigger='shown.bs.tab once from:#my-data-tab'`: the card's first inner tab
+loads when the My Data tab is shown (single card, no nested-subtab gymnastics —
+simpler than the Status tab's first-subtab case).
+
+**Visibility gate** — show the tab only when scans are enabled AND the user has a
+unix_uid AND at least one scan-capable resource is warmed. In the user-dashboard
+blueprint (`webapp/dashboards/user/blueprint.py`, the `/user` index handler that
+renders `dashboard.html`):
+
+```python
+from webapp.disk_scans import service as disk_scans_service
+...
+my_data_available = bool(
+    getattr(current_user, 'unix_uid', None) is not None
+    and disk_scans_service.scan_capable_resources()
+)
+```
+Pass `my_data_available` to `render_template`, and gate **both** the nav `<li>`
+and the pane on it (`{% if my_data_available %}`), mirroring the Status tab's
+`{% if fs_scan_resources and has_permission(...) %}` pattern. Plugin off →
+`scan_capable_resources()` is `[]` → tab hidden (graceful degradation, the
+constraint from PR #329).
+
+> **Note on multiple resources:** the user view is *not* per-resource-subtab'd —
+> "My Data" routes take no `resource`. If "my files across **each** filesystem"
+> is wanted later, either add a resource subtab strip here (like the Status tab)
+> with `mode='user'` cards that DO carry a resource, or have the user service
+> fns aggregate across all `scan_capable_resources()`. v1: single card, queried
+> over whichever collection(s) the resource fns default to — **decide and
+> document which resource(s) v1 covers** (likely Campaign_Store, matching
+> `FS_SCAN_RESOURCES`). If v1 must cover all warmed resources in one card, that
+> aggregation is the one place a small service addition (loop the resource fns,
+> merge histograms/dir rows) may be warranted — still SAM-side, no plugin change.
+
+---
+
+## Step 5 — Tests
+
+`tests/unit/test_webapp_disk_scans.py`:
+- **Security (critical):** as a logged-in non-admin user A, GET each user
+  fragment with `?owner_uid=<B>` and `?owner_user_id=<B's user_id>` → assert the
+  scan was called with A's unix_uid, never B's. (Spy on the `*_resource` service
+  fns / fake module, as the existing `_wire_resource_*` helpers do.)
+- Each user route is reachable by a plain `auth_client` **without**
+  `VIEW_ALL_FILESYSTEM_DATA` (contrast the resource routes' 403 test).
+- `forced_owner_uid is None` (user with no unix_uid) → empty/disabled state, no
+  scan call.
+- Entities route is NOT exposed in user mode (no `entities_user_fragment`), and
+  the card omits the tab.
+
+`tests/integration/test_status_dashboard.py` / a user-dashboard test:
+- "My Data" tab renders when `my_data_available` (monkeypatch
+  `scan_capable_resources` → `['Campaign_Store']`, ensure the test user has a
+  unix_uid — `benkirk` is preserved in the obfuscated DB, see
+  `project_test_db_fixtures`); absent when plugin off or user has no unix_uid.
+
+---
+
+## Key files
+
+| File | Change |
+|---|---|
+| `src/webapp/disk_scans/service.py` | **none** (reuse `*_resource(…, owner_uid=…)`); possibly an all-resource aggregator if v1 spans resources |
+| `src/webapp/disk_scans/routes.py` | `_user_ctx`; `forced_owner_uid` hardening in the 3 render helpers; 3 `@login_required` user fragments + `directories_user_page` |
+| `templates/.../user/partials/disk_scans_card.html` | `mode='user'` URL branch; hide entities tab |
+| `templates/.../user/disk_scans_directories_page.html` | `mode='user'` branch — hide owner picker, pin owner |
+| `templates/.../user/dashboard.html` | "My Data" nav-tab + pane (gated on `my_data_available`) |
+| `src/webapp/dashboards/user/blueprint.py` | compute + pass `my_data_available` |
+| `tests/unit/test_webapp_disk_scans.py` | own-data-only enforcement + login_required-only + empty state |
+| `tests/integration/test_status_dashboard.py` (or user-dashboard test) | tab visibility |
+
+## Gotchas
+
+- **Owner pinning is server-side and overrides request args in all three render
+  helpers** — this is the whole security story. Test it explicitly.
+- **Route collision:** new static prefixes (`/user/…`) must not be shadowed by
+  the existing `/<projcode>/…` converter routes; verify, or use `/me/…`.
+- **No-unix_uid accounts** (admin/service): empty state, never an unfiltered scan.
+- **Explorer page owner picker** must be hidden in user mode (else a user could
+  re-filter to another owner there).
+- **Webdev watch-sync:** after `webdev` restart, re-`touch` edited files to
+  force `develop.watch` sync (no source bind-mount).
+- **Semantics copy:** label it "files you own" — not "everything you can access"
+  and not "your project allocation." Matches the admin drill-down's attribution.
+
+## Verification
+
+1. `source etc/config_env.sh && pytest tests/unit/test_webapp_disk_scans.py
+   tests/integration/test_status_dashboard.py -v` then full `pytest` (~65s).
+2. Manual (`docker compose up webdev --watch`, logged in as `benkirk`):
+   - `/user` → "My Data" tab present; card lazy-loads on tab show; 3 tabs
+     (Large directories / Access history / File sizes), NO entities tab.
+   - Data is scoped to benkirk's owned files; band → directories drill stays
+     user-scoped; "Open full view ↗" page is owner-pinned with no owner picker.
+   - **Tamper test:** hit `…/disk-scans/user/directories?owner_uid=<other>` →
+     still benkirk's data.
+   - A Quick-Login user with no unix_uid: tab hidden (or empty state).
+3. PR vs `staging` (`gh pr create --base staging`).

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -92,6 +92,18 @@ def index():
 
     available_groups = _available_primary_groups(db.session, user_to_display.username)
 
+    # "My Data" tab — per-user filesystem-scan card (one subtab per warmed disk
+    # resource). Available to every authenticated user (no permission gate); the
+    # scan owner is pinned to the user's unix_uid server-side in disk_scans
+    # routes. Hidden when the fs-scans plugin is off / no resource is warmed, or
+    # when the account has no filesystem identity (unix_uid). fs_scan_resources
+    # also feeds the subtab strip in my_data_scans.html.
+    fs_scan_resources = disk_scans_service.scan_capable_resources()
+    my_data_available = bool(
+        getattr(user_to_display, 'unix_uid', None) is not None
+        and fs_scan_resources
+    )
+
     return render_template(
         'dashboards/user/dashboard.html',
         user=user_to_display,
@@ -105,7 +117,9 @@ def index():
         can_edit_primary_gid=True,   # user is editing their own
         usage_warning_threshold=USAGE_WARNING_THRESHOLD,
         usage_critical_threshold=USAGE_CRITICAL_THRESHOLD,
-        impersonator_id=impersonator_id
+        impersonator_id=impersonator_id,
+        my_data_available=my_data_available,
+        fs_scan_resources=fs_scan_resources,
     )
 
 

--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -369,8 +369,10 @@ def _user_ctx(resource_name: str) -> dict:
     ``unix_uid`` — the fragments then render the no-identity empty state rather
     than running an unfiltered (whole-resource) scan.
     """
+    # NB: don't stash 'mode' here — the render helpers build their template
+    # context as ``dict(..., mode=mode, **ctx)`` and would get a duplicate
+    # 'mode' keyword. Callers pass mode='user' explicitly instead.
     ctx = _resource_ctx(resource_name)
-    ctx['mode'] = 'user'
     ctx['forced_owner_uid'] = getattr(current_user, 'unix_uid', None)
     return ctx
 

--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -676,7 +676,7 @@ def _render_distribution(ctx, fragment_url, *, scan_call, kind,
     if not metric_toggle or metric not in _METRIC_WHITELIST:
         metric = 'data'
     log_on = log_toggle and _truthy(request.args.get('log'))
-    extra = dict(metric=metric, metric_toggle=metric_toggle,
+    extra = dict(kind=kind, metric=metric, metric_toggle=metric_toggle,
                  log_on=log_on, log_toggle=log_toggle,
                  bucket_header=bucket_header, fragment_url=fragment_url,
                  dir_fragment_url=dir_fragment_url)

--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -33,7 +33,7 @@ from typing import Optional, Tuple
 from urllib.parse import urlencode
 
 from flask import Blueprint, current_app, render_template, request, url_for
-from flask_login import login_required
+from flask_login import current_user, login_required
 
 from sam.core.users import User
 from sam.projects.projects import Project
@@ -358,8 +358,25 @@ def _resource_ctx(resource_name: str) -> dict:
     }
 
 
+def _user_ctx(resource_name: str) -> dict:
+    """``_resource_ctx`` for user mode: whole-collection, owner pinned to me.
+
+    ``forced_owner_uid`` is the authenticated user's ``unix_uid``; the render
+    helpers MUST use it and ignore any ``?owner_uid`` / ``?owner_user_id`` from
+    the query string (these routes are ``@login_required`` only, not
+    ``VIEW_ALL_FILESYSTEM_DATA``-gated, so trusting a client-supplied owner
+    would leak another user's footprint). ``None`` when the account has no
+    ``unix_uid`` — the fragments then render the no-identity empty state rather
+    than running an unfiltered (whole-resource) scan.
+    """
+    ctx = _resource_ctx(resource_name)
+    ctx['mode'] = 'user'
+    ctx['forced_owner_uid'] = getattr(current_user, 'unix_uid', None)
+    return ctx
+
+
 def _render_directories_fragment(ctx, fragment_url, *, mode, scan_call,
-                                 log_label, browse=False):
+                                 log_label, browse=False, forced_owner_uid=None):
     """Shared body for the project + resource directory fragments.
 
     Both render the *same* ``disk_scans_directories.html`` partial; they differ
@@ -369,6 +386,11 @@ def _render_directories_fragment(ctx, fragment_url, *, mode, scan_call,
     drill-down (clickable rows + ancestry breadcrumb), explorer-page only.
     """
     flt = _dir_filters()
+    # User mode: pin the owner server-side and drop any client-supplied owner so
+    # it can't re-enter via _scan / the breadcrumb. See _user_ctx.
+    if forced_owner_uid is not None:
+        flt['owner_uid'] = forced_owner_uid
+        flt['owner_user_id'] = None
     breadcrumb_items = (_dir_breadcrumb(mode, ctx, fragment_url, flt)
                         if browse and is_enabled() else None)
     base = dict(
@@ -521,7 +543,8 @@ def directories_resource_page(resource):
     )
 
 
-def _render_entities(ctx, fragment_url, *, scan_call, log_label, dir_fragment_url):
+def _render_entities(ctx, fragment_url, *, scan_call, log_label, dir_fragment_url,
+                     forced_owner_uid=None):
     """Shared body for the project + resource entity (owner|group) fragments.
 
     Both render the *same* ``disk_scans_entities.html`` partial; they differ
@@ -627,7 +650,8 @@ _METRIC_WHITELIST = {'data', 'files'}
 
 def _render_distribution(ctx, fragment_url, *, scan_call, kind,
                          bucket_header, log_label, dir_fragment_url,
-                         metric_toggle=False, log_toggle=False):
+                         metric_toggle=False, log_toggle=False,
+                         forced_owner_uid=None):
     """Shared body for the two distribution histogram fragments (both modes).
 
     The Access-history and File-size tabs are identical end to end — same
@@ -662,7 +686,10 @@ def _render_distribution(ctx, fragment_url, *, scan_call, kind,
             enabled=is_enabled(), error=None, **ctx, **extra,
         )
 
-    owner_uid = request.args.get('owner_uid', type=int)
+    # User mode pins the owner server-side (forced_owner_uid); ignore any
+    # client-supplied ?owner_uid in that case. See _user_ctx.
+    owner_uid = (forced_owner_uid if forced_owner_uid is not None
+                 else request.args.get('owner_uid', type=int))
     hist, chart_svg, error = None, None, None
     try:
         hist = scan_call(owner_uid, ctx['fileset'])
@@ -783,4 +810,131 @@ def file_sizes_resource_fragment(resource):
         dir_fragment_url=url_for('disk_scans.directories_resource_fragment',
                                  resource=resource),
         metric_toggle=True, log_toggle=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# User mode — "My Data": the resource card scoped to the logged-in user's own
+# files. @login_required ONLY (no VIEW_ALL_FILESYSTEM_DATA), so the owner is
+# pinned server-side to current_user.unix_uid via _user_ctx + the render
+# helpers' forced_owner_uid; any client-supplied ?owner_uid / ?owner_user_id is
+# ignored. No entities (owner|group) route — a single-owner view needs no
+# per-owner rollup, and the card hides that tab in user mode.
+# ---------------------------------------------------------------------------
+
+
+def _no_identity_fragment():
+    """Empty state for a user with no ``unix_uid`` — never runs a scan."""
+    return render_template(
+        'dashboards/user/partials/disk_scans_no_identity.html')
+
+
+@bp.route('/user/<resource>/directories')
+@login_required
+def directories_user_fragment(resource):
+    """HTMX fragment: largest directories the logged-in user OWNS on *resource*."""
+    ctx = _user_ctx(resource)
+    forced = ctx['forced_owner_uid']
+    if forced is None:
+        return _no_identity_fragment()
+    fragment_url = url_for('disk_scans.directories_user_fragment',
+                           resource=resource)
+
+    def _scan(flt):
+        return service.scan_directories_resource(
+            ctx['resource_name'], subpath=ctx['fileset'],
+            sort_by=flt['sort_by'], limit=flt['limit'],
+            owner_uid=flt['owner_uid'],
+            owner_gid=flt['owner_gid'],
+            accessed_before=flt['accessed_before'],
+            accessed_after=flt['accessed_after'],
+            atime_recursive=flt['atime_recursive'],
+            min_avg_size=flt['min_avg_size'],
+            max_avg_size=flt['max_avg_size'],
+            outermost_only=flt['outermost'],
+            leaves_only=flt['leaves_only'],
+        )
+
+    return _render_directories_fragment(
+        ctx, fragment_url, mode='user', scan_call=_scan,
+        log_label=f'user-owned uid={forced}',
+        browse=_truthy(request.args.get('browse')),
+        forced_owner_uid=forced,
+    )
+
+
+@bp.route('/user/<resource>/explore')
+@login_required
+def directories_user_page(resource):
+    """Standalone full-page directory explorer for the user's OWN files.
+
+    User mode — same page template as project/resource mode, parameterized by
+    ``mode='user'`` + the user fragment URL. The owner is pinned to the logged-in
+    user and the owner picker is hidden (``mode='user'`` in the filter panel), so
+    the explorer can't be re-filtered to another owner.
+    """
+    ctx = _user_ctx(resource)
+    forced = ctx['forced_owner_uid']
+    if forced is None:
+        return _no_identity_fragment()
+    flt = _dir_filters()
+    flt['owner_uid'] = forced
+    flt['owner_user_id'] = None
+    fragment_url = url_for('disk_scans.directories_user_fragment',
+                           resource=resource)
+    return render_template(
+        'dashboards/user/disk_scans_directories_page.html',
+        mode='user', fragment_url=fragment_url,
+        initial_url=_initial_fragment_url(fragment_url, ctx, flt, browse=True),
+        filters=flt, user_search_url=None,
+        limit_options=_LIMIT_OPTIONS, browse=True, **ctx,
+    )
+
+
+@bp.route('/user/<resource>/access-history')
+@login_required
+def access_history_user_fragment(resource):
+    """HTMX fragment: access-time histogram of the user's OWN files on *resource*."""
+    ctx = _user_ctx(resource)
+    forced = ctx['forced_owner_uid']
+    if forced is None:
+        return _no_identity_fragment()
+    fragment_url = url_for('disk_scans.access_history_user_fragment',
+                           resource=resource)
+
+    def _scan(owner_uid, subpath):
+        return service.scan_access_history_resource(
+            ctx['resource_name'], owner_uid=owner_uid, subpath=subpath)
+
+    return _render_distribution(
+        ctx, fragment_url, scan_call=_scan, kind='access_history',
+        bucket_header='Last accessed', log_label=f'user-owned uid={forced}',
+        dir_fragment_url=url_for('disk_scans.directories_user_fragment',
+                                 resource=resource),
+        forced_owner_uid=forced,
+    )
+
+
+@bp.route('/user/<resource>/file-sizes')
+@login_required
+def file_sizes_user_fragment(resource):
+    """HTMX fragment: file-size histogram of the user's OWN files on *resource*."""
+    ctx = _user_ctx(resource)
+    forced = ctx['forced_owner_uid']
+    if forced is None:
+        return _no_identity_fragment()
+    fragment_url = url_for('disk_scans.file_sizes_user_fragment',
+                           resource=resource)
+
+    def _scan(owner_uid, subpath):
+        return service.scan_file_sizes_resource(
+            ctx['resource_name'], owner_uid=owner_uid, subpath=subpath)
+
+    return _render_distribution(
+        ctx, fragment_url, scan_call=_scan, kind='file_sizes',
+        bucket_header='File size', log_label=f'user-owned uid={forced}',
+        dir_fragment_url=url_for('disk_scans.directories_user_fragment',
+                                 resource=resource),
+        metric_toggle=True, log_toggle=True,
+        forced_owner_uid=forced,
     )

--- a/src/webapp/templates/dashboards/user/dashboard.html
+++ b/src/webapp/templates/dashboards/user/dashboard.html
@@ -27,6 +27,13 @@
             <i class="fas fa-user-circle"></i> User Information
         </a>
     </li>
+    {% if my_data_available %}
+    <li class="nav-item">
+        <a class="nav-link" id="my-data-tab" data-bs-toggle="tab" href="#my-data" role="tab">
+            <i class="fas fa-hard-drive"></i> My Data
+        </a>
+    </li>
+    {% endif %}
 </ul>
 
 <!-- Tab Content -->
@@ -78,6 +85,14 @@
                             can_edit_primary_gid=can_edit_primary_gid) }}
     </div>
     <!-- End User Information Tab -->
+
+    {% if my_data_available %}
+    <!-- My Data Tab -->
+    <div class="tab-pane fade" id="my-data" role="tabpanel">
+        {% include 'dashboards/user/partials/my_data_scans.html' %}
+    </div>
+    <!-- End My Data Tab -->
+    {% endif %}
 </div>
 <!-- End Tab Content -->
 

--- a/src/webapp/templates/dashboards/user/disk_scans_directories_page.html
+++ b/src/webapp/templates/dashboards/user/disk_scans_directories_page.html
@@ -25,6 +25,9 @@
       {% if mode == 'resource' %}
         {{ resource_name }}
         <small class="text-muted fw-normal">— all directories</small>
+      {% elif mode == 'user' %}
+        My Data
+        <small class="text-muted fw-normal">— files you own on {{ resource_name }}</small>
       {% else %}
         {{ scoped_project.projcode if scoped_project else project.projcode }}
         <small class="text-muted fw-normal">directories on {{ resource_name }}</small>
@@ -89,7 +92,7 @@
   <div class="filter-sidebar mb-3">
     {{ dir_filters('disk-scans-filters-' ~ target_id, fragment_url, target_id,
                    filters, user_search_url, resource_name, scope, fileset,
-                   limit_options) }}
+                   limit_options, mode=mode) }}
   </div>
 
   <div class="card">

--- a/src/webapp/templates/dashboards/user/partials/_disk_scans_dir_filters.html
+++ b/src/webapp/templates/dashboards/user/partials/_disk_scans_dir_filters.html
@@ -21,7 +21,7 @@
   resolves it to the unix UID the scan data is keyed on (see _resolve_owner).
 #}
 {% macro dir_filters(form_id, fragment_url, target_id, filters, user_search_url,
-                     resource_name, scope, fileset, limit_options) %}
+                     resource_name, scope, fileset, limit_options, mode='project') %}
 <form id="{{ form_id }}"
       hx-get="{{ fragment_url }}"
       hx-target="#{{ target_id }}"
@@ -59,6 +59,10 @@
              style="width:160px;">
     </div>
 
+    {# User mode ("My Data") pins the owner to the logged-in user server-side,
+       so the owner picker is omitted — it must not be possible to re-filter the
+       explorer to another owner here. #}
+    {% if mode != 'user' %}
     <div style="min-width:240px;">
       {# optional_text='' — drops the muted "(optional)" hint, which is both
          redundant on a filter and low-contrast on the navy panel. #}
@@ -69,6 +73,7 @@
                          selected_label=filters.owner_label or '',
                          label_class='form-label') }}
     </div>
+    {% endif %}
 
     <div class="form-check form-switch align-self-center mb-2">
       <input class="form-check-input" type="checkbox" role="switch"

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_card.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_card.html
@@ -28,6 +28,12 @@
     {% set _acc_url   = url_for('disk_scans.access_history_resource_fragment', resource=resource_name, target_id=cid ~ '-access') %}
     {% set _files_url = url_for('disk_scans.file_sizes_resource_fragment',    resource=resource_name, target_id=cid ~ '-files') %}
     {% set _full_url  = url_for('disk_scans.directories_resource_page',       resource=resource_name) %}
+{% elif mode == 'user' %}
+    {% set _dirs_url  = url_for('disk_scans.directories_user_fragment',     resource=resource_name, target_id=cid ~ '-directories') %}
+    {% set _acc_url   = url_for('disk_scans.access_history_user_fragment',  resource=resource_name, target_id=cid ~ '-access') %}
+    {% set _files_url = url_for('disk_scans.file_sizes_user_fragment',      resource=resource_name, target_id=cid ~ '-files') %}
+    {% set _full_url  = url_for('disk_scans.directories_user_page',         resource=resource_name) %}
+    {# no _ent_url — the User / group counts tab is hidden in user mode #}
 {% else %}
     {% set _dirs_url  = url_for('disk_scans.directories_fragment',     projcode=projcode, resource=resource_name, scope=scope, fileset=fileset, target_id=cid ~ '-directories') %}
     {% set _ent_url   = url_for('disk_scans.entities_fragment',        projcode=projcode, resource=resource_name, scope=scope, fileset=fileset, target_id=cid ~ '-entities') %}
@@ -47,6 +53,7 @@
             <i class="fas fa-folder-tree me-1"></i> Large directories
         </button>
     </li>
+    {% if mode != 'user' %}
     <li class="nav-item" role="presentation">
         <button class="nav-link" id="{{ cid }}-ent-tab"
                 data-bs-toggle="tab" data-bs-target="#tab-{{ cid }}-ent"
@@ -58,6 +65,7 @@
             <i class="fas fa-users me-1"></i> User / group counts
         </button>
     </li>
+    {% endif %}
     <li class="nav-item" role="presentation">
         <button class="nav-link" id="{{ cid }}-acc-tab"
                 data-bs-toggle="tab" data-bs-target="#tab-{{ cid }}-acc"
@@ -97,6 +105,7 @@
             </p>
         </div>
     </div>
+    {% if mode != 'user' %}
     <div class="tab-pane fade" id="tab-{{ cid }}-ent" role="tabpanel">
         <div id="{{ cid }}-entities">
             <p class="text-muted small mb-0">
@@ -104,6 +113,7 @@
             </p>
         </div>
     </div>
+    {% endif %}
     <div class="tab-pane fade" id="tab-{{ cid }}-acc" role="tabpanel">
         <div id="{{ cid }}-access">
             <p class="text-muted small mb-0">

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
@@ -130,8 +130,8 @@
        accessed if any of its contents was). #}
     <p class="text-muted small fst-italic mb-2">
       <i class="fas fa-circle-info me-1"></i>
-      Note: results are computed by directory volume and grouped by most recent
-      contents access (individual files are not tracked).
+      Note: results are computed by directory and grouped by most recent access
+      (individual files are not tracked).
     </p>
   {% endif %}
   <div class="chart-container">

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
@@ -114,6 +114,16 @@
     {% endif %}
   </div>
 
+  {% if kind == 'file_sizes' %}
+    {# File-size bands are derived from each directory's average file size
+       (total bytes / file count), not from per-file stats — the scan does not
+       track individual files. Make that approximation explicit. #}
+    <p class="text-muted small fst-italic mb-2">
+      <i class="fas fa-circle-info me-1"></i>
+      Note: results are approximate, computed as average file sizes per
+      directory (individual files are not tracked).
+    </p>
+  {% endif %}
   <div class="chart-container">
     {{ chart_svg | safe }}
   </div>

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
@@ -122,6 +122,16 @@
      the owners dict (uid → {data, files}) is already on the histogram, so
      this is a pure client-side expand, mirroring the jobs table pattern. #}
   {% set umap = hist.username_map or {} %}
+  {# Fold the Owners column when no band has more than one owner (uniformly 1 —
+     e.g. the owner-pinned "My Data" view — or uniformly 0): the count carries
+     no signal and is pure noise. Shown as soon as any band has ≥2 owners.
+     Mirrors the directories table's all-zero Subdirs fold. #}
+  {% set _ns_owners = namespace(multi=false) %}
+  {% for _lbl in hist.bucket_labels %}
+    {% if (hist.buckets.get(_lbl, {}).get('owners') or {}) | length > 1 %}{% set _ns_owners.multi = true %}{% endif %}
+  {% endfor %}
+  {% set _show_owners = _ns_owners.multi %}
+  {% set _cols = 5 if _show_owners else 4 %}
   <div class="table-responsive mt-3">
     <table class="table table-sm table-hover align-middle mb-0">
       <thead class="table-light">
@@ -130,7 +140,7 @@
           <th>{{ bucket_header or 'Bucket' }}</th>
           <th class="text-end">Data</th>
           <th class="text-end">Files</th>
-          <th class="text-end">Owners</th>
+          {% if _show_owners %}<th class="text-end">Owners</th>{% endif %}
         </tr>
       </thead>
       <tbody>
@@ -167,14 +177,14 @@
             <td>{{ label }}</td>
             <td class="text-end font-monospace">{{ b_data | fmt_size }}</td>
             <td class="text-end">{{ b_files | fmt_number }}</td>
-            <td class="text-end">{{ owners | length | fmt_number }}</td>
+            {% if _show_owners %}<td class="text-end">{{ owners | length | fmt_number }}</td>{% endif %}
           </tr>
           {% if _direct %}
             {# Exactly one owner → drill straight to their directories. #}
             {% set _uid = owners | list | first %}
             {% set _uname = umap.get(_uid) or umap.get(_uid | string) or ('uid ' ~ _uid) %}
             <tr class="collapse" id="{{ rowid }}">
-              <td colspan="5" class="p-0 border-0">
+              <td colspan="{{ _cols }}" class="p-0 border-0">
                 {{ dir_drill(rowid ~ '-d1', _uid, _uname, b, _date_band,
                              resource_name, scope, dir_fragment_url) }}
               </td>
@@ -184,7 +194,7 @@
                table order matches the stacked bar. #}
             {% set ranked = owners.items() | sort(attribute='1.' ~ _metric, reverse=true) %}
             <tr class="collapse" id="{{ rowid }}">
-              <td colspan="5" class="bg-light">
+              <td colspan="{{ _cols }}" class="bg-light">
                 <div class="small text-muted mb-1">
                   Top users by {{ 'files' if _by_files else 'data' }} in <strong>{{ label }}</strong>
                   ({{ owners | length | fmt_number }} total)

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
@@ -123,6 +123,16 @@
       Note: results are approximate, computed as average file sizes per
       directory (individual files are not tracked).
     </p>
+  {% elif kind == 'access_history' %}
+    {# Access-history bands sum each directory's data volume, bucketed by the
+       most recent access time across the directory's contents — the scan does
+       not track individual files (so a directory's cold data counts as recently
+       accessed if any of its contents was). #}
+    <p class="text-muted small fst-italic mb-2">
+      <i class="fas fa-circle-info me-1"></i>
+      Note: results are computed by directory volume and grouped by most recent
+      contents access (individual files are not tracked).
+    </p>
   {% endif %}
   <div class="chart-container">
     {{ chart_svg | safe }}

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_distribution.html
@@ -18,6 +18,25 @@
 {% set _metric = metric or 'data' %}
 {% set _by_files = (_metric == 'files') %}
 
+{# Lazy-loaded directory drill for one owner within one band — non-recursive
+   (own files) to match the bar, filtered by the band's window: access-history
+   bands carry a date window (accessed_before/after); file-size bands carry an
+   avg-own-file-size window (size_min/size_max, last band open-ended). Shared by
+   the multi-owner per-user rows and the single-owner band row (where the
+   per-user table is skipped — there's only one user). Binds to
+   shown.bs.collapse so it fires under nav restore. #}
+{% macro dir_drill(dt_id, uid, uname, b, date_band, resource_name, scope, dir_fragment_url) %}
+<div class="p-2 bg-light" id="{{ dt_id }}"
+     hx-get="{{ dir_fragment_url }}?owner_uid={{ uid }}&resource={{ resource_name }}{% if scope %}&scope={{ scope }}{% endif %}{% if date_band %}{% if b.get('accessed_after') %}&accessed_after={{ b.accessed_after }}{% endif %}&accessed_before={{ b.accessed_before }}{% else %}&min_avg_size={{ b.size_min }}{% if b.get('size_max') is not none %}&max_avg_size={{ b.size_max }}{% endif %}{% endif %}&recursive=0&sort_by=size_nr&limit=25&target_id={{ dt_id }}"
+     hx-trigger="shown.bs.collapse from:closest tr.collapse once"
+     hx-swap="innerHTML">
+  <p class="text-muted small mb-0">
+    <i class="fas fa-spinner fa-spin me-1"></i>
+    Loading {{ uname }}'s directories…
+  </p>
+</div>
+{% endmacro %}
+
 {% if not enabled %}
   {{ scans_disabled() }}
 {% elif error %}
@@ -121,13 +140,27 @@
           {% set b_data = b.get('data', 0) or 0 %}
           {% set b_files = b.get('files', 0) or 0 %}
           {% set rowid = (target_id or 'ah') ~ '-ah' ~ loop.index %}
-          <tr {% if owners %}class="cursor-pointer"
+          {# Band drill window (same for every owner in the band): access-history
+             bands carry a date window, file-size bands an avg-size window. The
+             one-user shortcut — when a band has exactly one owner AND a drill
+             window, skip the (one-row) per-user table and expand the band row
+             straight to that owner's directories (less friction in single-owner
+             views like "My Data"). Any other band keeps the per-user table,
+             unchanged: ≥2 owners, or a lone owner with no window (still listed,
+             just not drillable). #}
+          {% set _date_band = b.get('accessed_before') %}
+          {% set _size_band = (b.get('size_min') is not none) or (b.get('size_max') is not none) %}
+          {% set _band_window = (_date_band or _size_band) and dir_fragment_url %}
+          {% set _single = (owners | length == 1) %}
+          {% set _direct = _single and _band_window %}
+          {% set _expandable = owners %}
+          <tr {% if _expandable %}class="cursor-pointer"
                 data-ah-bucket="{{ loop.index0 }}"
                 data-bs-toggle="collapse" data-bs-target="#{{ rowid }}"
                 aria-expanded="false" aria-controls="{{ rowid }}"
-                title="Show top users in this bucket"{% endif %}>
+                title="{{ 'Show directories in this band' if _direct else 'Show top users in this bucket' }}"{% endif %}>
             <td class="text-center p-0">
-              {% if owners %}
+              {% if _expandable %}
                 <i class="fas fa-chevron-right small collapse-icon text-muted"></i>
               {% endif %}
             </td>
@@ -136,7 +169,17 @@
             <td class="text-end">{{ b_files | fmt_number }}</td>
             <td class="text-end">{{ owners | length | fmt_number }}</td>
           </tr>
-          {% if owners %}
+          {% if _direct %}
+            {# Exactly one owner → drill straight to their directories. #}
+            {% set _uid = owners | list | first %}
+            {% set _uname = umap.get(_uid) or umap.get(_uid | string) or ('uid ' ~ _uid) %}
+            <tr class="collapse" id="{{ rowid }}">
+              <td colspan="5" class="p-0 border-0">
+                {{ dir_drill(rowid ~ '-d1', _uid, _uname, b, _date_band,
+                             resource_name, scope, dir_fragment_url) }}
+              </td>
+            </tr>
+          {% elif _expandable %}
             {# Sort the per-user breakdown by the active chart metric so the
                table order matches the stacked bar. #}
             {% set ranked = owners.items() | sort(attribute='1.' ~ _metric, reverse=true) %}
@@ -161,25 +204,16 @@
                     {% for uid, stats in ranked[:10] %}
                       {% set dpct = (100.0 * stats.get('data', 0) / b_data) if b_data else 0 %}
                       {% set fpct = (100.0 * stats.get('files', 0) / b_files) if b_files else 0 %}
-                      {# Drill one level deeper: this user's directories in this
-                         band. The service tags access-history bands with a date
-                         window (accessed_before) and file-size bands with an
-                         avg-size window (size_min/size_max); either makes the row
-                         expandable, filtering directories by the matching
-                         dimension (date range vs average own-file size). #}
                       {% set _uname = umap.get(uid) or umap.get(uid | string) or ('uid ' ~ uid) %}
-                      {% set _date_band = b.get('accessed_before') %}
-                      {% set _size_band = (b.get('size_min') is not none) or (b.get('size_max') is not none) %}
-                      {% set _has_dd = (_date_band or _size_band) and dir_fragment_url %}
                       {% set _urow = rowid ~ '-u' ~ loop.index %}
                       {% set _dt = rowid ~ '-d' ~ loop.index %}
-                      <tr {% if _has_dd %}class="cursor-pointer" data-bs-toggle="collapse"
+                      <tr {% if _band_window %}class="cursor-pointer" data-bs-toggle="collapse"
                             data-bs-target="#{{ _urow }}" aria-expanded="false"
                             aria-controls="{{ _urow }}"
                             title="Show this user's directories in this band"{% endif %}>
                         <td class="text-end text-muted">{{ loop.index }}</td>
                         <td class="font-monospace">
-                          {%- if _has_dd %}<i class="fas fa-chevron-right small collapse-icon text-muted me-1"></i>{% endif -%}
+                          {%- if _band_window %}<i class="fas fa-chevron-right small collapse-icon text-muted me-1"></i>{% endif -%}
                           {{ _uname }}
                         </td>
                         <td class="text-end font-monospace">{{ stats.get('data', 0) | fmt_size }}</td>
@@ -187,24 +221,11 @@
                         <td class="text-end">{{ stats.get('files', 0) | fmt_number }}</td>
                         <td class="text-end text-muted">{{ fpct | fmt_pct }}</td>
                       </tr>
-                      {% if _has_dd %}
+                      {% if _band_window %}
                         <tr class="collapse" id="{{ _urow }}">
                           <td colspan="6" class="p-0 border-0">
-                            {# Lazy-load on first expand, non-recursive (own files)
-                               to match the bar. Access-history bands filter by the
-                               date window; file-size bands filter by average
-                               own-file size (min_avg_size/max_avg_size, the last
-                               band has no upper bound). Bind to shown.bs.collapse
-                               so it fires under nav restore. #}
-                            <div class="p-2 bg-light" id="{{ _dt }}"
-                                 hx-get="{{ dir_fragment_url }}?owner_uid={{ uid }}&resource={{ resource_name }}{% if scope %}&scope={{ scope }}{% endif %}{% if _date_band %}{% if b.get('accessed_after') %}&accessed_after={{ b.accessed_after }}{% endif %}&accessed_before={{ b.accessed_before }}{% else %}&min_avg_size={{ b.size_min }}{% if b.get('size_max') is not none %}&max_avg_size={{ b.size_max }}{% endif %}{% endif %}&recursive=0&sort_by=size_nr&limit=25&target_id={{ _dt }}"
-                                 hx-trigger="shown.bs.collapse from:closest tr.collapse once"
-                                 hx-swap="innerHTML">
-                              <p class="text-muted small mb-0">
-                                <i class="fas fa-spinner fa-spin me-1"></i>
-                                Loading {{ _uname }}'s directories…
-                              </p>
-                            </div>
+                            {{ dir_drill(_dt, uid, _uname, b, _date_band,
+                                         resource_name, scope, dir_fragment_url) }}
                           </td>
                         </tr>
                       {% endif %}

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_no_identity.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_no_identity.html
@@ -1,0 +1,9 @@
+{# Shown by the "My Data" fragments when the logged-in account has no
+   filesystem identity (unix_uid is NULL). We deliberately do NOT run an
+   owner-filtered scan in that case — an absent owner filter would scan the
+   whole resource, which these @login_required-only routes must never do. #}
+<div class="alert alert-info py-2 mb-0" role="status">
+  <small><i class="fas fa-circle-info me-1"></i>
+    No filesystem identity (unix UID) is on record for your account, so your
+    filesystem-scan data can't be shown.</small>
+</div>

--- a/src/webapp/templates/dashboards/user/partials/my_data_scans.html
+++ b/src/webapp/templates/dashboards/user/partials/my_data_scans.html
@@ -1,0 +1,49 @@
+{# ── "My Data" tab body (User dashboard) ────────────────────────────────
+   One subtab per scan-capable disk resource (fs_scan_resources, from
+   service.scan_capable_resources()). Each subtab hosts the SAME scans card
+   the project disk page shows, but in user mode — rooted over the whole
+   filesystem and filtered to the files the logged-in user OWNS. The owner is
+   pinned server-side (see disk_scans/routes.py _user_ctx), so these routes are
+   @login_required only (no VIEW_ALL_FILESYSTEM_DATA).
+
+   The "User / group counts" tab is hidden in user mode (single owner).
+
+   Lazy-load: the active first subtab gets no shown.bs.tab when the parent
+   "My Data" tab opens, so its card's first inner tab listens to the parent tab
+   (#my-data-tab). Other subtabs load when their own subtab nav-link is shown.
+   Bind to the shown event, not click (feedback_persisted_collapse_htmx).
+
+   This partial is only included when fs_scan_resources is non-empty AND the
+   viewer has a unix_uid (gated in dashboard.html via my_data_available), so it
+   never needs its own empty/disabled state.
+#}
+<ul class="nav nav-pills mb-3" id="myDataSubtabs" role="tablist">
+    {% for res in fs_scan_resources %}
+    <li class="nav-item" role="presentation">
+        <a class="nav-link {% if loop.first %}active{% endif %}"
+           id="my-data-subtab-{{ loop.index }}"
+           data-bs-toggle="tab" href="#my-data-pane-{{ loop.index }}" role="tab">
+            <i class="fas fa-hard-drive me-1"></i> {{ res }}
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+<div class="tab-content" id="myDataSubtabContent">
+    {% for res in fs_scan_resources %}
+    <div class="tab-pane fade {% if loop.first %}show active{% endif %}"
+         id="my-data-pane-{{ loop.index }}" role="tabpanel">
+        {% if loop.first %}
+            {% set _trigger = 'shown.bs.tab once from:#my-data-tab' %}
+        {% else %}
+            {% set _trigger = 'shown.bs.tab once from:#my-data-subtab-' ~ loop.index %}
+        {% endif %}
+        {% with mode='user',
+                cid='my-data-r' ~ loop.index,
+                tablist_id='myDataCardTabs' ~ loop.index,
+                resource_name=res,
+                load_trigger=_trigger %}
+            {% include 'dashboards/user/partials/disk_scans_card.html' %}
+        {% endwith %}
+    </div>
+    {% endfor %}
+</div>

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -522,6 +522,8 @@ def test_access_history_user_drilldown_rows(app, auth_client, active_project, mo
     assert 'recursive=0' in body
     assert 'sort_by=size_nr' in body
     assert 'shown.bs.collapse' in body            # lazy-load trigger
+    # The file-size approximation caveat is file-sizes only, not access-history.
+    assert 'computed as average file sizes per' not in body
 
 
 def test_access_history_no_drilldown_without_bounds(app, auth_client, active_project, monkeypatch):
@@ -579,6 +581,8 @@ def test_file_sizes_user_drilldown_rows(app, auth_client, active_project, monkey
     assert 'max_avg_size=10485760' in body
     assert 'recursive=0' in body
     assert 'shown.bs.collapse' in body
+    # File-size tab carries the per-directory-average approximation caveat.
+    assert 'computed as average file sizes per' in body
 
 
 def test_directories_avg_size_flag(app, auth_client, active_project, monkeypatch):

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -1609,3 +1609,153 @@ class TestDiskEntityPie:
                 {'id': 8, 'name': 'g8', 'value': Decimal('3')}]
         svg = generate_disk_entity_pie_chart(data, 'group')
         assert '#disk-ent-group-7' in svg
+
+
+# ---------------------------------------------------------------------------
+# user mode ("My Data"): own-data-only enforcement + login_required-only access
+# ---------------------------------------------------------------------------
+#
+# These routes are @login_required ONLY (no VIEW_ALL_FILESYSTEM_DATA), so the
+# owner MUST be pinned server-side to the logged-in user's unix_uid and any
+# client-supplied ?owner_uid / ?owner_user_id MUST be ignored — otherwise any
+# user could read another user's footprint. The first test is the security
+# crux.
+
+def _benkirk_uid(session):
+    from sam import User
+    u = User.get_by_username(session, 'benkirk')
+    assert u is not None and u.unix_uid is not None, (
+        'benkirk must be preserved with a unix_uid in the snapshot — '
+        'see project_test_db_fixtures.md'
+    )
+    return u.unix_uid
+
+
+def test_user_directories_pins_owner_ignoring_query(
+        app, auth_client, session, monkeypatch):
+    """SECURITY: ?owner_uid / ?owner_user_id are ignored; the directory scan is
+    pinned to the logged-in user's unix_uid, never the client-supplied value."""
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    uid = _benkirk_uid(session)
+    captured = {}
+
+    def fake(resource_name, **kw):
+        captured.update(kw)
+        captured['resource_name'] = resource_name
+        return []
+    monkeypatch.setattr(service, 'scan_directories_resource', fake)
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/user/{_RES}/directories'
+        f'?owner_uid=999999&owner_user_id=999999'
+    )
+    assert resp.status_code == 200
+    assert captured['resource_name'] == _RES
+    assert captured['owner_uid'] == uid          # pinned to me
+    assert captured['owner_uid'] != 999999       # NOT the tampered value
+
+
+@pytest.mark.parametrize('endpoint,fn', [
+    ('access-history', 'scan_access_history_resource'),
+    ('file-sizes', 'scan_file_sizes_resource'),
+])
+def test_user_distribution_pins_owner_ignoring_query(
+        app, auth_client, session, monkeypatch, endpoint, fn):
+    """SECURITY: the histogram scans are pinned to the logged-in user too."""
+    from webapp.disk_scans import service
+    _enable_fs_scans(app, monkeypatch)
+    uid = _benkirk_uid(session)
+    captured = {}
+
+    def fake(resource_name, **kw):
+        captured.update(kw)
+        return None      # falsy → no chart generation; the call is what we check
+    monkeypatch.setattr(service, fn, fake)
+
+    resp = auth_client.get(
+        f'/dashboards/user/disk-scans/user/{_RES}/{endpoint}?owner_uid=999999'
+    )
+    assert resp.status_code == 200
+    assert captured['owner_uid'] == uid
+    assert captured['owner_uid'] != 999999
+
+
+@pytest.mark.parametrize(
+    'endpoint', ['directories', 'access-history', 'file-sizes', 'explore'])
+def test_user_routes_reachable_without_view_all(non_admin_client, endpoint):
+    """User routes are @login_required only — a user WITHOUT
+    VIEW_ALL_FILESYSTEM_DATA gets 200 (contrast the resource routes' 403)."""
+    resp = non_admin_client.get(
+        f'/dashboards/user/disk-scans/user/{_RES}/{endpoint}'
+    )
+    assert resp.status_code == 200
+
+
+def test_user_directories_no_identity_empty_state(app, auth_client, monkeypatch):
+    """Account with no unix_uid → info message, and NO scan is run (an absent
+    owner filter would otherwise scan the whole resource)."""
+    from types import SimpleNamespace
+    from webapp.disk_scans import service, routes
+    _enable_fs_scans(app, monkeypatch)
+    calls = {'n': 0}
+
+    def fake(*a, **k):
+        calls['n'] += 1
+        return []
+    monkeypatch.setattr(service, 'scan_directories_resource', fake)
+    # _user_ctx reads the owner via routes' module-level current_user.
+    monkeypatch.setattr(routes, 'current_user', SimpleNamespace(unix_uid=None))
+
+    resp = auth_client.get(f'/dashboards/user/disk-scans/user/{_RES}/directories')
+    assert resp.status_code == 200
+    assert calls['n'] == 0                                   # never scanned
+    assert 'No filesystem identity' in resp.get_data(as_text=True)
+
+
+def test_no_user_entities_route(app):
+    """User mode hides the User/group counts tab — there is no entities_user
+    endpoint — but the other three fragments + the explorer page do exist."""
+    from flask import url_for
+    from werkzeug.routing import BuildError
+    with app.test_request_context():
+        with pytest.raises(BuildError):
+            url_for('disk_scans.entities_user_fragment', resource=_RES)
+        for ep in ('directories_user_fragment', 'access_history_user_fragment',
+                   'file_sizes_user_fragment', 'directories_user_page'):
+            url_for(f'disk_scans.{ep}', resource=_RES)   # no raise
+
+
+def test_user_explore_hides_owner_picker(auth_client, session):
+    """The explorer 'full view' omits the owner picker in user mode (a user must
+    not be able to re-filter to another owner)."""
+    _benkirk_uid(session)
+    resp = auth_client.get(f'/dashboards/user/disk-scans/user/{_RES}/explore')
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'My Data' in body
+    assert 'Search users…' not in body          # owner fk-picker omitted
+
+
+# ---------------------------------------------------------------------------
+# "My Data" tab visibility on the user dashboard (/user/)
+# ---------------------------------------------------------------------------
+
+def test_my_data_tab_shown(auth_client, monkeypatch):
+    """benkirk has a unix_uid → My Data tab + one subtab per warmed resource."""
+    monkeypatch.setattr('webapp.disk_scans.service.scan_capable_resources',
+                        lambda app=None: ['Campaign_Store'])
+    resp = auth_client.get('/user/')
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'id="my-data-tab"' in body
+    assert 'id="my-data-subtab-1"' in body       # subtab strip rendered
+
+
+def test_my_data_tab_hidden_when_no_resources(auth_client, monkeypatch):
+    """Plugin off / no warmed resource → no My Data tab even with a unix_uid."""
+    monkeypatch.setattr('webapp.disk_scans.service.scan_capable_resources',
+                        lambda app=None: [])
+    resp = auth_client.get('/user/')
+    assert resp.status_code == 200
+    assert 'id="my-data-tab"' not in resp.get_data(as_text=True)

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -522,7 +522,8 @@ def test_access_history_user_drilldown_rows(app, auth_client, active_project, mo
     assert 'recursive=0' in body
     assert 'sort_by=size_nr' in body
     assert 'shown.bs.collapse' in body            # lazy-load trigger
-    # The file-size approximation caveat is file-sizes only, not access-history.
+    # Each tab carries its own caveat: access-history's, not the file-size one.
+    assert 'grouped by most recent' in body
     assert 'computed as average file sizes per' not in body
 
 
@@ -581,8 +582,9 @@ def test_file_sizes_user_drilldown_rows(app, auth_client, active_project, monkey
     assert 'max_avg_size=10485760' in body
     assert 'recursive=0' in body
     assert 'shown.bs.collapse' in body
-    # File-size tab carries the per-directory-average approximation caveat.
+    # File-size tab carries its own caveat, not the access-history one.
     assert 'computed as average file sizes per' in body
+    assert 'grouped by most recent' not in body
 
 
 def test_directories_avg_size_flag(app, auth_client, active_project, monkeypatch):

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -1759,3 +1759,73 @@ def test_my_data_tab_hidden_when_no_resources(auth_client, monkeypatch):
     resp = auth_client.get('/user/')
     assert resp.status_code == 200
     assert 'id="my-data-tab"' not in resp.get_data(as_text=True)
+
+
+# ---------------------------------------------------------------------------
+# distribution histogram: single-owner drill shortcut
+# ---------------------------------------------------------------------------
+#
+# A band with exactly one owner skips the (one-row) per-user table and expands
+# the band row straight to that owner's directories — one click instead of two.
+# This is what makes the single-user "My Data" histograms low-friction, but the
+# rule is generic (any single-owner band in any mode benefits).
+
+def _render_distribution_partial(app, owners):
+    from flask import render_template
+    hist = {
+        'bucket_labels': ['> 1 year'],
+        'buckets': {'> 1 year': {
+            'data': 100, 'files': 10, 'owners': owners,
+            'accessed_before': '2025-01-01', 'accessed_after': '2024-01-01',
+        }},
+        'total_data': 100, 'total_files': 10,
+        'username_map': {7: 'benkirk', 8: 'alice'},
+    }
+    with app.test_request_context():
+        return render_template(
+            'dashboards/user/partials/disk_scans_distribution.html',
+            hist=hist, chart_svg='<svg/>', enabled=True, error=None,
+            resource_name=_RES, scope='', fileset=None, target_id='t',
+            bucket_header='Last accessed', metric='data', metric_toggle=False,
+            log_toggle=False, log_on=False, fragment_url='/frag',
+            dir_fragment_url='/dirs')
+
+
+def test_single_owner_band_drills_straight_to_directories(app):
+    """One owner → no per-user table; the band row drills to their directories."""
+    body = _render_distribution_partial(app, {7: {'data': 100, 'files': 10}})
+    assert 'owner_uid=7' in body                       # directory drill present
+    assert 'Top users by' not in body                  # per-user table skipped
+    assert 'Show directories in this band' in body     # band row title
+
+
+def test_multi_owner_band_keeps_per_user_table(app):
+    """Two+ owners → the per-user aggregation table is retained."""
+    body = _render_distribution_partial(
+        app, {7: {'data': 60, 'files': 6}, 8: {'data': 40, 'files': 4}})
+    assert 'Top users by' in body                       # per-user table kept
+    assert 'Show top users in this bucket' in body
+    assert 'owner_uid=7' in body and 'owner_uid=8' in body   # each user drills
+
+
+def test_single_owner_band_without_window_keeps_table(app):
+    """The shortcut only applies when there's a drill window. A lone owner in a
+    window-less band keeps the per-user table (listed, but not drillable) —
+    behaviour unchanged from before the shortcut."""
+    from flask import render_template
+    hist = {
+        'bucket_labels': ['unknown'],
+        'buckets': {'unknown': {'data': 5, 'files': 1, 'owners': {7: {'data': 5, 'files': 1}}}},
+        'total_data': 5, 'total_files': 1, 'username_map': {7: 'benkirk'},
+    }
+    with app.test_request_context():
+        body = render_template(
+            'dashboards/user/partials/disk_scans_distribution.html',
+            hist=hist, chart_svg='<svg/>', enabled=True, error=None,
+            resource_name=_RES, scope='', fileset=None, target_id='t',
+            bucket_header='Last accessed', metric='data', metric_toggle=False,
+            log_toggle=False, log_on=False, fragment_url='/frag',
+            dir_fragment_url='/dirs')
+    assert 'benkirk' in body                            # user still listed
+    assert 'Top users by' in body                       # per-user table kept
+    assert 'owner_uid=7' not in body                    # but no directory drill

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -1797,6 +1797,7 @@ def test_single_owner_band_drills_straight_to_directories(app):
     assert 'owner_uid=7' in body                       # directory drill present
     assert 'Top users by' not in body                  # per-user table skipped
     assert 'Show directories in this band' in body     # band row title
+    assert '>Owners<' not in body                      # uniform-1 column folded
 
 
 def test_multi_owner_band_keeps_per_user_table(app):
@@ -1806,6 +1807,7 @@ def test_multi_owner_band_keeps_per_user_table(app):
     assert 'Top users by' in body                       # per-user table kept
     assert 'Show top users in this bucket' in body
     assert 'owner_uid=7' in body and 'owner_uid=8' in body   # each user drills
+    assert '>Owners<' in body                            # column shown (≥2 owners)
 
 
 def test_single_owner_band_without_window_keeps_table(app):


### PR DESCRIPTION
## Summary

Surfaces the shared filesystem-scans card — **Large directories** + **Access-history** and **File-size** histograms — scoped to the **files the logged-in user owns**, as a **"My Data"** tab on the User Dashboard (`/user`). Available to **every authenticated user** (`@login_required` only — **no** `VIEW_ALL_FILESYSTEM_DATA`), with a per-resource subtab strip mirroring the Status dashboard's Filesystem Scans tab (PR #329).

SAM-side only — **no plugin change**. Reuses the existing `*_resource(resource_name, owner_uid=…)` service fns as-is.

## Security (the must-get-right item)

These routes are `@login_required` only, so the scan owner is **pinned server-side** to `current_user.unix_uid` and any client-supplied `?owner_uid` / `?owner_user_id` is **ignored**. A `forced_owner_uid` kwarg threaded into the three render helpers (`_render_directories_fragment`, `_render_distribution`, `_render_entities`) overrides the request-args owner *before* scan + render. Accounts with no `unix_uid` get a no-identity empty state and **never** trigger an unfiltered whole-resource scan.

Dedicated tests assert that `?owner_uid=<other>&owner_user_id=<other>` is ignored and the scan runs as the logged-in user.

## Changes

- **`disk_scans/routes.py`** — `_user_ctx` (owner pinned); `forced_owner_uid` hardening in the 3 render helpers; 4 `@login_required` user routes (`/user/<resource>/{directories,access-history,file-sizes,explore}`); `_no_identity_fragment` empty state.
- **`disk_scans_card.html`** — `mode='user'` URL branch; hide the "User / group counts" tab.
- **`_disk_scans_dir_filters.html`** + **`disk_scans_directories_page.html`** — hide the owner picker in user mode (can't re-filter to another owner).
- **`my_data_scans.html`** *(new)* — per-resource subtab strip of `mode='user'` cards.
- **`disk_scans_no_identity.html`** *(new)* — no-filesystem-identity notice.
- **`dashboards/user/dashboard.html`** — My Data nav-tab + pane, gated on `my_data_available`.
- **`dashboards/user/blueprint.py`** — compute/pass `my_data_available` (unix_uid + warmed resource; **no** permission gate) + `fs_scan_resources`.
- **`docs/plans/MY_DATA_TAB.md`** — feature plan.

## Tests

Added to `tests/unit/test_webapp_disk_scans.py`:
- **Security:** owner pinned to logged-in user for directories + both histograms; tampered `?owner_uid` ignored.
- **No permission gate:** user routes reachable by a non-admin (200), contrasting the resource routes' 403.
- **Empty state:** no-`unix_uid` account → info message, no scan call.
- **No entities route** in user mode; the other 3 fragments + explorer exist.
- **Owner picker hidden** on the explorer page.
- **Tab visibility:** present when a resource is warmed, hidden when none.

> ⚠️ Full suite not run locally (workflow convention — author runs pytest by hand). Verified: app builds, all 4 routes register without colliding with `/<projcode>/…`, all templates compile.

## Verification

- `/user` → "My Data" tab; per-resource subtabs; 3 tabs per card (no "User / group counts").
- Data scoped to the user's owned files; "Open full view ↗" owner-pinned, no owner picker.
- Tamper test: `…/disk-scans/user/<resource>/directories?owner_uid=<other>` → still your data.
- Quick-Login user with no unix_uid → tab hidden / empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)