### PR TITLE
Refactor threshold + outage forms onto HtmxFormSchema validation

### DIFF
--- a/src/sam/schemas/forms/__init__.py
+++ b/src/sam/schemas/forms/__init__.py
@@ -206,12 +206,17 @@ from .user import (
     ExtendAllocationsForm,
     SetShellForm,
     SetPrimaryGidForm,
+    SetThresholdForm,
 )
 from .adjustments import (
     CreateChargeAdjustmentForm,
 )
 from .admin import (
     ClearRateLimitForm,
+)
+from .status import (
+    CreateOutageForm,
+    EditOutageForm,
 )
 
 __all__ = [
@@ -268,8 +273,12 @@ __all__ = [
     'ExtendAllocationsForm',
     'SetShellForm',
     'SetPrimaryGidForm',
+    'SetThresholdForm',
     # Adjustments
     'CreateChargeAdjustmentForm',
     # Admin
     'ClearRateLimitForm',
+    # Status
+    'CreateOutageForm',
+    'EditOutageForm',
 ]

--- a/src/sam/schemas/forms/status.py
+++ b/src/sam/schemas/forms/status.py
@@ -1,0 +1,74 @@
+"""
+Marshmallow form validation schemas for status-dashboard (outage) routes.
+
+Covers: Create Outage, Edit Outage.
+
+Note on time zones: the outage modals use ``<input type="datetime-local">``,
+which is TZ-blind — it submits a naive wall-clock string. The browser's IANA
+zone is sent alongside in a hidden ``tz`` field; ``@post_load`` converts the
+submitted naive-local datetimes into the naive-UTC storage convention via
+``sam.fmt.naive_local_to_utc``. The ``tz`` field is transport-only and is popped
+before the validated dict reaches the route.
+"""
+
+import marshmallow.fields as f
+import marshmallow.validate as v
+from marshmallow import post_load
+
+from . import HtmxFormSchema
+
+# Allowed values mirror the model enums (system_status.models.outages) and the
+# system <select> options in the create modal.
+_SYSTEMS = ['derecho', 'casper', 'jupyterhub', 'all']
+_SEVERITIES = ['critical', 'major', 'minor', 'maintenance']
+_STATUSES = ['investigating', 'identified', 'monitoring', 'resolved']
+
+_DATETIME_LOCAL = '%Y-%m-%dT%H:%M'   # HTML datetime-local wire format
+
+
+def _to_naive_utc(data):
+    """Convert any present datetime-local fields from browser-local to naive-UTC."""
+    from sam.fmt import naive_local_to_utc
+    tz = data.pop('tz', None)
+    for key in ('start_time', 'estimated_resolution'):
+        if data.get(key) is not None:
+            data[key] = naive_local_to_utc(data[key], tz)
+    return data
+
+
+class CreateOutageForm(HtmxFormSchema):
+    """Report a new system outage.
+
+    ``system_name`` is resolved to a ``system_id`` by the model's
+    ``system_name`` setter (a DB hit) — that stays in the route per CLAUDE.md §9.
+    """
+    system_name = f.Str(required=True, validate=v.OneOf(_SYSTEMS))
+    title = f.Str(required=True, validate=v.Length(min=1, max=255))
+    severity = f.Str(required=True, validate=v.OneOf(_SEVERITIES))
+    component = f.Str(load_default=None)
+    description = f.Str(load_default=None)
+    tz = f.Str(load_default=None)   # transport-only; popped in post_load
+    start_time = f.DateTime(_DATETIME_LOCAL, load_default=None)
+    estimated_resolution = f.DateTime(_DATETIME_LOCAL, load_default=None)
+
+    @post_load
+    def to_naive_utc(self, data, **kwargs):
+        return _to_naive_utc(data)
+
+
+class EditOutageForm(HtmxFormSchema):
+    """Update an existing outage.
+
+    ``title`` is optional on edit (the route applies it only when present, to
+    preserve the existing pre-refactor behavior).
+    """
+    title = f.Str(load_default=None, validate=v.Length(max=255))
+    status = f.Str(required=True, validate=v.OneOf(_STATUSES))
+    severity = f.Str(required=True, validate=v.OneOf(_SEVERITIES))
+    description = f.Str(load_default=None)
+    tz = f.Str(load_default=None)   # transport-only; popped in post_load
+    estimated_resolution = f.DateTime(_DATETIME_LOCAL, load_default=None)
+
+    @post_load
+    def to_naive_utc(self, data, **kwargs):
+        return _to_naive_utc(data)

--- a/src/sam/schemas/forms/user.py
+++ b/src/sam/schemas/forms/user.py
@@ -32,6 +32,24 @@ class SetPrimaryGidForm(HtmxFormSchema):
     unix_gid = f.Integer(required=True)
 
 
+class SetThresholdForm(HtmxFormSchema):
+    """Set a project+resource consumption-rate limit (% of prorated allocation).
+
+    Blank input removes the limit: the base ``@pre_load`` strips empty strings,
+    so an empty ``threshold_pct`` falls through to ``load_default=None``. A value
+    must be an integer strictly greater than 100 (a rate limit below the prorated
+    rate would be permanently tripped). The route persists via
+    ``Account.update_thresholds`` per-window — a DB hit that stays inline.
+    """
+    threshold_pct = f.Integer(
+        load_default=None,
+        validate=v.Range(
+            min=101,
+            error='Must be an integer greater than 100 (or blank to remove the limit).',
+        ),
+    )
+
+
 class AddMemberForm(HtmxFormSchema):
     username = f.Str(required=True, validate=v.Length(min=1))
     start_date = f.Date('%Y-%m-%d', load_default=None)

--- a/src/webapp/dashboards/status/blueprint.py
+++ b/src/webapp/dashboards/status/blueprint.py
@@ -5,6 +5,8 @@ System Status dashboard blueprint.
 from flask import Blueprint, render_template, request, flash, redirect, url_for, make_response, current_app
 from flask_login import login_required, current_user
 from webapp.utils.rbac import require_permission, Permission
+from marshmallow import ValidationError
+from sam.schemas.forms import CreateOutageForm, EditOutageForm
 from datetime import datetime, timedelta
 import logging
 
@@ -491,43 +493,30 @@ def htmx_create_outage():
     storage. `tz` falls back to the configured display TZ if missing
     (older clients, scripted POSTs)."""
     from system_status.models import SystemOutage
-    from sam.fmt import naive_local_to_utc
 
-    system_name = request.form.get('system_name', '').strip()
-    title = request.form.get('title', '').strip()
-    severity = request.form.get('severity', '').strip()
+    try:
+        data = CreateOutageForm().load(request.form)
+    except ValidationError as e:
+        field_errors, form_level = CreateOutageForm.split_errors(e.messages)
+        return render_template(
+            'dashboards/status/fragments/_outage_create_body.html',
+            field_errors=field_errors, errors=form_level, form=request.form,
+        )
 
-    if not system_name or not title or not severity:
-        flash('System, title, and severity are required.', 'error')
-        return redirect(url_for('status_dashboard.index'))
-
-    operator_tz = request.form.get('tz', '').strip() or None
-
+    # Schema's @post_load already converted the datetime-local values to
+    # naive-UTC via the submitted `tz`. system_name → system_id resolution
+    # happens in the model setter (a DB hit) and stays here per CLAUDE.md §9.
     outage = SystemOutage(
-        system_name=system_name,
-        title=title,
-        severity=severity,
-        component=request.form.get('component', '').strip() or None,
-        description=request.form.get('description', '').strip() or None,
+        system_name=data['system_name'],
+        title=data['title'],
+        severity=data['severity'],
+        component=data.get('component'),
+        description=data.get('description'),
         status='investigating',
-        start_time=datetime.now(),  # already UTC under TZ=UTC
+        start_time=data.get('start_time') or datetime.now(),  # default: now (UTC)
     )
-
-    start_time_str = request.form.get('start_time', '').strip()
-    if start_time_str:
-        try:
-            outage.start_time = naive_local_to_utc(
-                datetime.fromisoformat(start_time_str), operator_tz)
-        except ValueError:
-            pass
-
-    est_res_str = request.form.get('estimated_resolution', '').strip()
-    if est_res_str:
-        try:
-            outage.estimated_resolution = naive_local_to_utc(
-                datetime.fromisoformat(est_res_str), operator_tz)
-        except ValueError:
-            pass
+    if data.get('estimated_resolution') is not None:
+        outage.estimated_resolution = data['estimated_resolution']
 
     db.session.add(outage)
     db.session.commit()
@@ -552,33 +541,24 @@ def htmx_update_outage(outage_id):
         response.headers['HX-Redirect'] = url_for('status_dashboard.index')
         return response
 
-    valid_statuses = ['investigating', 'identified', 'monitoring', 'resolved']
-    valid_severities = ['critical', 'major', 'minor', 'maintenance']
+    try:
+        data = EditOutageForm().load(request.form)
+    except ValidationError as e:
+        field_errors, form_level = EditOutageForm.split_errors(e.messages)
+        return render_template(
+            'dashboards/status/fragments/_outage_edit_body.html',
+            field_errors=field_errors, errors=form_level, form=request.form,
+        )
 
-    title = request.form.get('title', '').strip()
-    if title:
-        outage.title = title
-    status = request.form.get('status', '').strip()
-    if status in valid_statuses:
-        outage.status = status
-    severity = request.form.get('severity', '').strip()
-    if severity in valid_severities:
-        outage.severity = severity
-
-    outage.description = request.form.get('description', '').strip() or None
-
-    # Naive-UTC conversion mirrors htmx_create_outage; see its docstring.
-    from sam.fmt import naive_local_to_utc
-    operator_tz = request.form.get('tz', '').strip() or None
-    est_res_str = request.form.get('estimated_resolution', '').strip()
-    if est_res_str:
-        try:
-            outage.estimated_resolution = naive_local_to_utc(
-                datetime.fromisoformat(est_res_str), operator_tz)
-        except ValueError:
-            pass
-    else:
-        outage.estimated_resolution = None
+    # title is optional on edit — only apply when provided (preserves prior
+    # behavior of keeping the existing title on a blank submit).
+    if data.get('title'):
+        outage.title = data['title']
+    outage.status = data['status']
+    outage.severity = data['severity']
+    outage.description = data.get('description')
+    # @post_load already converted to naive-UTC; None clears the field.
+    outage.estimated_resolution = data.get('estimated_resolution')
 
     outage.updated_at = datetime.now()
     db.session.commit()

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -12,7 +12,9 @@ from flask_login import login_required, current_user
 from datetime import datetime, date, timedelta
 from marshmallow import ValidationError
 
-from sam.schemas.forms.user import EditAllocationForm, SetShellForm, SetPrimaryGidForm
+from sam.schemas.forms.user import (
+    EditAllocationForm, SetShellForm, SetPrimaryGidForm, SetThresholdForm,
+)
 
 from webapp.extensions import db
 from sam.queries.dashboard import get_user_dashboard_data, get_resource_detail_data, get_project_dashboard_data
@@ -1453,23 +1455,18 @@ def htmx_save_threshold(project, resource_name, window):
     if not account:
         return '<div class="alert alert-danger">Account not found for this resource</div>', 404
 
-    raw = request.form.get('threshold_pct', '').strip()
-    if raw == '':
-        new_val = None
-    else:
-        try:
-            new_val = int(raw)
-            if new_val <= 100:
-                raise ValueError
-        except ValueError:
-            return render_template(
-                'dashboards/user/fragments/threshold_form_htmx.html',
-                projcode=projcode,
-                resource_name=resource_name,
-                window=window,
-                current_threshold=raw,
-                error='Must be an integer greater than 100, or leave blank to remove the limit.',
-            )
+    try:
+        form_data = SetThresholdForm().load(request.form)
+    except ValidationError as e:
+        return render_template(
+            'dashboards/user/fragments/threshold_form_htmx.html',
+            projcode=projcode,
+            resource_name=resource_name,
+            window=window,
+            current_threshold=request.form.get('threshold_pct', ''),
+            errors=SetThresholdForm.flatten_errors(e.messages),
+        )
+    new_val = form_data['threshold_pct']
 
     with management_transaction(db.session):
         if window == 30:

--- a/src/webapp/static/js/htmx-config.js
+++ b/src/webapp/static/js/htmx-config.js
@@ -205,7 +205,11 @@ document.body.addEventListener('reloadUserCard', function(evt) {
         info:    { header: 'bg-info text-white',    close: 'btn-close-white', icon: 'fa-info-circle',          btn: 'btn-primary' }
     };
     var ALL_HEADER_CLASSES = 'bg-danger bg-warning bg-info text-white';
-    var ALL_BTN_CLASSES = 'btn-danger btn-warning btn-primary';
+    // Include the outline variants so a stray base class (e.g. btn-outline-primary)
+    // is always stripped before the variant solid color is applied — otherwise an
+    // outline (colored text) + solid (colored bg) combine into e.g. blue-on-blue.
+    var ALL_BTN_CLASSES = 'btn-danger btn-warning btn-primary btn-info '
+                        + 'btn-outline-danger btn-outline-warning btn-outline-primary btn-outline-info';
     var ALL_ICON_CLASSES = 'fa-exclamation-triangle fa-exclamation-circle fa-info-circle';
 
     function _openSamConfirm(opts) {

--- a/src/webapp/templates/dashboards/fragments/form_fields.html
+++ b/src/webapp/templates/dashboards/fragments/form_fields.html
@@ -163,6 +163,41 @@
 {% endmacro %}
 
 
+{# ─── datetime-local input ─────────────────────────────────────────────── #}
+{#
+  `<input type="datetime-local">` — TZ-blind wall-clock picker.
+  `default` may be a datetime object or a 'YYYY-MM-DDTHH:MM' string.
+  On error re-render the submitted (raw, browser-local) value comes from `form`.
+  NOTE: callers whose value is populated/converted client-side (e.g. the outage
+  edit modal's tz handling in modals.js) should pass an explicit `id=` so the
+  JS keeps targeting the same element.
+#}
+{% macro datetime_field(name, label, required=False, optional_text='(optional)',
+                        help=None, default='', id=None, label_class='form-label',
+                        disabled=False) %}
+{%- set _id = id or name -%}
+{%- set _form_value = form.get(name) if form else None -%}
+{%- if _form_value is not none -%}
+  {%- set _value = _form_value -%}
+{%- elif default and default.strftime is defined -%}
+  {%- set _value = default.strftime('%Y-%m-%dT%H:%M') -%}
+{%- else -%}
+  {%- set _value = default or '' -%}
+{%- endif -%}
+<div class="mb-3">
+    {{ _label(name, label, required=required, optional_text=optional_text, id=_id, label_class=label_class) }}
+    <input type="datetime-local" class="form-control{{ _invalid(name) }}" id="{{ _id }}"
+           name="{{ name }}"
+           {%- if required %} required{% endif -%}
+           {%- if disabled %} disabled{% endif %}
+           value="{{ _value }}"
+           {{- _aria(name, _id) }}>
+    {{ _field_error(name, _id) }}
+    {%- if help %}<small class="form-text text-muted">{{ help }}</small>{% endif %}
+</div>
+{% endmacro %}
+
+
 {# ─── textarea ─────────────────────────────────────────────────────────── #}
 {% macro textarea_field(name, label, required=False, optional_text='(optional)',
                         rows=3, maxlength=None, placeholder=None, help=None,

--- a/src/webapp/templates/dashboards/fragments/glossary.html
+++ b/src/webapp/templates/dashboards/fragments/glossary.html
@@ -73,20 +73,23 @@ allocations are charged.
 
 {# ── Transaction & adjustment types (popover) ── #}
 {% macro g_txn_types() -%}
-<strong>NEW</strong> — initial allocation ·
-<strong>SUPPLEMENT</strong> — extra units added ·
-<strong>EXTENSION</strong> — end date moved out ·
-<strong>TRANSFER</strong> — units moved between projects ·
-<strong>ADJUSTMENT</strong> — manual correction to the balance.
+{# Popover HTML collapses source newlines, so use explicit <br>&bull; per item
+   (matches g_rolling_rate) rather than '·' separators, which otherwise wrap
+   mid-sentence. #}
+&bull; <strong>NEW</strong> — initial allocation
+<br>&bull; <strong>SUPPLEMENT</strong> — extra units added
+<br>&bull; <strong>EXTENSION</strong> — end date moved out
+<br>&bull; <strong>TRANSFER</strong> — units moved between projects
+<br>&bull; <strong>ADJUSTMENT</strong> — manual correction to the balance.
 {%- endmacro %}
 
 {# ── Scheduler / queue states (popover) ── #}
 {% macro g_queue_states() -%}
 Counts below split each of Jobs, Cores and GPUs by scheduler state:
-<strong>Running</strong> — currently executing ·
-<strong>Pending</strong> — eligible and waiting in the queue ·
-<strong>Held</strong> — blocked (dependency, hold, or insufficient resources).
-Pending/held work does not consume the allocation until it starts.
+<br>&bull; <strong>Running</strong> — currently executing
+<br>&bull; <strong>Pending</strong> — eligible and waiting in the queue
+<br>&bull; <strong>Held</strong> — blocked (dependency, hold, or insufficient resources).
+<br>Pending/held work does not consume the allocation until it starts.
 {%- endmacro %}
 
 {% macro g_held() -%}

--- a/src/webapp/templates/dashboards/fragments/modals.html
+++ b/src/webapp/templates/dashboards/fragments/modals.html
@@ -57,7 +57,10 @@
             <div class="modal-body" id="samConfirmModalBody"></div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-outline-primary" id="samConfirmModalConfirm">Confirm</button>
+                {# Color is applied per-variant by htmx-config.js (_openSamConfirm);
+                   the base btn-danger is just the default/fallback. Keep this in
+                   ALL_BTN_CLASSES so the variant reset can strip it cleanly. #}
+                <button type="button" class="btn btn-danger" id="samConfirmModalConfirm">Confirm</button>
             </div>
         </div>
     </div>

--- a/src/webapp/templates/dashboards/status/fragments/_outage_create_body.html
+++ b/src/webapp/templates/dashboards/status/fragments/_outage_create_body.html
@@ -1,0 +1,38 @@
+{#
+  Create-outage modal body — re-renderable fragment.
+
+  Rendered both inside #createOutageFormBody (initial modal markup) and standalone
+  by htmx_create_outage on a validation error (swapped back into that div). The
+  `id=` overrides preserve the element ids that static/js/modals.js targets
+  (createStartTime, etc.). Errors come from CreateOutageForm via split_errors.
+
+  Context (error re-render): form, field_errors, errors.
+#}
+{% from 'dashboards/fragments/form_fields.html'
+   import text_field, select_field, textarea_field, datetime_field, form_errors_panel with context %}
+
+{{ form_errors_panel() }}
+
+{{ select_field('system_name', 'System', required=True,
+                placeholder='-- Select system --', id='createSystem',
+                options=[('derecho', 'Derecho'), ('casper', 'Casper'),
+                         ('jupyterhub', 'JupyterHub'), ('all', 'All Systems')]) }}
+
+{{ text_field('title', 'Title', required=True, id='createTitle',
+              placeholder='Brief outage description') }}
+
+{{ select_field('severity', 'Severity', required=True,
+                placeholder='-- Select severity --', id='createSeverity',
+                options=[('critical', 'Critical'), ('major', 'Major'),
+                         ('minor', 'Minor'), ('maintenance', 'Maintenance')]) }}
+
+{{ text_field('component', 'Component', id='createComponent',
+              placeholder='e.g. Login nodes, Lustre, Scheduler') }}
+
+{{ textarea_field('description', 'Description', id='createDescription',
+                  placeholder='Detailed information about the outage...') }}
+
+{{ datetime_field('start_time', 'Start Time', optional_text='', id='createStartTime',
+                  help='Enter in your local time. Stored as UTC; displayed back in ' ~ local_tz_label() ~ '. Adjust if the outage started earlier.') }}
+
+{{ datetime_field('estimated_resolution', 'Estimated Resolution', id='createEstimatedResolution') }}

--- a/src/webapp/templates/dashboards/status/fragments/_outage_edit_body.html
+++ b/src/webapp/templates/dashboards/status/fragments/_outage_edit_body.html
@@ -1,0 +1,31 @@
+{#
+  Edit-outage modal body — re-renderable fragment.
+
+  Rendered inside #editOutageFormBody (initial modal markup) and standalone by
+  htmx_update_outage on a validation error. Fields are populated client-side by
+  static/js/modals.js (the 'outage-edit' action) from the clicked row's data
+  attributes, with UTC→local conversion for the datetime — so the `id=` overrides
+  must match the ids that JS sets (editTitle, editStatus, ...). On error
+  re-render the submitted values come back via `form`.
+
+  Context (error re-render): form, field_errors, errors.
+#}
+{% from 'dashboards/fragments/form_fields.html'
+   import text_field, select_field, textarea_field, datetime_field, form_errors_panel with context %}
+
+{{ form_errors_panel() }}
+
+{{ text_field('title', 'Title', id='editTitle') }}
+
+{{ select_field('status', 'Status', required=True, optional_text='', id='editStatus',
+                options=[('investigating', 'Investigating'), ('identified', 'Identified'),
+                         ('monitoring', 'Monitoring'), ('resolved', 'Resolved')]) }}
+
+{{ select_field('severity', 'Severity', required=True, optional_text='', id='editSeverity',
+                options=[('critical', 'Critical'), ('major', 'Major'),
+                         ('minor', 'Minor'), ('maintenance', 'Maintenance')]) }}
+
+{{ textarea_field('description', 'Description', id='editDescription') }}
+
+{{ datetime_field('estimated_resolution', 'Estimated Resolution', id='editEstimatedResolution',
+                  help='Times shown in your local TZ. Clear to remove estimated resolution time.') }}

--- a/src/webapp/templates/dashboards/status/fragments/outage_modals.html
+++ b/src/webapp/templates/dashboards/status/fragments/outage_modals.html
@@ -13,59 +13,20 @@
                 </h5>
                 <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
+            {# novalidate: CreateOutageForm is the source of truth; validation
+               errors render inline (swapped into #createOutageFormBody) instead
+               of a native bubble. The hidden tz input + footer live OUTSIDE the
+               swapped body so the JS-populated tz survives an error re-render. #}
             <form hx-post="{{ url_for('status_dashboard.htmx_create_outage') }}"
-                  hx-disabled-elt="find button[type='submit']">
+                  hx-target="#createOutageFormBody"
+                  hx-swap="innerHTML"
+                  hx-disabled-elt="find button[type='submit']"
+                  novalidate>
                 {# Captured at submit-time by JS so the server can convert the
                    naive datetime-local values into naive-UTC for storage. #}
                 <input type="hidden" name="tz" id="createTz">
-                <div class="modal-body">
-                    <div class="mb-3">
-                        <label for="createSystem" class="form-label">System <span class="text-danger">*</span></label>
-                        <select class="form-select" id="createSystem" name="system_name" required>
-                            <option value="">-- Select system --</option>
-                            <option value="derecho">Derecho</option>
-                            <option value="casper">Casper</option>
-                            <option value="jupyterhub">JupyterHub</option>
-                            <option value="all">All Systems</option>
-                        </select>
-                    </div>
-                    <div class="mb-3">
-                        <label for="createTitle" class="form-label">Title <span class="text-danger">*</span></label>
-                        <input type="text" class="form-control" id="createTitle" name="title"
-                               placeholder="Brief outage description" required>
-                    </div>
-                    <div class="mb-3">
-                        <label for="createSeverity" class="form-label">Severity <span class="text-danger">*</span></label>
-                        <select class="form-select" id="createSeverity" name="severity" required>
-                            <option value="">-- Select severity --</option>
-                            <option value="critical">Critical</option>
-                            <option value="major">Major</option>
-                            <option value="minor">Minor</option>
-                            <option value="maintenance">Maintenance</option>
-                        </select>
-                    </div>
-                    <div class="mb-3">
-                        <label for="createComponent" class="form-label">Component <span class="text-muted">(optional)</span></label>
-                        <input type="text" class="form-control" id="createComponent" name="component"
-                               placeholder="e.g. Login nodes, Lustre, Scheduler">
-                    </div>
-                    <div class="mb-3">
-                        <label for="createDescription" class="form-label">Description <span class="text-muted">(optional)</span></label>
-                        <textarea class="form-control" id="createDescription" name="description" rows="3"
-                                  placeholder="Detailed information about the outage..."></textarea>
-                    </div>
-                    <div class="mb-3">
-                        <label for="createStartTime" class="form-label">Start Time</label>
-                        <input type="datetime-local" class="form-control" id="createStartTime" name="start_time">
-                        <small class="form-text text-muted">
-                            Enter in your local time. Stored as UTC; displayed back in {{ local_tz_label() }}.
-                            Adjust if the outage started earlier.
-                        </small>
-                    </div>
-                    <div class="mb-3">
-                        <label for="createEstimatedResolution" class="form-label">Estimated Resolution <span class="text-muted">(optional)</span></label>
-                        <input type="datetime-local" class="form-control" id="createEstimatedResolution" name="estimated_resolution">
-                    </div>
+                <div class="modal-body" id="createOutageFormBody">
+                    {% include 'dashboards/status/fragments/_outage_create_body.html' %}
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
@@ -91,46 +52,22 @@
                 </h5>
                 <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            {# Edit form is populated via inline JS (fields set from data attributes on button) #}
+            {# Edit form is populated via inline JS (fields set from data
+               attributes on the clicked row button; see modals.js 'outage-edit').
+               novalidate: EditOutageForm validates server-side; errors swap into
+               #editOutageFormBody. Hidden outage_id/tz + footer stay OUTSIDE the
+               swapped body so they (and the JS-set hx-post URL) survive a
+               re-render. hx-post is set dynamically by JS per outage id. #}
             <form id="editOutageForm"
-                  hx-disabled-elt="find button[type='submit']">
+                  hx-target="#editOutageFormBody"
+                  hx-swap="innerHTML"
+                  hx-disabled-elt="find button[type='submit']"
+                  novalidate>
                 <input type="hidden" id="editOutageId" name="outage_id">
                 {# Browser TZ — same purpose as on the create form. #}
                 <input type="hidden" name="tz" id="editTz">
-                <div class="modal-body">
-                    <div class="mb-3">
-                        <label for="editTitle" class="form-label">Title</label>
-                        <input type="text" class="form-control" id="editTitle" name="title">
-                    </div>
-                    <div class="mb-3">
-                        <label for="editStatus" class="form-label">Status</label>
-                        <select class="form-select" id="editStatus" name="status">
-                            <option value="investigating">Investigating</option>
-                            <option value="identified">Identified</option>
-                            <option value="monitoring">Monitoring</option>
-                            <option value="resolved">Resolved</option>
-                        </select>
-                    </div>
-                    <div class="mb-3">
-                        <label for="editSeverity" class="form-label">Severity</label>
-                        <select class="form-select" id="editSeverity" name="severity">
-                            <option value="critical">Critical</option>
-                            <option value="major">Major</option>
-                            <option value="minor">Minor</option>
-                            <option value="maintenance">Maintenance</option>
-                        </select>
-                    </div>
-                    <div class="mb-3">
-                        <label for="editDescription" class="form-label">Description <span class="text-muted">(optional)</span></label>
-                        <textarea class="form-control" id="editDescription" name="description" rows="3"></textarea>
-                    </div>
-                    <div class="mb-3">
-                        <label for="editEstimatedResolution" class="form-label">Estimated Resolution <span class="text-muted">(optional)</span></label>
-                        <input type="datetime-local" class="form-control" id="editEstimatedResolution" name="estimated_resolution">
-                        <small class="form-text text-muted">
-                            Times shown in your local TZ. Clear to remove estimated resolution time.
-                        </small>
-                    </div>
+                <div class="modal-body" id="editOutageFormBody">
+                    {% include 'dashboards/status/fragments/_outage_edit_body.html' %}
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>

--- a/src/webapp/templates/dashboards/user/fragments/threshold_form_htmx.html
+++ b/src/webapp/templates/dashboards/user/fragments/threshold_form_htmx.html
@@ -15,16 +15,19 @@
     resource_name      — resource name string
     window             — 30 or 90
     current_threshold  — current integer value, or None
-    error              — validation error string, or None
+    errors             — list of validation error strings (server-side), or None
 #}
 <span id="threshold-btn-{{ window }}d-{{ projcode }}"
       class="d-inline-flex align-items-center gap-1">
+    {# novalidate: the server (SetThresholdForm) is the source of truth, so
+       inline errors render here instead of a native browser bubble. #}
     <form hx-post="{{ url_for('user_dashboard.htmx_save_threshold', projcode=projcode, resource_name=resource_name, window=window) }}"
           hx-target="#htmx-rolling-{{ projcode }}-{{ resource_name }}"
           hx-swap="innerHTML"
-          class="d-inline-flex align-items-center gap-1 m-0">
-        {% if error %}
-        <span class="text-danger" style="font-size:0.7rem;">{{ error }}</span>
+          class="d-inline-flex align-items-center gap-1 m-0"
+          novalidate>
+        {% if errors %}
+        <span class="text-danger" style="font-size:0.7rem;">{{ errors | join('; ') }}</span>
         {% endif %}
         <input type="number" name="threshold_pct"
                value="{{ current_threshold if current_threshold is not none else '' }}"

--- a/tests/api/test_outage_threshold_form_schemas.py
+++ b/tests/api/test_outage_threshold_form_schemas.py
@@ -1,0 +1,98 @@
+"""Tests for the validation-outlier refactor schemas:
+SetThresholdForm (sam.schemas.forms.user) and Create/EditOutageForm
+(sam.schemas.forms.status).
+
+These schemas are pure input coercion + shape validation. DB-backed checks
+(account lookup, system_name → system_id resolution) stay in the routes per
+CLAUDE.md §9.
+"""
+import datetime as dt
+
+import pytest
+from marshmallow import ValidationError
+
+from sam.schemas.forms import SetThresholdForm, CreateOutageForm, EditOutageForm
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestSetThresholdForm:
+    def test_blank_clears_limit(self):
+        """Empty string → load_default None (remove the limit)."""
+        assert SetThresholdForm().load({'threshold_pct': ''}) == {'threshold_pct': None}
+
+    def test_absent_clears_limit(self):
+        assert SetThresholdForm().load({}) == {'threshold_pct': None}
+
+    def test_valid_value(self):
+        assert SetThresholdForm().load({'threshold_pct': '150'})['threshold_pct'] == 150
+
+    @pytest.mark.parametrize('bad', ['100', '0', '-5'])
+    def test_must_exceed_100(self, bad):
+        with pytest.raises(ValidationError) as ei:
+            SetThresholdForm().load({'threshold_pct': bad})
+        assert 'threshold_pct' in ei.value.messages
+
+    def test_non_integer_rejected(self):
+        with pytest.raises(ValidationError):
+            SetThresholdForm().load({'threshold_pct': 'abc'})
+
+
+class TestCreateOutageForm:
+    def _valid(self):
+        return {'system_name': 'derecho', 'title': 'Login down', 'severity': 'minor'}
+
+    def test_minimal_valid(self):
+        data = CreateOutageForm().load(self._valid())
+        assert data['system_name'] == 'derecho'
+        assert data['title'] == 'Login down'
+        assert data['severity'] == 'minor'
+        # optional fields fall through to None; tz is popped
+        assert data['start_time'] is None
+        assert data['estimated_resolution'] is None
+        assert 'tz' not in data
+
+    def test_missing_required(self):
+        with pytest.raises(ValidationError) as ei:
+            CreateOutageForm().load({})
+        assert set(ei.value.messages) == {'system_name', 'title', 'severity'}
+
+    def test_bad_enum_values(self):
+        bad = self._valid()
+        bad['system_name'] = 'nope'
+        bad['severity'] = 'apocalyptic'
+        with pytest.raises(ValidationError) as ei:
+            CreateOutageForm().load(bad)
+        assert 'system_name' in ei.value.messages
+        assert 'severity' in ei.value.messages
+
+    def test_datetime_local_parsed_and_converted_to_utc(self):
+        payload = self._valid()
+        payload['start_time'] = '2026-06-28T10:00'
+        payload['tz'] = 'America/Denver'   # MDT = UTC-6 in June
+        data = CreateOutageForm().load(payload)
+        # naive-UTC storage: 10:00 MDT → 16:00 UTC
+        assert data['start_time'] == dt.datetime(2026, 6, 28, 16, 0)
+        assert 'tz' not in data
+
+
+class TestEditOutageForm:
+    def test_title_optional(self):
+        data = EditOutageForm().load({'status': 'monitoring', 'severity': 'major'})
+        assert data['title'] is None
+        assert data['status'] == 'monitoring'
+
+    def test_status_required_and_validated(self):
+        with pytest.raises(ValidationError) as ei:
+            EditOutageForm().load({'severity': 'minor'})
+        assert 'status' in ei.value.messages
+
+        with pytest.raises(ValidationError) as ei:
+            EditOutageForm().load({'status': 'bogus', 'severity': 'minor'})
+        assert 'status' in ei.value.messages
+
+    def test_estimated_resolution_blank_is_none(self):
+        data = EditOutageForm().load(
+            {'status': 'resolved', 'severity': 'minor', 'estimated_resolution': ''})
+        assert data['estimated_resolution'] is None


### PR DESCRIPTION
**Stacked on #336** (base = `boostrap_elements`). Rebase onto `staging` after #336 merges.

## Summary

Closes the gap left by #336: the **threshold** and **outage create/edit** forms were intentionally left on native HTML5 validation because their routes read `request.form` directly with no schema. This brings both into CLAUDE.md §9 compliance — they validate via a marshmallow `HtmxFormSchema`, render the polished inline server-side errors, and carry `novalidate` so the native browser bubbles are gone. Plus two small UI fixes surfaced while smoke-testing.

## Threshold (user dashboard)
- New `SetThresholdForm` (`sam/schemas/forms/user.py`): integer `threshold_pct`, `Range(min=101)`, blank → `None` (remove the limit). Replaces the inline `int()`+`<=100` ladder in `htmx_save_threshold`.
- `threshold_form_htmx.html`: renders the `errors` list; `novalidate`.

## Outage create/edit (status dashboard)
- New `CreateOutageForm` / `EditOutageForm` (`sam/schemas/forms/status.py`): `OneOf` for system/severity/status (replacing hardcoded lists + *silent* rejection), `DateTime` for the datetime-local fields, and a `@post_load` that converts submitted wall-clock → naive-UTC via the hidden `tz` field — replacing the routes' silent `fromisoformat` try/except.
- Routes validate via schema; on error re-render the modal-body partial with inline `is-invalid` errors (`split_errors`) instead of flash+redirect. **Success path unchanged (`HX-Redirect`).** `system_name` → `system_id` resolution stays in the route (DB).
- `outage_modals.html`: each modal body extracted into a re-renderable partial built from the `form_fields.html` macros; `hx-target` to the body div; `novalidate`. Hidden `tz`/`outage_id` + footer kept **outside** the swapped body.

### Important: load-bearing JS preserved
The outage datetime fields are `datetime-local` (TZ-blind); `modals.js` does the UTC↔browser-local conversion and sets the edit form's `hx-post` URL. That JS is kept as-is — the macros use explicit `id=` to preserve the element ids it targets. (A full convert to the hx-get fragment pattern was deliberately **not** done: a server can't render a pre-filled local datetime without knowing the browser TZ at render time.)

## Reusable macro
- New `datetime_field` macro in `form_fields.html` (`type="datetime-local"`, same `is-invalid`/`aria-*`/`invalid-feedback` wiring as the other inputs).

## Drive-by UI fixes
- **Blue-on-blue confirm button**: the styled `samConfirmModal` left its base `btn-outline-primary` on the confirm button — the JS variant reset only stripped `btn-danger/warning/primary`, so the outline class survived and combined with the `info` variant's solid `btn-primary` into invisible blue-on-blue (the "Resolve outage" button). Fixed: base class → `btn-danger` (strippable default), and `ALL_BTN_CLASSES` now also strips the `btn-outline-*` variants so it can't recur.
- **Newline-eating popovers**: `g_txn_types` and `g_queue_states` glossary popovers used ` ·` inline separators; popover HTML collapses source newlines, so items wrapped mid-sentence. Switched both to explicit `<br>&bull;` per item, matching the correct `g_rolling_rate` popover.

## Test Results
- Full suite: **2435 passed**, 23 skipped, 1 xfailed (~68s)
- New `tests/api/test_outage_threshold_form_schemas.py` (14 cases): threshold bounds/blank, outage required/`OneOf`, datetime-local → naive-UTC.

## Playwright smoke (done)
- Outage create — empty submit → inline `is-invalid` + `aria-invalid` on System/Title/Severity, no native bubble, modal stays open; Start Time still auto-prefilled by the JS.
- Outage create — valid submit → "Outage reported." flash + HX-Redirect; appears in Active Issues.
- Resolve confirm button → now white-on-blue "MARK RESOLVED"; resolve flow clears the active issue. (Test outage row cleaned up.)
- Threshold form: covered by unit tests + mirrors the production shell/gid route pattern; its editor lives in lazy-loaded rolling-rate sections not reachable from the default dashboard view, so it was not click-tested. Outage *edit* uses the identical schema/partial path as create.
- Transaction-types / queue-state popovers: verified the rendered HTML now emits `<br>&bull;` per item (same mechanism as the working rolling-rate popover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)