### PR TITLE
UX tweaks: resource-details chart & table polish

### DIFF
--- a/src/sam/enums.py
+++ b/src/sam/enums.py
@@ -35,6 +35,33 @@ class ResourceTypeName(StrEnum):
         """Return True for resource types charged via comp/dav summaries."""
         return name in (cls.HPC, cls.DAV)
 
+    @classmethod
+    def allocation_unit(cls, name, amount=None):
+        """Unit label shown next to an allocation figure, or None.
+
+        HPC/DAV are core-hours; DISK/ARCHIVE are labelled 'TiB' (the stored
+        amount is technically TiB-years, but 'TiB' reads cleaner on the
+        dashboard). DATA ACCESS has no natural unit.
+
+        ``amount == 1`` is an access-boolean grant (e.g. Gust,
+        HPC_Futures_Lab, Quasar) and is always unitless regardless of type,
+        so the dashboard never renders the awkward "1 hours" / "1 TiB".
+        """
+        if amount == 1:
+            return None
+        return _ALLOCATION_UNIT_BY_TYPE.get(name)
+
+
+#: Allocation unit label keyed by resource type (see
+#: ``ResourceTypeName.allocation_unit``). None = no natural unit.
+_ALLOCATION_UNIT_BY_TYPE = {
+    ResourceTypeName.HPC:         'hours',
+    ResourceTypeName.DAV:         'hours',
+    ResourceTypeName.DISK:        'TiB',
+    ResourceTypeName.ARCHIVE:     'TiB',
+    ResourceTypeName.DATA_ACCESS: None,
+}
+
 
 class FacilityName(StrEnum):
     """Common facility names. Not exhaustive — additional facilities exist

--- a/src/sam/fmt.py
+++ b/src/sam/fmt.py
@@ -438,6 +438,11 @@ def register_jinja_filters(app) -> None:
     app.jinja_env.filters['fmt_hours']    = hours
     app.jinja_env.filters['fmt_factor']   = factor
     app.jinja_env.filters['to_local_dt']  = to_local_dt
+    # Resource-type allocation unit label ('hours' / 'TiB' / None). Used on
+    # the headline "<n> allocated" figures. Usage:
+    #   {{ resource.resource_type | alloc_unit(resource.allocated) }}
+    from sam.enums import ResourceTypeName
+    app.jinja_env.filters['alloc_unit']   = ResourceTypeName.allocation_unit
     # Global (not a filter) so templates can render "{{ local_tz_label() }}"
     # alongside naive-local timestamps that don't go through to_local_dt.
     app.jinja_env.globals['local_tz_label'] = local_tz_label

--- a/src/sam/queries/charges.py
+++ b/src/sam/queries/charges.py
@@ -772,6 +772,100 @@ def get_monthly_user_counts_for_project(
     return {row.month: int(row.users or 0) for row in query.all()}
 
 
+_USAGE_METRIC_ROW_KEY = {
+    'charges':    'total_charges',
+    'jobs':       'total_jobs',
+    'core_hours': 'total_core_hours',
+}
+
+
+def get_daily_user_usage_for_project(
+    session: Session,
+    projcode: Union[str, List[str]],
+    resource: str,
+    start_date: datetime,
+    end_date: datetime,
+    metric: str = 'charges',
+    top_n: int = 10,
+) -> Dict:
+    """
+    Per-day usage broken down by the top-N users over the whole window,
+    with the remainder rolled into a single "Others" series. Powers the
+    stacked-by-user Usage Trend bar chart on the resource-details page.
+
+    The top-N set is ranked by each user's *period total* of the selected
+    metric (NOT per-day), so the legend reflects the dominant users across
+    the entire visible range — the set of interest. Every (date, user) cell
+    is zero-filled so all series arrays align positionally with ``dates``.
+
+    Args:
+        metric: one of 'charges' / 'jobs' / 'core_hours'. Selects which
+            CompChargeSummary aggregate is stacked and ranked.
+        top_n: number of named users; the rest aggregate into "Others".
+
+    Returns:
+        {
+          'dates':  [date, ...],                            # ascending
+          'series': [
+              {'label': 'Others',  'values': [num, ...]},   # first (bottom)
+              {'label': <username>, 'values': [num, ...]},  # lowest→highest rank
+              ...
+          ],
+        }
+        ``series`` omits the "Others" entry when there are <= top_n users.
+        Returns {'dates': [], 'series': []} when there is no activity.
+    """
+    value_key = _USAGE_METRIC_ROW_KEY.get(metric, 'total_charges')
+
+    rows = query_comp_charge_summaries(
+        session, start_date, end_date,
+        projcode=projcode, resource=resource, per_day=True,
+    )
+    if not rows:
+        return {'dates': [], 'series': []}
+
+    # Pivot to per_user[username][date] = summed metric (across queue/machine),
+    # accumulating each user's period total for ranking.
+    all_dates = set()
+    per_user: Dict[str, Dict] = {}
+    user_totals: Dict[str, float] = {}
+    for row in rows:
+        username = row['username']
+        d = row['activity_date']
+        val = row[value_key] or 0
+        all_dates.add(d)
+        bucket = per_user.setdefault(username, {})
+        bucket[d] = bucket.get(d, 0) + val
+        user_totals[username] = user_totals.get(username, 0) + val
+
+    dates = sorted(all_dates)
+
+    # Rank users by period total desc; top_n named, remainder -> Others.
+    ranked = sorted(user_totals, key=lambda u: user_totals[u], reverse=True)
+    named = ranked[:top_n]
+    others = ranked[top_n:]
+
+    series: List[Dict] = []
+
+    # Others first so it sits at the bottom of the visual stack (matches
+    # get_disk_usage_timeseries_by_user and the stacked-area renderers).
+    if others:
+        series.append({
+            'label': 'Others',
+            'values': [sum(per_user[u].get(d, 0) for u in others) for d in dates],
+        })
+
+    # Named users ordered lowest->highest rank (reversed) so the largest band
+    # ends up on top — the renderer's reversed legend/palette expects this.
+    for username in reversed(named):
+        series.append({
+            'label': username,
+            'values': [per_user[username].get(d, 0) for d in dates],
+        })
+
+    return {'dates': dates, 'series': series}
+
+
 def get_daily_breakdown_for_project(
     session: Session,
     projcode: Union[str, List[str]],

--- a/src/sam/queries/dashboard.py
+++ b/src/sam/queries/dashboard.py
@@ -920,6 +920,10 @@ def get_resource_detail_data(
     # Determine resource type to query appropriate tables
     resource_type = resource.resource_type.resource_type if resource.resource_type else ResourceTypeName.HPC
 
+    # Surface the type so the template can label the allocation figure with
+    # its unit (hours / TiB) via the alloc_unit filter.
+    resource_summary['resource_type'] = str(resource_type)
+
     # Resolve the scope project (controls daily charge aggregation)
     if scope_projcode and scope_projcode != projcode:
         scope_proj = Project.get_by_projcode(session, scope_projcode)

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -277,6 +277,112 @@ def generate_usage_timeseries_matplotlib(daily_data, link_to_day_rows=False,
     return svg_io.getvalue()
 
 
+def _usage_stacked_cache_key(timeseries, metric='charges'):
+    return _content_hash([_content_hash(timeseries), metric])
+
+
+# One entry per (resource, time-range, metric). Stacked-by-user variant of
+# the Usage Trend bar chart — each daily bar is segmented by the top-N users
+# over the window + "Others".
+@caching.chart_cached(name='usage_timeseries_stacked', maxsize=128,
+                      key_fn=_usage_stacked_cache_key)
+def generate_usage_timeseries_stacked_by_user(timeseries, metric='charges') -> str:
+    """
+    Stacked-bar Usage Trend chart: one bar per day, segmented by the top-N
+    users over the visible window + "Others", with a clickable right-side
+    legend.
+
+    Args:
+        timeseries: dict shaped as
+            ``sam.queries.charges.get_daily_user_usage_for_project`` returns:
+            ``{'dates': [date, ...], 'series': [{'label','values'}, ...]}``.
+            ``series[0]`` is conventionally ``'Others'`` (drawn first so it
+            sits at the bottom of the stack with a neutral grey).
+        metric: one of 'charges' / 'jobs' / 'core_hours' — controls the
+            y-axis label and the cache key.
+
+    Interactions (wired via svg-chart-links.js):
+        - every bar segment of a non-zero day links to
+          ``#day-bar-YYYY-MM-DD`` → expands that day's row in the Historical
+          Usage table (same as the flat-bar chart).
+        - each named legend entry links to ``#usage-user-<username>`` →
+          expands that user's row in the Usage by User card. 'Others' is
+          never linked.
+
+    Returns:
+        SVG string ready for template rendering.
+    """
+    if not timeseries or not timeseries.get('dates') or not timeseries.get('series'):
+        return '<div class="text-center text-muted">No usage data recorded for this period</div>'
+
+    dates = list(timeseries['dates'])
+    series = list(timeseries['series'])
+
+    # Others (always first per get_daily_user_usage_for_project) gets a
+    # neutral grey; named users use the Unity 10-colour stacked palette.
+    colors = []
+    cycle_idx = 0
+    for s in series:
+        if s['label'] == 'Others':
+            colors.append(UNITY_NCAR_GRAY_LIGHT)
+        else:
+            colors.append(UNITY_STACK_10[cycle_idx % 10])
+            cycle_idx += 1
+
+    fig, ax = plt.subplots(figsize=(18, 5))
+
+    # Stack the daily bars: accumulate `bottom` across series. Every segment
+    # of a given day carries the same #day-bar-<iso> url so a click anywhere
+    # in that day's stack expands the day (preserves the flat-bar behaviour).
+    bottoms = [0.0] * len(dates)
+    for s, color in zip(series, colors):
+        vals = list(s['values'])
+        bars = ax.bar(dates, vals, width=1, bottom=bottoms,
+                      color=color, edgecolor=UNITY_NCAR_NAVY, lw=0.3)
+        for d, value, rect in zip(dates, vals, bars.patches):
+            if not value:
+                continue
+            iso = d.isoformat() if hasattr(d, 'isoformat') else str(d)
+            rect.set_url(f'#day-bar-{iso}')
+        bottoms = [b + v for b, v in zip(bottoms, vals)]
+
+    ax.set_ylabel(_USAGE_METRIC_YLABELS.get(metric, 'Charges'))
+    ax.yaxis.set_major_formatter(fmt.mpl_number_formatter())
+    ax.grid(True, alpha=0.3)
+
+    # Reversed-order legend so it reads top-to-bottom matching the visual
+    # stack; each handle/text is addressable by index for set_url().
+    import matplotlib.patches as mpatches
+    rev_series = list(reversed(series))
+    rev_colors = list(reversed(colors))
+    handles = [mpatches.Patch(color=c, label=s['label'])
+               for s, c in zip(rev_series, rev_colors)]
+    leg = ax.legend(
+        handles=handles,
+        loc='center left',
+        bbox_to_anchor=(1.01, 0.5),
+        frameon=False,
+        fontsize=11,
+        title_fontsize=12,
+        labelspacing=0.7,
+    )
+
+    # Named legend entries → expand that user's Usage-by-User row.
+    for s, patch, text in zip(rev_series, leg.get_patches(), leg.get_texts()):
+        if s['label'] == 'Others':
+            continue
+        url = f'#usage-user-{s["label"]}'
+        patch.set_url(url)
+        text.set_url(url)
+
+    fig.autofmt_xdate()
+
+    svg_io = StringIO()
+    fig.savefig(svg_io, format='svg', bbox_inches='tight', transparent=True)
+    plt.close(fig)
+    return svg_io.getvalue()
+
+
 # ---------------------------------------------------------------------------
 # 1b. Disk usage stacked-area chart (Resource Usage Details — DISK)
 # ---------------------------------------------------------------------------

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -29,6 +29,7 @@ from sam.queries.charges import (
     get_daily_breakdown_for_project,
     get_user_summary_for_project,
     get_daily_summary_for_project,
+    get_daily_user_usage_for_project,
     get_monthly_user_counts_for_project,
     get_charges_by_projcode,
 )
@@ -48,7 +49,11 @@ from webapp.api.access_control import (
     require_project_access,
     require_threshold_edit,
 )
-from ..charts import generate_usage_timeseries_matplotlib, generate_disk_usage_stacked_area
+from ..charts import (
+    generate_usage_timeseries_matplotlib,
+    generate_usage_timeseries_stacked_by_user,
+    generate_disk_usage_stacked_area,
+)
 from webapp.disk_scans import is_enabled as is_fs_scans_enabled
 from webapp.disk_scans import service as disk_scans_service
 
@@ -816,13 +821,32 @@ def resource_details_usage_chart(project):
     if metric not in available:
         metric = 'charges'
 
-    series = (detail_data or {}).get(_USAGE_CHART_DATA_KEY[metric])
-    svg = generate_usage_timeseries_matplotlib(
-        series or {'dates': [], 'values': []},
-        link_to_day_rows=True,
+    # Stacked-by-user variant: each daily bar is segmented by the top-10
+    # users over the whole window + "Others", ranked by the displayed metric.
+    # Falls back to the flat single-series bars when the period has <= 1 user
+    # (a 1-colour stack is pointless and the Usage by User card is hidden
+    # there too) or for non-compute resources, where comp_charge_summary
+    # yields no per-user rows.
+    scope_projcodes = _resolve_scope_projcodes(project, scope)
+    stacked = get_daily_user_usage_for_project(
+        db.session, scope_projcodes, resource_name, start_date, end_date,
         metric=metric,
     )
-    has_data = bool(series and series.get('values'))
+    named_series = [s for s in stacked['series'] if s['label'] != 'Others']
+
+    if len(named_series) > 1:
+        svg = generate_usage_timeseries_stacked_by_user(stacked, metric=metric)
+        has_data = True
+        is_stacked = True
+    else:
+        series = (detail_data or {}).get(_USAGE_CHART_DATA_KEY[metric])
+        svg = generate_usage_timeseries_matplotlib(
+            series or {'dates': [], 'values': []},
+            link_to_day_rows=True,
+            metric=metric,
+        )
+        has_data = bool(series and series.get('values'))
+        is_stacked = False
 
     return render_template(
         'dashboards/user/partials/usage_chart.html',
@@ -835,6 +859,7 @@ def resource_details_usage_chart(project):
         start_date=start_date.strftime('%Y-%m-%d'),
         end_date=end_date.strftime('%Y-%m-%d'),
         has_data=has_data,
+        is_stacked=is_stacked,
     )
 
 

--- a/src/webapp/static/css/components.css
+++ b/src/webapp/static/css/components.css
@@ -252,3 +252,18 @@ tbody.alloc-tree-body.collapsing { transition: none !important; }
 .sortable-header::after { content: ' \2195'; color: #adb5bd; font-size: 0.8em; }
 .sortable-header.sort-asc::after { content: ' \2191'; color: #495057; }
 .sortable-header.sort-desc::after { content: ' \2193'; color: #495057; }
+
+/* resource_details Historical Usage / Usage by User tables.
+   Each lazily-loaded user/queue/date subtree renders as its own nested
+   <table> inside a colspan cell, so without a fixed layout its columns
+   size independently and the numeric values drift out of alignment with
+   the parent table. Pinning both the parent (.usage-table-N) and the
+   nested subtree (same class) to table-layout:fixed with a shared
+   colgroup makes every tier line up column-for-column. The -5 variant is
+   Historical Usage (Date + 4 numeric); -4 is Usage by User (Username +
+   3 numeric). */
+.usage-table-5, .usage-table-4 { table-layout: fixed; }
+.usage-table-5 .ucol-name { width: 36%; }
+.usage-table-5 .ucol-num  { width: 16%; }
+.usage-table-4 .ucol-name { width: 40%; }
+.usage-table-4 .ucol-num  { width: 20%; }

--- a/src/webapp/static/js/svg-chart-links.js
+++ b/src/webapp/static/js/svg-chart-links.js
@@ -20,6 +20,9 @@
  *     #disk-ent-group-<gid> (disk-scans By User / By Group tab) → expand
  *     that entity's row in the table below (found via data-owner-uid /
  *     data-group-gid), which lazy-loads its directories.
+ *   - Legend href starts with #usage-user-<username> (stacked-by-user
+ *     Usage Trend chart on the compute resource-details page) → expand
+ *     that user's row in the Usage by User card below.
  *
  * Safe on pages where the target containers aren't included — each
  * branch checks for its targets and silently no-ops.
@@ -45,6 +48,9 @@
     // data-group-gid (see disk_scans_entities.html).
     var ENT_OWNER_PREFIX = '#disk-ent-owner-';
     var ENT_GROUP_PREFIX = '#disk-ent-group-';
+    // Stacked-by-user Usage Trend chart (compute resource-details): a legend
+    // username click expands that user's row in the Usage by User card.
+    var USAGE_USER_PREFIX = '#usage-user-';
 
     // Distribution histogram (Access-history / File-size tabs) → expand the
     // matching bucket's per-user detail row. The bucket <tr> carries
@@ -123,6 +129,34 @@
         }, 60);
     }
 
+    // Legend username → expand that user's row in the Usage by User card.
+    // The user row's first <td> carries data-sort-value="<username>"
+    // (resource_details.html), scoped to #users-table. Looking up by username
+    // (not the render-time uid) is robust to the table's client-side
+    // re-sorting. The card body (#collapseUsers) is opened first in case the
+    // analyst collapsed it. Single-triple users render inline with no
+    // collapse target — we just scroll to them.
+    function openUserRow(username) {
+        if (!window.bootstrap) return;
+        var card = document.getElementById('collapseUsers');
+        if (card) {
+            bootstrap.Collapse.getOrCreateInstance(card, {toggle: false}).show();
+        }
+        var cell = document.querySelector(
+            '#users-table td[data-sort-value="' + username + '"]');
+        if (!cell) return;
+        var row = cell.closest('tr');
+        if (!row) return;
+        var sel = row.getAttribute('data-bs-target');
+        if (sel) {
+            var el = document.querySelector(sel);
+            if (el) bootstrap.Collapse.getOrCreateInstance(el, {toggle: false}).show();
+        }
+        setTimeout(function () {
+            row.scrollIntoView({behavior: 'smooth', block: 'center'});
+        }, 60);
+    }
+
     document.addEventListener('click', function (e) {
         var a = e.target.closest && e.target.closest('svg a');
         if (!a) return;
@@ -162,6 +196,15 @@
             if (gid === '') return;
             e.preventDefault();
             openEntityRow('data-group-gid', gid, a.closest('.tab-pane'));
+            return;
+        }
+
+        // Stacked-chart legend → expand the user's Usage-by-User row
+        if (href.indexOf(USAGE_USER_PREFIX) === 0) {
+            var uname = href.slice(USAGE_USER_PREFIX.length);
+            if (uname === '') return;
+            e.preventDefault();
+            openUserRow(uname);
             return;
         }
 

--- a/src/webapp/templates/dashboards/user/partials/day_subtree.html
+++ b/src/webapp/templates/dashboards/user/partials/day_subtree.html
@@ -27,7 +27,10 @@
       No activity for this day in the selected scope.
     </div>
   {% else %}
-    <table class="table table-sm table-borderless mb-0">
+    <table class="table table-sm table-borderless mb-0 usage-table-5">
+      <colgroup>
+        <col class="ucol-name"><col class="ucol-num"><col class="ucol-num"><col class="ucol-num"><col class="ucol-num">
+      </colgroup>
       <tbody>
         {% for sub in day.rows %}
           {% set jid = did ~ '-jobs' ~ loop.index %}

--- a/src/webapp/templates/dashboards/user/partials/day_subtree.html
+++ b/src/webapp/templates/dashboards/user/partials/day_subtree.html
@@ -33,7 +33,6 @@
           {% set jid = did ~ '-jobs' ~ loop.index %}
           <tr class="table-light">
             <td class="ps-4 text-muted">
-              <i class="fas fa-angle-right me-1"></i>
               <code>{{ sub.username }}</code> / <em>{{ sub.queue }}</em>
               {% if jobs_machine %}{{ jobs_button(jid) }}{% endif %}
             </td>

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_directories.html
@@ -65,8 +65,8 @@
    it is NOT a client re-sort; the column headers remain available too. #}
 {% set _pills = [
   (_size_key,  'Size',      'fa-hard-drive'),
-  (_files_key, '# Files',   'fa-hashtag'),
-  ('dirs',     '# Subdirs', 'fa-folder-tree'),
+  (_files_key, 'Files',     'fa-hashtag'),
+  ('dirs',     'Subdirs',   'fa-folder-tree'),
 ] %}
 {# Recursive subdirectory count (dir_count_r) is 0 by definition for leaves,
    so the Dirs column + its sort pill are meaningless (and would degenerate

--- a/src/webapp/templates/dashboards/user/partials/project_card.html
+++ b/src/webapp/templates/dashboards/user/partials/project_card.html
@@ -155,7 +155,7 @@
                             <td><strong>{{ resource.resource_name }}</strong></td>
                             <td>
                                 <div class="d-flex justify-content-between small mb-1">
-                                    <span class="fw-semibold {% if not is_expired %}text-primary{% endif %}">{{ resource.allocated | fmt_number }} allocated</span>
+                                    <span class="fw-semibold {% if not is_expired %}text-primary{% endif %}">{{ resource.allocated | fmt_number }}{% set _unit = resource.resource_type | alloc_unit(resource.allocated) %}{% if _unit %} {{ _unit }}{% endif %} allocated</span>
                                     {% if first.bar_state == 'active' and first.days_until_expiration is not none and first.days_until_expiration >= 0 %}
                                         <span class="text-dark">{{ first.days_until_expiration }}d remaining</span>
                                     {% elif first.bar_state == 'expired' %}

--- a/src/webapp/templates/dashboards/user/partials/usage_chart.html
+++ b/src/webapp/templates/dashboards/user/partials/usage_chart.html
@@ -43,6 +43,8 @@
 {% if has_data %}
 <div class="text-muted small text-center mt-2">
     <i class="fas fa-hand-pointer me-1"></i>
-    Click a bar to expand that day in <em>Historical Usage</em> below. Reload the page to reset all selections.
+    Click a bar to expand that day in <em>Historical Usage</em> below.
+    {% if is_stacked %}Click a username in the legend to expand that user in <em>Usage by User</em>.{% endif %}
+    Reload the page to reset all selections.
 </div>
 {% endif %}

--- a/src/webapp/templates/dashboards/user/partials/user_subtree.html
+++ b/src/webapp/templates/dashboards/user/partials/user_subtree.html
@@ -40,7 +40,6 @@
             {% set djid = uid ~ '-d' ~ loop.index ~ '-jobs' %}
             <tr class="table-light">
               <td class="ps-4 text-muted">
-                <i class="fas fa-angle-right me-1"></i>
                 <small>{{ d.date }}</small>
                 <em class="ms-2">{{ q0.queue }}</em>
                 {% if jobs_machine %}{{ jobs_button(djid) }}{% endif %}
@@ -62,7 +61,7 @@
             {% set queue_is_leaf = (q.dates|length == 1) %}
             <tr {% if q.dates|length > 1 %}class="table-secondary cursor-pointer" data-bs-toggle="collapse" data-bs-target="#user-queue-dates-{{ qid }}" aria-expanded="false"{% else %}class="table-secondary"{% endif %}>
               <td class="ps-4 text-muted">
-                <i class="fas fa-angle-right me-1"></i><em>{{ q.queue }}</em>
+                <em>{{ q.queue }}</em>
                 {% if q.dates|length > 1 %}
                   <i class="fas fa-chevron-right ms-1 small text-muted collapse-icon"></i>
                 {% endif %}
@@ -83,7 +82,7 @@
                 {% set djid = qid ~ '-d' ~ loop.index ~ '-jobs' %}
                 <tr class="collapse table-light" id="user-queue-dates-{{ qid }}">
                   <td class="ps-5 text-muted">
-                    <i class="fas fa-angle-right me-1"></i><small>{{ d.date }}</small>
+                    <small>{{ d.date }}</small>
                     {% if jobs_machine %}{{ jobs_button(djid) }}{% endif %}
                   </td>
                   <td class="text-end"><small>{{ d.jobs | fmt_number }}</small></td>

--- a/src/webapp/templates/dashboards/user/partials/user_subtree.html
+++ b/src/webapp/templates/dashboards/user/partials/user_subtree.html
@@ -32,7 +32,10 @@
     {% set multi_queue = (user.queues|length > 1) %}
     {% set q0 = user.queues[0] %}
     {% set single_q_multi_d = (not multi_queue and q0.dates|length > 1) %}
-    <table class="table table-sm table-borderless mb-0">
+    <table class="table table-sm table-borderless mb-0 usage-table-4">
+      <colgroup>
+        <col class="ucol-name"><col class="ucol-num"><col class="ucol-num"><col class="ucol-num">
+      </colgroup>
       <tbody>
         {% if single_q_multi_d %}
           {# Streamlined dates (skip the redundant single-queue tier). #}

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -18,7 +18,10 @@
    touching the non-sortable Total / empty-state tbodies. #}
 {% macro user_breakdown_table(breakdown, table_id) %}
 <div class="table-responsive">
-    <table class="table table-sm table-hover" id="{{ table_id }}">
+    <table class="table table-sm table-hover usage-table-4" id="{{ table_id }}">
+        <colgroup>
+            <col class="ucol-name"><col class="ucol-num"><col class="ucol-num"><col class="ucol-num">
+        </colgroup>
         <thead class="thead-dark">
             <tr>
                 <th class="sortable-header" data-sort="text">Username</th>
@@ -110,7 +113,10 @@
    via get_monthly_user_counts_for_project). #}
 {% macro daily_breakdown_table(breakdown, table_id, span_days) %}
 <div class="table-responsive">
-    <table class="table table-sm table-hover" id="{{ table_id }}">
+    <table class="table table-sm table-hover usage-table-5" id="{{ table_id }}">
+        <colgroup>
+            <col class="ucol-name"><col class="ucol-num"><col class="ucol-num"><col class="ucol-num"><col class="ucol-num">
+        </colgroup>
         <thead class="thead-dark">
             <tr>
                 <th>Date</th>

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -287,7 +287,7 @@
                         <td><strong>{{ resource_name }}</strong></td>
                         <td>{{ summary.start_date | fmt_date }}</td>
                         <td>{{ summary.end_date | fmt_date }}</td>
-                        <td class="text-primary">{{ summary.allocated | fmt_number }}</td>
+                        <td class="text-primary">{{ summary.allocated | fmt_number }}{% set _unit = summary.resource_type | alloc_unit(summary.allocated) %}{% if _unit %} {{ _unit }}{% endif %}</td>
                         <td class="text-warning">
                             {{ summary.used | fmt_number }}{% if summary.is_inheriting and summary.self_used is not none %}
                             <span class="text-muted small" title="This project's contribution to the shared pool">({{ summary.self_used | fmt_number }} yours)</span>

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -483,7 +483,9 @@
     </div>
 </div>
 
-<!-- User Breakdown Card -->
+<!-- User Breakdown Card — suppressed for a single user, where it just
+     restates the Historical Usage totals. -->
+{% if user_breakdown | length > 1 %}
 <div class="card mb-4">
     <div class="card-header cursor-pointer" data-bs-toggle="collapse" data-bs-target="#collapseUsers" aria-expanded="true">
         <h5 class="mb-0">
@@ -500,6 +502,7 @@
         </div>
     </div>
 </div>
+{% endif %}
 
 <!-- Allocation Management Modals -->
 {% include 'dashboards/user/fragments/allocation_modals.html' %}

--- a/tests/unit/test_enums.py
+++ b/tests/unit/test_enums.py
@@ -1,0 +1,36 @@
+"""Unit tests for sam.enums — pure Python, no DB."""
+
+import pytest
+
+from sam.enums import ResourceTypeName
+
+
+class TestAllocationUnit:
+    """ResourceTypeName.allocation_unit — the label shown next to a project
+    card's '<n> allocated' figure."""
+
+    @pytest.mark.parametrize('rtype, expected', [
+        ('HPC', 'hours'),
+        ('DAV', 'hours'),
+        ('DISK', 'TiB'),
+        ('ARCHIVE', 'TiB'),
+        ('DATA ACCESS', None),
+        ('something-unknown', None),
+    ])
+    def test_unit_by_type(self, rtype, expected):
+        assert ResourceTypeName.allocation_unit(rtype) == expected
+
+    @pytest.mark.parametrize('rtype', ['HPC', 'DAV', 'DISK', 'ARCHIVE'])
+    def test_access_boolean_amount_one_is_unitless(self, rtype):
+        # allocated == 1 is an access-boolean grant (Gust, HPC_Futures_Lab,
+        # Quasar, ...) — never labelled, regardless of type.
+        assert ResourceTypeName.allocation_unit(rtype, 1) is None
+
+    def test_real_amount_keeps_unit(self):
+        assert ResourceTypeName.allocation_unit('HPC', 1_500_000) == 'hours'
+        assert ResourceTypeName.allocation_unit('DISK', 5_000) == 'TiB'
+
+    def test_enum_member_arg_matches_string(self):
+        # StrEnum members compare equal to their string values, so passing the
+        # member works the same as passing the bare DB string.
+        assert ResourceTypeName.allocation_unit(ResourceTypeName.HPC) == 'hours'

