### PR TITLE
Add help popover to Rolling Consumption Rate "Limit" action

### DIFF
--- a/src/webapp/templates/dashboards/fragments/glossary.html
+++ b/src/webapp/templates/dashboards/fragments/glossary.html
@@ -25,6 +25,17 @@ rate</em> — the pace needed to spend exactly the allocation over its period.
 rate crosses it.
 {%- endmacro %}
 
+{# ── Consumption-rate limit (popover) ── #}
+{% macro g_threshold_limit(window=None) -%}
+Sets a <strong>hard limit</strong> on a project's resource consumption rate.
+Exceeding this threshold prevents the system from scheduling new jobs until
+usage has decreased — useful to avoid exhausting a project's resources too
+early in the allotted period.
+<br><br>Recommended limits:
+<br>&bull; <strong{% if window == 30 %} class="text-warning"{% endif %}>120%</strong> over 30 days
+<br>&bull; <strong{% if window == 90 %} class="text-warning"{% endif %}>105%</strong> over 90 days
+{%- endmacro %}
+
 {% macro g_shared_pool() -%}
 This allocation draws from a pool shared with sibling projects under a master
 allocation. The bar shows total pool consumption; the lighter inner segment

--- a/src/webapp/templates/dashboards/user/fragments/rolling_rate_htmx.html
+++ b/src/webapp/templates/dashboards/user/fragments/rolling_rate_htmx.html
@@ -17,7 +17,7 @@
 #}
 
 {% from 'dashboards/fragments/help.html' import help_icon with context %}
-{% from 'dashboards/fragments/glossary.html' import g_rolling_rate with context %}
+{% from 'dashboards/fragments/glossary.html' import g_rolling_rate, g_threshold_limit with context %}
 <div class="mt-3 pt-3 border-top">
     <h6 class="mb-1">
         <i class="fas fa-thermometer-half text-muted me-1"></i> Rolling Consumption Rate
@@ -36,9 +36,11 @@
     {% set center_pos = 50 %}
 
     {# ── Grid wrapper: col1=label(4rem) col2=bar(1fr) col3=annotations(auto)
-           All rows — both bars + scale — share the same column widths so
-           0%/100%/200% always align with the bar edges. ── #}
-    <div style="display:grid; grid-template-columns:4rem 1fr auto; column-gap:0.5rem; row-gap:3px; align-items:center;">
+           col4=limit action(auto).  All rows — both bars + scale — share the
+           same column widths so 0%/100%/200% align with the bar edges, and the
+           col4 action buttons line up vertically regardless of the variable
+           "running hot/cold" annotation width in col3. ── #}
+    <div style="display:grid; grid-template-columns:4rem 1fr auto auto; column-gap:0.5rem; row-gap:3px; align-items:center;">
 
     {% for label, win, win_days in [('30-day', rolling_30, 30), ('90-day', rolling_90, 90)] %}
     {% if win %}
@@ -116,7 +118,7 @@
             {% endif %}
         </div>
 
-        {# col 3: badge + annotation + optional limit edit button #}
+        {# col 3: badge + annotation #}
         <div class="d-flex align-items-center gap-1 text-nowrap">
             {% if state == 'over_limit' %}
             <span class="badge bg-danger"><i class="fas fa-exclamation-triangle me-1"></i>over {{ win.threshold_pct }}% lim</span>
@@ -129,10 +131,15 @@
                 {% endif %}
                 &middot; {{ state_label }}
             </span>
-            {# Threshold edit lives on the master allocation's account, not the
-               child's — the displayed pct is pool burn, so a child-side
-               threshold is never compared against. Hide the edit button on
-               inheriting projects; users edit via the master parent project. #}
+        </div>
+
+        {# col 4: limit action + help — its own grid column so the buttons line
+           up vertically across rows regardless of the col-3 annotation width.
+           Threshold edit lives on the master allocation's account, not the
+           child's — the displayed pct is pool burn, so a child-side threshold
+           is never compared against. Hide the edit button on inheriting
+           projects; users edit via the master parent project. #}
+        <div class="d-flex align-items-center gap-1 text-nowrap">
             {% if can_edit_threshold and not rolling_is_inheriting %}
             <span id="threshold-btn-{{ win_days }}d-{{ projcode }}">
                 {% if win.threshold_pct is none %}
@@ -151,19 +158,22 @@
                 </button>
                 {% endif %}
             </span>
+            {{ help_icon(g_threshold_limit(window=win_days), rich=True,
+                         title='Consumption Rate Limit', placement='left') }}
             {% endif %}
         </div>
 
     {% endif %}
     {% endfor %}
 
-        {# Scale row — col1: empty spacer, col2: tick labels, col3: nothing #}
+        {# Scale row — col1: empty spacer, col2: tick labels, col3+col4: nothing #}
         <span></span>
         <div class="position-relative" style="height:1.1rem; font-size:0.65rem; color:#6c757d; margin-top:1px;">
             <span style="position:absolute; left:0;">0%</span>
             <span style="position:absolute; left:{{ center_pos }}%; transform:translateX(-50%);">&#9650; 100%</span>
             <span style="position:absolute; right:0;">200%</span>
         </div>
+        <span></span>
         <span></span>
 
     </div>{# /grid #}


### PR DESCRIPTION
## Summary

Adds a `?` help popover next to the **Limit** buttons on the user dashboard's
Rolling Consumption Rate section, using the Bootstrap-5 help pattern from
PR #335 (`help_icon` + glossary macros + `tooltip-init.js`).

The popover explains that a limit is a **hard cap** on a project's consumption
rate — exceeding it prevents the system from scheduling new jobs until usage
drops — and lists recommended limits, emphasizing the value relevant to that
row's window:

- **120%** over 30 days
- **105%** over 90 days

It also fixes vertical alignment of the limit buttons/popovers: the
variable-width "running hot/cold" annotation previously pushed them to
different horizontal positions per row. The action button + help icon now sit
in their own `auto` grid column (grid widened from 3 → 4 columns), so they
line up across the 30-day and 90-day rows.

## Changes
- `glossary.html`: new `g_threshold_limit(window=None)` popover macro.
- `rolling_rate_htmx.html`: import the macro; move the limit action + help
  icon into a dedicated grid column; render the rich popover with per-window
  emphasis.

Template-only — no routes, schema, or JS wiring affected (`tooltip-init.js`
already re-inits popovers after HTMX swaps). The `SetThresholdForm` schema and
threshold routes are untouched.

## Verification
1. `docker compose up webdev --watch` → http://localhost:5050
2. Open the User Dashboard for a project where you can edit thresholds.
3. Confirm the `?` icon sits right of each `+ limit` / `✎ limit` button, the
   buttons line up vertically across both rows, and the popover shows the
   explanation with the window-appropriate recommendation emphasized.
4. Open `+ limit`, then Cancel — confirm the popover re-inits after the HTMX swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)