### PR TITLE
feat(help): reusable tooltip/popover system for dashboard jargon

### DIFF
--- a/src/webapp/static/css/components.css
+++ b/src/webapp/static/css/components.css
@@ -267,3 +267,23 @@ tbody.alloc-tree-body.collapsing { transition: none !important; }
 .usage-table-5 .ucol-num  { width: 16%; }
 .usage-table-4 .ucol-name { width: 40%; }
 .usage-table-4 .ucol-num  { width: 20%; }
+
+/* Help affordances (help.html macros, activated by tooltip-init.js).
+   .help-icon — chrome-less ⓘ/? button next to a heading or label.
+   .help-term — inline term/column-header with a dotted-underline cue. */
+.help-icon {
+    color: #adb5bd;
+    font-size: inherit;
+    line-height: 1;
+    vertical-align: baseline;
+    cursor: help;
+    text-decoration: none;
+}
+.help-icon:hover,
+.help-icon:focus-visible { color: #6c757d; }
+.help-term {
+    cursor: help;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+    text-decoration-thickness: 1px;
+}

--- a/src/webapp/static/js/tooltip-init.js
+++ b/src/webapp/static/js/tooltip-init.js
@@ -1,0 +1,54 @@
+/*
+ * tooltip-init.js — global activation of Bootstrap tooltips & popovers.
+ *
+ * The app emits help affordances declaratively via the help.html macros
+ * (data-bs-toggle="tooltip" / "popover"). Bootstrap does not auto-initialize
+ * these, so we do it here: once on load, and again for any fragment HTMX swaps
+ * into the page. Instances are disposed before HTMX removes their trigger so no
+ * orphaned popup lingers in <body>.
+ *
+ * Self-hosted (CSP script-src 'self'); no inline script required.
+ */
+(function () {
+  'use strict';
+
+  function initIn(root) {
+    if (!root || !window.bootstrap) return;
+    root.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
+      if (!bootstrap.Tooltip.getInstance(el)) new bootstrap.Tooltip(el);
+    });
+    root.querySelectorAll('[data-bs-toggle="popover"]').forEach(function (el) {
+      if (!bootstrap.Popover.getInstance(el)) new bootstrap.Popover(el);
+    });
+  }
+
+  function disposeIn(el) {
+    if (!el || !window.bootstrap) return;
+    var tip = bootstrap.Tooltip.getInstance(el);
+    if (tip) tip.dispose();
+    var pop = bootstrap.Popover.getInstance(el);
+    if (pop) pop.dispose();
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    initIn(document);
+  });
+
+  // Fragments swapped in by HTMX (rolling-rate, card bodies, modals, ...).
+  document.body.addEventListener('htmx:afterSwap', function (evt) {
+    initIn(evt.target);
+  });
+
+  // Dispose before HTMX removes a node, and its descendants, to avoid orphans.
+  document.body.addEventListener('htmx:beforeCleanupElement', function (evt) {
+    var el = evt.target;
+    if (!el || !el.matches) return;
+    if (el.matches('[data-bs-toggle="tooltip"], [data-bs-toggle="popover"]')) {
+      disposeIn(el);
+    }
+    if (el.querySelectorAll) {
+      el.querySelectorAll('[data-bs-toggle="tooltip"], [data-bs-toggle="popover"]')
+        .forEach(disposeIn);
+    }
+  });
+})();

--- a/src/webapp/templates/dashboards/allocations/partials/adjustment_details_modal.html
+++ b/src/webapp/templates/dashboards/allocations/partials/adjustment_details_modal.html
@@ -3,6 +3,8 @@
    Context: ``r`` is a single row dict from ``get_recent_charge_adjustments``.
    Style mirrors ``render_project_info`` in project_card.html. Empty / None
    fields are omitted entirely. #}
