### PR TITLE
fix(allocations): show resources with empty accounts in Add Allocation dropdown

### DIFF
--- a/src/sam/accounting/accounts.py
+++ b/src/sam/accounting/accounts.py
@@ -104,6 +104,61 @@ class Account(Base, SoftDeleteMixin, SessionMixin):
         session.add(account)
         session.flush()
 
+        cls._seed_members(session, account)
+        return account
+
+    @classmethod
+    def get_or_create(cls, session, *, project_id: int, resource_id: int) -> 'Account':
+        """Get the account for a project+resource pair, reviving or creating as needed.
+
+        Idempotent companion to :meth:`create`. Handles the three states a
+        ``(project_id, resource_id)`` slot can be in — note the table's
+        ``project_resource_ux`` UNIQUE index is NOT scoped by ``deleted``, so a
+        soft-deleted row still occupies the slot and a blind ``create()`` would
+        raise an IntegrityError:
+
+          1. A soft-deleted account exists → un-delete it, re-seed members, return.
+          2. A live account exists → return it unchanged.
+          3. No account exists → create one (delegates to :meth:`create`).
+
+        All allocation-creation paths route account acquisition through here so
+        re-allocating a resource whose account was previously removed just works.
+
+        Does NOT commit; caller must wrap in management_transaction().
+        """
+        existing = cls.get_by_project_and_resource(
+            session, project_id, resource_id, exclude_deleted=False
+        )
+        if existing is None:
+            return cls.create(session, project_id=project_id, resource_id=resource_id)
+
+        if existing.deleted:
+            existing.deleted = False
+            session.flush()
+            cls._seed_members(session, existing)
+        return existing
+
+    @classmethod
+    def _seed_members(cls, session, account: 'Account') -> None:
+        """Populate open-ended AccountUser rows for a (new or revived) account.
+
+        Adds start_date=now, end_date=None membership rows for:
+          - The project lead
+          - The project admin (if set)
+          - Every user currently active (end_date IS NULL) on any sibling
+            Account of the same project
+
+        Enforces the invariant that a project's lead, admin, and existing members
+        become members of every Account added to the project. Skips users who are
+        already active members of this account (so reviving an account is safe to
+        re-run). Does NOT commit.
+        """
+        from sam.projects.projects import Project
+
+        project = session.get(Project, account.project_id)
+        if project is None:
+            raise ValueError(f"Project {account.project_id} not found")
+
         propagate_user_ids: Set[int] = set()
         if project.project_lead_user_id is not None:
             propagate_user_ids.add(project.project_lead_user_id)
@@ -113,13 +168,22 @@ class Account(Base, SoftDeleteMixin, SessionMixin):
         sibling_members = session.query(AccountUser).join(
             Account, AccountUser.account_id == Account.account_id
         ).filter(
-            Account.project_id == project_id,
+            Account.project_id == account.project_id,
             Account.account_id != account.account_id,
             Account.is_active,
             AccountUser.end_date.is_(None),
         ).all()
         for au in sibling_members:
             propagate_user_ids.add(au.user_id)
+
+        # Don't duplicate members already active on this account (revive path).
+        existing_member_ids = {
+            au.user_id for au in session.query(AccountUser).filter(
+                AccountUser.account_id == account.account_id,
+                AccountUser.end_date.is_(None),
+            ).all()
+        }
+        propagate_user_ids -= existing_member_ids
 
         now = datetime.now()
         for user_id in propagate_user_ids:
@@ -130,7 +194,6 @@ class Account(Base, SoftDeleteMixin, SessionMixin):
                 end_date=None,
             ))
         session.flush()
