### PR TITLE
Fix batched/per-project allocation divergence at the 90-day boundary

### DIFF
--- a/src/sam/queries/dashboard.py
+++ b/src/sam/queries/dashboard.py
@@ -54,7 +54,7 @@ charge-aggregation queries. Merging them would either pessimize the N=1
 case or complicate the N=many case — both are net losses for readers.
 """
 
-from datetime import datetime, date
+from datetime import datetime, date, timedelta
 from typing import Any, List, Dict, Optional, TypedDict
 
 from sqlalchemy import func
@@ -310,7 +310,12 @@ def _select_query_alloc(account: Account, now: datetime):
             key=lambda a: a.end_date if a.end_date else datetime.max,
         )
         end = most_recent.end_date
-        if end is None or (now - end).days <= 90:
+        # Use an exact timedelta comparison (NOT (now - end).days <= 90):
+        # .days truncates toward zero, so it keeps an allocation for a full
+        # extra day in [90d, 91d) after expiry, diverging from
+        # get_detailed_allocation_usage() — which this mirrors — and breaking
+        # the batched/per-project equivalence at the 90-day boundary.
+        if end is None or (now - end) <= timedelta(days=90):
             return most_recent
     return None
 


### PR DESCRIPTION
## Context

CI started failing on `test_user_dashboard_batched_matches_per_project`:

```
UCSU0092: batched returned 4, per-project returned 0
```

It passed locally but failed in CI — a classic time-bomb. **Not caused by any feature PR**; it trips on every PR's CI from ~2026-06-29 onward (the dashboard-query code is identical across branches).

## Root cause

The user dashboard has two allocation-display code paths that are documented to produce identical output (locked by the equivalence test):

- `Project.get_detailed_allocation_usage()` (per-project) gates the most-recent-allocation fallback with `(now - end) <= timedelta(days=90)` — an **exact** timedelta.
- `_select_query_alloc()` (batched, user dashboard) used `(now - end).days <= 90` — **integer-truncated** days.

`.days` floors the timedelta, so the batched path keeps an expired allocation for a full extra day in the `[90d, 91d)` window after expiry. The two paths disagree for any project whose most-recent allocation expired **90–91 days ago**.

`UCSU0092`'s allocations expired **2026-03-31 23:59:59**, so the divergence window is **2026-06-29 23:59:59 → 2026-06-30 23:59:59**. CI runs in **UTC (~6h ahead of the dev's local clock)**, so CI's `now` was inside that window while the dev's wasn't → red in CI, green locally.

## Fix

One line: align `_select_query_alloc` to the canonical **exact-timedelta** comparison it claims to mirror. Both paths now agree across the whole boundary.

| `now` vs expiry | per-project | batched (before) | batched (after) |
|---|---|---|---|
| 89 d | 4 | 4 | 4 |
| 90 d + 6 h (CI window) | 0 | **4 ✗** | **0 ✓** |
| 91 d+ | 0 | 0 | 0 |

## Test Results

- `test_query_functions.py`: **109 passed** (serial + 12-worker xdist) — including the previously-failing equivalence test.
- Full suite: **2438 passed, 23 skipped, 1 xfailed**.

## Impact on open PRs

This unblocks CI for all open PRs (incl. #341). Once merged to `staging`, re-run CI / rebase and they go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)