### PR TITLE
Disk usage chart: viewable by timeframe (90d/180d/1yr/Epoch)

### DIFF
--- a/src/sam/queries/disk_usage.py
+++ b/src/sam/queries/disk_usage.py
@@ -303,6 +303,22 @@ def bulk_get_subtree_disk_capacity(
     return out
 
 
+def get_earliest_disk_activity_date(session, account_ids):
+    """Earliest DiskChargeSummary.activity_date across the given accounts.
+
+    Anchors the disk chart's "Epoch" button to the full storage history
+    of the project (spans allocation boundaries). Returns None when no
+    accounts are given or no snapshots exist.
+    """
+    if not account_ids:
+        return None
+    return (
+        session.query(func.min(DiskChargeSummary.activity_date))
+        .filter(DiskChargeSummary.account_id.in_(account_ids))
+        .scalar()
+    )
+
+
 def get_disk_usage_timeseries_by_user(
     session: Session,
     *,

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -23,6 +23,7 @@ from sam.queries.disk_usage import (
     get_directory_user_breakdown_at,
     get_disk_usage_timeseries_by_user,
     get_disk_usage_timeseries_for_directory,
+    get_earliest_disk_activity_date,
     get_subtree_directory_usage_at,
 )
 from sam.queries.rolling_usage import get_project_rolling_usage
@@ -929,6 +930,11 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
     scope_node = _find_disk_node(full_tree, scope) or full_tree
     scope_account_ids = _collect_disk_account_ids(scope_node)
 
+    # Anchor the "Epoch" preset on the timeframe picker to the earliest
+    # disk snapshot we hold for this scope's accounts — full storage
+    # history, which may span allocation boundaries.
+    epoch_date = get_earliest_disk_activity_date(db.session, scope_account_ids)
+
     # Build the {directory_name → projcode} map by walking the scoped
     # subtree's in-memory ProjectDirectory data (already loaded by
     # build_disk_subtree). Lets the Filesets-card query hit
@@ -1071,6 +1077,7 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
         has_children=bool(project.has_children),
         start_date=start_date.strftime('%Y-%m-%d'),
         end_date=end_date.strftime('%Y-%m-%d'),
+        epoch_date=epoch_date.strftime('%Y-%m-%d') if epoch_date else None,
         usage_chart=usage_chart,
         show_scans=show_scans,
         scan_info=scan_info,

--- a/src/webapp/templates/dashboards/fragments/date_range_picker.html
+++ b/src/webapp/templates/dashboards/fragments/date_range_picker.html
@@ -1,4 +1,4 @@
-{% macro date_range_picker(action, start_date, end_date, hidden_fields={}, epoch_date=None) %}
+{% macro date_range_picker(action, start_date, end_date, hidden_fields={}, epoch_date=None, presets=None) %}
 {#
   Compact date range picker with quick-select presets and optional custom inputs.
 
@@ -9,6 +9,9 @@
     hidden_fields - dict of extra hidden form fields (e.g. {'projcode': 'SCSG0001'})
     epoch_date    - optional YYYY-MM-DD string; when provided adds an "Epoch" button
                     that navigates to start=epoch_date, end=today (e.g. allocation start)
+    presets       - optional list of (label, days) tuples overriding the default
+                    quick-select buttons; e.g. [('90d', 90), ('180d', 180), ('1yr', 365)]
+                    for the weekly-cadence disk chart. Defaults to 7d/30d/90d/6mo/1yr.
 
   Behavior lives in static/js/pickers.js (CSP: no inline scripts); the
   data attributes + .drp-hidden JSON block below are its contract.
@@ -34,7 +37,7 @@
                             class="btn btn-outline-secondary"
                             data-action="drp-epoch">Epoch</button>
                     {% endif %}
-                    {% set presets = [('7d', 7), ('30d', 30), ('90d', 90), ('6mo', 180), ('1yr', 365)] %}
+                    {% set presets = presets or [('7d', 7), ('30d', 30), ('90d', 90), ('6mo', 180), ('1yr', 365)] %}
                     {% for label, days in presets %}
                     <button type="button"
                             class="btn btn-outline-secondary"

--- a/src/webapp/templates/dashboards/fragments/date_range_picker.html
+++ b/src/webapp/templates/dashboards/fragments/date_range_picker.html
@@ -32,17 +32,24 @@
 
                 <!-- Quick-select preset buttons -->
                 <div class="btn-group btn-group-sm" role="group" aria-label="Date range presets">
+                    {# data-scroll-preserve: nav-view-persistence.js snapshots
+                       scrollY on click (capture phase, before pickers.js does
+                       the full-page nav) and restores it on reload, so changing
+                       the range doesn't jump back to the top. Same mechanism the
+                       queue-history time picker uses. #}
                     {% if epoch_date %}
                     <button type="button"
                             class="btn btn-outline-secondary"
-                            data-action="drp-epoch">Epoch</button>
+                            data-action="drp-epoch"
+                            data-scroll-preserve>Epoch</button>
                     {% endif %}
                     {% set presets = presets or [('7d', 7), ('30d', 30), ('90d', 90), ('6mo', 180), ('1yr', 365)] %}
                     {% for label, days in presets %}
                     <button type="button"
                             class="btn btn-outline-secondary"
                             data-action="drp-days"
-                            data-days="{{ days }}">{{ label }}</button>
+                            data-days="{{ days }}"
+                            data-scroll-preserve>{{ label }}</button>
                     {% endfor %}
                 </div>
 
@@ -62,7 +69,7 @@
                     <input type="date" name="end_date"
                            value="{{ end_date }}"
                            class="form-control form-control-sm" style="width:140px">
-                    <button type="submit" class="btn  btn-primary">
+                    <button type="submit" class="btn  btn-primary" data-scroll-preserve>
                         <i class="fas fa-check"></i> Apply
                     </button>
                 </div>

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -2,6 +2,7 @@
 {% from 'dashboards/shared/usage_bar.html' import render_usage_bar with context %}
 {% from 'dashboards/fragments/help.html' import term with context %}
 {% from 'dashboards/fragments/glossary.html' import g_tib with context %}
+{% from 'dashboards/fragments/date_range_picker.html' import date_range_picker %}
 
 {% block title %}Disk Usage Details - {{ resource_name }} - SAM{% endblock %}
 
@@ -252,6 +253,20 @@
     </div>
 </div>
 {% endif %}
+
+{# ── Timeframe picker (governs the Usage Over Time chart below; the
+   capacity header, tree, and per-user table stay point-in-time at the
+   latest snapshot). Weekly snapshot cadence → 90d/180d/1yr presets; the
+   Epoch button jumps to the earliest snapshot we hold for this scope. ── #}
+{{ date_range_picker(
+    action=url_for('user_dashboard.resource_details', projcode=projcode),
+    start_date=start_date,
+    end_date=end_date,
+    hidden_fields=({'resource': resource_name, 'scope': scope, 'fileset': fileset}
+                   if fileset else {'resource': resource_name, 'scope': scope}),
+    epoch_date=epoch_date,
+    presets=[('90d', 90), ('180d', 180), ('1yr', 365)]
+) }}
 
 {# ── Stacked-area chart ─────────────────────────────────────────────── #}
 <div class="card mb-4">

--- a/tests/unit/test_disk_usage_queries.py
+++ b/tests/unit/test_disk_usage_queries.py
@@ -20,6 +20,7 @@ from sam.queries.disk_usage import (
     build_disk_subtree,
     bulk_get_directory_usage_at,
     get_disk_usage_timeseries_by_user,
+    get_earliest_disk_activity_date,
 )
 from sam.summaries.disk_summaries import (
     DiskChargeSummary,
@@ -203,6 +204,43 @@ class TestDiskUsageTimeseries:
             start_date=_date(2026, 4, 1),
         )
         assert out['dates'] == [d2]
+
+
+# ============================================================================
+# get_earliest_disk_activity_date
+# ============================================================================
+
+
+class TestEarliestDiskActivityDate:
+
+    def test_empty_account_ids_returns_none(self, session):
+        assert get_earliest_disk_activity_date(session, []) is None
+
+    def test_returns_min_date_across_snapshots(self, session):
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        early = _date(2026, 1, 3)
+        late = _date(2026, 4, 11)
+        _seed_row(session, account=account, user=lead, snap=late, bytes_=BYTES_PER_TIB)
+        _seed_row(session, account=account, user=lead, snap=early, bytes_=BYTES_PER_TIB)
+        session.flush()
+
+        assert get_earliest_disk_activity_date(
+            session, [account.account_id],
+        ) == early
+
+    def test_no_snapshots_returns_none(self, session):
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        session.flush()
+
+        assert get_earliest_disk_activity_date(
+            session, [account.account_id],
+        ) is None
 
 
 # ============================================================================


### PR DESCRIPTION
## Context

On the Resource Usage Details page, HPC/DAV resources get a full date-range picker (presets + custom + an **Epoch** button) above their usage chart. **Disk** resources never got one — they silently fell back to a hard-coded **90-day** window, so the project disk stacked-area chart could only ever show ~12 weekly points with no way to widen the view.

This adds the same picker to the disk chart, with presets tuned to the **weekly** snapshot cadence — and, while in the shared picker, fixes a long-standing scroll-jump that affected **both** disk and HPC/DAV.

## What changed

- **Presets:** `90d / 180d / 1yr` (7d/30d dropped — too few weekly points) + **Custom** range + **Epoch**.
- **Epoch** anchors to the earliest `DiskChargeSummary` snapshot for the scoped project's accounts — the **full storage history**, intentionally **spanning allocation boundaries** (chosen over "current allocation start" so you see the whole life of the data). It's a pure `MIN(activity_date)` over the subtree accounts with no allocation join, so allocation windows can't truncate it.
- The capacity header, project tree, and per-user table stay point-in-time at the latest snapshot — only the stacked-area chart responds to the timeframe.
- The shared `date_range_picker` macro gained an optional `presets=` param; the existing 7d/30d/90d/6mo/1yr list is the default fallback, so **HPC/DAV pickers are unchanged**.
- **Scroll preservation (bug fix):** changing the date range navigates via a full-page GET, which previously reset scroll to the top and hid the chart you were inspecting — on **both** disk and HPC/DAV. The queue-history time picker already avoids this via `data-scroll-preserve` (nav-view-persistence.js snapshots `scrollY` on click, capture phase, and restores it on reload). The date picker was missing that opt-in; this adds it to the preset buttons, Epoch, and the custom **Apply** submit. No JS change.

## Files

| File | Change |
|---|---|
| `sam/queries/disk_usage.py` | new `get_earliest_disk_activity_date()` (returns `None` for empty accounts / no snapshots) |
| `fragments/date_range_picker.html` | optional `presets=` param; `data-scroll-preserve` on navigating controls |
| `dashboards/user/blueprint.py` | compute `epoch_date`, pass to disk template |
| `resource_details_disk.html` | render picker above the chart; preserves `fileset` when drilled in |
| `tests/unit/test_disk_usage_queries.py` | `TestEarliestDiskActivityDate` |

## Note on Epoch / dev DB

In the **dev** DB, `disk_charge_summary` only goes back to **2025-05-23**, so every long-lived project's Epoch saturates at that floor (e.g. NMMM0003 → 2025-05-24). Newer projects show later, varying epochs (WYOM0227 → 2026-06-20), confirming the per-project logic works. Deploying against the **prod** DB should surface genuinely longer epochs.

## Verification

- Visit `/user/resource-details/<projcode>?resource=Campaign_Store`; confirm the picker renders above "Usage Over Time" with **90d / 180d / 1yr / Epoch / Custom**, 90d highlighted on load.
- Click 180d/1yr/Epoch → chart widens, subtitle + range display update, active button highlights.
- Drill into a fileset, change timeframe → stays in fileset view.
- Regression: HPC/DAV picker unchanged (still 7d/30d/90d/6mo/1yr + Epoch).
- **Scroll:** scroll down to the chart, click a preset → page reloads at the **same scroll position** (verified via Playwright on both disk `NCIS0001/Campaign_Store` and HPC `SCSG0001/Derecho`: scrollY restored, not reset to 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)