+{% from 'dashboards/fragments/help.html' import help_icon with context %}
+{% from 'dashboards/fragments/glossary.html' import g_adjustment with context %}
 
 {# Set the modal title out-of-band so the shared audit modal reflects the
    fragment type. The target id is declared on the <h5> in dashboard.html. #}
@@ -25,7 +27,9 @@
     </div>
 
     <div class="stat-item">
-        <span class="stat-label">Type:</span>
+        <span class="stat-label">Type:
+            {{ help_icon(g_adjustment(), rich=True, title='Charge adjustments', placement='right') }}
+        </span>
         <span class="stat-value">{{ r.adjustment_type }}</span>
     </div>
 

--- a/src/webapp/templates/dashboards/allocations/partials/transaction_details_modal.html
+++ b/src/webapp/templates/dashboards/allocations/partials/transaction_details_modal.html
@@ -5,6 +5,8 @@
    ``render_project_info`` (dashboards/user/partials/project_card.html). Fields
    with empty / None values are simply omitted — the user doesn't see rows
    like "Requested amount —". #}
+{% from 'dashboards/fragments/help.html' import help_icon with context %}
+{% from 'dashboards/fragments/glossary.html' import g_txn_types with context %}
 
 {# Set the modal title out-of-band so the shared audit modal reflects the
    fragment type. The target id is declared on the <h5> in dashboard.html. #}
@@ -33,7 +35,9 @@
     </div>
 
     <div class="stat-item">
-        <span class="stat-label">Type:</span>
+        <span class="stat-label">Type:
+            {{ help_icon(g_txn_types(), rich=True, title='Transaction types', placement='right') }}
+        </span>
         <span class="stat-value">{{ r.transaction_type }}</span>
     </div>
 

--- a/src/webapp/templates/dashboards/base.html
+++ b/src/webapp/templates/dashboards/base.html
@@ -225,6 +225,7 @@
     <script src="{{ url_for('static', filename='js/path-preview.js') }}"></script>
     <script src="{{ url_for('static', filename='js/fk-picker.js') }}"></script>
     <script src="{{ url_for('static', filename='js/htmx-config.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/tooltip-init.js') }}"></script>
     <script src="{{ url_for('static', filename='js/collapse-chevron.js') }}"></script>
     <script src="{{ url_for('static', filename='js/sortable_table.js') }}"></script>
     <script src="{{ url_for('static', filename='js/svg-chart-links.js') }}"></script>

--- a/src/webapp/templates/dashboards/fragments/badges.html
+++ b/src/webapp/templates/dashboards/fragments/badges.html
@@ -25,12 +25,23 @@
     'expired':    'Expired',
     'open-ended': 'Open-ended',
 } -%}
