### PR TITLE
Disk usage chart: Data Volume / File Count toggle

### DIFF
--- a/src/sam/queries/disk_usage.py
+++ b/src/sam/queries/disk_usage.py
@@ -319,6 +319,16 @@ def get_earliest_disk_activity_date(session, account_ids):
     )
 
 
+def _disk_metric_col(model, metric):
+    """Pick the summed column for a disk timeseries by metric.
+
+    ``'files'`` → ``number_of_files``; anything else → ``bytes``. Works for
+    both ``DiskChargeSummary`` (project path) and ``DiskActivity`` (fileset
+    path), which carry both columns.
+    """
+    return model.number_of_files if metric == 'files' else model.bytes
+
+
 def get_disk_usage_timeseries_by_user(
     session: Session,
     *,
@@ -326,15 +336,17 @@ def get_disk_usage_timeseries_by_user(
     start_date: Optional[_stdlib_date] = None,
     end_date: Optional[_stdlib_date] = None,
     top_n: int = 10,
+    metric: str = 'bytes',
 ) -> Dict[str, Any]:
-    """Per-user disk-bytes time series for a stacked-area chart.
+    """Per-user disk time series for a stacked-area chart.
 
-    Sums ``DiskChargeSummary.bytes`` grouped by ``(activity_date,
-    user_id)`` for the given accounts and date range. Picks the top
-    ``top_n`` users by their *latest-snapshot* bytes; everyone else is
-    lumped into a single ``"Others"`` series. Missing (date, user) pairs
-    are dense-filled with 0 so every series has the same length as
-    ``dates``.
+    Sums ``DiskChargeSummary.bytes`` (``metric='bytes'``, default) or
+    ``DiskChargeSummary.number_of_files`` (``metric='files'``) grouped by
+    ``(activity_date, user_id)`` for the given accounts and date range.
+    Picks the top ``top_n`` users by their *latest-snapshot* value for the
+    selected metric; everyone else is lumped into a single ``"Others"``
+    series. Missing (date, user) pairs are dense-filled with 0 so every
+    series has the same length as ``dates``.
 
     Series order is **stack-friendly**: ``Others`` first (so it renders
     at the bottom of the stacked area in a neutral colour), then named
@@ -364,7 +376,7 @@ def get_disk_usage_timeseries_by_user(
         DiskChargeSummary.activity_date,
         DiskChargeSummary.user_id,
         DiskChargeSummary.username,
-        func.coalesce(func.sum(DiskChargeSummary.bytes), 0).label('bytes'),
+        func.coalesce(func.sum(_disk_metric_col(DiskChargeSummary, metric)), 0).label('value'),
     ).filter(
         DiskChargeSummary.account_id.in_(account_ids),
     )
@@ -437,10 +449,11 @@ def get_disk_usage_timeseries_for_directory(
     start_date: Optional[_stdlib_date] = None,
     end_date: Optional[_stdlib_date] = None,
     top_n: int = 10,
+    metric: str = 'bytes',
 ) -> Dict[str, Any]:
-    """Per-user disk-bytes timeseries for a single fileset.
+    """Per-user disk timeseries for a single fileset.
 
-    Same return shape and ranking semantics as
+    Same return shape, ``metric`` handling, and ranking semantics as
     :func:`get_disk_usage_timeseries_by_user`, but reads from
     ``disk_activity`` directly so it can filter by ``directory_name``.
     Used by the dashboard when the user clicks a fileset row to scope
@@ -461,7 +474,7 @@ def get_disk_usage_timeseries_for_directory(
     q = session.query(
         DiskActivity.activity_date,
         DiskActivity.username,
-        func.coalesce(func.sum(DiskActivity.bytes), 0).label('bytes'),
+        func.coalesce(func.sum(_disk_metric_col(DiskActivity, metric)), 0).label('value'),
     ).filter(
         DiskActivity.directory_name == directory_name,
         DiskActivity.resource_name == resource_name,

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -392,8 +392,8 @@ _BYTES_PER_TIB = 1024 ** 4
 _BYTES_PER_PIB = 1024 ** 5
 
 
-def _disk_usage_stacked_area_cache_key(timeseries, link_kind=None):
-    return _content_hash([_content_hash(timeseries), link_kind or ''])
+def _disk_usage_stacked_area_cache_key(timeseries, link_kind=None, metric='bytes'):
+    return _content_hash([_content_hash(timeseries), link_kind or '', metric])
 
 
 # `link_kind` ('user' | None) controls whether legend usernames are
@@ -402,8 +402,8 @@ def _disk_usage_stacked_area_cache_key(timeseries, link_kind=None):
 # user_proj_stacked_area chart's pattern.
 @caching.chart_cached(name='disk_usage_stacked_area', maxsize=128,
                       key_fn=_disk_usage_stacked_area_cache_key)
-def generate_disk_usage_stacked_area(timeseries, link_kind=None) -> str:
-    """Render a stacked-area chart of disk bytes vs time.
+def generate_disk_usage_stacked_area(timeseries, link_kind=None, metric='bytes') -> str:
+    """Render a stacked-area chart of disk usage vs time.
 
     Args:
         timeseries: dict shaped as ``sam.queries.disk_usage.get_disk_usage_timeseries_by_user``
@@ -415,10 +415,13 @@ def generate_disk_usage_stacked_area(timeseries, link_kind=None) -> str:
             for no links. The 'Others' bucket is never linked.
             ``svg-chart-links.js`` intercepts the click and shows the
             modal — ``set_url()`` only emits the ``<a>`` wrapper.
+        metric: ``'bytes'`` (default) renders a byte-volume y-axis
+            auto-scaled to TiB or PiB; ``'files'`` renders a raw file-count
+            y-axis with compact, integer ticks.
 
-    Y-axis is auto-scaled to TiB or PiB based on the peak stacked total
-    (>= 1 PiB → PiB, else TiB). X-axis is date-formatted. Legend on the
-    right.
+    For ``metric='bytes'`` the y-axis is auto-scaled to TiB or PiB based on
+    the peak stacked total (>= 1 PiB → PiB, else TiB). X-axis is
+    date-formatted. Legend on the right.
     """
     if not timeseries or not timeseries.get('dates') or not timeseries.get('series'):
         return '<div class="text-center text-muted">No disk-usage history for this period</div>'
@@ -428,23 +431,29 @@ def generate_disk_usage_stacked_area(timeseries, link_kind=None) -> str:
     if not dates or not series:
         return '<div class="text-center text-muted">No disk-usage history for this period</div>'
 
-    stacked_totals = [
-        sum(s['values'][i] for s in series)
-        for i in range(len(dates))
-    ]
-    peak = max(stacked_totals) if stacked_totals else 0
-    if peak >= _BYTES_PER_PIB:
-        scale = _BYTES_PER_PIB
-        unit_label = 'PiB'
+    if metric == 'files':
+        # Raw file counts: no scaling; compact integer y-axis ticks.
+        scaled_series = [list(s['values']) for s in series]
+        ylabel = 'Number of files'
     else:
-        scale = _BYTES_PER_TIB
-        unit_label = 'TiB'
+        stacked_totals = [
+            sum(s['values'][i] for s in series)
+            for i in range(len(dates))
+        ]
+        peak = max(stacked_totals) if stacked_totals else 0
+        if peak >= _BYTES_PER_PIB:
+            scale = _BYTES_PER_PIB
+            unit_label = 'PiB'
+        else:
+            scale = _BYTES_PER_TIB
+            unit_label = 'TiB'
+        scaled_series = [
+            [v / scale for v in s['values']]
+            for s in series
+        ]
+        ylabel = f'Disk usage ({unit_label})'
 
     fig, ax = plt.subplots(figsize=(18, 5))
-    scaled_series = [
-        [v / scale for v in s['values']]
-        for s in series
-    ]
     # Others (always first per get_disk_usage_timeseries_by_user) gets a
     # neutral grey so it doesn't compete with the named-user palette.
     # Named users use the Unity 10-color stacked palette.
@@ -457,7 +466,11 @@ def generate_disk_usage_stacked_area(timeseries, link_kind=None) -> str:
             colors.append(UNITY_STACK_10[cycle_idx % 10])
             cycle_idx += 1
     ax.stackplot(dates, *scaled_series, colors=colors, alpha=0.85)
-    ax.set_ylabel(f'Disk usage ({unit_label})')
+    ax.set_ylabel(ylabel)
+    if metric == 'files':
+        from matplotlib.ticker import MaxNLocator
+        ax.yaxis.set_major_formatter(fmt.mpl_number_formatter())
+        ax.yaxis.set_major_locator(MaxNLocator(integer=True))
     ax.grid(True, alpha=0.3)
 
     # Build the legend explicitly with reversed-order Patch handles so

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -767,6 +767,8 @@ _USAGE_CHART_DATA_KEY = {
     'core_hours': 'daily_core_hours',
 }
 
+_VALID_DISK_USAGE_CHART_METRIC = {'bytes', 'files'}
+
 
 @bp.route('/resource-details/usage-chart/<projcode>')
 @login_required
@@ -863,6 +865,103 @@ def resource_details_usage_chart(project):
         end_date=end_date.strftime('%Y-%m-%d'),
         has_data=has_data,
         is_stacked=is_stacked,
+    )
+
+
+@bp.route('/resource-details/disk-usage-chart/<projcode>')
+@login_required
+@require_project_access(include_ancestors=True)
+def resource_details_disk_usage_chart(project):
+    """HTMX fragment: Disk "Usage Over Time" stacked-area chart for a metric.
+
+    Loaded by the disk resource-details page on initial render and
+    re-fetched when the analyst toggles the Data Volume / File Count tab.
+    Mirrors ``resource_details_usage_chart`` (the HPC/DAV equivalent):
+    rebuilds the disk subtree to resolve the scoped account ids (or the
+    fileset's directory), renders the chart for the requested metric, and
+    returns the tab strip + chart as one unit so the active tab follows.
+    """
+    resource_name = (request.args.get('resource') or '').strip()
+    if not resource_name:
+        abort(400, 'resource is required')
+
+    metric = request.args.get('metric', 'bytes')
+    if metric not in _VALID_DISK_USAGE_CHART_METRIC:
+        metric = 'bytes'
+
+    # Same default window as the disk page (last 90 days).
+    try:
+        if request.args.get('start_date'):
+            start_date = datetime.strptime(request.args.get('start_date'), '%Y-%m-%d')
+        else:
+            start_date = datetime.now() - timedelta(days=90)
+        if request.args.get('end_date'):
+            end_date = datetime.strptime(request.args.get('end_date'), '%Y-%m-%d')
+        else:
+            end_date = datetime.now()
+    except ValueError:
+        abort(400, 'Invalid date format. Please use YYYY-MM-DD.')
+
+    scope = (request.args.get('scope') or '').strip() or project.projcode
+    if scope != project.projcode:
+        scope_project = Project.get_by_projcode(db.session, scope)
+        if not scope_project or scope_project.tree_root != project.tree_root:
+            scope = project.projcode
+    fileset = request.args.get('fileset') or None
+
+    # Rebuild the subtree to resolve the scoped accounts / valid filesets
+    # (mirrors _render_disk_resource_details). Cheap relative to the chart.
+    full = build_disk_subtree(db.session, project, resource_name)
+    scope_node = _find_disk_node(full['tree'], scope) or full['tree']
+    scope_account_ids = _collect_disk_account_ids(scope_node)
+
+    # Drop an invalid ?fileset= (not one of this scope's directories) and
+    # fall back to project-scope rendering, matching the page route.
+    if fileset is not None:
+        valid_dirs = _collect_directory_to_projcode(scope_node)
+        if fileset not in valid_dirs:
+            fileset = None
+
+    chart_start = start_date.date() if hasattr(start_date, 'date') else start_date
+    chart_end = end_date.date() if hasattr(end_date, 'date') else end_date
+    if fileset is None:
+        timeseries = get_disk_usage_timeseries_by_user(
+            db.session,
+            account_ids=scope_account_ids,
+            start_date=chart_start,
+            end_date=chart_end,
+            top_n=15,
+            metric=metric,
+        )
+    else:
+        timeseries = get_disk_usage_timeseries_for_directory(
+            db.session,
+            resource_name=resource_name,
+            directory_name=fileset,
+            start_date=chart_start,
+            end_date=chart_end,
+            top_n=15,
+            metric=metric,
+        )
+
+    disk_link_kind = (
+        'user' if has_permission(current_user, Permission.VIEW_USERS) else None
+    )
+    chart_svg = generate_disk_usage_stacked_area(
+        timeseries, link_kind=disk_link_kind, metric=metric,
+    )
+
+    return render_template(
+        'dashboards/user/partials/disk_usage_chart.html',
+        chart_svg=chart_svg,
+        metric=metric,
+        projcode=project.projcode,
+        resource_name=resource_name,
+        scope=scope,
+        fileset=fileset,
+        start_date=start_date.strftime('%Y-%m-%d'),
+        end_date=end_date.strftime('%Y-%m-%d'),
+        has_data=bool(timeseries.get('series')),
     )
 
 
@@ -982,13 +1081,6 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
         used_tib = used_bytes / (1024 ** 4)
         total_files = _disk_subtree_total_files(scope_node)
         activity_date = _disk_subtree_latest_activity_date(scope_node)
-        timeseries = get_disk_usage_timeseries_by_user(
-            db.session,
-            account_ids=scope_account_ids,
-            start_date=start_date.date() if hasattr(start_date, 'date') else start_date,
-            end_date=end_date.date() if hasattr(end_date, 'date') else end_date,
-            top_n=15,
-        )
         user_rows = _build_disk_user_table(
             db.session, scope_account_ids, activity_date, used_bytes,
         )
@@ -1004,14 +1096,6 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
         used_tib = used_bytes / (1024 ** 4)
         total_files = fileset_row['files']
         activity_date = subtree_activity_date
-        timeseries = get_disk_usage_timeseries_for_directory(
-            db.session,
-            resource_name=resource_name,
-            directory_name=fileset,
-            start_date=start_date.date() if hasattr(start_date, 'date') else start_date,
-            end_date=end_date.date() if hasattr(end_date, 'date') else end_date,
-            top_n=15,
-        )
         breakdown = get_directory_user_breakdown_at(
             db.session,
             resource_name=resource_name,
@@ -1054,14 +1138,10 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
             )
 
     percent_used = (used_tib / allocated_tib * 100) if allocated_tib > 0 else 0.0
-    # Operators (VIEW_USERS) get clickable legend usernames that pop the
-    # user-details modal; non-operators get plain text since the modal
-    # endpoint would 403 on click. Same gating shape as the queue-load
-    # chart in status/blueprint.py:_render_user_proj_chart.
-    disk_link_kind = (
-        'user' if has_permission(current_user, Permission.VIEW_USERS) else None
-    )
-    usage_chart = generate_disk_usage_stacked_area(timeseries, link_kind=disk_link_kind)
+    # The stacked-area chart itself is rendered lazily by the
+    # `resource_details_disk_usage_chart` HTMX fragment (one code path,
+    # per-metric caching, Data Volume / File Count tab swap) — not inline
+    # here. The page only emits the deferred loader wrapper.
 
     return render_template(
         'dashboards/user/resource_details_disk.html',
@@ -1078,7 +1158,6 @@ def _render_disk_resource_details(*, project, resource, start_date, end_date):
         start_date=start_date.strftime('%Y-%m-%d'),
         end_date=end_date.strftime('%Y-%m-%d'),
         epoch_date=epoch_date.strftime('%Y-%m-%d') if epoch_date else None,
-        usage_chart=usage_chart,
         show_scans=show_scans,
         scan_info=scan_info,
         capacity={

--- a/src/webapp/templates/dashboards/user/partials/disk_usage_chart.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_usage_chart.html
@@ -1,0 +1,42 @@
+{# Disk "Usage Over Time" chart fragment — loaded by the disk
+   resource-details page (hx-trigger="load") and re-rendered when the
+   Data Volume / File Count tab is clicked. Each tab's hx-get points back
+   at the same route with a different `metric=`, so the server re-renders
+   the tab strip + chart as one unit into #disk-usage-chart-wrapper and
+   the active tab follows the new metric.
+
+   nav-tabs (not data-bs-toggle="tab") — the whole partial swaps in place,
+   so there are no separate tab panes; the active state is server-rendered.
+   scope / fileset / start_date / end_date are threaded through every
+   hx-get so swapping metric preserves the current subtree, fileset, and
+   timeframe. #}
+
+{% set _LABELS = {'bytes': 'Data Volume', 'files': 'File Count'} %}
+
+<ul class="nav nav-tabs mb-3" role="tablist">
+    {% for opt in ['bytes', 'files'] %}
+    <li class="nav-item" role="presentation">
+        <button type="button"
+                class="nav-link{% if metric == opt %} active{% endif %}"
+                role="tab"
+                aria-selected="{{ 'true' if metric == opt else 'false' }}"
+                hx-get="{{ url_for('user_dashboard.resource_details_disk_usage_chart',
+                                   projcode=projcode,
+                                   resource=resource_name,
+                                   scope=scope,
+                                   fileset=fileset,
+                                   start_date=start_date,
+                                   end_date=end_date,
+                                   metric=opt) }}"
+                hx-target="#disk-usage-chart-wrapper"
+                hx-swap="innerHTML">
+            {% if opt == 'bytes' %}<i class="fas fa-hdd me-1"></i>{% else %}<i class="fas fa-copy me-1"></i>{% endif %}
+            {{ _LABELS[opt] }}
+        </button>
+    </li>
+    {% endfor %}
+</ul>
+
+<div class="chart-container">
+    {{ chart_svg | safe }}
+</div>

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -286,8 +286,27 @@
     </div>
     <div id="collapseDiskUsage" class="collapse show">
         <div class="card-body">
-            <div class="chart-container">
-                {{ usage_chart | safe }}
+            {# Chart loads via HTMX so the Data Volume / File Count tab can
+               swap the SVG in place. nav-view-persistence.js round-trips
+               the `metric` URL param through localStorage via the
+               data-chart-persist-* attributes (metric only — never the
+               dates, so the timeframe picker stays authoritative). #}
+            <div id="disk-usage-chart-wrapper"
+                 hx-get="{{ url_for('user_dashboard.resource_details_disk_usage_chart',
+                                    projcode=projcode,
+                                    resource=resource_name,
+                                    scope=scope,
+                                    fileset=fileset,
+                                    start_date=start_date,
+                                    end_date=end_date,
+                                    metric='bytes') }}"
+                 hx-trigger="load"
+                 hx-swap="innerHTML"
+                 data-chart-persist-id="disk-usage-chart-{{ projcode }}-{{ resource_name }}"
+                 data-chart-persist-keys="metric">
+                <div class="text-center text-muted py-5">
+                    <i class="fas fa-spinner fa-spin"></i> Loading chart…
+                </div>
             </div>
         </div>
     </div>

--- a/tests/unit/test_disk_usage_chart.py
+++ b/tests/unit/test_disk_usage_chart.py
@@ -1,0 +1,56 @@
+"""Unit tests for the disk "Usage Over Time" stacked-area chart renderer.
+
+``generate_disk_usage_stacked_area`` renders bytes (TiB/PiB y-axis) or
+file counts (raw integer y-axis) from the same timeseries shape, selected
+by ``metric``. matplotlib's SVG backend rasterizes axis text to vector
+paths (``svg.fonttype`` defaults to ``'path'``), so we assert on behavior
+— empty handling and that the two metrics produce distinct output — rather
+than grepping for label strings.
+"""
+
+import pytest
+
+from webapp.dashboards.charts import generate_disk_usage_stacked_area
+
+pytestmark = pytest.mark.unit
+
+_TIB = 1024 ** 4
+
+
+def _timeseries():
+    # Values where byte-scaling vs no-scaling clearly diverges.
+    return {
+        'dates': ['2026-04-04', '2026-04-11'],
+        'series': [
+            {'username': 'Others', 'values': [1 * _TIB, 2 * _TIB]},
+            {'username': 'alice', 'values': [3 * _TIB, 4 * _TIB]},
+        ],
+    }
+
+
+def test_empty_timeseries_returns_placeholder_for_both_metrics():
+    for metric in ('bytes', 'files'):
+        out = generate_disk_usage_stacked_area({'dates': [], 'series': []}, metric=metric)
+        assert '<svg' not in out
+        assert 'No disk-usage history' in out
+
+
+def test_both_metrics_render_svg():
+    for metric in ('bytes', 'files'):
+        out = generate_disk_usage_stacked_area(_timeseries(), metric=metric)
+        assert '<svg' in out
+
+
+def test_bytes_and_files_render_differently():
+    """Same data, different metric → different SVG (and distinct cache keys,
+    so the two variants never collide in the LRU)."""
+    svg_bytes = generate_disk_usage_stacked_area(_timeseries(), metric='bytes')
+    svg_files = generate_disk_usage_stacked_area(_timeseries(), metric='files')
+    assert svg_bytes != svg_files
+
+
+def test_default_metric_matches_explicit_bytes():
+    assert (
+        generate_disk_usage_stacked_area(_timeseries())
+        == generate_disk_usage_stacked_area(_timeseries(), metric='bytes')
+    )

--- a/tests/unit/test_disk_usage_queries.py
+++ b/tests/unit/test_disk_usage_queries.py
@@ -20,6 +20,7 @@ from sam.queries.disk_usage import (
     build_disk_subtree,
     bulk_get_directory_usage_at,
     get_disk_usage_timeseries_by_user,
+    get_disk_usage_timeseries_for_directory,
     get_earliest_disk_activity_date,
 )
 from sam.summaries.disk_summaries import (
@@ -204,6 +205,100 @@ class TestDiskUsageTimeseries:
             start_date=_date(2026, 4, 1),
         )
         assert out['dates'] == [d2]
+
+
+# ============================================================================
+# metric='files' — file-count variant of both timeseries functions
+# ============================================================================
+
+
+class TestDiskUsageTimeseriesFileMetric:
+
+    def test_files_metric_values_and_ranking_differ_from_bytes(self, session):
+        """With metric='files', summed values AND top-N ranking follow
+        number_of_files, not bytes (the two rankings are deliberately
+        opposite here)."""
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        big_bytes = make_user(session)   # most bytes, fewest files
+        many_files = make_user(session)  # fewest bytes, most files
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        snap = _date(2026, 4, 11)
+        _seed_row(session, account=account, user=big_bytes, snap=snap,
+                  bytes_=10 * BYTES_PER_TIB, files=1)
+        _seed_row(session, account=account, user=many_files, snap=snap,
+                  bytes_=1 * BYTES_PER_TIB, files=1000)
+        session.flush()
+
+        out = get_disk_usage_timeseries_by_user(
+            session, account_ids=[account.account_id], top_n=10, metric='files',
+        )
+        by_user = {s['username']: s['values'] for s in out['series']}
+        assert by_user[big_bytes.username] == [1]
+        assert by_user[many_files.username] == [1000]
+        # Largest-by-files sits on top of the stack (last series).
+        assert out['series'][-1]['username'] == many_files.username
+
+    def test_files_metric_null_file_count_coalesces_to_zero(self, session):
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        snap = _date(2026, 4, 11)
+        _seed_row(session, account=account, user=lead, snap=snap,
+                  bytes_=BYTES_PER_TIB, files=None)
+        session.flush()
+
+        out = get_disk_usage_timeseries_by_user(
+            session, account_ids=[account.account_id], metric='files',
+        )
+        assert out['series'][0]['values'] == [0]
+
+    def test_default_metric_is_bytes(self, session):
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        snap = _date(2026, 4, 11)
+        _seed_row(session, account=account, user=lead, snap=snap,
+                  bytes_=4 * BYTES_PER_TIB, files=7)
+        session.flush()
+
+        default = get_disk_usage_timeseries_by_user(
+            session, account_ids=[account.account_id],
+        )
+        explicit = get_disk_usage_timeseries_by_user(
+            session, account_ids=[account.account_id], metric='bytes',
+        )
+        assert default == explicit
+        assert default['series'][0]['values'] == [4 * BYTES_PER_TIB]
+
+    def test_directory_files_metric(self, session):
+        resource = _disk_resource(session)
+        lead = make_user(session)
+        other = make_user(session)
+        project = make_project(session, lead=lead)
+        account = make_account(session, project=project, resource=resource)
+        snap = _date(2026, 4, 11)
+        directory = '/gpfs/csfs1/test/files_metric'
+        # lead: many bytes / few files; other: few bytes / many files.
+        _seed_disk_activity(session, account=account, user=lead, directory=directory,
+                            snap=snap, bytes_=9 * BYTES_PER_TIB, files=2,
+                            resource_name=resource.resource_name)
+        _seed_disk_activity(session, account=account, user=other, directory=directory,
+                            snap=snap, bytes_=1 * BYTES_PER_TIB, files=500,
+                            resource_name=resource.resource_name)
+        session.flush()
+
+        out = get_disk_usage_timeseries_for_directory(
+            session, resource_name=resource.resource_name,
+            directory_name=directory, metric='files',
+        )
+        by_user = {s['username']: s['values'] for s in out['series']}
+        assert by_user[lead.username] == [2]
+        assert by_user[other.username] == [500]
+        assert out['series'][-1]['username'] == other.username
 
 
 # ============================================================================

--- a/tests/unit/test_resource_details_disk_chart_route.py
+++ b/tests/unit/test_resource_details_disk_chart_route.py
@@ -1,0 +1,87 @@
+"""Route tests for the disk "Usage Over Time" chart HTMX fragment.
+
+Exercises ``resource_details_disk_usage_chart`` at
+``webapp/dashboards/user/blueprint.py`` — the fragment the disk
+resource-details page lazy-loads (and re-fetches on the Data Volume /
+File Count tab swap).
+
+Auth is via the standard ``auth_client`` fixture (logged in as
+``benkirk``, which has ``VIEW_PROJECTS``). The matplotlib render is
+patched to a sentinel so these stay pure route/markup tests; access
+control (``require_project_access``) is covered centrally by the
+decorator's own tests.
+"""
+import re
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_DISK_RESOURCE = 'Campaign_Store'
+
+
+@pytest.fixture
+def _sentinel_chart(monkeypatch):
+    """Patch the SVG renderer so the route returns deterministic markup
+    without invoking matplotlib. Captures the metric it was called with."""
+    captured = {'metric': None}
+
+    def _fake(timeseries, link_kind=None, metric='bytes'):
+        captured['metric'] = metric
+        return '<svg data-test="disk-chart"></svg>'
+
+    monkeypatch.setattr(
+        'webapp.dashboards.user.blueprint.generate_disk_usage_stacked_area',
+        _fake,
+    )
+    return captured
+
+
+def _active_tab_label(html):
+    """Return the label of the tab carrying the ``active`` class."""
+    m = re.search(r'nav-link active.*?(Data Volume|File Count)', html, re.S)
+    return m.group(1) if m else None
+
+
+def _url(projcode, **params):
+    qs = '&'.join(f'{k}={v}' for k, v in params.items())
+    return f'/user/resource-details/disk-usage-chart/{projcode}?{qs}'
+
+
+class TestDiskUsageChartRoute:
+
+    def test_default_metric_is_bytes_tab(self, auth_client, active_project, _sentinel_chart):
+        resp = auth_client.get(_url(active_project.projcode, resource=_DISK_RESOURCE))
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert 'Data Volume' in html and 'File Count' in html
+        assert _active_tab_label(html) == 'Data Volume'
+        assert _sentinel_chart['metric'] == 'bytes'
+
+    def test_files_metric_tab_active(self, auth_client, active_project, _sentinel_chart):
+        resp = auth_client.get(
+            _url(active_project.projcode, resource=_DISK_RESOURCE, metric='files')
+        )
+        assert resp.status_code == 200
+        assert _active_tab_label(resp.get_data(as_text=True)) == 'File Count'
+        assert _sentinel_chart['metric'] == 'files'
+
+    def test_invalid_metric_coerces_to_bytes(self, auth_client, active_project, _sentinel_chart):
+        resp = auth_client.get(
+            _url(active_project.projcode, resource=_DISK_RESOURCE, metric='bogus')
+        )
+        assert resp.status_code == 200
+        assert _active_tab_label(resp.get_data(as_text=True)) == 'Data Volume'
+        assert _sentinel_chart['metric'] == 'bytes'
+
+    def test_missing_resource_returns_400(self, auth_client, active_project):
+        resp = auth_client.get(
+            f'/user/resource-details/disk-usage-chart/{active_project.projcode}'
+        )
+        assert resp.status_code == 400
+
+    def test_invalid_date_returns_400(self, auth_client, active_project):
+        resp = auth_client.get(
+            _url(active_project.projcode, resource=_DISK_RESOURCE, start_date='not-a-date')
+        )
+        assert resp.status_code == 400


### PR DESCRIPTION
## Context

The Disk **Usage Over Time** stacked-area chart plotted only **volume (bytes)** per user. The same `DiskChargeSummary` / `DiskActivity` snapshot rows also carry `number_of_files`, so we can plot an identical *file-count* stack with no new data source. This adds a nav-tab toggle to switch the same chart between **Data Volume** and **File Count**, using the HTMX tab construct already on this page's *Filesystem Scans* card and the HPC/DAV *Usage Trend* chart.

> **Stacked on #340** (`disk_usage_timeframe`). This PR is based on that branch so the diff shows only the file-count work; it will auto-retarget to `staging` once #340 merges. (Can retarget to `staging` directly on request.)

## What changed

- **Query layer** (`sam/queries/disk_usage.py`): `metric='bytes'` param (new `_disk_metric_col` helper) on both `get_disk_usage_timeseries_by_user` and `get_disk_usage_timeseries_for_directory`. It drives the summed column **and** the top-N ranking; NULL file counts coalesce to 0. Default `'bytes'` preserves existing callers/tests.
- **Chart layer** (`webapp/dashboards/charts.py`): `generate_disk_usage_stacked_area(..., metric)` — bytes keeps TiB/PiB auto-scaling; files uses an integer y-axis via `fmt.mpl_number_formatter()` + `MaxNLocator(integer=True)`, ylabel "Number of files". Cache key now includes `metric` (prevents the two variants colliding in the LRU).
- **Route** (`webapp/dashboards/user/blueprint.py`): new HTMX fragment `resource_details_disk_usage_chart`, mirroring the HPC/DAV `resource_details_usage_chart`. The disk chart is now **HTMX-deferred** (`hx-trigger="load"`) — the inline render was removed from `_render_disk_resource_details`. One code path, per-metric caching, and metric persistence across reloads.
- **Templates**: new `partials/disk_usage_chart.html` (nav-tabs **Data Volume** / **File Count**); `resource_details_disk.html` chart card becomes a deferred loader with `data-chart-persist-keys="metric"`.

## Why metric-only persistence

`data-chart-persist-keys="metric"` round-trips **only** the metric through localStorage — never `start_date`/`end_date`. `nav-view-persistence.js` strips persisted keys from the hx-get URL, so persisting dates would let stale localStorage override a freshly-picked timeframe. Tab swaps re-send the current window, so the timeframe picker (#340) stays authoritative.

## Tests (green)

- `test_disk_usage_queries.py`: file-count ranking differs from bytes (both functions), NULL→0, `default == metric='bytes'`.
- `test_disk_usage_chart.py`: empty→placeholder, both metrics render, bytes≠files output, default==bytes.
- `test_resource_details_disk_chart_route.py`: default/files/invalid-metric tab state, missing-resource & invalid-date → 400.

## Verification

1. Visit `/user/resource-details/<projcode>?resource=Campaign_Store`; chart loads (spinner → SVG) with **Data Volume** active, TiB/PiB y-axis.
2. Click **File Count** → swaps in place, integer y-axis, users re-ranked by file count.
3. Change timeframe → window updates **and** metric tab preserved; switch metric → timeframe preserved.
4. Drill into a fileset, toggle metric → stays in fileset view (DiskActivity source).
5. Reload → selected metric tab restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)