### PR TITLE
Destor parity for the Filesystem Scans web UI (multi-database)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,6 +182,12 @@ FLASK_SECRET_KEY=your_generated_64_character_hex_string_here
 # Unlike job_history, FS_SCAN_PG_HOST is a directly-routable CNPG cluster
 # host (e.g. csg-postgres.k8s.ucar.edu) — NOT host.docker.internal — so
 # it flows through to the container from here via env_file unchanged.
+#
+# FS_SCAN_PG_DB is the default/Campaign_Store database. FS_SCAN_RESOURCE_DATABASES
+# maps each scan resource to its CNPG database (Campaign_Store → campaign,
+# Destor → desc1); the plugin reaches the second database via its `database=`
+# selector using the SAME host/credentials (the role must have read access to
+# both). Omit a resource (or its database) to disable just that one.
 # FS_SCANS_ENABLED=1
 # FS_SCAN_DB_BACKEND=postgres
 # FS_SCAN_PG_HOST=csg-postgres.k8s.ucar.edu
@@ -190,6 +196,7 @@ FLASK_SECRET_KEY=your_generated_64_character_hex_string_here
 # FS_SCAN_PG_PASSWORD=
 # FS_SCAN_PG_REQUIRE_SSL=false
 # FS_SCAN_PG_DB=campaign
+# FS_SCAN_RESOURCE_DATABASES=Campaign_Store:campaign,Destor:desc1
 
 #-------------------------------------------------
 # MCP Server Configuration

--- a/.env.example
+++ b/.env.example
@@ -185,9 +185,10 @@ FLASK_SECRET_KEY=your_generated_64_character_hex_string_here
 #
 # FS_SCAN_PG_DB is the default/Campaign_Store database. FS_SCAN_RESOURCE_DATABASES
 # maps each scan resource to its CNPG database (Campaign_Store → campaign,
-# Destor → desc1); the plugin reaches the second database via its `database=`
-# selector using the SAME host/credentials (the role must have read access to
-# both). Omit a resource (or its database) to disable just that one.
+# Destor → destor; the DB is named `destor`, while `desc1` is only the Lustre
+# mount /lustre/desc1). The plugin reaches the second database via its
+# `database=` selector using the SAME host/credentials (the role must have read
+# access to both). Omit a resource (or its database) to disable just that one.
 # FS_SCANS_ENABLED=1
 # FS_SCAN_DB_BACKEND=postgres
 # FS_SCAN_PG_HOST=csg-postgres.k8s.ucar.edu
@@ -196,7 +197,7 @@ FLASK_SECRET_KEY=your_generated_64_character_hex_string_here
 # FS_SCAN_PG_PASSWORD=
 # FS_SCAN_PG_REQUIRE_SSL=false
 # FS_SCAN_PG_DB=campaign
-# FS_SCAN_RESOURCE_DATABASES=Campaign_Store:campaign,Destor:desc1
+# FS_SCAN_RESOURCE_DATABASES=Campaign_Store:campaign,Destor:destor
 
 #-------------------------------------------------
 # MCP Server Configuration

--- a/compose.yaml
+++ b/compose.yaml
@@ -69,8 +69,8 @@ services:
       # fs-scans talks to the CNPG cluster host DIRECTLY (a routable DNS
       # name, e.g. csg-postgres.k8s.ucar.edu — NOT host-routed like
       # job_history). Its settings (FS_SCAN_DB_BACKEND, FS_SCAN_PG_HOST,
-      # FS_SCAN_PG_*) flow through from the host `.env` via env_file;
-      # no override here on purpose.
+      # FS_SCAN_PG_*, FS_SCAN_RESOURCE_DATABASES) flow through from the host
+      # `.env` via env_file; no override here on purpose.
       # ── Per-service application policy
       - "DISABLE_AUTH=0"         # Explicitly disabled — must remain 0 in production
       - "FLASK_DEBUG=0"
@@ -148,8 +148,9 @@ services:
       - "JOB_HISTORY_PG_HOST=host.docker.internal"
       # fs-scans talks to the CNPG cluster host DIRECTLY (a routable DNS
       # name, NOT host-routed like job_history). Its settings
-      # (FS_SCAN_DB_BACKEND, FS_SCAN_PG_HOST, FS_SCAN_PG_*) flow through
-      # from the host `.env` via env_file; no override here on purpose.
+      # (FS_SCAN_DB_BACKEND, FS_SCAN_PG_HOST, FS_SCAN_PG_*,
+      # FS_SCAN_RESOURCE_DATABASES) flow through from the host `.env` via
+      # env_file; no override here on purpose.
       # ── Webdev-specific application policy (no DISABLE_AUTH — keep
       #    click-login stub default; user picks RBAC tier via UI)
       - "PYTHONDONTWRITEBYTECODE=1"

--- a/docs/plans/DESTOR_SCAN_VIEW.md
+++ b/docs/plans/DESTOR_SCAN_VIEW.md
@@ -8,8 +8,9 @@
 
 Campaign_Store filesystem-scan analytics (project disk-page card + gated
 Status whole-FS tab) read from one CNPG database (`campaign`). Destor is a
-*second* CNPG database (`desc1`) on the same `csg-postgres-ro` cluster. This
-change gives Destor the same scan-view experience, reading from `desc1`.
+*second* CNPG database (`destor`) on the same `csg-postgres` cluster — note the
+DB is named `destor`; `desc1` is only the Lustre mount `/lustre/desc1`. This
+change gives Destor the same scan-view experience, reading from `destor`.
 
 ## The cross-repo prerequisite (done)
 
@@ -23,7 +24,7 @@ no global `FS_SCAN_PG_DB` swap (which would be unsafe under gthread workers).
 
 - **Config** (`webapp/config.py`): `FS_SCAN_RESOURCE_DATABASES` (resource NAME
   → CNPG database, parsed from `Name:db,Name2:db2`; default
-  `Campaign_Store:<FS_SCAN_PG_DB>,Destor:desc1`). `FS_SCAN_RESOURCES` default
+  `Campaign_Store:<FS_SCAN_PG_DB>,Destor:destor`). `FS_SCAN_RESOURCES` default
   now includes `Destor`.
 - **Session loader** (`webapp/disk_scans/session.py`): `init_fs_scans` warms
   one engine set **per distinct database**. State is keyed by database:
@@ -33,7 +34,7 @@ no global `FS_SCAN_PG_DB` swap (which would be unsafe under gthread workers).
   `None` outside an app context) and `get_databases()`.
   `collections_for_resource(resource)` resolves the resource's database, then
   returns *that* database's warmed collections. One unreachable database
-  (e.g. desc1 not yet provisioned) is skipped, not fatal.
+  (e.g. destor not yet provisioned) is skipped, not fatal.
 - **Service** (`webapp/disk_scans/service.py`): every public wrapper resolves
   `database_for_resource(resource_name)` and threads it into the query cores →
   `FsScanQueries(filesystems=…, database=…)`. `_scoped` now intersects
@@ -51,12 +52,16 @@ no global `FS_SCAN_PG_DB` swap (which would be unsafe under gthread workers).
   through; once Destor warms collections, `scan_capable_resources()` surfaces
   a Destor subtab and the disk-page card renders for Destor resources.
 
-## Ops precondition
+## Ops precondition (verified satisfied 2026-06-23)
 