+{# Hover explanations — applied as a Bootstrap tooltip (tooltip-init.js) so the
+   badge is self-documenting wherever it appears. #}
+{%- set _STATUS_TOOLTIPS = {
+    'active':     'Currently within its allocation period.',
+    'inactive':   'Not active — deactivated or outside its date range.',
+    'locked':     'Frozen: no further charging or changes until unlocked.',
+    'expired':    'Allocation period has ended.',
+    'open-ended': 'No end date — runs indefinitely.',
+} -%}
 
 
 {% macro status_badge(state, extra='', small=False, label=None) -%}
 {%- set key = state|lower -%}
 {%- set variant = _STATUS_VARIANTS.get(key, 'bg-secondary') -%}
 {%- set text = label if label is not none else _STATUS_LABELS.get(key, state) -%}
+{%- set tip = _STATUS_TOOLTIPS.get(key) -%}
 <span class="badge {{ variant }}{% if extra %} {{ extra }}{% endif %}"
+      {%- if tip %} data-bs-toggle="tooltip" data-bs-title="{{ tip }}"{% endif %}
       {%- if small %} style="font-size:0.7em;"{% endif %}>{{ text }}</span>
 {%- endmacro %}

--- a/src/webapp/templates/dashboards/fragments/glossary.html
+++ b/src/webapp/templates/dashboards/fragments/glossary.html
@@ -17,7 +17,7 @@
 {% macro g_rolling_rate() -%}
 Charges over the last 30/90 days compared with the <em>prorated steady-state
 rate</em> — the pace needed to spend exactly the allocation over its period.
-<strong>100% = on pace:</strong>
+<br>&bull; <strong>100% = on pace</strong>
 <br>&bull; &lt;80% — <span class="text-info">running cold</span>
 <br>&bull; 80–115% — <span class="text-success">near steady</span>
 <br>&bull; &gt;115% — <span class="text-warning">running hot</span>

--- a/src/webapp/templates/dashboards/fragments/glossary.html
+++ b/src/webapp/templates/dashboards/fragments/glossary.html
@@ -36,6 +36,14 @@ Marks how far through the allocation period today falls — a pacing reference,
 not a usage threshold. Usage to the left of this line means you're under pace.
 {%- endmacro %}
 
+{% macro g_usage_bar() -%}
+The filled portion is consumed usage against the allocated total. On a
+<em>shared</em> allocation, the lighter inner segment (and "(N yours)") is this
+project's own share of a pool drawn down by sibling projects too. The vertical
+marker shows how far through the allocation period today falls — a pacing
+reference, not a threshold.
+{%- endmacro %}
+
 
 {# ── Units (tooltips) ── #}
 {% macro g_au() -%}

--- a/src/webapp/templates/dashboards/fragments/glossary.html
+++ b/src/webapp/templates/dashboards/fragments/glossary.html
@@ -17,12 +17,12 @@
 {% macro g_rolling_rate() -%}
 Charges over the last 30/90 days compared with the <em>prorated steady-state
 rate</em> — the pace needed to spend exactly the allocation over its period.
-<strong>100% = on pace.</strong>
-<br>&lt;80% <span class="text-info">running cold</span> ·
-80–115% <span class="text-success">near steady</span> ·
-&gt;115% <span class="text-warning">running hot</span>.
-A dashed line marks an optional user-set limit; the bar turns red once the rate
-crosses it.
+<strong>100% = on pace:</strong>
+<br>&bull; &lt;80% — <span class="text-info">running cold</span>
+<br>&bull; 80–115% — <span class="text-success">near steady</span>
+<br>&bull; &gt;115% — <span class="text-warning">running hot</span>
+<br>A dashed line marks an optional user-set limit; the bar turns red once the
+rate crosses it.
 {%- endmacro %}
 
 {% macro g_shared_pool() -%}

--- a/src/webapp/templates/dashboards/fragments/glossary.html
+++ b/src/webapp/templates/dashboards/fragments/glossary.html
@@ -1,0 +1,80 @@
+{#
+  Canonical, reused explanation strings for SAM jargon and computed metrics.
+  Centralized so the same term reads identically everywhere (and is edited in
+  one place). Import with the help macros:
+
+      {% from 'dashboards/fragments/help.html' import help_icon, term with context %}
+      {% from 'dashboards/fragments/glossary.html'
+         import g_rolling_rate, g_txn_types, g_shared_pool, g_elapsed, g_au,
+                g_core_hours, g_charges, g_tib, g_tib_years, g_adjustment with context %}
+
+  Tooltip strings (returned by the *_short macros) are one short line.
+  Popover strings (the plain macros) may contain simple HTML.
+#}
+
+
+{# ── Rolling consumption rate (popover) ── #}
+{% macro g_rolling_rate() -%}
+Charges over the last 30/90 days compared with the <em>prorated steady-state
+rate</em> — the pace needed to spend exactly the allocation over its period.
+<strong>100% = on pace.</strong>
+<br>&lt;80% <span class="text-info">running cold</span> ·
+80–115% <span class="text-success">near steady</span> ·
+&gt;115% <span class="text-warning">running hot</span>.
+A dashed line marks an optional user-set limit; the bar turns red once the rate
+crosses it.
+{%- endmacro %}
+
+{% macro g_shared_pool() -%}
+This allocation draws from a pool shared with sibling projects under a master
+allocation. The bar shows total pool consumption; the lighter inner segment
+(and "(N yours)") is this project's own contribution.
+{%- endmacro %}
+
+{% macro g_elapsed() -%}
+Marks how far through the allocation period today falls — a pacing reference,
+not a usage threshold. Usage to the left of this line means you're under pace.
+{%- endmacro %}
+
+
+{# ── Units (tooltips) ── #}
+{% macro g_au() -%}
+Allocation Units — the charged cost of compute, weighted by job size, node type
+and queue. Drawn down from your allocated total.
+{%- endmacro %}
+
+{% macro g_core_hours() -%}
+Core-hours = cores used × wall-clock hours. The raw usage measure, before
+allocation-unit weighting.
+{%- endmacro %}
+
+{% macro g_charges() -%}
+Allocation units drawn down by this activity over the selected date range — the
+billed amount, not a job count.
+{%- endmacro %}
+
+{% macro g_tib() -%}
+Tebibyte (2⁴⁰ bytes ≈ 1.1 TB). Storage allocations are sized in TiB.
+{%- endmacro %}
+
+{% macro g_tib_years() -%}
+TiB held × years held — storage capacity integrated over time, the way disk
+allocations are charged.
+{%- endmacro %}
+
+
+{# ── Transaction & adjustment types (popover) ── #}
+{% macro g_txn_types() -%}
+<strong>NEW</strong> — initial allocation ·
+<strong>SUPPLEMENT</strong> — extra units added ·
+<strong>EXTENSION</strong> — end date moved out ·
+<strong>TRANSFER</strong> — units moved between projects ·
+<strong>ADJUSTMENT</strong> — manual correction to the balance.
+{%- endmacro %}
+
+{% macro g_adjustment() -%}
+A manual correction applied to an account's balance, outside normal job
+charging (e.g. a refund or a usage reclassification). "On shared account from
+&lt;projcode&gt;" means the adjustment landed on a pooled allocation owned by
+another project.
+{%- endmacro %}

--- a/src/webapp/templates/dashboards/fragments/glossary.html
+++ b/src/webapp/templates/dashboards/fragments/glossary.html
@@ -80,6 +80,31 @@ allocations are charged.
 <strong>ADJUSTMENT</strong> — manual correction to the balance.
 {%- endmacro %}
 
+{# ── Scheduler / queue states (popover) ── #}
+{% macro g_queue_states() -%}
+Counts below split each of Jobs, Cores and GPUs by scheduler state:
+<strong>Running</strong> — currently executing ·
+<strong>Pending</strong> — eligible and waiting in the queue ·
+<strong>Held</strong> — blocked (dependency, hold, or insufficient resources).
+Pending/held work does not consume the allocation until it starts.
+{%- endmacro %}
+
+{% macro g_held() -%}
+Jobs blocked from starting — by a dependency, an explicit hold, or insufficient
+free resources. They consume no allocation until released and run.
+{%- endmacro %}
+
+{% macro g_active_users() -%}
+Distinct users with at least one job in the system right now (running, pending
+or held) — not currently-logged-in users.
+{%- endmacro %}
+
+{% macro g_utilization() -%}
+Percentage of the system's capacity currently committed to jobs. The
+"allocated / total" line below shows committed vs. installed capacity —
+allocated can be below total when capacity is idle or reserved.
+{%- endmacro %}
+
 {% macro g_adjustment() -%}
 A manual correction applied to an account's balance, outside normal job
 charging (e.g. a refund or a usage reclassification). "On shared account from

--- a/src/webapp/templates/dashboards/fragments/help.html
+++ b/src/webapp/templates/dashboards/fragments/help.html
@@ -1,0 +1,75 @@
+{#
+  Reusable help affordances — one place for inline explanations of jargon and
+  computed metrics. Backed by Bootstrap 5.3 Tooltip/Popover, which are activated
+  globally (and re-activated after HTMX swaps) by static/js/tooltip-init.js.
+
+  IMPORT WITH CONTEXT (so url_for / filters resolve if ever needed):
+
+      {% from 'dashboards/fragments/help.html' import help_icon, term with context %}
+
+  Two affordances
+  ---------------
+  * help_icon(text, ...)  — a small focusable ⓘ/? icon. Hover OR keyboard-focus
+                            shows the explanation. Use next to a heading or label.
+  * term(label, text, ...) — wraps an inline word/column-header with a dotted
+                            underline + tooltip (an <abbr>-style affordance) for
+                            spots where a trailing icon would be awkward.
+
+  rich=False (default) → hover/focus TOOLTIP. Keep text to one short line.
+  rich=True            → click POPOVER that can hold multi-line / simple HTML.
+                         Dismisses on the next outside click (trigger=focus).
+
+  Canonical, reused definition strings live in glossary.html so wording stays
+  consistent; pass one-off explanations inline.
+#}
+
+
+{# ─── help icon (tooltip or popover) ───────────────────────────────────────
+   text       explanation. Plain text for tooltips; may contain simple HTML
+              when rich=True (Bootstrap sanitizes by default).
+   rich       True → click popover; False → hover/focus tooltip.
+   title      optional popover heading (rich only; ignored for tooltips).
+   placement  top|right|bottom|left (Bootstrap data-bs-placement).
+   icon       Font Awesome name without the "fa-" prefix.
+   label      accessible name for the button (defaults to "More information").
+#}
+{% macro help_icon(text, rich=False, title=None, placement='top',
+                   icon='question-circle', label='More information') %}
+<button type="button"
+        class="help-icon btn btn-link p-0 border-0 align-baseline"
+        tabindex="0"
+        aria-label="{{ label }}"
+        {%- if rich %}
+        data-bs-toggle="popover"
+        data-bs-trigger="focus"
+        data-bs-html="true"
+        {%- if title %} data-bs-title="{{ title }}"{% endif %}
+        data-bs-content="{{ text }}"
+        {%- else %}
+        data-bs-toggle="tooltip"
+        data-bs-title="{{ text }}"
+        {%- endif %}
+        data-bs-placement="{{ placement }}">
+    <i class="fas fa-{{ icon }}" aria-hidden="true"></i>
+</button>
+{%- endmacro %}
+
+
+{# ─── inline term with a dotted-underline tooltip ──────────────────────────
+   Renders <label> with a help cue. rich=True upgrades it to a click popover.
+#}
+{% macro term(label, text, rich=False, title=None, placement='top') %}
+<span class="help-term"
+      tabindex="0"
+      {%- if rich %}
+      data-bs-toggle="popover"
+      data-bs-trigger="focus"
+      data-bs-html="true"
+      {%- if title %} data-bs-title="{{ title }}"{% endif %}
+      data-bs-content="{{ text }}"
+      {%- else %}
+      data-bs-toggle="tooltip"
+      data-bs-title="{{ text }}"
+      {%- endif %}
+      data-bs-placement="{{ placement }}">{{ label }}</span>
+{%- endmacro %}

--- a/src/webapp/templates/dashboards/fragments/help.html
+++ b/src/webapp/templates/dashboards/fragments/help.html
@@ -43,11 +43,11 @@
         data-bs-toggle="popover"
         data-bs-trigger="focus"
         data-bs-html="true"
-        {%- if title %} data-bs-title="{{ title }}"{% endif %}
-        data-bs-content="{{ text }}"
+        {%- if title %} data-bs-title="{{ title | forceescape }}"{% endif %}
+        data-bs-content="{{ text | forceescape }}"
         {%- else %}
         data-bs-toggle="tooltip"
-        data-bs-title="{{ text }}"
+        data-bs-title="{{ text | forceescape }}"
         {%- endif %}
         data-bs-placement="{{ placement }}">
     <i class="fas fa-{{ icon }}" aria-hidden="true"></i>
@@ -65,11 +65,11 @@
       data-bs-toggle="popover"
       data-bs-trigger="focus"
       data-bs-html="true"
-      {%- if title %} data-bs-title="{{ title }}"{% endif %}
-      data-bs-content="{{ text }}"
+      {%- if title %} data-bs-title="{{ title | forceescape }}"{% endif %}
+      data-bs-content="{{ text | forceescape }}"
       {%- else %}
       data-bs-toggle="tooltip"
-      data-bs-title="{{ text }}"
+      data-bs-title="{{ text | forceescape }}"
       {%- endif %}
       data-bs-placement="{{ placement }}">{{ label }}</span>
 {%- endmacro %}

--- a/src/webapp/templates/dashboards/status/partials/job_statistics.html
+++ b/src/webapp/templates/dashboards/status/partials/job_statistics.html
@@ -1,3 +1,5 @@
+{% from 'dashboards/fragments/help.html' import help_icon with context %}
+{% from 'dashboards/fragments/glossary.html' import g_held, g_active_users with context %}
 {% macro job_statistics(status) %}
 <div class="row mb-4">
     <div class="col-md-3">
@@ -14,13 +16,13 @@
     </div>
     <div class="col-md-3">
         <div class="metric-card">
-            <h6>Held Jobs</h6>
+            <h6>Held Jobs {{ help_icon(g_held(), placement='top') }}</h6>
             <div class="value">{{ status.held_jobs | fmt_number }}</div>
         </div>
     </div>
     <div class="col-md-3">
         <div class="metric-card">
-            <h6>Active Users</h6>
+            <h6>Active Users {{ help_icon(g_active_users(), placement='top') }}</h6>
             <div class="value">{{ status.active_users | fmt_number }}</div>
         </div>
     </div>

--- a/src/webapp/templates/dashboards/status/partials/queue_table.html
+++ b/src/webapp/templates/dashboards/status/partials/queue_table.html
@@ -1,3 +1,5 @@
+{% from 'dashboards/fragments/help.html' import help_icon with context %}
+{% from 'dashboards/fragments/glossary.html' import g_queue_states with context %}
 {% macro queue_table(queues, show_gpus=false, system='derecho', hours=None) %}
 {# `hours`, when set, flows through into the row-click drill-down URL so the
    user's chosen time range survives sideways navigation between queues. #}
@@ -7,7 +9,9 @@
             <tr>
                 <th>Queue</th>
                 <th>Users</th>
-                <th colspan="3" class="text-center">Jobs</th>
+                <th colspan="3" class="text-center">Jobs
+                    {{ help_icon(g_queue_states(), rich=True, title='Scheduler states', placement='top') }}
+                </th>
                 <th colspan="3" class="text-center">Cores</th>
                 {% if show_gpus %}<th colspan="3" class="text-center">GPUs</th>{% endif %}
                 <th>Nodes</th>

--- a/src/webapp/templates/dashboards/status/partials/utilization_metrics.html
+++ b/src/webapp/templates/dashboards/status/partials/utilization_metrics.html
@@ -1,3 +1,5 @@
+{% from 'dashboards/fragments/help.html' import help_icon with context %}
+{% from 'dashboards/fragments/glossary.html' import g_utilization with context %}
 {% macro utilization_metrics(status, show_memory=true, show_gpus=true, show_viz=false) %}
 {# Calculate column width based on number of metrics shown #}
 {% set num_cols = 1 + (1 if show_gpus else 0) + (1 if show_viz else 0) + (1 if show_memory else 0) %}
@@ -5,7 +7,7 @@
 <div class="row mb-4">
     <div class="col-md-{{ col_width }}">
         <div class="metric-card">
-            <h6>CPU Utilization</h6>
+            <h6>CPU Utilization {{ help_icon(g_utilization(), rich=True, title='Utilization', placement='top') }}</h6>
             <div class="value">{{ (status.cpu_utilization_percent|default(0, true))|round(1) }}%</div>
             <div class="progress mt-2">
                 <div class="progress-bar bg-{{ 'danger' if (status.cpu_utilization_percent|default(0, true)) >= 90 else 'warning' if (status.cpu_utilization_percent|default(0, true)) >= 75 else 'success' }}"

--- a/src/webapp/templates/dashboards/user/fragments/rolling_rate_htmx.html
+++ b/src/webapp/templates/dashboards/user/fragments/rolling_rate_htmx.html
@@ -16,11 +16,16 @@
     can_edit_threshold     — bool: show Add/Edit Limit buttons
 #}
 
+{% from 'dashboards/fragments/help.html' import help_icon with context %}
+{% from 'dashboards/fragments/glossary.html' import g_rolling_rate with context %}
 <div class="mt-3 pt-3 border-top">
-    <h6 class="mb-1"><i class="fas fa-thermometer-half text-muted me-1"></i> Rolling Consumption Rate</h6>
+    <h6 class="mb-1">
+        <i class="fas fa-thermometer-half text-muted me-1"></i> Rolling Consumption Rate
+        {{ help_icon(g_rolling_rate(), rich=True, title='Rolling Consumption Rate', placement='right') }}
+    </h6>
     <p class="text-muted small mb-2">
-        Charges over the last 30 and 90 days vs. the prorated steady-state rate.
-        <strong>100% = steady state</strong>; left of center is cold, right is hot.
+        Charges over the last 30 and 90 days vs. the prorated steady-state rate
+        (<strong>100% = on pace</strong>).
         {% if rolling_is_inheriting and rolling_root_projcode %}
         <br><i class="fas fa-share-alt me-1"></i>Pool shared with master project
         <strong>{{ rolling_root_projcode }}</strong> — rate covers the whole shared allocation.

--- a/src/webapp/templates/dashboards/user/partials/account_adjustments.html
+++ b/src/webapp/templates/dashboards/user/partials/account_adjustments.html
@@ -9,8 +9,11 @@
     adjustments_master_projcode — projcode of the master/shared account when the
                                   current allocation inherits, else None
 #}
+{% from 'dashboards/fragments/help.html' import help_icon with context %}
+{% from 'dashboards/fragments/glossary.html' import g_adjustment with context %}
 <h6 class="mt-4 mb-2">
     Charge Adjustments
+    {{ help_icon(g_adjustment(), rich=True, title='Charge adjustments', placement='right') }}
     {% if adjustments_master_projcode %}
     <small class="text-muted">
         (on shared account from <code>{{ adjustments_master_projcode }}</code>)

--- a/src/webapp/templates/dashboards/user/partials/account_allocation_history.html
+++ b/src/webapp/templates/dashboards/user/partials/account_allocation_history.html
@@ -12,6 +12,8 @@
   Context:
     allocation_transactions — list[AllocationTransaction], pre-sorted desc by creation_time
 #}
+{% from 'dashboards/fragments/help.html' import help_icon with context %}
+{% from 'dashboards/fragments/glossary.html' import g_txn_types with context %}
 <h6 class="mb-2">Transactions</h6>
 
 {% if allocation_transactions %}
@@ -20,7 +22,9 @@
         <thead class="table-light">
             <tr>
                 <th style="white-space:nowrap;">Date</th>
-                <th>Type</th>
+                <th>Type
+                    {{ help_icon(g_txn_types(), rich=True, title='Transaction types', placement='top') }}
+                </th>
                 <th class="text-end">Amount</th>
                 <th>Effective</th>
                 <th>By</th>

--- a/src/webapp/templates/dashboards/user/partials/project_card.html
+++ b/src/webapp/templates/dashboards/user/partials/project_card.html
@@ -1,5 +1,7 @@
 {% from 'dashboards/fragments/badges.html' import status_badge %}
 {% from 'dashboards/shared/usage_bar.html' import render_usage_bar with context %}
+{% from 'dashboards/fragments/help.html' import help_icon with context %}
+{% from 'dashboards/fragments/glossary.html' import g_usage_bar with context %}
 
 {# Macro: Project Information Section #}
 {% macro render_project_info(project) %}
@@ -101,7 +103,9 @@
             <thead class="thead-light">
                 <tr>
                     <th>Resource</th>
-                    <th style="min-width: 220px;">Allocation</th>
+                    <th style="min-width: 220px;">Allocation
+                        {{ help_icon(g_usage_bar(), rich=True, title='Allocation usage', placement='top') }}
+                    </th>
                     {% if can_edit_allocations %}
                     <th class="text-center" style="width: 80px;">Actions</th>
                     {% endif %}

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -1,6 +1,8 @@
 {% extends 'dashboards/base.html' %}
 {% from 'dashboards/shared/usage_bar.html' import render_usage_bar with context %}
 {% from 'dashboards/user/partials/_resource_details_macros.html' import jobs_button, jobs_collapse_row with context %}
+{% from 'dashboards/fragments/help.html' import term with context %}
+{% from 'dashboards/fragments/glossary.html' import g_core_hours, g_charges with context %}
 
 {% block title %}Resource Details - {{ resource_name }} - SAM{% endblock %}
 
@@ -26,8 +28,8 @@
             <tr>
                 <th class="sortable-header" data-sort="text">Username</th>
                 <th class="sortable-header text-end" data-sort="numeric">Jobs</th>
-                <th class="sortable-header text-end" data-sort="numeric">Core-Hours</th>
-                <th class="sortable-header text-end sort-desc" data-sort="numeric">Charges</th>
+                <th class="sortable-header text-end" data-sort="numeric">{{ term('Core-Hours', g_core_hours()) }}</th>
+                <th class="sortable-header text-end sort-desc" data-sort="numeric">{{ term('Charges', g_charges()) }}</th>
             </tr>
         </thead>
         {% if breakdown %}

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -1,5 +1,7 @@
 {% extends 'dashboards/base.html' %}
 {% from 'dashboards/shared/usage_bar.html' import render_usage_bar with context %}
+{% from 'dashboards/fragments/help.html' import term with context %}
+{% from 'dashboards/fragments/glossary.html' import g_tib with context %}
 
 {% block title %}Disk Usage Details - {{ resource_name }} - SAM{% endblock %}
 
@@ -116,7 +118,7 @@
                             <th>Resource</th>
                             <th>Scope</th>
                             <th>As of</th>
-                            <th>Allocated</th>
+                            <th>{{ term('Allocated', g_tib()) }}</th>
                             <th>Used</th>
                             <th>Remaining</th>
                             <th class="text-end">Files</th>


### PR DESCRIPTION
## Summary

Tooltips were underutilized: Bootstrap 5.3 was bundled but `Tooltip`/`Popover`
were never initialized, and explanation was ad-hoc (scattered native `title=`
attributes, form `help=` text, the `samConfirm()` modal). This PR adds a single
reusable help affordance and applies it across the jargon-heavy dashboard
displays.

### Infrastructure
- **`dashboards/fragments/help.html`** — `help_icon()` and `term()` macros. One
  `rich=` flag switches between a hover/focus **tooltip** (short defs) and a
  click **popover** (multi-line/HTML). Content is piped through `forceescape`
  so embedded HTML attributes don't break the host attribute.
- **`dashboards/fragments/glossary.html`** — canonical definition strings so a
  term reads identically everywhere.
- **`static/js/tooltip-init.js`** — activates `[data-bs-toggle=tooltip|popover]`
  on load and after `htmx:afterSwap`; disposes on `htmx:beforeCleanupElement`
  so no orphan popups linger. Self-hosted → CSP `script-src 'self'` safe.
- `base.html` loads the init; `components.css` styles `.help-icon` / `.help-term`.

### Rollout
- **Rolling Consumption Rate** — popover explaining the prorated steady-state
  baseline and the cold/steady/hot/over-limit states + threshold line.
- **Shared/inherited usage bars** — popover on the project-card Allocation header
  (rest-of-tree vs. self segment, "(N yours)", elapsed-period marker).
- **Transactions & adjustments** — type definitions
  (NEW/SUPPLEMENT/EXTENSION/TRANSFER/ADJUSTMENT) on the resource-summary
  subsections and the allocations-dashboard detail modals.
- **Units & status** — Core-Hours/Charges/TiB header tooltips; `status_badge`
  now self-documents (active/inactive/locked/expired/open-ended) everywhere.
- **System status** — scheduler states (Running/Pending/Held) on the queue
  table, Held Jobs / Active Users, and CPU Utilization (allocated vs. total).

## Smoke test (Playwright)

Every new affordance was found in the running app with a Bootstrap instance
attached (proving `tooltip-init.js` activated it), and representatives of each
type were triggered to confirm they render. No orphaned `.popover`/`.tooltip`
nodes remained after dismissal.

| # | Help element | Type | Page | Verified |
|---|---|---|---|---|
| 1 | Rolling Consumption Rate | popover | resource-details (HPC) | render + HTML formatting |
| 2 | Transactions **Type** | popover | resource-details | 5 txn types render |
| 3 | Charge Adjustments | popover | resource-details | attached |
| 4 | Core-Hours | tooltip | resource-details | renders |
| 5 | Charges | tooltip | resource-details | attached |
| 6 | Allocation header (usage bar) | popover | user dashboard | ×5, attached |
| 7 | status_badge | tooltip | user dashboard | ×3 (expired) |
| 8 | Allocated (TiB) | tooltip | disk resource-details | renders |
| 9 | CPU Utilization | popover | System Status | ×2 |
| 10 | Held Jobs | tooltip | System Status | ×2 |
| 11 | Active Users | tooltip | System Status | ×2 |
| 12 | Queue **Jobs** states | popover | System Status | ×2 |
| 13 | Transaction-details modal **Type** | popover | Allocations (HTMX modal) | renders, 5 types |
| 14 | Adjustment-details modal **Type** | popover | Allocations (HTMX modal) | renders |

The two HTMX-loaded modals (#13, #14) confirm the `htmx:afterSwap` re-init path.

## Fixes during review
- **Attribute escaping** — glossary popover HTML (e.g. `<span class="text-info">`)
  was leaking out of `data-bs-content` because Jinja treats macro output as safe
  `Markup`; fixed with `forceescape`.
- **Rolling-rate bullets** — the cold/steady/hot states were joined inline with
  `·` separators (looked like stray mid-sentence bullets); now each is on its
  own line.

## Test plan
- All changed templates pass a Jinja syntax parse.
- Playwright smoke test above (logged in as benkirk admin against local webdev).
- Check the browser console for CSP violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)