--- a/tests/unit/test_webapp_disk_scans.py
+++ b/tests/unit/test_webapp_disk_scans.py
@@ -1459,11 +1459,11 @@ def test_directories_subdirs_column_hidden_under_leaves_only(
     # has a non-zero dir_count_r).
     on = auth_client.get(base).get_data(as_text=True)
     assert 'Dirs' in on
-    assert '# Subdirs' in on
+    assert 'Subdirs' in on
     # With leaves-only, both are suppressed.
     off = auth_client.get(base + '&leaves_only=1').get_data(as_text=True)
     assert 'Dirs' not in off
-    assert '# Subdirs' not in off
+    assert 'Subdirs' not in off
 
 
 def test_directories_dirs_column_hidden_when_uniformly_zero(
@@ -1483,7 +1483,7 @@ def test_directories_dirs_column_hidden_when_uniformly_zero(
             f'/directories?resource={_RES}&recursive=0')
     body = auth_client.get(base).get_data(as_text=True)
     assert 'Dirs' not in body
-    assert '# Subdirs' not in body
+    assert 'Subdirs' not in body
 
 
 def test_directories_page_renders(auth_client, active_project):


### PR DESCRIPTION
A batch of UX polish on the compute **resource-details** page, the project **Resources** card, and the shared disk-scans table.

## Changes

1. **disk-scans:** drop the redundant `#` from the "Large Directories" sort pill labels (`# Files` → `Files`, `# Subdirs` → `Subdirs`) — the icons already convey "count".
2. **resource-details:** drop the leading `>` chevrons from the usage subtree rows — they collided visually with the trailing expand chevrons. `ps-*` padding already conveys indentation.
3. **resource-details:** give the Historical Usage / Usage by User tables `table-layout: fixed` with matching colgroups so the lazily-loaded nested subtree columns line up with the parent table.
4. **resource-details:** hide the "Usage by User" card entirely when a resource/period has ≤1 user (it just restated the Historical Usage totals).
5. **resource-details ⭐:** stack the **Usage Trend** bars by the **top-10 users over the visible window + "Others"**, with a clickable right-side legend.
   - Top-10 is ranked by the *displayed* metric (charges/jobs/core-hours), so the legend always matches the stack.
   - Clicking a bar segment still expands that day in Historical Usage (unchanged).
   - Clicking a username in the legend opens the Usage by User card and expands/scrolls to that user's row.
   - Falls back to the original flat bars for ≤1-user periods and non-compute resources.
6. **resources card ⭐:** label the headline allocation figure with its **unit** — `hours` for HPC/DAV, `TiB` for disk/archive, and no unit for access-boolean grants (e.g. `1 allocated`). Applied to the project Resources card and the resource-details Resource Summary "Allocated" cell only — not to dense tables/tooltips/CLI.
   - New centralized `ResourceTypeName.allocation_unit()` + `alloc_unit` Jinja filter; unit suppressed when `allocated == 1` (catches HPC/DISK-typed access grants like Gust, HPC_Futures_Lab, Quasar).

Reuses the established stacked top-N+Others pattern from the disk / queue-load dashboards (`generate_*_stacked_area`, `get_disk_usage_timeseries_by_user`, `svg-chart-links.js`).

## Tests
- `tests/unit/test_enums.py` covers `allocation_unit` (type map + `amount == 1` suppression).

## Verification
- Open `/user/resource-details/<projcode>?resource=Derecho` for a multi-user project: bars are segmented by user with a top-10 legend; metric pills track the top-10 set; bar-click expands the day; legend-click expands the user; single-user → flat-bar fallback.
- Open a user dashboard: Resources card shows "1.50M hours allocated", "5,000 TiB allocated", and "1 allocated" (unitless) for access grants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)