-The `pg-appuser` role (csg/pg-appuser ExternalSecret) **must be GRANTed read
-access on `desc1`**. The webapp uses the same host/credentials for both
-databases; without the grant, desc1 warms nothing and Destor silently drops
-from the UI.
+The webapp role reaches `destor` with the **same** host/credentials as
+`campaign` (the plugin's `database=` selector only swaps the DB name). The
+application role `pguser` **already has** `CONNECT` on `destor` plus `USAGE` +
+`SELECT` on every collection schema (`espat`, `gdex`, `glade_p_archive`,
+`mirrors`, `p`) — provisioned identically to `campaign`, confirmed by direct
+inspection. So **no grant was required**. If a future collection schema is
+added to `destor` without the same grants, the webapp would see an empty
+collection; re-run the campaign-style grants in that case.
 
 ## Verification
 
@@ -65,7 +70,7 @@ from the UI.
   threading to the facade (project + resource mode), cache key includes
   database, one-unreachable-database resilience.
 - E2E (containers built with the multi-db plugin): a Destor-resourced project
-  disk page shows the Filesystem Scans card (badge = a `desc1` scan date); the
+  disk page shows the Filesystem Scans card (badge = a `destor` scan date); the
   Status → Filesystem Scans tab shows a **Destor** subtab beside Campaign_Store;
   a Campaign_Store project is unaffected (no cross-DB leakage); Admin →
   Configuration shows both databases' collections + scan dates.

--- a/docs/plans/DESTOR_SCAN_VIEW.md
+++ b/docs/plans/DESTOR_SCAN_VIEW.md
@@ -1,0 +1,76 @@
+# Destor parity for the fs-scans Filesystem-Scans web UI
+
+**Status:** SAM consumer side implemented on branch `destor_scan_view`
+(PR → `staging`). Depends on the `fs_scans` plugin's `database=` selector
+(hpc-usage-queries PR #94, branch `fs_scan_plugin_multi_db`).
+
+## Why
+
+Campaign_Store filesystem-scan analytics (project disk-page card + gated
+Status whole-FS tab) read from one CNPG database (`campaign`). Destor is a
+*second* CNPG database (`desc1`) on the same `csg-postgres-ro` cluster. This
+change gives Destor the same scan-view experience, reading from `desc1`.
+
+## The cross-repo prerequisite (done)
+
+The plugin was hard-wired to a single database (`FS_SCAN_PG_DB`). It now
+accepts a backward-compatible `database=` on `get_engine` / `get_session` /
+`list_pg_schemas` / `get_all_filesystems` / `FsScanQueries`, defaulting to
+`PG_DB_NAME`. SAM holds a separate `FsScanQueries(database=…)` per resource —
+no global `FS_SCAN_PG_DB` swap (which would be unsafe under gthread workers).
+
+## What changed on the SAM side
+
+- **Config** (`webapp/config.py`): `FS_SCAN_RESOURCE_DATABASES` (resource NAME
+  → CNPG database, parsed from `Name:db,Name2:db2`; default
+  `Campaign_Store:<FS_SCAN_PG_DB>,Destor:desc1`). `FS_SCAN_RESOURCES` default
+  now includes `Destor`.
+- **Session loader** (`webapp/disk_scans/session.py`): `init_fs_scans` warms
+  one engine set **per distinct database**. State is keyed by database:
+  `state['databases'] = {db: {'collections': [...], 'engines': {coll: engine}}}`
+  (collection names can repeat across databases, so a flat dict would collide).
+  New seams: `database_for_resource(resource)` (reads the config map; safe →
+  `None` outside an app context) and `get_databases()`.
+  `collections_for_resource(resource)` resolves the resource's database, then
+  returns *that* database's warmed collections. One unreachable database
+  (e.g. desc1 not yet provisioned) is skipped, not fatal.
+- **Service** (`webapp/disk_scans/service.py`): every public wrapper resolves
+  `database_for_resource(resource_name)` and threads it into the query cores →
+  `FsScanQueries(filesystems=…, database=…)`. `_scoped` now intersects
+  reachability against `collections_for_resource(resource_name)` (the
+  resource's database), not the global union.
+- **Cache** (`webapp/disk_scans/cache.py`): `cached_scan(database=…)` folds the
+  database into the cache key, so a collection name shared across databases
+  can't share an entry.
+- **Admin card** (`webapp/utils/config_inspect.py`): iterates the per-database
+  state (one health row per database) and pins each scan-date probe to its
+  database (`FsScanQueries(filesystems=[c], database=db)`).
+- **Deploy**: `helm/values.yaml`, `.env.example`, `compose.yaml` document/set
+  `FS_SCAN_RESOURCE_DATABASES`.
+- Routes / templates / `scope.py` unchanged — they already pass `resource_name`
+  through; once Destor warms collections, `scan_capable_resources()` surfaces
+  a Destor subtab and the disk-page card renders for Destor resources.
+
+## Ops precondition
+
+The `pg-appuser` role (csg/pg-appuser ExternalSecret) **must be GRANTed read
+access on `desc1`**. The webapp uses the same host/credentials for both
+databases; without the grant, desc1 warms nothing and Destor silently drops
+from the UI.
+
+## Verification
+
+- Unit: `tests/unit/test_webapp_disk_scans.py` — per-database warming,
+  `collections_for_resource` / `database_for_resource` routing, database
+  threading to the facade (project + resource mode), cache key includes
+  database, one-unreachable-database resilience.
+- E2E (containers built with the multi-db plugin): a Destor-resourced project
+  disk page shows the Filesystem Scans card (badge = a `desc1` scan date); the
+  Status → Filesystem Scans tab shows a **Destor** subtab beside Campaign_Store;
+  a Campaign_Store project is unaffected (no cross-DB leakage); Admin →
+  Configuration shows both databases' collections + scan dates.
+
+## Out of scope
+
+CLI disk-charging and quota reconciliation parity for Destor (`GladeCsvReader`
+already maps Destor; `DestorQuotaReader` still raises `NotImplementedError`).

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -187,19 +187,25 @@ webapp:
     JOB_HISTORY_PG_PORT: "5432"
     JOB_HISTORY_MACHINES: "derecho,casper"
     # fs-scans plugin (filesystem-scan analytics on disk resource-details pages).
-    # Same CNPG cluster as job_history above, but a different logical database:
-    # collections (cisl, mmm, aiml, …) are POSTGRES SCHEMAS within FS_SCAN_PG_DB.
-    # The plugin reads FS_SCAN_PG_* at engine-creation time; FS_SCAN_PG_USER /
-    # FS_SCAN_PG_PASSWORD are injected below from the fsDbCredentials
-    # ExternalSecret (csg/pg-appuser, same role as job_history). FS_SCANS_ENABLED
-    # is the SAM-side master switch — set "0" to disable the integration entirely.
-    # Destor (FS_SCAN_PG_DB=desc1) is a future second database; today only
-    # Campaign_Store (campaign) is scanned.
+    # Same CNPG cluster as job_history above; collections (cisl, mmm, aiml, …)
+    # are POSTGRES SCHEMAS within a per-resource database. The plugin reads
+    # FS_SCAN_PG_* at engine-creation time; FS_SCAN_PG_USER / FS_SCAN_PG_PASSWORD
+    # are injected below from the fsDbCredentials ExternalSecret (csg/pg-appuser,
+    # same role as job_history). FS_SCANS_ENABLED is the SAM-side master switch —
+    # set "0" to disable the integration entirely.
+    #
+    # FS_SCAN_PG_DB is the default/Campaign_Store database. FS_SCAN_RESOURCE_DATABASES
+    # maps each scan resource to its database: Campaign_Store → campaign, Destor →
+    # desc1. The plugin reaches the second database (desc1) via its `database=`
+    # selector using these SAME host/credentials, so the pg-appuser role MUST be
+    # GRANTed read access on desc1. A resource whose database is unreachable simply
+    # warms nothing and drops out of the UI.
     FS_SCANS_ENABLED: "1"
     FS_SCAN_DB_BACKEND: "postgres"
     FS_SCAN_PG_HOST: "csg-postgres-ro.k8s.ucar.edu"
     FS_SCAN_PG_PORT: "5432"
     FS_SCAN_PG_DB: "campaign"
+    FS_SCAN_RESOURCE_DATABASES: "Campaign_Store:campaign,Destor:desc1"
     # disable creating projects until ID system transition & GID pool
     CREATE_PROJECTS_ENABLED: "0"
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -196,16 +196,18 @@ webapp:
     #
     # FS_SCAN_PG_DB is the default/Campaign_Store database. FS_SCAN_RESOURCE_DATABASES
     # maps each scan resource to its database: Campaign_Store → campaign, Destor →
-    # desc1. The plugin reaches the second database (desc1) via its `database=`
-    # selector using these SAME host/credentials, so the pg-appuser role MUST be
-    # GRANTed read access on desc1. A resource whose database is unreachable simply
-    # warms nothing and drops out of the UI.
+    # destor (the CNPG database is named `destor`; `desc1` is only the Lustre MOUNT
+    # /lustre/desc1). The plugin reaches the second database via its `database=`
+    # selector using these SAME host/credentials; the pg-appuser role already has
+    # read access on `destor` (USAGE + SELECT on its collection schemas, same as
+    # campaign). A resource whose database is unreachable simply warms nothing and
+    # drops out of the UI.
     FS_SCANS_ENABLED: "1"
     FS_SCAN_DB_BACKEND: "postgres"
     FS_SCAN_PG_HOST: "csg-postgres-ro.k8s.ucar.edu"
     FS_SCAN_PG_PORT: "5432"
     FS_SCAN_PG_DB: "campaign"
-    FS_SCAN_RESOURCE_DATABASES: "Campaign_Store:campaign,Destor:desc1"
+    FS_SCAN_RESOURCE_DATABASES: "Campaign_Store:campaign,Destor:destor"
     # disable creating projects until ID system transition & GID pool
     CREATE_PROJECTS_ENABLED: "0"
 

--- a/src/webapp/config.py
+++ b/src/webapp/config.py
@@ -153,17 +153,37 @@ class SAMWebappConfig(SAMConfig):
 
     # Disk resources that have filesystem-scan collections, surfaced as
     # subtabs on the Status dashboard's gated "Filesystem Scans" tab. An
-    # explicit list (NOT derived from the Resource table) — append 'Destor'
-    # when it ships. Resource NAMES, not IDs (see feedback_no_duplicate_db_ids);
-    # the resource→collections mapping lives in the
-    # disk_scans.session.collections_for_resource seam. A configured resource
-    # with no warmed collections is filtered out at render time
+    # explicit list (NOT derived from the Resource table). Resource NAMES, not
+    # IDs (see feedback_no_duplicate_db_ids); the resource→database/collections
+    # mapping lives in the disk_scans.session seam. A configured resource with
+    # no warmed collections is filtered out at render time
     # (service.scan_capable_resources), so the tab/subtab never shows empty.
     FS_SCAN_RESOURCES = [
         s.strip()
-        for s in os.getenv('FS_SCAN_RESOURCES', 'Campaign_Store').split(',')
+        for s in os.getenv('FS_SCAN_RESOURCES', 'Campaign_Store,Destor').split(',')
         if s.strip()
     ]
+
+    # Maps each scan resource NAME to the CNPG database that holds its
+    # collections. Each disk resource is one database on the shared cluster
+    # (Campaign_Store → campaign, Destor → desc1); the plugin reaches a second
+    # database via its `database=` selector (same host/credentials). Parsed
+    # from `FS_SCAN_RESOURCE_DATABASES` as `Name:db,Name2:db2`; the default
+    # tracks the plugin's own `FS_SCAN_PG_DB` for Campaign_Store so a
+    # single-database deployment keeps working unchanged. `init_fs_scans` warms
+    # one engine set per DISTINCT database here; a resource whose database is
+    # unreachable simply warms nothing and drops out of the UI.
+    FS_SCAN_RESOURCE_DATABASES = {
+        name.strip(): db.strip()
+        for name, _, db in (
+            pair.partition(':')
+            for pair in os.getenv(
+                'FS_SCAN_RESOURCE_DATABASES',
+                f"Campaign_Store:{os.getenv('FS_SCAN_PG_DB', 'campaign')},Destor:desc1",
+            ).split(',')
+        )
+        if name.strip() and db.strip()
+    }
 
     # Session cookies (common defaults; subclasses tighten for prod)
     SESSION_COOKIE_HTTPONLY    = True

--- a/src/webapp/config.py
+++ b/src/webapp/config.py
@@ -166,8 +166,9 @@ class SAMWebappConfig(SAMConfig):
 
     # Maps each scan resource NAME to the CNPG database that holds its
     # collections. Each disk resource is one database on the shared cluster
-    # (Campaign_Store → campaign, Destor → desc1); the plugin reaches a second
-    # database via its `database=` selector (same host/credentials). Parsed
+    # (Campaign_Store → campaign, Destor → destor; NB the DB is named `destor`,
+    # while `desc1` is only the Lustre MOUNT /lustre/desc1). The plugin reaches
+    # a second database via its `database=` selector (same host/credentials). Parsed
     # from `FS_SCAN_RESOURCE_DATABASES` as `Name:db,Name2:db2`; the default
     # tracks the plugin's own `FS_SCAN_PG_DB` for Campaign_Store so a
     # single-database deployment keeps working unchanged. `init_fs_scans` warms
@@ -179,7 +180,7 @@ class SAMWebappConfig(SAMConfig):
             pair.partition(':')
             for pair in os.getenv(
                 'FS_SCAN_RESOURCE_DATABASES',
-                f"Campaign_Store:{os.getenv('FS_SCAN_PG_DB', 'campaign')},Destor:desc1",
+                f"Campaign_Store:{os.getenv('FS_SCAN_PG_DB', 'campaign')},Destor:destor",
             ).split(',')
         )
         if name.strip() and db.strip()

--- a/src/webapp/disk_scans/__init__.py
+++ b/src/webapp/disk_scans/__init__.py
@@ -20,7 +20,10 @@ per-request session context manager — the service layer constructs
 """
 
 from webapp.disk_scans.session import (
+    collections_for_resource,
+    database_for_resource,
     get_collections,
+    get_databases,
     get_engines,
     get_module,
     init_fs_scans,
@@ -32,5 +35,8 @@ __all__ = [
     'is_enabled',
     'get_module',
     'get_collections',
+    'get_databases',
     'get_engines',
+    'collections_for_resource',
+    'database_for_resource',
 ]

--- a/src/webapp/disk_scans/cache.py
+++ b/src/webapp/disk_scans/cache.py
@@ -172,17 +172,20 @@ def cached_scan(
     opts: Dict[str, Any],
     compute: Callable[[], Any],
     bucket: str = 'default',
+    database: Optional[str] = None,
 ) -> Any:
     """Return a cached scan result or compute + store it.
 
     *compute* must produce the FINAL caller-facing result (e.g. owner rows
     with resolved usernames already attached), so a cache hit reproduces it
     exactly without re-querying. The cache is keyed on the resolved scope +
-    *opts* + the per-collection scan dates.
+    *opts* + the per-collection scan dates + *database*.
 
     *bucket* selects which adapter stores the entry — ``'filtered'`` for the
     short-TTL explorer permutations, ``'default'`` (the passive/landing path)
-    otherwise.
+    otherwise. *database* is the CNPG database the query targets; it's part of
+    the key so collection-name collisions across databases (e.g. a schema named
+    the same in ``campaign`` and ``desc1``) never share a cache entry.
     """
     adapter = get_cache_adapter(bucket)
     if adapter is None:
@@ -194,6 +197,7 @@ def cached_scan(
 
     key = (
         query_type,
+        database,
         tuple(sorted(collections)),
         tuple(sorted(path_prefixes)),
         tuple(sorted((k, _norm(v)) for k, v in opts.items())),

--- a/src/webapp/disk_scans/service.py
+++ b/src/webapp/disk_scans/service.py
@@ -27,7 +27,7 @@ from webapp.disk_scans.cache import cached_scan
 from webapp.disk_scans.scope import resolve_scan_scope
 from webapp.disk_scans.session import (
     collections_for_resource,
-    get_collections,
+    database_for_resource,
     get_module,
     is_enabled,
 )
@@ -91,8 +91,11 @@ def _scoped(
             if (coll := mod.collection_for_path(p)) is not None
         })
 
-    # Keep only collections that are actually reachable (the warmed set).
-    collections = [c for c in collections if c in set(get_collections())]
+    # Keep only collections that are actually reachable for THIS resource's
+    # database (the warmed set behind resource_name) — not the global union, so
+    # a collection name shared across databases can't leak across resources.
+    collections = [c for c in collections
+                   if c in set(collections_for_resource(resource_name))]
     keep = set(collections)
 
     # Drop any path whose collection isn't queryable. This excludes paths on
@@ -125,7 +128,8 @@ def scan_overview(session, project, resource_name: str) -> Dict[str, Any]:
     mod, path_prefixes, collections = _scoped(session, project, resource_name)
     if not collections:
         return {'collections': [], 'scan_dates': {}, 'reference': None}
-    q = mod.FsScanQueries(filesystems=collections)
+    q = mod.FsScanQueries(filesystems=collections,
+                          database=database_for_resource(resource_name))
     scan_dates = {}
     for c in collections:
         dates = q.scan_dates(filesystems=[c])
@@ -233,18 +237,20 @@ def _scan_directories(
     single_owner: bool = False,
     min_depth: Optional[int] = None,
     max_depth: Optional[int] = None,
+    database: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Mode-agnostic directory query core shared by project + resource modes.
 
     Callers resolve ``(mod, collections, path_prefixes)`` first — project mode
     via :func:`_scoped` (refuses unscoped), resource mode via
     :func:`collections_for_resource` (deliberately unscoped, ``path_prefixes``
-    may be ``None`` for the whole-collection fast path). Any of
+    may be ``None`` for the whole-collection fast path). ``database`` selects
+    the CNPG database (resolved from the resource by the caller). Any of
     ``owner_uid / accessed_before / accessed_after / leaves_only`` being set
     routes the result into the short-TTL ``'filtered'`` cache bucket so heavy
     interactive exploration can't crowd the hot default-path entries.
     """
-    q = mod.FsScanQueries(filesystems=collections)
+    q = mod.FsScanQueries(filesystems=collections, database=database)
     filtered = bool(owner_uid is not None or owner_gid is not None
                     or accessed_before or accessed_after or leaves_only
                     or min_avg_size is not None or max_avg_size is not None)
@@ -265,7 +271,8 @@ def _scan_directories(
         'directories', q, collections,
         # cache key tolerates an unscoped (None) prefix list — normalise to [].
         path_prefixes or [], opts,
-        lambda: q.list_directories(
+        database=database,
+        compute=lambda: q.list_directories(
             path_prefixes=path_prefixes,
             sort_by=sort_by,
             limit=limit,
@@ -333,6 +340,7 @@ def scan_directories(
         min_avg_size=min_avg_size, max_avg_size=max_avg_size,
         leaves_only=leaves_only,
         single_owner=single_owner, min_depth=min_depth, max_depth=max_depth,
+        database=database_for_resource(resource_name),
     )
     return _drop_nested(rows) if outermost_only else rows
 
@@ -384,22 +392,24 @@ def scan_directories_resource(
         atime_recursive=atime_recursive,
         min_avg_size=min_avg_size, max_avg_size=max_avg_size,
         leaves_only=leaves_only,
+        database=database_for_resource(resource_name),
     )
     return _drop_nested(rows) if outermost_only else rows
 
 
 def _owner_summary(
     mod, collections: List[str], path_prefixes: Optional[List[str]],
-    *, limit: Optional[int],
+    *, limit: Optional[int], database: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Mode-agnostic per-owner (UID) rollup core, usernames resolved.
 
     Callers resolve ``(mod, collections, path_prefixes)`` first — project mode
     via :func:`_scoped` (always scoped), resource mode via
     :func:`collections_for_resource` (``path_prefixes=None`` → whole-collection
-    fast path). Each row gains a ``username`` key (``None`` if unresolvable).
+    fast path). ``database`` selects the CNPG database. Each row gains a
+    ``username`` key (``None`` if unresolvable).
     """
-    q = mod.FsScanQueries(filesystems=collections)
+    q = mod.FsScanQueries(filesystems=collections, database=database)
 
     def _compute():
         rows = q.owner_summary(path_prefixes=path_prefixes, limit=limit)
@@ -411,15 +421,15 @@ def _owner_summary(
 
     # cache key tolerates an unscoped (None) prefix list — normalise to [].
     return cached_scan('owner', q, collections, path_prefixes or [],
-                       {'limit': limit}, _compute)
+                       {'limit': limit}, _compute, database=database)
 
 
 def _group_summary(
     mod, collections: List[str], path_prefixes: Optional[List[str]],
-    *, limit: Optional[int],
+    *, limit: Optional[int], database: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Mode-agnostic per-group (GID) rollup core, group names resolved."""
-    q = mod.FsScanQueries(filesystems=collections)
+    q = mod.FsScanQueries(filesystems=collections, database=database)
 
     def _compute():
         rows = q.group_summary(path_prefixes=path_prefixes, limit=limit)
@@ -430,15 +440,15 @@ def _group_summary(
         return rows
 
     return cached_scan('group', q, collections, path_prefixes or [],
-                       {'limit': limit}, _compute)
+                       {'limit': limit}, _compute, database=database)
 
 
 def _access_history(
     mod, collections: List[str], path_prefixes: Optional[List[str]],
-    *, owner_uid: Optional[int],
+    *, owner_uid: Optional[int], database: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Mode-agnostic access-time histogram core (band date windows tagged)."""
-    q = mod.FsScanQueries(filesystems=collections)
+    q = mod.FsScanQueries(filesystems=collections, database=database)
 
     def _compute():
         hist = q.access_history(path_prefixes=path_prefixes, owner_uid=owner_uid)
@@ -455,16 +465,16 @@ def _access_history(
 
     return cached_scan(
         'access_history', q, collections, path_prefixes or [],
-        {'owner_uid': owner_uid}, _compute,
+        {'owner_uid': owner_uid}, _compute, database=database,
     )
 
 
 def _file_sizes(
     mod, collections: List[str], path_prefixes: Optional[List[str]],
-    *, owner_uid: Optional[int],
+    *, owner_uid: Optional[int], database: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Mode-agnostic file-size histogram core (avg-size windows tagged)."""
-    q = mod.FsScanQueries(filesystems=collections)
+    q = mod.FsScanQueries(filesystems=collections, database=database)
 
     def _compute():
         hist = q.file_size_histogram(path_prefixes=path_prefixes, owner_uid=owner_uid)
@@ -480,7 +490,7 @@ def _file_sizes(
 
     return cached_scan(
         'file_sizes', q, collections, path_prefixes or [],
-        {'owner_uid': owner_uid}, _compute,
+        {'owner_uid': owner_uid}, _compute, database=database,
     )
 
 
@@ -516,7 +526,8 @@ def scan_owner_summary(
     mod, path_prefixes, collections = _scoped(session, project, resource_name, subpath)
     if not collections:
         return []
-    return _owner_summary(mod, collections, path_prefixes, limit=limit)
+    return _owner_summary(mod, collections, path_prefixes, limit=limit,
+                          database=database_for_resource(resource_name))
 
 
 def scan_group_summary(
@@ -536,7 +547,8 @@ def scan_group_summary(
     mod, path_prefixes, collections = _scoped(session, project, resource_name, subpath)
     if not collections:
         return []
-    return _group_summary(mod, collections, path_prefixes, limit=limit)
+    return _group_summary(mod, collections, path_prefixes, limit=limit,
+                          database=database_for_resource(resource_name))
 
 
 def scan_access_history(
@@ -558,7 +570,8 @@ def scan_access_history(
     mod, path_prefixes, collections = _scoped(session, project, resource_name, subpath)
     if not collections:
         return None
-    return _access_history(mod, collections, path_prefixes, owner_uid=owner_uid)
+    return _access_history(mod, collections, path_prefixes, owner_uid=owner_uid,
+                           database=database_for_resource(resource_name))
 
 
 def scan_file_sizes(
@@ -583,7 +596,8 @@ def scan_file_sizes(
     mod, path_prefixes, collections = _scoped(session, project, resource_name, subpath)
     if not collections:
         return None
-    return _file_sizes(mod, collections, path_prefixes, owner_uid=owner_uid)
+    return _file_sizes(mod, collections, path_prefixes, owner_uid=owner_uid,
+                       database=database_for_resource(resource_name))
 
 
 # ── Resource-mode (whole-filesystem) siblings ──────────────────────────────
@@ -604,7 +618,8 @@ def scan_owner_summary_resource(
     if not collections:
         return []
     path_prefixes = [subpath] if subpath else None
-    return _owner_summary(mod, collections, path_prefixes, limit=limit)
+    return _owner_summary(mod, collections, path_prefixes, limit=limit,
+                          database=database_for_resource(resource_name))
 
 
 def scan_group_summary_resource(
@@ -618,7 +633,8 @@ def scan_group_summary_resource(
     if not collections:
         return []
     path_prefixes = [subpath] if subpath else None
-    return _group_summary(mod, collections, path_prefixes, limit=limit)
+    return _group_summary(mod, collections, path_prefixes, limit=limit,
+                          database=database_for_resource(resource_name))
 
 
 def scan_access_history_resource(
@@ -632,7 +648,8 @@ def scan_access_history_resource(
     if not collections:
         return None
     path_prefixes = [subpath] if subpath else None
-    return _access_history(mod, collections, path_prefixes, owner_uid=owner_uid)
+    return _access_history(mod, collections, path_prefixes, owner_uid=owner_uid,
+                           database=database_for_resource(resource_name))
 
 
 def scan_file_sizes_resource(
@@ -646,7 +663,8 @@ def scan_file_sizes_resource(
     if not collections:
         return None
     path_prefixes = [subpath] if subpath else None
-    return _file_sizes(mod, collections, path_prefixes, owner_uid=owner_uid)
+    return _file_sizes(mod, collections, path_prefixes, owner_uid=owner_uid,
+                       database=database_for_resource(resource_name))
 
 
 def scan_capable_resources(app=None) -> List[str]:

--- a/src/webapp/disk_scans/session.py
+++ b/src/webapp/disk_scans/session.py
@@ -64,10 +64,13 @@ def init_fs_scans(app: Flask) -> None:
     is logged. The webapp continues to boot.
     """
     state: Dict[str, Any] = {
-        'module':      None,
-        'collections': [],   # list[str] of warmed collection schemas
-        'engines':     {},   # collection -> Engine (for health/config card)
-        'enabled':     False,
+        'module':    None,
+        # database -> {'collections': [str], 'engines': {collection: Engine}}.
+        # One disk resource maps to one database (see FS_SCAN_RESOURCE_DATABASES);
+        # collection schemas can repeat across databases, so we key by database
+        # rather than flattening to a single {collection: engine} dict.
+        'databases': {},
+        'enabled':   False,
     }
     app.extensions[_EXT_KEY] = state
 
@@ -88,19 +91,7 @@ def init_fs_scans(app: Flask) -> None:
 
     state['module'] = mod
 
-    # Discover collection schemas (postgres backend). A failure here means
-    # the backend is unreachable/unconfigured — degrade gracefully.
-    try:
-        collections = mod.list_pg_schemas()
-    except Exception as exc:
-        logger.warning(
-            'fs-scans: could not list collections (backend unreachable?) — '
-            'features disabled: %s',
-            exc,
-        )
-        return
-
-    # `application_name` tags each connection with pod + collection so
+    # `application_name` tags each connection with pod + db + collection so
     # postgres `pg_stat_activity` can attribute load. Mirrors the
     # job_history loader: the plugin owns ``connect_args`` inside its
     # ``get_engine``, so we attach a post-creation ``connect`` listener
@@ -112,52 +103,82 @@ def init_fs_scans(app: Flask) -> None:
     # from inside the connect listener.
     stmt_timeout_ms = int(app.config.get('FS_SCAN_STATEMENT_TIMEOUT_MS', 0) or 0)
 
-    def _warm(collection: str):
-        """Create + tag + health-check one collection's engine.
+    def _warm(collection: str, database: Optional[str]):
+        """Create + tag + health-check one collection's engine in *database*.
 
         Returns the Engine on success, or None on failure (logged). Safe to
         run concurrently: the plugin's ``get_engine`` cache is lock-guarded.
+        ``database`` selects the CNPG database (the plugin's ``database=``
+        selector); ``None`` uses the plugin's default ``FS_SCAN_PG_DB``.
         """
         try:
-            engine = mod.get_engine(collection)
+            engine = mod.get_engine(collection, database=database)
             if engine.url.drivername.startswith('postgresql'):
+                tag = f'sam-webapp:{pod_id}:fs_scans:{database or "default"}:{collection}'
                 _apply_connection_settings(
-                    engine, f'sam-webapp:{pod_id}:fs_scans:{collection}',
-                    statement_timeout_ms=stmt_timeout_ms,
+                    engine, tag, statement_timeout_ms=stmt_timeout_ms,
                 )
             # Health check — also forces the pool to open one connection
             # so the application_name listener fires before first query.
             with engine.connect() as conn:
                 conn.execute(text('SELECT 1'))
             logger.info(
-                'fs-scans engine ready: collection=%s url=%s',
-                collection, _safe_url(engine),
+                'fs-scans engine ready: db=%s collection=%s url=%s',
+                database or 'default', collection, _safe_url(engine),
             )
             return engine
         except Exception as exc:
             logger.warning(
-                'fs-scans engine init failed for collection=%s: %s',
-                collection, exc,
+                'fs-scans engine init failed for db=%s collection=%s: %s',
+                database or 'default', collection, exc,
             )
             return None
 
-    # Warm collections concurrently — each opens a fresh TLS connection to the
-    # remote CNPG (~1-1.5s), so serial warming of a dozen-plus collections
-    # would add ~20s to webapp boot. Bounded pool keeps it to a few seconds.
-    engines: Dict[str, Any] = {}
-    if collections:
-        max_workers = min(len(collections), 8)
-        with ThreadPoolExecutor(max_workers=max_workers,
-                                thread_name_prefix='fs-scans-warm') as pool:
-            for collection, engine in zip(
-                collections, pool.map(_warm, collections)
-            ):
-                if engine is not None:
-                    engines[collection] = engine
+    # The set of DISTINCT databases to warm comes from the resource→database
+    # map (Campaign_Store → campaign, Destor → desc1). An empty map falls back
+    # to the plugin's single default database (None → FS_SCAN_PG_DB), preserving
+    # the original single-database behavior.
+    resource_dbs: Dict[str, str] = app.config.get('FS_SCAN_RESOURCE_DATABASES') or {}
+    db_names = sorted(set(resource_dbs.values())) or [None]
 
-    state['engines'] = engines
-    state['collections'] = sorted(engines)
-    state['enabled'] = bool(engines)
+    databases: Dict[str, Any] = {}
+    for database in db_names:
+        # Discover collection schemas for this database. A failure here means
+        # that database is unreachable/unconfigured — skip it, but keep going so
+        # one bad database (e.g. desc1 not yet provisioned) can't disable the
+        # rest.
+        try:
+            collections = mod.list_pg_schemas(database=database)
+        except Exception as exc:
+            logger.warning(
+                'fs-scans: could not list collections for db=%s (unreachable?) — '
+                'skipping: %s', database or 'default', exc,
+            )
+            continue
+
+        # Warm collections concurrently — each opens a fresh TLS connection to
+        # the remote CNPG (~1-1.5s), so serial warming of a dozen-plus
+        # collections would add ~20s to webapp boot. Bounded pool keeps it to a
+        # few seconds.
+        engines: Dict[str, Any] = {}
+        if collections:
+            max_workers = min(len(collections), 8)
+            with ThreadPoolExecutor(max_workers=max_workers,
+                                    thread_name_prefix='fs-scans-warm') as pool:
+                for collection, engine in zip(
+                    collections,
+                    pool.map(lambda c: _warm(c, database), collections),
+                ):
+                    if engine is not None:
+                        engines[collection] = engine
+        if engines:
+            databases[database] = {
+                'collections': sorted(engines),
+                'engines':     engines,
+            }
+
+    state['databases'] = databases
+    state['enabled'] = any(d['collections'] for d in databases.values())
 
 
 def _apply_connection_settings(
@@ -212,10 +233,45 @@ def get_module(app: Optional[Flask] = None):
     return state.get('module')
 
 
-def get_collections(app: Optional[Flask] = None) -> List[str]:
-    """Return the list of warmed/reachable collection schemas (possibly empty)."""
+def get_databases(app: Optional[Flask] = None) -> Dict[str, Any]:
+    """Return ``{database: {'collections': [...], 'engines': {...}}}`` (warmed).
+
+    The per-database warmed state. Used by the Admin → Configuration card to
+    render one health row per CNPG database, and by the resource→database
+    helpers below. Empty when the plugin is disabled/unreachable.
+    """
     state = (app or current_app).extensions.get(_EXT_KEY) or {}
-    return state.get('collections') or []
+    return state.get('databases') or {}
+
+
+def get_collections(app: Optional[Flask] = None) -> List[str]:
+    """Union of warmed/reachable collection schemas across all databases.
+
+    A flat, deduplicated view for callers that don't care which database a
+    collection lives in. Resource-scoped reachability should use
+    :func:`collections_for_resource` instead, which is database-aware.
+    """
+    out: set = set()
+    for db in get_databases(app).values():
+        out.update(db.get('collections') or [])
+    return sorted(out)
+
+
+def database_for_resource(
+    resource_name: str, app: Optional[Flask] = None
+) -> Optional[str]:
+    """The CNPG database that backs a disk *resource* (or ``None``).
+
+    Reads the ``FS_SCAN_RESOURCE_DATABASES`` map (resource NAME → database).
+    Threaded into ``FsScanQueries(database=...)`` by the service layer so each
+    resource's queries hit its own database. Safe outside an app context
+    (returns ``None``) so service helpers can resolve it unconditionally.
+    """
+    try:
+        cfg = (app or current_app).config
+    except RuntimeError:
+        return None
+    return (cfg.get('FS_SCAN_RESOURCE_DATABASES') or {}).get(resource_name)
 
 
 def collections_for_resource(
@@ -224,28 +280,29 @@ def collections_for_resource(
     """Warmed collection schemas that make up a disk *resource*, unscoped.
 
     The single decision point for resource→collections when a query is **not**
-    project-scoped (resource mode). Today every warmed collection lives in the
-    one ``campaign`` CNPG database (one DB per resource via the plugin's
-    ``FS_SCAN_PG_DB``), so this returns :func:`get_collections` verbatim — i.e.
-    the whole resource.
-
-    This is the **seam** where a future resource→database map plugs in: once a
-    second resource (e.g. Destor) ships its own collections, branch here on
-    *resource_name* rather than scattering the mapping across callers. Returns
-    ``[]`` when the plugin is off (so resource-mode callers degrade to "no
+    project-scoped (resource mode). Resolves the resource's database via
+    :func:`database_for_resource`, then returns that database's warmed
+    collections. Returns ``[]`` when the plugin is off, the resource is
+    unmapped, or its database warmed nothing (so callers degrade to "no
     results", same as project mode).
     """
-    return get_collections(app)
+    database = database_for_resource(resource_name, app)
+    if database is None:
+        return []
+    return list(get_databases(app).get(database, {}).get('collections') or [])
 
 
 def get_engines(app: Optional[Flask] = None) -> Dict[str, Any]:
-    """Return ``{collection: Engine}`` for warmed collections (possibly empty).
+    """Return a flat ``{collection: Engine}`` merged across databases.
 
-    Used by the Admin → Configuration Database card to ping each fs-scans
-    collection and report health / scan-date freshness.
+    Legacy/convenience view. Collection names that repeat across databases
+    collide (last wins) — the Admin card uses :func:`get_databases` instead so
+    it can render each database separately.
     """
-    state = (app or current_app).extensions.get(_EXT_KEY) or {}
-    return state.get('engines') or {}
+    out: Dict[str, Any] = {}
+    for db in get_databases(app).values():
+        out.update(db.get('engines') or {})
+    return out
 
 
 def _safe_url(engine) -> str:

--- a/src/webapp/utils/config_inspect.py
+++ b/src/webapp/utils/config_inspect.py
@@ -424,17 +424,17 @@ def gather_runtime_state(app, db) -> Dict[str, Any]:
     # each. Registered on app.extensions by webapp.disk_scans.init_fs_scans;
     # absent / empty when the plugin is disabled, in which case no rows appear.
     fs_state = app.extensions.get('fs_scans') or {}
-    fs_engines = fs_state.get('engines') or {}
-    if fs_engines:
+    fs_databases = fs_state.get('databases') or {}
+    if fs_databases:
         fs_mod = fs_state.get('module')
-        # Group warmed engines by their backing database (campaign, desc1, …).
-        by_db: Dict[str, list] = {}
-        for collection, engine in fs_engines.items():
-            by_db.setdefault(engine.url.database or 'fs_scans', []).append(
-                (collection, engine)
-            )
-        for dbname, items in sorted(by_db.items()):
-            items.sort()
+        # One health row per backing CNPG database (campaign → Campaign_Store,
+        # desc1 → Destor); the warmed state is already grouped by database.
+        for dbname, db_state in sorted(fs_databases.items()):
+            engines = db_state.get('engines') or {}
+            if not engines:
+                continue
+            items = sorted(engines.items())
+            display_db = dbname or 'fs_scans'
             # Health from one representative engine — all share host + db.
             rep_engine = items[0][1]
             ok, latency_ms, err = _ping_engine(rep_engine)
@@ -443,13 +443,15 @@ def gather_runtime_state(app, db) -> Dict[str, Any]:
             except Exception:
                 stats = None
             # Per-collection scan-date freshness (best-effort; one tiny
-            # scan_metadata read each). A failing collection reports None
-            # rather than sinking the whole card.
+            # scan_metadata read each, pinned to THIS database). A failing
+            # collection reports None rather than sinking the whole card.
             collections = []
             for collection, _engine in items:
                 scan_date = None
                 try:
-                    dates = fs_mod.FsScanQueries(filesystems=[collection]).scan_dates()
+                    dates = fs_mod.FsScanQueries(
+                        filesystems=[collection], database=dbname,
+                    ).scan_dates()
                     if dates:
                         scan_date = max(dates).date().isoformat()
                 except Exception:
@@ -457,7 +459,7 @@ def gather_runtime_state(app, db) -> Dict[str, Any]:
                 collections.append({'name': collection, 'scan_date': scan_date})
             present = [c['scan_date'] for c in collections if c['scan_date']]
             databases.append({
-                'name':         f'fs_scans ({dbname})',
+                'name':         f'fs_scans ({display_db})',
                 'url':          format_db_url_safe(rep_engine),
                 'status':       'healthy' if ok else 'unhealthy',
                 'latency_ms':   latency_ms,

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -74,8 +74,9 @@ def _wire_service(monkeypatch, *, prefixes, collections, warmed,
     from webapp.disk_scans import service
 
     class _FakeQueries:
-        def __init__(self, filesystems):
+        def __init__(self, filesystems, database=None):
             capture['filesystems'] = list(filesystems)
+            capture['database'] = database
 
         def list_directories(self, **kw):
             capture['list_kwargs'] = kw
@@ -96,7 +97,11 @@ def _wire_service(monkeypatch, *, prefixes, collections, warmed,
         normalize_path=_fake_normalize,
     )
     monkeypatch.setattr(service, 'get_module', lambda: mod)
-    monkeypatch.setattr(service, 'get_collections', lambda: list(warmed))
+    # _scoped intersects reachability against the resource's database, so stub
+    # the database-aware seam (not get_collections) with the warmed set.
+    monkeypatch.setattr(service, 'collections_for_resource',
+                        lambda r, app=None: list(warmed))
+    monkeypatch.setattr(service, 'database_for_resource', lambda r, app=None: None)
     monkeypatch.setattr(
         service, 'resolve_scan_scope',
         lambda session, project, resource_name: (list(prefixes), list(collections)),
@@ -898,7 +903,7 @@ def test_scan_access_history_tags_band_bounds(monkeypatch):
     }
 
     class _Q:
-        def __init__(self, filesystems):
+        def __init__(self, filesystems, database=None):
             pass
 
         def access_history(self, **kw):
@@ -908,12 +913,13 @@ def test_scan_access_history_tags_band_bounds(monkeypatch):
                                 collection_for_path=lambda p: 'cisl',
                                 normalize_path=lambda p: p)
     monkeypatch.setattr(service, 'get_module', lambda: mod)
-    monkeypatch.setattr(service, 'get_collections', lambda: ['cisl'])
+    monkeypatch.setattr(service, 'collections_for_resource', lambda r, app=None: ['cisl'])
+    monkeypatch.setattr(service, 'database_for_resource', lambda r, app=None: None)
     monkeypatch.setattr(service, 'resolve_scan_scope',
                         lambda s, p, r: (['/glade/campaign/cisl/csg'], ['cisl']))
     monkeypatch.setattr(
         service, 'cached_scan',
-        lambda qt, q, colls, pfx, opts, compute, bucket='default': compute(),
+        lambda qt, q, colls, pfx, opts, compute, bucket='default', database=None: compute(),
     )
 
     out = service.scan_access_history(None, object(), 'Campaign_Store')
@@ -964,7 +970,7 @@ def test_scan_file_sizes_tags_band_bounds(monkeypatch):
     }
 
     class _Q:
-        def __init__(self, filesystems):
+        def __init__(self, filesystems, database=None):
             pass
 
         def file_size_histogram(self, **kw):
@@ -974,12 +980,13 @@ def test_scan_file_sizes_tags_band_bounds(monkeypatch):
                                 collection_for_path=lambda p: 'cisl',
                                 normalize_path=lambda p: p)
     monkeypatch.setattr(service, 'get_module', lambda: mod)
-    monkeypatch.setattr(service, 'get_collections', lambda: ['cisl'])
+    monkeypatch.setattr(service, 'collections_for_resource', lambda r, app=None: ['cisl'])
+    monkeypatch.setattr(service, 'database_for_resource', lambda r, app=None: None)
     monkeypatch.setattr(service, 'resolve_scan_scope',
                         lambda s, p, r: (['/glade/campaign/cisl/csg'], ['cisl']))
     monkeypatch.setattr(
         service, 'cached_scan',
-        lambda qt, q, colls, pfx, opts, compute, bucket='default': compute(),
+        lambda qt, q, colls, pfx, opts, compute, bucket='default', database=None: compute(),
     )
 
     out = service.scan_file_sizes(None, object(), 'Campaign_Store')
@@ -997,7 +1004,7 @@ def test_directories_bucket_selection(monkeypatch):
     )
     seen = []
 
-    def fake_cached(qt, q, colls, pfx, opts, compute, bucket='default'):
+    def fake_cached(qt, q, colls, pfx, opts, compute, bucket='default', database=None):
         seen.append(bucket)
         return compute()
 
@@ -1036,8 +1043,9 @@ def _wire_resource_service(monkeypatch, *, collections, capture):
     from webapp.disk_scans import service
 
     class _FakeQueries:
-        def __init__(self, filesystems):
+        def __init__(self, filesystems, database=None):
             capture['filesystems'] = list(filesystems)
+            capture['database'] = database
 
         def list_directories(self, **kw):
             capture['list_kwargs'] = kw
@@ -1046,7 +1054,8 @@ def _wire_resource_service(monkeypatch, *, collections, capture):
     mod = types.SimpleNamespace(FsScanQueries=_FakeQueries)
     monkeypatch.setattr(service, 'get_module', lambda: mod)
     monkeypatch.setattr(service, 'collections_for_resource',
-                        lambda r: list(collections))
+                        lambda r, app=None: list(collections))
+    monkeypatch.setattr(service, 'database_for_resource', lambda r, app=None: None)
     return service
 
 
@@ -1090,13 +1099,191 @@ def test_scan_directories_resource_empty_when_plugin_off(monkeypatch):
     assert service.scan_directories_resource('Campaign_Store') == []
 
 
-def test_collections_for_resource_delegates(monkeypatch):
-    """The resource→collections seam returns the warmed set (today)."""
+def test_collections_for_resource_maps_via_database(monkeypatch):
+    """The seam resolves the resource's database, then returns THAT database's
+    warmed collections — so Campaign_Store and Destor see disjoint sets."""
     from webapp.disk_scans import session as sess
-    monkeypatch.setattr(sess, 'get_collections', lambda app=None: ['campaign'])
-    assert sess.collections_for_resource('Campaign_Store') == ['campaign']
-    monkeypatch.setattr(sess, 'get_collections', lambda app=None: [])
+    monkeypatch.setattr(
+        sess, 'database_for_resource',
+        lambda r, app=None: {'Campaign_Store': 'campaign', 'Destor': 'desc1'}.get(r))
+    monkeypatch.setattr(sess, 'get_databases', lambda app=None: {
+        'campaign': {'collections': ['cisl', 'mmm'], 'engines': {}},
+        'desc1':    {'collections': ['gdex'], 'engines': {}},
+    })
+    assert sess.collections_for_resource('Campaign_Store') == ['cisl', 'mmm']
+    assert sess.collections_for_resource('Destor') == ['gdex']
+    # Unmapped resource → no database → no collections (never unscoped).
+    assert sess.collections_for_resource('Nope') == []
+    # Mapped but unwarmed database → [].
+    monkeypatch.setattr(sess, 'get_databases', lambda app=None: {})
     assert sess.collections_for_resource('Campaign_Store') == []
+
+
+def test_database_for_resource_reads_config_map(app, monkeypatch):
+    """database_for_resource reads the FS_SCAN_RESOURCE_DATABASES config map,
+    and is safe (None) outside an app context."""
+    from webapp.disk_scans import session as sess
+    monkeypatch.setitem(app.config, 'FS_SCAN_RESOURCE_DATABASES',
+                        {'Campaign_Store': 'campaign', 'Destor': 'desc1'})
+    with app.app_context():
+        assert sess.database_for_resource('Campaign_Store') == 'campaign'
+        assert sess.database_for_resource('Destor') == 'desc1'
+        assert sess.database_for_resource('Unknown') is None
+    # No app context → None (lets service helpers resolve unconditionally).
+    assert sess.database_for_resource('Campaign_Store') is None
+
+
+# ---------------------------------------------------------------------------
+# Destor parity: database threading (project + resource mode), cache key,
+# per-database session warming
+# ---------------------------------------------------------------------------
+
+def test_scan_directories_threads_resource_database(monkeypatch):
+    """The resource's database (Destor → desc1) reaches FsScanQueries."""
+    cap = {}
+    svc = _wire_service(
+        monkeypatch,
+        prefixes=['/lustre/desc1/gdex/proj'],
+        collections=['gdex'], warmed=['gdex'],
+        collection_map={'/lustre/desc1/gdex/proj': 'gdex'},
+        capture=cap,
+    )
+    monkeypatch.setattr(svc, 'database_for_resource',
+                        lambda r, app=None: 'desc1' if r == 'Destor' else None)
+    svc.scan_directories(None, object(), 'Destor')
+    assert cap['filesystems'] == ['gdex']
+    assert cap['database'] == 'desc1'       # threaded to the facade
+
+
+def test_scan_directories_resource_threads_database(monkeypatch):
+    """Resource mode threads the resource's database to the facade too."""
+    cap = {}
+    svc = _wire_resource_service(monkeypatch, collections=['gdex'], capture=cap)
+    monkeypatch.setattr(svc, 'database_for_resource', lambda r, app=None: 'desc1')
+    svc.scan_directories_resource('Destor')
+    assert cap['database'] == 'desc1'
+
+
+def test_cached_scan_database_is_in_key(monkeypatch):
+    """Same scope + opts but a different database → distinct cache entries, so a
+    collection name shared across databases can't collide."""
+    from webapp.disk_scans import cache as c
+    monkeypatch.delenv('CACHE_REDIS_URL', raising=False)
+    c._adapters.clear()
+
+    calls = {'n': 0}
+    def compute():
+        calls['n'] += 1
+        return [{'v': calls['n']}]
+
+    q = _FakeQ('2026-06-14T00:00:00')
+    opts = {'limit': 50}
+    r1 = c.cached_scan('owner', q, ['gdex'], ['/gdex'], opts, compute, database='campaign')
+    r2 = c.cached_scan('owner', q, ['gdex'], ['/gdex'], opts, compute, database='desc1')
+    assert r1 == [{'v': 1}] and r2 == [{'v': 2}]      # different db → recompute
+    assert calls['n'] == 2
+    # Same (db, scope, opts) repeats → served from cache.
+    c.cached_scan('owner', q, ['gdex'], ['/gdex'], opts, compute, database='desc1')
+    assert calls['n'] == 2
+
+
+class _WarmConn:
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+    def execute(self, *a, **k): return None
+
+
+class _WarmURL:
+    drivername = 'sqlite'     # skip the postgres connect-listener in _warm
+
+    def __init__(self, db):
+        self.database = db
+        self.username = self.host = self.port = None
+
+
+class _WarmEngine:
+    def __init__(self, db):
+        self.url = _WarmURL(db)
+
+    def connect(self):
+        return _WarmConn()
+
+
+def test_init_fs_scans_warms_each_database_separately(app, monkeypatch):
+    """init_fs_scans discovers + warms each configured database independently,
+    keys state by database, and wires resource → database → collections."""
+    from webapp import disk_scans
+    from webapp.disk_scans import session as sess
+
+    schemas = {'campaign': ['cisl', 'mmm'], 'desc1': ['gdex']}
+
+    class _FakeMod:
+        def list_pg_schemas(self, database=None):
+            return list(schemas.get(database, []))
+
+        def get_engine(self, collection, database=None):
+            return _WarmEngine(database)
+
+    from sam.plugins import FS_SCANS
+    monkeypatch.setattr(FS_SCANS, 'load', lambda: _FakeMod())
+    monkeypatch.setitem(app.config, 'FS_SCANS_ENABLED', True)
+    monkeypatch.setitem(app.config, 'FS_SCAN_RESOURCE_DATABASES',
+                        {'Campaign_Store': 'campaign', 'Destor': 'desc1'})
+
+    orig = app.extensions.get('fs_scans')
+    try:
+        disk_scans.init_fs_scans(app)
+        dbs = sess.get_databases(app)
+        assert set(dbs) == {'campaign', 'desc1'}
+        assert dbs['campaign']['collections'] == ['cisl', 'mmm']
+        assert dbs['desc1']['collections'] == ['gdex']
+        assert sess.is_enabled(app) is True
+        # resource → database → collections, end to end
+        assert sess.collections_for_resource('Campaign_Store', app) == ['cisl', 'mmm']
+        assert sess.collections_for_resource('Destor', app) == ['gdex']
+        # union view spans both databases
+        assert sess.get_collections(app) == ['cisl', 'gdex', 'mmm']
+    finally:
+        if orig is not None:
+            app.extensions['fs_scans'] = orig
+        else:
+            app.extensions.pop('fs_scans', None)
+
+
+def test_init_fs_scans_survives_one_unreachable_database(app, monkeypatch):
+    """If one database is unreachable (desc1 not provisioned), the other still
+    warms and the feature stays enabled for it."""
+    from webapp import disk_scans
+    from webapp.disk_scans import session as sess
+
+    class _FakeMod:
+        def list_pg_schemas(self, database=None):
+            if database == 'desc1':
+                raise RuntimeError('desc1 not reachable')
+            return ['cisl']
+
+        def get_engine(self, collection, database=None):
+            return _WarmEngine(database)
+
+    from sam.plugins import FS_SCANS
+    monkeypatch.setattr(FS_SCANS, 'load', lambda: _FakeMod())
+    monkeypatch.setitem(app.config, 'FS_SCANS_ENABLED', True)
+    monkeypatch.setitem(app.config, 'FS_SCAN_RESOURCE_DATABASES',
+                        {'Campaign_Store': 'campaign', 'Destor': 'desc1'})
+
+    orig = app.extensions.get('fs_scans')
+    try:
+        disk_scans.init_fs_scans(app)
+        dbs = sess.get_databases(app)
+        assert set(dbs) == {'campaign'}                  # desc1 skipped, not fatal
+        assert sess.is_enabled(app) is True
+        assert sess.collections_for_resource('Destor', app) == []
+        assert sess.collections_for_resource('Campaign_Store', app) == ['cisl']
+    finally:
+        if orig is not None:
+            app.extensions['fs_scans'] = orig
+        else:
+            app.extensions.pop('fs_scans', None)
 
 
 # -- resource mode (service): entity + histogram siblings --------------------
@@ -1111,8 +1298,9 @@ def _wire_resource_entities(monkeypatch, *, collections, capture):
     from webapp.disk_scans import service
 
     class _FakeQueries:
-        def __init__(self, filesystems):
+        def __init__(self, filesystems, database=None):
             capture['filesystems'] = list(filesystems)
+            capture['database'] = database
 
         def owner_summary(self, **kw):
             capture['owner_kwargs'] = kw
@@ -1142,6 +1330,7 @@ def _wire_resource_entities(monkeypatch, *, collections, capture):
     monkeypatch.setattr(service, 'get_module', lambda: mod)
     monkeypatch.setattr(service, 'collections_for_resource',
                         lambda r, app=None: list(collections))
+    monkeypatch.setattr(service, 'database_for_resource', lambda r, app=None: None)
     return service
 
 

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -1105,10 +1105,10 @@ def test_collections_for_resource_maps_via_database(monkeypatch):
     from webapp.disk_scans import session as sess
     monkeypatch.setattr(
         sess, 'database_for_resource',
-        lambda r, app=None: {'Campaign_Store': 'campaign', 'Destor': 'desc1'}.get(r))
+        lambda r, app=None: {'Campaign_Store': 'campaign', 'Destor': 'destor'}.get(r))
     monkeypatch.setattr(sess, 'get_databases', lambda app=None: {
         'campaign': {'collections': ['cisl', 'mmm'], 'engines': {}},
-        'desc1':    {'collections': ['gdex'], 'engines': {}},
+        'destor':    {'collections': ['gdex'], 'engines': {}},
     })
     assert sess.collections_for_resource('Campaign_Store') == ['cisl', 'mmm']
     assert sess.collections_for_resource('Destor') == ['gdex']
@@ -1124,10 +1124,10 @@ def test_database_for_resource_reads_config_map(app, monkeypatch):
     and is safe (None) outside an app context."""
     from webapp.disk_scans import session as sess
     monkeypatch.setitem(app.config, 'FS_SCAN_RESOURCE_DATABASES',
-                        {'Campaign_Store': 'campaign', 'Destor': 'desc1'})
+                        {'Campaign_Store': 'campaign', 'Destor': 'destor'})
     with app.app_context():
         assert sess.database_for_resource('Campaign_Store') == 'campaign'
-        assert sess.database_for_resource('Destor') == 'desc1'
+        assert sess.database_for_resource('Destor') == 'destor'
         assert sess.database_for_resource('Unknown') is None
     # No app context → None (lets service helpers resolve unconditionally).
     assert sess.database_for_resource('Campaign_Store') is None
@@ -1139,7 +1139,7 @@ def test_database_for_resource_reads_config_map(app, monkeypatch):
 # ---------------------------------------------------------------------------
 
 def test_scan_directories_threads_resource_database(monkeypatch):
-    """The resource's database (Destor → desc1) reaches FsScanQueries."""
+    """The resource's database (Destor → destor) reaches FsScanQueries."""
     cap = {}
     svc = _wire_service(
         monkeypatch,
@@ -1149,19 +1149,19 @@ def test_scan_directories_threads_resource_database(monkeypatch):
         capture=cap,
     )
     monkeypatch.setattr(svc, 'database_for_resource',
-                        lambda r, app=None: 'desc1' if r == 'Destor' else None)
+                        lambda r, app=None: 'destor' if r == 'Destor' else None)
     svc.scan_directories(None, object(), 'Destor')
     assert cap['filesystems'] == ['gdex']
-    assert cap['database'] == 'desc1'       # threaded to the facade
+    assert cap['database'] == 'destor'        # threaded to the facade
 
 
 def test_scan_directories_resource_threads_database(monkeypatch):
     """Resource mode threads the resource's database to the facade too."""
     cap = {}
     svc = _wire_resource_service(monkeypatch, collections=['gdex'], capture=cap)
-    monkeypatch.setattr(svc, 'database_for_resource', lambda r, app=None: 'desc1')
+    monkeypatch.setattr(svc, 'database_for_resource', lambda r, app=None: 'destor')
     svc.scan_directories_resource('Destor')
-    assert cap['database'] == 'desc1'
+    assert cap['database'] == 'destor'
 
 
 def test_cached_scan_database_is_in_key(monkeypatch):
@@ -1179,11 +1179,11 @@ def test_cached_scan_database_is_in_key(monkeypatch):
     q = _FakeQ('2026-06-14T00:00:00')
     opts = {'limit': 50}
     r1 = c.cached_scan('owner', q, ['gdex'], ['/gdex'], opts, compute, database='campaign')
-    r2 = c.cached_scan('owner', q, ['gdex'], ['/gdex'], opts, compute, database='desc1')
+    r2 = c.cached_scan('owner', q, ['gdex'], ['/gdex'], opts, compute, database='destor')
     assert r1 == [{'v': 1}] and r2 == [{'v': 2}]      # different db → recompute
     assert calls['n'] == 2
     # Same (db, scope, opts) repeats → served from cache.
-    c.cached_scan('owner', q, ['gdex'], ['/gdex'], opts, compute, database='desc1')
+    c.cached_scan('owner', q, ['gdex'], ['/gdex'], opts, compute, database='destor')
     assert calls['n'] == 2
 
 
@@ -1215,7 +1215,7 @@ def test_init_fs_scans_warms_each_database_separately(app, monkeypatch):
     from webapp import disk_scans
     from webapp.disk_scans import session as sess
 
-    schemas = {'campaign': ['cisl', 'mmm'], 'desc1': ['gdex']}
+    schemas = {'campaign': ['cisl', 'mmm'], 'destor': ['gdex']}
 
     class _FakeMod:
         def list_pg_schemas(self, database=None):
@@ -1228,15 +1228,15 @@ def test_init_fs_scans_warms_each_database_separately(app, monkeypatch):
     monkeypatch.setattr(FS_SCANS, 'load', lambda: _FakeMod())
     monkeypatch.setitem(app.config, 'FS_SCANS_ENABLED', True)
     monkeypatch.setitem(app.config, 'FS_SCAN_RESOURCE_DATABASES',
-                        {'Campaign_Store': 'campaign', 'Destor': 'desc1'})
+                        {'Campaign_Store': 'campaign', 'Destor': 'destor'})
 
     orig = app.extensions.get('fs_scans')
     try:
         disk_scans.init_fs_scans(app)
         dbs = sess.get_databases(app)
-        assert set(dbs) == {'campaign', 'desc1'}
+        assert set(dbs) == {'campaign', 'destor'}
         assert dbs['campaign']['collections'] == ['cisl', 'mmm']
-        assert dbs['desc1']['collections'] == ['gdex']
+        assert dbs['destor']['collections'] == ['gdex']
         assert sess.is_enabled(app) is True
         # resource → database → collections, end to end
         assert sess.collections_for_resource('Campaign_Store', app) == ['cisl', 'mmm']
@@ -1251,15 +1251,15 @@ def test_init_fs_scans_warms_each_database_separately(app, monkeypatch):
 
 
 def test_init_fs_scans_survives_one_unreachable_database(app, monkeypatch):
-    """If one database is unreachable (desc1 not provisioned), the other still
+    """If one database is unreachable (destor not provisioned), the other still
     warms and the feature stays enabled for it."""
     from webapp import disk_scans
     from webapp.disk_scans import session as sess
 
     class _FakeMod:
         def list_pg_schemas(self, database=None):
-            if database == 'desc1':
-                raise RuntimeError('desc1 not reachable')
+            if database == 'destor':
+                raise RuntimeError('destor not reachable')
             return ['cisl']
 
         def get_engine(self, collection, database=None):
@@ -1269,13 +1269,13 @@ def test_init_fs_scans_survives_one_unreachable_database(app, monkeypatch):
     monkeypatch.setattr(FS_SCANS, 'load', lambda: _FakeMod())
     monkeypatch.setitem(app.config, 'FS_SCANS_ENABLED', True)
     monkeypatch.setitem(app.config, 'FS_SCAN_RESOURCE_DATABASES',
-                        {'Campaign_Store': 'campaign', 'Destor': 'desc1'})
+                        {'Campaign_Store': 'campaign', 'Destor': 'destor'})
 
     orig = app.extensions.get('fs_scans')
     try:
         disk_scans.init_fs_scans(app)
         dbs = sess.get_databases(app)
-        assert set(dbs) == {'campaign'}                  # desc1 skipped, not fatal
+        assert set(dbs) == {'campaign'}                  # destor skipped, not fatal
         assert sess.is_enabled(app) is True
         assert sess.collections_for_resource('Destor', app) == []
         assert sess.collections_for_resource('Campaign_Store', app) == ['cisl']


### PR DESCRIPTION
## Summary

Gives the **Destor** disk resource the same filesystem-scan web UI that Campaign_Store has — the project disk-page card and the gated Status whole-FS tab — reading from a **second CNPG database (`desc1`)** on the shared cluster.

This consumes the `fs_scans` plugin's new `database=` selector so a single process can query `campaign` (Campaign_Store) and `desc1` (Destor) without any global `FS_SCAN_PG_DB` swap (which would be unsafe under gthread workers).

> **Depends on:** benkirk/hpc-usage-queries#94 (plugin `database=` selector). CI here runs against the `HPC_USAGE_QUERIES_REF`-pinned plugin build.

## Changes

- **config** (`webapp/config.py`): `FS_SCAN_RESOURCE_DATABASES` map (resource NAME → CNPG database; default `Campaign_Store:<FS_SCAN_PG_DB>,Destor:desc1`). `FS_SCAN_RESOURCES` default now includes `Destor`.
- **session loader** (`webapp/disk_scans/session.py`): `init_fs_scans` warms one engine set per **distinct** database; state is keyed by database (`state['databases']`) because collection schema names can repeat across databases. New `database_for_resource()` (safe → `None` outside an app context) and `get_databases()`. `collections_for_resource()` resolves the resource's database and returns only that database's warmed collections. One unreachable database (e.g. desc1 not yet provisioned) is skipped, not fatal.
- **service** (`webapp/disk_scans/service.py`): every public wrapper threads `database_for_resource(resource_name)` into `FsScanQueries(database=…)`; `_scoped` intersects reachability against the resource's database, not the global union.
- **cache** (`webapp/disk_scans/cache.py`): `database` folded into the cache key (no cross-database collision on a shared schema name like `gdex`).
- **admin card** (`webapp/utils/config_inspect.py`): iterates per-database state (one health row per database); scan-date probe pinned to its database.
- **deploy**: `helm/values.yaml`, `.env.example`, `compose.yaml` set/document `FS_SCAN_RESOURCE_DATABASES`.
- Routes / templates / `scope.py` unchanged — once `desc1` warms collections, `scan_capable_resources()` surfaces the Destor subtab and the disk-page card renders for Destor projects automatically.

## Ops precondition

The `pg-appuser` role must be GRANTed read access on `desc1` (same host/credentials as `campaign`). Documented in `docs/plans/DESTOR_SCAN_VIEW.md`; being applied alongside this PR.

## Test plan

- `tests/unit/test_webapp_disk_scans.py`: updated stubs for the new signatures + new coverage — per-database warming, resource→database→collections routing, database threading to the facade (project + resource mode), cache key includes database, one-unreachable-database resilience.
- E2E (containers built with the multi-db plugin): Destor-resourced project disk page shows the Filesystem Scans card (badge = a `desc1` scan date); Status → Filesystem Scans shows a **Destor** subtab beside Campaign_Store; a Campaign_Store project is unaffected (no cross-DB leakage); Admin → Configuration shows both databases.

## Out of scope

CLI disk-charging / quota reconciliation parity for Destor (`DestorQuotaReader` still raises `NotImplementedError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)