-        return account
 
     @classmethod
     def get_by_project_and_resource(cls, session, project_id: int, resource_id: int,

--- a/src/sam/accounting/allocations.py
+++ b/src/sam/accounting/allocations.py
@@ -194,13 +194,9 @@ class Allocation(Base, TimestampMixin, SoftDeleteMixin, SessionMixin):
         if amount <= 0:
             raise ValueError(f"Amount must be > 0, got {amount}")
 
-        account = Account.get_by_project_and_resource(
-            session, project_id, resource_id, exclude_deleted=True
+        account = Account.get_or_create(
+            session, project_id=project_id, resource_id=resource_id
         )
-        if account is None:
-            account = Account.create(
-                session, project_id=project_id, resource_id=resource_id
-            )
 
         allocation = cls(
             account_id=account.account_id,

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -115,6 +115,23 @@ def _project_form_data(form=None) -> dict:
     )
 
 
+def _resources_with_allocation(project) -> set:
+    """resource_ids the project already holds an allocation on (via a live account).
+
+    Used to filter the "Add Allocation" resource dropdown. We exclude by
+    *allocation*, not by *account*: an empty account (synced or member-only,
+    with no allocation yet) must NOT hide its resource — the admin still needs
+    to grant that first allocation. Soft-deleted accounts are also excluded
+    here so their resource stays offered; ``Account.get_or_create`` revives
+    such an account instead of colliding on the ``project_resource_ux`` slot.
+    """
+    return {
+        acct.resource_id
+        for acct in project.accounts
+        if not acct.deleted and acct.allocations
+    }
+
+
 # ---------------------------------------------------------------------------
 # Create Project
 # ---------------------------------------------------------------------------
@@ -687,12 +704,10 @@ def htmx_add_allocation_form(project):
     import calendar
     from sam.resources.resources import Resource
 
-    # Resources already linked to this project (via any account, even deleted).
-    linked_resource_ids = {
-        acct.resource_id for acct in project.accounts
-    }
+    # Resources the project already holds an allocation on (empty accounts don't count).
+    linked_resource_ids = _resources_with_allocation(project)
 
-    # Offer all active resources not yet linked to this project.
+    # Offer all active resources the project doesn't yet have an allocation on.
     available_resources = (
         db.session.query(Resource)
         .filter(Resource.is_active)
@@ -765,7 +780,7 @@ def htmx_add_allocation(project):
     def _reload_add_form(extra_errors=None):
         import calendar
         from sam.resources.resources import Resource as R
-        linked_ids = {a.resource_id for a in project.accounts}
+        linked_ids = _resources_with_allocation(project)
         available = (
             db.session.query(R)
             .filter(R.is_active)

--- a/tests/unit/test_accounting_models.py
+++ b/tests/unit/test_accounting_models.py
@@ -9,7 +9,9 @@ from datetime import datetime, timedelta
 import pytest
 
 from sam import AllocationTransactionType, Contract
+from sam.accounting.accounts import Account, AccountUser
 from sam.accounting.allocations import (
+    Allocation,
     AllocationTransaction,
     LEGACY_TRANSACTION_TYPES,
     LEGACY_TYPE_MAP,
@@ -17,11 +19,18 @@ from sam.accounting.allocations import (
     replay_amount,
 )
 from sam.manage.allocations import (
+    create_allocation,
     log_allocation_transaction,
     update_allocation,
 )
 
-from factories import make_allocation, make_user
+from factories import (
+    make_account,
+    make_allocation,
+    make_project,
+    make_resource,
+    make_user,
+)
 
 
 pytestmark = pytest.mark.unit
@@ -273,3 +282,92 @@ class TestReplayAmount:
         # B1 fix: EDIT row carries +4 delta, not 465; legacy replay matches stored amount.
         assert replayed == pytest.approx(465.0)
         assert replayed != pytest.approx(926.0)
+
+
+class TestAccountGetOrCreate:
+    """Account.get_or_create handles the empty- and soft-deleted-account slots
+    that the "Add Allocation" dropdown now offers (project_resource_ux is NOT
+    scoped by deleted, so a blind Account.create on an occupied slot would
+    raise IntegrityError)."""
+
+    @pytest.fixture
+    def acting_user(self, session):
+        return make_user(session)
+
+    def test_returns_existing_live_account(self, session):
+        """An empty (allocation-less) live account is reused, not duplicated."""
+        acct = make_account(session)
+        got = Account.get_or_create(
+            session, project_id=acct.project_id, resource_id=acct.resource_id,
+        )
+        assert got.account_id == acct.account_id
+        assert got.deleted is False
+        # No second account row created for this (project, resource).
+        n = session.query(Account).filter_by(
+            project_id=acct.project_id, resource_id=acct.resource_id,
+        ).count()
+        assert n == 1
+
+    def test_creates_when_absent(self, session):
+        """No account on the slot → a fresh one is created."""
+        project = make_project(session)
+        resource = make_resource(session)
+        got = Account.get_or_create(
+            session, project_id=project.project_id, resource_id=resource.resource_id,
+        )
+        assert got.account_id is not None
+        assert got.project_id == project.project_id
+        assert got.resource_id == resource.resource_id
+        assert got.deleted is False
+
+    def test_revives_soft_deleted_account(self, session):
+        """A soft-deleted account on the slot is un-deleted and re-seeded —
+        the same row is reused (no UNIQUE collision on project_resource_ux)."""
+        acct = make_account(session)
+        acct_id = acct.account_id
+        acct.deleted = True
+        session.flush()
+
+        got = Account.get_or_create(
+            session, project_id=acct.project_id, resource_id=acct.resource_id,
+        )
+        assert got.account_id == acct_id      # same row, revived
+        assert got.deleted is False
+        # Still exactly one row for the slot.
+        n = session.query(Account).filter_by(
+            project_id=acct.project_id, resource_id=acct.resource_id,
+        ).count()
+        assert n == 1
+        # Lead re-seeded as an active member.
+        member_ids = {
+            au.user_id for au in session.query(AccountUser).filter(
+                AccountUser.account_id == acct_id,
+                AccountUser.end_date.is_(None),
+            ).all()
+        }
+        assert got.project.project_lead_user_id in member_ids
+
+    def test_create_allocation_on_soft_deleted_slot_does_not_collide(
+        self, session, acting_user
+    ):
+        """The end-to-end fix: granting an allocation on a resource whose only
+        account was soft-deleted must succeed (revive + attach), not raise
+        IntegrityError on the project_resource_ux unique index."""
+        acct = make_account(session)
+        project_id, resource_id = acct.project_id, acct.resource_id
+        acct.deleted = True
+        session.flush()
+
+        alloc = create_allocation(
+            session,
+            project_id=project_id,
+            resource_id=resource_id,
+            amount=5_000.0,
+            start_date=datetime.now(),
+            end_date=datetime.now() + timedelta(days=365),
+            user_id=acting_user.user_id,
+        )
+        assert isinstance(alloc, Allocation)
+        # Allocation hangs off the revived (single) account.
+        assert alloc.account.account_id == acct.account_id
+        assert alloc.account.deleted is False

--- a/tests/unit/test_projects_routes_helpers.py
+++ b/tests/unit/test_projects_routes_helpers.py
@@ -12,8 +12,11 @@ import pytest
 from webapp.dashboards.admin.projects_routes import (
     _propose_extend_end,
     _propose_renew_dates,
+    _resources_with_allocation,
     _snap_to_end_of_month,
 )
+
+from factories import make_account, make_allocation, make_project, make_resource
 
 
 pytestmark = pytest.mark.unit
@@ -151,3 +154,58 @@ class TestProposeExtendEnd:
         latest  = _Alloc(datetime(2024, 11, 1), datetime(2025, 10, 31))
         # Anchor = latest; period = 1 year; end_date + period = Oct 31 2026.
         assert _propose_extend_end([earlier, latest]) == '2026-10-31'
+
+
+# ---------------------------------------------------------------------------
+# _resources_with_allocation — the "Add Allocation" dropdown exclusion set.
+# Regression guard for the WYOM0253 bug: an empty (allocation-less) account
+# must NOT hide its resource from the dropdown.
+# ---------------------------------------------------------------------------
+
+
+class TestResourcesWithAllocation:
+
+    def test_empty_account_does_not_hide_its_resource(self, session):
+        """A live account with zero allocations is excluded from the set, so
+        its resource stays offerable (the WYOM0253 / Derecho case)."""
+        project = make_project(session)
+        empty_res = make_resource(session)
+        make_account(session, project=project, resource=empty_res)  # no allocation
+
+        assert empty_res.resource_id not in _resources_with_allocation(project)
+
+    def test_resource_with_allocation_is_included(self, session):
+        """A resource the project actually holds an allocation on is in the set
+        (so it's filtered out of the dropdown)."""
+        project = make_project(session)
+        allocated_res = make_resource(session)
+        acct = make_account(session, project=project, resource=allocated_res)
+        make_allocation(session, account=acct)
+
+        assert allocated_res.resource_id in _resources_with_allocation(project)
+
+    def test_mixed_project_returns_only_allocated_resources(self, session):
+        """Only resources with an allocation appear; empty-account resources don't."""
+        project = make_project(session)
+        allocated_res = make_resource(session)
+        empty_res = make_resource(session)
+        acct = make_account(session, project=project, resource=allocated_res)
+        make_allocation(session, account=acct)
+        make_account(session, project=project, resource=empty_res)
+
+        result = _resources_with_allocation(project)
+        assert allocated_res.resource_id in result
+        assert empty_res.resource_id not in result
+
+    def test_soft_deleted_account_with_allocation_is_excluded(self, session):
+        """A soft-deleted account is excluded so its resource stays offerable;
+        Account.get_or_create revives the row on re-allocation rather than
+        colliding on project_resource_ux."""
+        project = make_project(session)
+        resource = make_resource(session)
+        acct = make_account(session, project=project, resource=resource)
+        make_allocation(session, account=acct)
+        acct.deleted = True
+        session.flush()
+
+        assert resource.resource_id not in _resources_with_allocation(project)


### PR DESCRIPTION
## Problem

On `/admin/project/<projcode>/edit` → **Add Allocation**, a resource was missing from the dropdown whenever the project had **any** account on it — *including an empty, allocation-less account*.

Empty accounts are a normal, common state (created by upstream sync, or when a user is added to a project/resource before any allocation is granted — ~1k exist in prod). Because the allocation tree is allocation-driven, an empty account is **also invisible there**, so an admin had **no UI path** to grant that resource's first allocation.

**Reported case:** WYOM0253 had an empty `Derecho` account, so "Derecho" never appeared in the dropdown even though the project held *no* Derecho allocation — while "Derecho GPU" (a distinct resource with no account) appeared normally.

## Root cause

The dropdown built its exclusion set from `project.accounts` (account existence), not from whether an **allocation** exists:

```python
linked_resource_ids = {acct.resource_id for acct in project.accounts}  # counts empty accounts
```

## Fix

**1. Exclude by *allocation*, not *account*** (`webapp/dashboards/admin/projects_routes.py`)
New shared helper `_resources_with_allocation(project)`, used by both `htmx_add_allocation_form` and the `_reload_add_form` error-mirror so the two copies can't drift. Resources whose only account is empty (or soft-deleted) are offered again.

**2. Harden account acquisition** (`sam/accounting/accounts.py`, `allocations.py`)
The `account.project_resource_ux` UNIQUE index is **not** scoped by `deleted`, so a soft-deleted account still occupies the `(project, resource)` slot. Once such a resource became offerable, the old blind `Account.create()` would raise an `IntegrityError`. Added `Account.get_or_create()` — reuses a live account, **revives** a soft-deleted one (un-delete + re-seed members), or creates fresh — and routed `Allocation.create()` through it. Member-seeding extracted to `Account._seed_members()` and made idempotent for the revive path.

## Tests

- `TestAccountGetOrCreate` — reuse-live / create-when-absent / revive-soft-deleted / `create_allocation` on a soft-deleted slot does **not** collide.
- `TestResourcesWithAllocation` — empty account doesn't hide its resource (the WYOM0253 regression guard); allocated resource excluded; mixed project; soft-deleted excluded.
- Full suite green (run by maintainer).

## Verified live (Playwright, webdev :5050)

| Project | State | Dropdown result |
|---|---|---|
| **NMMM0048** | empty Casper + Derecho accounts | Casper & Derecho now **offered** ✓ |
| **WYOM0253** | real allocations on Casper + Derecho | both correctly **excluded**; GPU variants still offered ✓ |

End-to-end create path exercised — the new allocation attaches to the existing account (no duplicate account, no constraint error).

## Out of scope (follow-up)

`webapp/dashboards/allocations/blueprint.py` `htmx_resources_for_project` is a *different* dropdown (allocations dashboard) with its own account-join design — worth a separate look for an analogous gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)