### PR TITLE
Add operator User/Resource Access remediation card to Edit Project

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -162,6 +162,12 @@ webapp:
     JUPYTERHUB_CACHE_TTL: "300"
     SAM_DB_SERVER: "sam-sql.ucar.edu"
     SAM_DB_REQUIRE_SSL: "true"
+    # Match the SAM DB server's timezone (sam-sql.ucar.edu runs Mountain). The
+    # app stamps naive datetimes (AccountUser.start_date, allocation dates, …)
+    # that are compared against the DB's NOW()/func.now(); a UTC pod put them
+    # ~6h in the DB's future, so freshly-granted access read back as inactive.
+    # system_status keeps its own explicit naive-UTC clock (sam.fmt.utcnow_naive).
+    TZ: "America/Denver"
     STATUS_DB_DRIVER: "postgresql"
     STATUS_DB_SERVER: "csg-postgres.k8s.ucar.edu"
     # STATUS_DB_POOL_* defaults (size=2, overflow=4, recycle=600) live in

--- a/src/sam/accounting/accounts.py
+++ b/src/sam/accounting/accounts.py
@@ -185,7 +185,10 @@ class Account(Base, SoftDeleteMixin, SessionMixin):
         }
         propagate_user_ids -= existing_member_ids
 
-        now = datetime.now()
+        # Floor to the second: MySQL DATETIME has no fractional part and rounds
+        # half-up, which can push a microsecond-stamped "now" into the next
+        # second and make a just-seeded member briefly is_active=False.
+        now = datetime.now().replace(microsecond=0)
         for user_id in propagate_user_ids:
             session.add(AccountUser(
                 account_id=account.account_id,

--- a/src/sam/fmt.py
+++ b/src/sam/fmt.py
@@ -31,7 +31,7 @@ Quick reference
 """
 import math
 import os
-from datetime import date, datetime, timezone
+from datetime import date, datetime
 from typing import Optional, Union
 from zoneinfo import ZoneInfo
 
@@ -96,18 +96,6 @@ def naive_local_to_utc(
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=tz)
     return dt.astimezone(_UTC).replace(tzinfo=None)
-
-
-def utcnow_naive() -> datetime:
-    """Naive-UTC 'now' for the collector / system_status convention.
-
-    That subsystem stores naive-UTC timestamps (see ``to_local_dt`` above), so
-    its comparisons and inserts must use UTC wall-clock regardless of the
-    process timezone.  Use this instead of ``datetime.now()`` anywhere in the
-    status/collector paths so they stay correct even though the SAM/MySQL side
-    runs in the DB's local (Mountain) timezone.
-    """
-    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 

--- a/src/sam/fmt.py
+++ b/src/sam/fmt.py
@@ -31,7 +31,7 @@ Quick reference
 """
 import math
 import os
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Optional, Union
 from zoneinfo import ZoneInfo
 
@@ -96,6 +96,18 @@ def naive_local_to_utc(
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=tz)
     return dt.astimezone(_UTC).replace(tzinfo=None)
+
+
+def utcnow_naive() -> datetime:
+    """Naive-UTC 'now' for the collector / system_status convention.
+
+    That subsystem stores naive-UTC timestamps (see ``to_local_dt`` above), so
+    its comparisons and inserts must use UTC wall-clock regardless of the
+    process timezone.  Use this instead of ``datetime.now()`` anywhere in the
+    status/collector paths so they stay correct even though the SAM/MySQL side
+    runs in the DB's local (Mountain) timezone.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 

--- a/src/sam/manage/__init__.py
+++ b/src/sam/manage/__init__.py
@@ -34,6 +34,9 @@ __all__ = [
     'add_user_to_project',
     'remove_user_from_project',
     'change_project_admin',
+    'grant_user_resource_access',
+    'revoke_user_resource_access',
+    'reconcile_project_access',
     'management_transaction',
     'validate_allocation_dates',
     'log_allocation_transaction',
@@ -199,4 +202,138 @@ def change_project_admin(
 
     # Flush changes but do not commit
     # Caller is responsible for committing
+    session.flush()
+
+
+def grant_user_resource_access(
+    session: Session,
+    project_id: int,
+    user_id: int,
+    resource_id: int,
+) -> None:
+    """
+    Grant a single user access to a single project resource.
+
+    Operator-level repair for partial-access errors: adds one open-ended
+    AccountUser row on the (project, resource) account if the user does not
+    already have currently-active access there. Idempotent.
+
+    NOTE: This function does NOT commit the session. The caller is responsible
+    for wrapping it in management_transaction().
+
+    Args:
+        session: SQLAlchemy session
+        project_id: Project ID
+        user_id: User ID to grant access
+        resource_id: Resource ID whose project account the user should join
+
+    Raises:
+        ValueError: If the project has no (non-deleted) account for the resource
+    """
+    account = Account.get_by_project_and_resource(session, project_id, resource_id)
+    if account is None:
+        raise ValueError(
+            f"Project {project_id} has no account for resource {resource_id}"
+        )
+
+    existing = session.query(AccountUser).filter(
+        AccountUser.account_id == account.account_id,
+        AccountUser.user_id == user_id,
+        AccountUser.is_active,
+    ).first()
+
+    if existing is None:
+        # Floor to the second: MySQL DATETIME has no fractional part and
+        # rounds half-up, which can push a microsecond-stamped "now" into the
+        # next second and make the just-granted row briefly is_active=False.
+        session.add(AccountUser(
+            account_id=account.account_id,
+            user_id=user_id,
+            start_date=datetime.now().replace(microsecond=0),
+            end_date=None,
+        ))
+
+    session.flush()
+
+
+def revoke_user_resource_access(
+    session: Session,
+    project_id: int,
+    user_id: int,
+    resource_id: int,
+) -> None:
+    """
+    Revoke a single user's access to a single project resource.
+
+    Deletes the user's AccountUser row(s) on the (project, resource) account
+    (ORM delete to trigger audit events, mirroring remove_user_from_project).
+    The project lead cannot be revoked.
+
+    NOTE: This function does NOT commit the session. The caller is responsible
+    for wrapping it in management_transaction().
+
+    Args:
+        session: SQLAlchemy session
+        project_id: Project ID
+        user_id: User ID to revoke
+        resource_id: Resource ID whose project account the user should leave
+
+    Raises:
+        ValueError: If the user is the project lead, or no account exists
+    """
+    project = session.get(Project, project_id)
+    if not project:
+        raise ValueError(f"Project {project_id} not found")
+
+    if project.project_lead_user_id == user_id:
+        raise ValueError("Cannot revoke the project lead's access")
+
+    account = Account.get_by_project_and_resource(session, project_id, resource_id)
+    if account is None:
+        raise ValueError(
+            f"Project {project_id} has no account for resource {resource_id}"
+        )
+
+    account_users = session.query(AccountUser).filter(
+        AccountUser.account_id == account.account_id,
+        AccountUser.user_id == user_id,
+    ).all()
+
+    for account_user in account_users:
+        session.delete(account_user)
+
+    session.flush()
+
+
+def reconcile_project_access(session: Session, project_id: int) -> None:
+    """
+    Give every project member access to every project resource.
+
+    Fills the user×resource access grid by re-running the membership-seeding
+    invariant (Account._seed_members) over each non-deleted account, so the
+    lead, admin, and all existing members become members of every account.
+    Only adds access; never revokes.
+
+    NOTE: This function does NOT commit the session. The caller is responsible
+    for wrapping it in management_transaction().
+
+    Args:
+        session: SQLAlchemy session
+        project_id: Project ID
+
+    Raises:
+        ValueError: If the project does not exist
+    """
+    project = session.get(Project, project_id)
+    if not project:
+        raise ValueError(f"Project {project_id} not found")
+
+    accounts = session.query(Account).filter(
+        Account.project_id == project_id,
+        Account.is_active,
+    ).all()
+
+    for account in accounts:
+        Account._seed_members(session, account)
+
     session.flush()

--- a/src/sam/schemas/forms/__init__.py
+++ b/src/sam/schemas/forms/__init__.py
@@ -196,6 +196,7 @@ from .projects import (
     AddLinkedDirectoryForm,
     EditLinkedDirectoryForm,
     BulkDeactivateProjectDirectoriesForm,
+    AccessGridToggleForm,
 )
 from .user import (
     AddMemberForm,
@@ -264,6 +265,7 @@ __all__ = [
     'AddLinkedDirectoryForm',
     'EditLinkedDirectoryForm',
     'BulkDeactivateProjectDirectoriesForm',
+    'AccessGridToggleForm',
     # User
     'AddMemberForm',
     'EditAllocationForm',

--- a/src/sam/schemas/forms/projects.py
+++ b/src/sam/schemas/forms/projects.py
@@ -143,3 +143,17 @@ class EditLinkedDirectoryForm(HtmxFormSchema):
     @post_load
     def normalize(self, data, **kwargs):
         return _normalize_directory_suffix(data)
+
+
+class AccessGridToggleForm(HtmxFormSchema):
+    """Toggle one user's access to one project resource from the operator
+    User/Resource Access grid.
+
+    ``grant`` follows the unchecked-checkbox convention: an HTML checkbox that
+    is unchecked sends no key, so ``load_default=False`` correctly represents
+    "revoke". FK existence checks (user_id -> User, resource_id -> Resource)
+    stay in the route since schemas don't touch the DB.
+    """
+    user_id = f.Int(required=True)
+    resource_id = f.Int(required=True)
+    grant = f.Bool(load_default=False)

--- a/src/system_status/base.py
+++ b/src/system_status/base.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import relationship, declarative_base, declared_attr, Sessio
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.sql import func
 
-from sam.fmt import utcnow_naive  # status timestamps are naive-UTC, not local
+from .timeutil import utcnow_naive  # status timestamps are naive-UTC, not local
 import os
 
 

--- a/src/system_status/base.py
+++ b/src/system_status/base.py
@@ -1,7 +1,6 @@
 #-------------------------------------------------------------------------bh-
 #-------------------------------------------------------------------------eh-
 
-from datetime import datetime
 from typing import Optional
 from sqlalchemy import (
     Column, Integer, String, Float, DateTime, Date, Boolean, Numeric,
@@ -10,6 +9,8 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship, declarative_base, declared_attr, Session
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.sql import func
+
+from sam.fmt import utcnow_naive  # status timestamps are naive-UTC, not local
 import os
 
 
@@ -76,7 +77,7 @@ class StatusTimestampMixin:
 
     @declared_attr
     def created_at(cls):
-        return Column(DateTime, nullable=False, default=datetime.now,
+        return Column(DateTime, nullable=False, default=utcnow_naive,
                      server_default=text('CURRENT_TIMESTAMP'))
 
 

--- a/src/system_status/cli.py
+++ b/src/system_status/cli.py
@@ -408,14 +408,14 @@ class SystemStatusCLI:
 
     def _display_reservations(self, system_name):
         """Display active or upcoming reservations."""
-        from datetime import datetime
+        from sam.fmt import utcnow_naive  # status timestamps are naive-UTC
         from system_status.models import System
         reservations = (
             self.session.query(ResourceReservation)
             .join(System, ResourceReservation.system_id == System.system_id)
             .filter(
                 System.name == system_name,
-                ResourceReservation.end_time >= datetime.now(),
+                ResourceReservation.end_time >= utcnow_naive(),
             )
             .order_by(ResourceReservation.start_time)
             .all()

--- a/src/system_status/cli.py
+++ b/src/system_status/cli.py
@@ -408,7 +408,7 @@ class SystemStatusCLI:
 
     def _display_reservations(self, system_name):
         """Display active or upcoming reservations."""
-        from sam.fmt import utcnow_naive  # status timestamps are naive-UTC
+        from system_status.timeutil import utcnow_naive  # status timestamps are naive-UTC
         from system_status.models import System
         reservations = (
             self.session.query(ResourceReservation)

--- a/src/system_status/models/lookups.py
+++ b/src/system_status/models/lookups.py
@@ -8,7 +8,7 @@
 # `get_or_create_*` helpers in `system_status.queries.lookups`).
 #-------------------------------------------------------------------------eh-
 
-from datetime import datetime
+from sam.fmt import utcnow_naive  # status timestamps are naive-UTC, not local
 
 from sqlalchemy import (
     Column, DateTime, Enum, ForeignKey, Integer, String, UniqueConstraint, text
@@ -26,7 +26,7 @@ class System(StatusBase, SessionMixin):
     system_id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String(32), nullable=False, unique=True)
     created_at = Column(DateTime, nullable=False,
-                        default=datetime.now,
+                        default=utcnow_naive,
                         server_default=text("CURRENT_TIMESTAMP"))
 
     queues = relationship("QueueDef", back_populates="system",
@@ -60,7 +60,7 @@ class QueueDef(StatusBase, SessionMixin):
     system_id = Column(Integer, ForeignKey("systems.system_id"), nullable=False, index=True)
     name = Column(String(32), nullable=False)
     created_at = Column(DateTime, nullable=False,
-                        default=datetime.now,
+                        default=utcnow_naive,
                         server_default=text("CURRENT_TIMESTAMP"))
 
     system = relationship("System", back_populates="queues")
@@ -85,7 +85,7 @@ class Filesystem(StatusBase, SessionMixin):
     filesystem_id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String(32), nullable=False, unique=True)
     created_at = Column(DateTime, nullable=False,
-                        default=datetime.now,
+                        default=utcnow_naive,
                         server_default=text("CURRENT_TIMESTAMP"))
 
     def __str__(self):
@@ -116,7 +116,7 @@ class UserDef(StatusBase, SessionMixin):
     user_id = Column(Integer, primary_key=True, autoincrement=True)
     username = Column(String(32), nullable=False, unique=True)
     created_at = Column(DateTime, nullable=False,
-                        default=datetime.now,
+                        default=utcnow_naive,
                         server_default=text("CURRENT_TIMESTAMP"))
 
     def __str__(self):
@@ -145,7 +145,7 @@ class ProjectCodeDef(StatusBase, SessionMixin):
     project_code_id = Column(Integer, primary_key=True, autoincrement=True)
     project_code = Column(String(16), nullable=False, unique=True)
     created_at = Column(DateTime, nullable=False,
-                        default=datetime.now,
+                        default=utcnow_naive,
                         server_default=text("CURRENT_TIMESTAMP"))
 
     def __str__(self):
@@ -173,7 +173,7 @@ class LoginNodeDef(StatusBase, SessionMixin):
         nullable=False,
     )
     created_at = Column(DateTime, nullable=False,
-                        default=datetime.now,
+                        default=utcnow_naive,
                         server_default=text("CURRENT_TIMESTAMP"))
 
     system = relationship("System", back_populates="login_node_defs")

--- a/src/system_status/models/lookups.py
+++ b/src/system_status/models/lookups.py
@@ -8,7 +8,7 @@
 # `get_or_create_*` helpers in `system_status.queries.lookups`).
 #-------------------------------------------------------------------------eh-
 
-from sam.fmt import utcnow_naive  # status timestamps are naive-UTC, not local
+from ..timeutil import utcnow_naive  # status timestamps are naive-UTC, not local
 
 from sqlalchemy import (
     Column, DateTime, Enum, ForeignKey, Integer, String, UniqueConstraint, text

--- a/src/system_status/models/outages.py
+++ b/src/system_status/models/outages.py
@@ -2,7 +2,7 @@
 # System Outages and Reservations Models
 #-------------------------------------------------------------------------eh-
 
-from datetime import datetime
+from sam.fmt import utcnow_naive  # status timestamps are naive-UTC, not local
 from sqlalchemy import Column, Integer, String, Text, DateTime, Index, Enum as SQLEnum, ForeignKey
 from sqlalchemy.orm import relationship
 from ..base import StatusBase, SessionMixin
@@ -53,12 +53,12 @@ class SystemOutage(StatusBase, SessionMixin):
     description = Column(Text, nullable=True)
 
     # Timestamps
-    start_time = Column(DateTime, nullable=False, default=datetime.now)
+    start_time = Column(DateTime, nullable=False, default=utcnow_naive)
     end_time = Column(DateTime, nullable=True)
     estimated_resolution = Column(DateTime, nullable=True)
 
-    created_at = Column(DateTime, nullable=False, default=datetime.now)
-    updated_at = Column(DateTime, nullable=True, onupdate=datetime.now)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)
+    updated_at = Column(DateTime, nullable=True, onupdate=utcnow_naive)
 
     # Relationship
     system = relationship(System, foreign_keys=[system_id])
@@ -114,8 +114,8 @@ class ResourceReservation(StatusBase, SessionMixin):
     node_count = Column(Integer, nullable=True)
     partition = Column(String(64), nullable=True)
 
-    created_at = Column(DateTime, nullable=False, default=datetime.now)
-    updated_at = Column(DateTime, nullable=True, onupdate=datetime.now)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)
+    updated_at = Column(DateTime, nullable=True, onupdate=utcnow_naive)
 
     # Relationship
     system = relationship(System, foreign_keys=[system_id])

--- a/src/system_status/models/outages.py
+++ b/src/system_status/models/outages.py
@@ -2,7 +2,7 @@
 # System Outages and Reservations Models
 #-------------------------------------------------------------------------eh-
 
-from sam.fmt import utcnow_naive  # status timestamps are naive-UTC, not local
+from ..timeutil import utcnow_naive  # status timestamps are naive-UTC, not local
 from sqlalchemy import Column, Integer, String, Text, DateTime, Index, Enum as SQLEnum, ForeignKey
 from sqlalchemy.orm import relationship
 from ..base import StatusBase, SessionMixin

--- a/src/system_status/queries/__init__.py
+++ b/src/system_status/queries/__init__.py
@@ -10,6 +10,8 @@ from typing import List, Optional, Dict, Any
 from sqlalchemy.orm import Session
 from sqlalchemy import desc
 
+from sam.fmt import utcnow_naive  # status/collector timestamps are naive-UTC
+
 from system_status.models import (
     DerechoStatus,
     CasperStatus, CasperNodeTypeStatus,
@@ -147,10 +149,10 @@ def get_upcoming_reservations(session: Session, max_staleness_minutes: int = 30)
     newly-inserted records (where updated_at is NULL) are not incorrectly filtered out.
     """
     from sqlalchemy import func
-    cutoff = datetime.now() - timedelta(minutes=max_staleness_minutes)
+    cutoff = utcnow_naive() - timedelta(minutes=max_staleness_minutes)
     last_seen = func.coalesce(ResourceReservation.updated_at, ResourceReservation.created_at)
     return session.query(ResourceReservation).filter(
-        ResourceReservation.end_time >= datetime.now(),
+        ResourceReservation.end_time >= utcnow_naive(),
         last_seen >= cutoff,
     ).order_by(ResourceReservation.start_time).all()
 

--- a/src/system_status/queries/__init__.py
+++ b/src/system_status/queries/__init__.py
@@ -10,7 +10,7 @@ from typing import List, Optional, Dict, Any
 from sqlalchemy.orm import Session
 from sqlalchemy import desc
 
-from sam.fmt import utcnow_naive  # status/collector timestamps are naive-UTC
+from ..timeutil import utcnow_naive  # status/collector timestamps are naive-UTC
 
 from system_status.models import (
     DerechoStatus,

--- a/src/system_status/timeutil.py
+++ b/src/system_status/timeutil.py
@@ -1,0 +1,19 @@
+"""Naive-UTC clock for the system_status / collector convention.
+
+The status subsystem stores naive **UTC** timestamps (unlike the SAM/MySQL
+side, which is naive local/Mountain).  Its reads, window computations, writes,
+and model defaults must therefore use a UTC wall-clock regardless of the
+process timezone (the app pod runs in the DB's local TZ; see
+``helm/values.yaml`` ``TZ``).
+
+Kept deliberately dependency-free (stdlib only) so the low-level model modules
+(``base.py``, ``models/*.py``) can import it at definition time without pulling
+in ``sam.fmt`` → ``config`` — which collides with ``webapp/config.py`` during
+the webapp's early boot import order.
+"""
+from datetime import datetime, timezone
+
+
+def utcnow_naive() -> datetime:
+    """Return the current UTC time as a naive datetime (tzinfo stripped)."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)

--- a/src/webapp/api/access_control.py
+++ b/src/webapp/api/access_control.py
@@ -247,6 +247,38 @@ def require_project_permission(
     return decorator
 
 
+def require_project_operator_access(f: Callable) -> Callable:
+    """Gate a project route on **site-operator** privileges.
+
+    Requires the caller to hold BOTH ``EDIT_PROJECTS`` and
+    ``EDIT_PROJECT_MEMBERS`` at the **system** level (``has_permission``).
+    Unlike ``require_project_permission`` / ``require_member_management``,
+    project lead/admin stewardship does NOT grant access, and facility
+    scope is not consulted — this is for cross-project remediation tools
+    that only site operators should see, such as the User/Resource Access
+    grid on the Edit Project page.
+
+    Resolves ``<projcode>`` from the URL and passes the ``project`` object
+    to the view (same contract as the other project decorators).
+    """
+    @wraps(f)
+    def decorated_function(projcode: str, *args, **kwargs):
+        if not current_user.is_authenticated:
+            abort(401)
+
+        project, error = get_project_or_404(db.session, projcode)
+        if error:
+            return error
+
+        if not (has_permission(current_user, Permission.EDIT_PROJECTS)
+                and has_permission(current_user, Permission.EDIT_PROJECT_MEMBERS)):
+            abort(403)
+
+        return f(project, *args, **kwargs)
+
+    return decorated_function
+
+
 def _require_project_check(check_fn: Callable) -> Callable:
     """Decorator factory wrapping a ``can_*(user, project)`` helper.
 

--- a/src/webapp/api/v1/status.py
+++ b/src/webapp/api/v1/status.py
@@ -24,6 +24,7 @@ from webapp.utils.api_auth import api_key_required
 from webapp.api.helpers import register_error_handlers
 from webapp.extensions import db, csrf
 from datetime import datetime
+from system_status.timeutil import utcnow_naive  # status timestamps are naive-UTC
 import sys
 from pathlib import Path
 
@@ -75,7 +76,7 @@ def _validate_timestamp(data):
     """
     timestamp_str = data.get('timestamp')
     if not timestamp_str:
-        return datetime.now()
+        return utcnow_naive()
 
     try:
         # Try ISO format first
@@ -121,7 +122,7 @@ def _handle_reservations(reservations_data, system_name):
             existing.end_time = datetime.fromisoformat(resv_data['end_time'])
             existing.node_count = resv_data.get('node_count')
             existing.partition = resv_data.get('partition')
-            existing.updated_at = datetime.now()
+            existing.updated_at = utcnow_naive()
             reservation_ids.append(existing.reservation_id)
         else:
             # Insert new reservation
@@ -370,7 +371,7 @@ def report_outage():
 
     try:
         # Parse timestamps
-        start_time = datetime.now()
+        start_time = utcnow_naive()
         if data.get('start_time'):
             try:
                 start_time = datetime.fromisoformat(data['start_time'].replace('Z', '+00:00'))
@@ -566,7 +567,7 @@ def update_outage(outage_id):
         else:
             outage.estimated_resolution = None
 
-    outage.updated_at = datetime.now()
+    outage.updated_at = utcnow_naive()
     db.session.commit()
     return jsonify({'success': True, 'outage_id': outage_id, 'status': outage.status}), 200
 
@@ -615,14 +616,14 @@ def get_reservations():
 
     # Filter by upcoming
     if request.args.get('upcoming_only', 'true').lower() in ('true', '1', 'yes'):
-        query = query.filter(ResourceReservation.end_time >= datetime.now())
+        query = query.filter(ResourceReservation.end_time >= utcnow_naive())
 
     # Exclude stale reservations (not reported by collector in last 30 minutes).
     # Uses COALESCE(updated_at, created_at) so newly-inserted records (updated_at=NULL)
     # are not incorrectly filtered out.
     from sqlalchemy import func
     from datetime import timedelta
-    cutoff = datetime.now() - timedelta(minutes=30)
+    cutoff = utcnow_naive() - timedelta(minutes=30)
     last_seen = func.coalesce(ResourceReservation.updated_at, ResourceReservation.created_at)
     query = query.filter(last_seen >= cutoff)
 

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -22,6 +22,7 @@ from webapp.api.access_control import (
     require_project_permission, require_allocation_permission,
     require_project_facility_permission,
     require_allocation_facility_permission,
+    require_project_operator_access,
 )
 from webapp.utils.project_permissions import (
     can_edit_project_governance,
@@ -2509,3 +2510,188 @@ def htmx_admin_project_directory_bulk_deactivate():
         _PROJECT_DIRECTORIES_RELOAD_TRIGGERS,
         f'Deactivated {n} project director{"ies" if n != 1 else "y"} under "{prefix}".',
     )
+
+
+# ---------------------------------------------------------------------------
+# User / Resource Access grid (site-operator remediation)
+#
+# Surfaces and repairs partial-access errors: the underlying access model is a
+# grid of AccountUser rows (member × resource account). SAM normally hides this,
+# so when an out-of-band edit leaves a member without an account on some
+# resource, only the CLI (`sam-search project … --list-users --verbose`) shows
+# it. These operator-only routes render that grid and let an operator toggle a
+# single cell or reconcile the whole project.
+# ---------------------------------------------------------------------------
+
+_ACCESS_GRID_TEMPLATE = 'dashboards/admin/fragments/project_access_grid_htmx.html'
+
+
+def _build_access_grid_context(project, active_only: bool) -> dict:
+    """Build the member × resource access grid for *project*.
+
+    Columns are resources with a currently-active allocation when
+    ``active_only`` is True, otherwise every non-deleted account's resource
+    (so expired/lapsed resources are also shown). Each cell is checked when
+    the member has a currently-active AccountUser on that column's account —
+    computed from one membership query, not per-cell lookups.
+    """
+    from sam.accounting.accounts import AccountUser
+
+    active_by_resource = project.get_all_allocations_by_resource()
+    active_resource_names = set(active_by_resource.keys())
+
+    columns = []
+    if active_only:
+        for resource_name, allocation in active_by_resource.items():
+            account = allocation.account
+            columns.append({
+                'account_id': account.account_id,
+                'resource_id': account.resource_id,
+                'resource_name': resource_name,
+                'has_active_alloc': True,
+            })
+    else:
+        for account in project.accounts:
+            if not account.is_active or not account.resource:
+                continue
+            resource_name = account.resource.resource_name
+            columns.append({
+                'account_id': account.account_id,
+                'resource_id': account.resource_id,
+                'resource_name': resource_name,
+                'has_active_alloc': resource_name in active_resource_names,
+            })
+    columns.sort(key=lambda c: (c['resource_name'] or '').lower())
+
+    # One query for the whole grid: which (user, account) memberships are active.
+    account_ids = [c['account_id'] for c in columns]
+    active_links = set()
+    if account_ids:
+        rows = db.session.query(
+            AccountUser.user_id, AccountUser.account_id
+        ).filter(
+            AccountUser.account_id.in_(account_ids),
+            AccountUser.is_active,
+        ).all()
+        active_links = {(uid, aid) for uid, aid in rows}
+
+    lead_user_id = project.project_lead_user_id
+    members = sorted(
+        project.users,
+        key=lambda u: (u.display_name or u.username or '').lower(),
+    )
+
+    member_rows = []
+    for user in members:
+        cells = [{
+            'column': col,
+            'checked': (user.user_id, col['account_id']) in active_links,
+        } for col in columns]
+        member_rows.append({
+            'user': user,
+            'is_lead': user.user_id == lead_user_id,
+            'cells': cells,
+        })
+
+    return {
+        'project': project,
+        'projcode': project.projcode,
+        'columns': columns,
+        'member_rows': member_rows,
+        'active_only': active_only,
+    }
+
+
+def _render_access_grid(project, active_only: bool, errors=None):
+    """Render the access-grid card fragment, optionally with an error banner."""
+    ctx = _build_access_grid_context(project, active_only)
+    ctx['errors'] = errors or []
+    return render_template(_ACCESS_GRID_TEMPLATE, **ctx)
+
+
+def _access_grid_active_only(source) -> bool:
+    """Read the Active-Only flag from a request args/form mapping.
+
+    Follows the project-directories card convention: the checkbox sends
+    ``active_only=1`` only when checked, so an absent value means OFF. The
+    initial container load passes ``active_only=1`` explicitly to default ON,
+    and every control hx-includes the switch so the current mode rides along.
+    """
+    return source.get('active_only') == '1'
+
+
+@bp.route('/htmx/access-grid/<projcode>')
+@login_required
+@require_project_operator_access
+def htmx_access_grid(project):
+    """Lazy-loaded operator-only User/Resource Access grid for a project."""
+    return _render_access_grid(project, _access_grid_active_only(request.args))
+
+
+@bp.route('/htmx/access-grid/<projcode>/toggle', methods=['POST'])
+@login_required
+@require_project_operator_access
+def htmx_access_grid_toggle(project):
+    """Grant or revoke one member's access to one project resource."""
+    from marshmallow import ValidationError
+    from sam.schemas.forms import AccessGridToggleForm
+    from sam.core.users import User
+    from sam.resources.resources import Resource
+    from sam.manage import (
+        grant_user_resource_access, revoke_user_resource_access,
+    )
+
+    active_only = _access_grid_active_only(request.form)
+
+    data = {k: v for k, v in request.form.items() if v != ''}
+    data['grant'] = 'grant' in request.form
+    try:
+        form_data = AccessGridToggleForm().load(data)
+    except ValidationError as e:
+        return _render_access_grid(
+            project, active_only,
+            errors=AccessGridToggleForm.flatten_errors(e.messages),
+        )
+
+    # FK existence checks (schemas don't touch the DB).
+    errors = []
+    if not db.session.get(User, form_data['user_id']):
+        errors.append('Selected user does not exist.')
+    if not db.session.get(Resource, form_data['resource_id']):
+        errors.append('Selected resource does not exist.')
+    if errors:
+        return _render_access_grid(project, active_only, errors=errors)
+
+    try:
+        with management_transaction(db.session):
+            if form_data['grant']:
+                grant_user_resource_access(
+                    db.session, project.project_id,
+                    form_data['user_id'], form_data['resource_id'],
+                )
+            else:
+                revoke_user_resource_access(
+                    db.session, project.project_id,
+                    form_data['user_id'], form_data['resource_id'],
+                )
+    except ValueError as e:
+        return _render_access_grid(project, active_only, errors=[str(e)])
+
+    return _render_access_grid(project, active_only)
+
+
+@bp.route('/htmx/access-grid/<projcode>/reconcile', methods=['POST'])
+@login_required
+@require_project_operator_access
+def htmx_access_grid_reconcile(project):
+    """Give every project member access to every project resource."""
+    from sam.manage import reconcile_project_access
+
+    active_only = _access_grid_active_only(request.form)
+    try:
+        with management_transaction(db.session):
+            reconcile_project_access(db.session, project.project_id)
+    except ValueError as e:
+        return _render_access_grid(project, active_only, errors=[str(e)])
+
+    return _render_access_grid(project, active_only)

--- a/src/webapp/dashboards/status/blueprint.py
+++ b/src/webapp/dashboards/status/blueprint.py
@@ -7,7 +7,8 @@ from flask_login import login_required, current_user
 from webapp.utils.rbac import require_permission, Permission
 from marshmallow import ValidationError
 from sam.schemas.forms import CreateOutageForm, EditOutageForm
-from datetime import datetime, timedelta
+from sam.fmt import utcnow_naive  # status/collector timestamps are naive-UTC
+from datetime import timedelta
 import logging
 
 from webapp.extensions import db
@@ -108,7 +109,7 @@ def index():
         outages=outages,
         reservations=reservations,
         google_calendar_embed_url=current_app.config.get('GOOGLE_CALENDAR_EMBED_URL', ''),
-        now=datetime.now(),
+        now=utcnow_naive(),
         selected_hours=selected_hours,
         chart_hours=chart_hours,
         # Scan-capable disk resources for the gated "Filesystem Scans" tab.
@@ -136,7 +137,7 @@ def nodetype_history(system, node_type):
         hours = int(request.args.get('days')) * 24
     else:
         hours = 168  # 7-day default
-    end_date = datetime.now()
+    end_date = utcnow_naive()
     start_date = end_date - timedelta(hours=hours)
 
     session = db.session
@@ -189,7 +190,7 @@ def partition_history(system, partition):
         hours = int(request.args.get('days')) * 24
     else:
         hours = 168  # 7-day default
-    end_date = datetime.now()
+    end_date = utcnow_naive()
     start_date = end_date - timedelta(hours=hours)
 
     session = db.session
@@ -258,7 +259,7 @@ def queue_history(system, queue_name):
         hours = int(request.args.get('days')) * 24
     else:
         hours = 168  # 7-day default
-    end_date = datetime.now()
+    end_date = utcnow_naive()
     start_date = end_date - timedelta(hours=hours)
 
     session = db.session
@@ -355,7 +356,7 @@ def _render_user_proj_chart(*, system, queue_name, endpoint_name, endpoint_kwarg
         hours = 168
 
     top_n = 15
-    end_date = datetime.now()
+    end_date = utcnow_naive()
     start_date = end_date - timedelta(hours=hours)
 
     timeseries = status_queries.get_user_proj_timeseries(
@@ -513,7 +514,7 @@ def htmx_create_outage():
         component=data.get('component'),
         description=data.get('description'),
         status='investigating',
-        start_time=data.get('start_time') or datetime.now(),  # default: now (UTC)
+        start_time=data.get('start_time') or utcnow_naive(),  # default: now (UTC)
     )
     if data.get('estimated_resolution') is not None:
         outage.estimated_resolution = data['estimated_resolution']
@@ -560,7 +561,7 @@ def htmx_update_outage(outage_id):
     # @post_load already converted to naive-UTC; None clears the field.
     outage.estimated_resolution = data.get('estimated_resolution')
 
-    outage.updated_at = datetime.now()
+    outage.updated_at = utcnow_naive()
     db.session.commit()
 
     flash('Outage updated.', 'success')
@@ -579,7 +580,7 @@ def htmx_resolve_outage(outage_id):
     outage = db.session.query(SystemOutage).get(outage_id)
     if outage:
         outage.status = 'resolved'
-        outage.updated_at = datetime.now()
+        outage.updated_at = utcnow_naive()
         db.session.commit()
         flash('Outage resolved.', 'success')
     else:

--- a/src/webapp/dashboards/status/blueprint.py
+++ b/src/webapp/dashboards/status/blueprint.py
@@ -7,7 +7,7 @@ from flask_login import login_required, current_user
 from webapp.utils.rbac import require_permission, Permission
 from marshmallow import ValidationError
 from sam.schemas.forms import CreateOutageForm, EditOutageForm
-from sam.fmt import utcnow_naive  # status/collector timestamps are naive-UTC
+from system_status.timeutil import utcnow_naive  # status/collector timestamps are naive-UTC
 from datetime import timedelta
 import logging
 

--- a/src/webapp/static/css/admin.css
+++ b/src/webapp/static/css/admin.css
@@ -74,3 +74,35 @@
 .logout-link {
     color: var(--ncar-vermilion);
 }
+
+/* ===================================================================
+   User / Resource Access grid
+   =================================================================== */
+
+/* Keep the Member column pinned while the (potentially many) resource
+   columns scroll horizontally on wide projects. */
+.access-grid th.sticky-col,
+.access-grid td.sticky-col {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+    background: var(--bs-body-bg, #fff);
+    box-shadow: 1px 0 0 var(--bs-border-color, #dee2e6);
+}
+
+.access-grid thead th.sticky-col {
+    z-index: 3;
+}
+
+.access-grid tbody tr:hover td.sticky-col {
+    background: var(--bs-tertiary-bg, #f8f9fa);
+}
+
+/* Chevron affordance on the collapsible card header. */
+.access-grid-chevron {
+    transition: transform 0.15s ease;
+}
+
+.access-grid-toggle.collapsed .access-grid-chevron {
+    transform: rotate(-90deg);
+}

--- a/src/webapp/templates/dashboards/admin/edit_project.html
+++ b/src/webapp/templates/dashboards/admin/edit_project.html
@@ -171,19 +171,33 @@
 
 </div>
 
-<!-- ── User / Resource Access grid (site operators only) ──────────────────
-     Hidden from project lead/admin — only system operators holding BOTH
-     EDIT_PROJECTS and EDIT_PROJECT_MEMBERS see this remediation tool. The
-     initial load passes active_only=1 so the grid defaults to Active-only. -->
 {% if has_permission(Permission.EDIT_PROJECTS)
       and has_permission(Permission.EDIT_PROJECT_MEMBERS) %}
-<div id="accessGridContainer" class="mt-4"
-     hx-get="{{ url_for('admin_dashboard.htmx_access_grid', projcode=project.projcode, active_only=1) }}"
-     hx-trigger="load"
-     hx-swap="innerHTML">
-  <div class="text-center text-muted py-4">
-    <i class="fas fa-spinner fa-spin fa-2x" aria-hidden="true"></i>
-    <p class="mt-2">Loading user/resource access…</p>
+{# User / Resource Access grid (site operators only) — hidden from project
+   lead/admin; only system operators holding BOTH EDIT_PROJECTS and
+   EDIT_PROJECT_MEMBERS see this remediation tool. Collapsed by default
+   (rare-use); the grid lazy-loads on first expand with active_only=1. #}
+<div class="card mt-4">
+  <div class="card-header access-grid-toggle collapsed d-flex align-items-center justify-content-between py-2"
+       role="button" tabindex="0"
+       data-bs-toggle="collapse" data-bs-target="#accessGridCollapse"
+       aria-expanded="false" aria-controls="accessGridCollapse">
+    <span class="fw-semibold">
+      <i class="fas fa-user-shield text-primary me-1"></i> User / Resource Access
+      <span class="text-muted small fw-normal ms-1">— operator remediation for partial-access errors</span>
+    </span>
+    <i class="fas fa-chevron-down text-muted access-grid-chevron"></i>
+  </div>
+  <div class="collapse" id="accessGridCollapse">
+    <div id="accessGridContainer"
+         hx-get="{{ url_for('admin_dashboard.htmx_access_grid', projcode=project.projcode, active_only=1) }}"
+         hx-trigger="shown.bs.collapse from:#accessGridCollapse once"
+         hx-swap="innerHTML">
+      <div class="text-center text-muted py-4">
+        <i class="fas fa-spinner fa-spin fa-2x" aria-hidden="true"></i>
+        <p class="mt-2">Loading user/resource access…</p>
+      </div>
+    </div>
   </div>
 </div>
 {% endif %}

--- a/src/webapp/templates/dashboards/admin/edit_project.html
+++ b/src/webapp/templates/dashboards/admin/edit_project.html
@@ -171,6 +171,23 @@
 
 </div>
 
+<!-- ── User / Resource Access grid (site operators only) ──────────────────
+     Hidden from project lead/admin — only system operators holding BOTH
+     EDIT_PROJECTS and EDIT_PROJECT_MEMBERS see this remediation tool. The
+     initial load passes active_only=1 so the grid defaults to Active-only. -->
+{% if has_permission(Permission.EDIT_PROJECTS)
+      and has_permission(Permission.EDIT_PROJECT_MEMBERS) %}
+<div id="accessGridContainer" class="mt-4"
+     hx-get="{{ url_for('admin_dashboard.htmx_access_grid', projcode=project.projcode, active_only=1) }}"
+     hx-trigger="load"
+     hx-swap="innerHTML">
+  <div class="text-center text-muted py-4">
+    <i class="fas fa-spinner fa-spin fa-2x" aria-hidden="true"></i>
+    <p class="mt-2">Loading user/resource access…</p>
+  </div>
+</div>
+{% endif %}
+
 <!-- ═══════════════════════════════════════════════════════ MODALS -->
 
 <!-- Add Allocation Modal (lazy-loaded) -->

--- a/src/webapp/templates/dashboards/admin/fragments/project_access_grid_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_access_grid_htmx.html
@@ -1,0 +1,122 @@
+{% from 'dashboards/fragments/form_fields.html' import form_errors_panel with context %}
+{#
+  Operator-only User / Resource Access grid (site operators only — gated by the
+  container in edit_project.html on EDIT_PROJECTS + EDIT_PROJECT_MEMBERS).
+
+  Surfaces and repairs partial-access errors: a cell is checked when the member
+  has currently-active access to that resource's account. The whole card is the
+  swap target — every control posts back and re-renders #accessGridContainer.
+
+  Context:
+    project       : Project
+    projcode      : str
+    columns       : list[{account_id, resource_id, resource_name, has_active_alloc}]
+    member_rows   : list[{user, is_lead, cells:[{column, checked}]}]
+    active_only   : bool
+    errors        : list[str]
+#}
+<div class="card">
+  <div class="card-header d-flex flex-wrap align-items-center justify-content-between gap-2">
+    <div>
+      <h5 class="mb-0 d-inline-block">
+        <i class="fas fa-user-shield text-primary"></i> User / Resource Access
+      </h5>
+      <span class="text-muted small ms-2">
+        Per-resource account access for each project member. All-checked is the
+        healthy state; gaps indicate partial access to repair.
+      </span>
+    </div>
+    <div class="d-flex align-items-center gap-3">
+      <div class="form-check form-switch mb-0">
+        <input type="checkbox" class="form-check-input"
+               id="accessGridActiveOnly"
+               name="active_only" value="1"
+               {% if active_only %}checked{% endif %}
+               hx-get="{{ url_for('admin_dashboard.htmx_access_grid', projcode=projcode) }}"
+               hx-trigger="change"
+               hx-target="#accessGridContainer"
+               hx-swap="innerHTML"
+               hx-include="this">
+        <label class="form-check-label small text-muted fw-normal"
+               for="accessGridActiveOnly">
+          Active only
+        </label>
+      </div>
+      {% if member_rows and columns %}
+      <button type="button" class="btn btn-sm btn-warning"
+              hx-post="{{ url_for('admin_dashboard.htmx_access_grid_reconcile', projcode=projcode) }}"
+              hx-include="#accessGridActiveOnly"
+              hx-target="#accessGridContainer"
+              hx-swap="innerHTML"
+              hx-confirm="Give every member access to every resource shown on this project?">
+        <i class="fas fa-magic"></i> Reconcile all
+      </button>
+      {% endif %}
+    </div>
+  </div>
+
+  <div class="card-body">
+    {{ form_errors_panel() }}
+
+    {% if not columns %}
+    <p class="text-muted mb-0">
+      {% if active_only %}
+        This project has no resources with a currently-active allocation.
+        Turn off <em>Active only</em> to include expired resources.
+      {% else %}
+        This project has no resource accounts.
+      {% endif %}
+    </p>
+    {% elif not member_rows %}
+    <p class="text-muted mb-0">This project has no members.</p>
+    {% else %}
+    <div class="table-responsive">
+      <table class="table table-sm table-hover align-middle mb-0">
+        <thead>
+          <tr>
+            <th scope="col">Member</th>
+            {% for col in columns %}
+            <th scope="col" class="text-center {% if not col.has_active_alloc %}text-muted{% endif %}">
+              {{ col.resource_name }}
+              {% if not col.has_active_alloc %}
+              <span class="badge bg-secondary fw-normal ms-1" title="No currently-active allocation">expired</span>
+              {% endif %}
+            </th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in member_rows %}
+          <tr>
+            <td>
+              {{ row.user.display_name }}
+              <span class="text-muted small">({{ row.user.username }})</span>
+              {% if row.is_lead %}
+              <span class="badge bg-info text-dark fw-normal ms-1">lead</span>
+              {% endif %}
+            </td>
+            {% for cell in row.cells %}
+            <td class="text-center">
+              <input type="checkbox" class="form-check-input"
+                     name="grant" value="1"
+                     {% if cell.checked %}checked{% endif %}
+                     {% if row.is_lead %}checked disabled
+                       title="The project lead always has access and cannot be revoked here."
+                     {% else %}
+                       hx-post="{{ url_for('admin_dashboard.htmx_access_grid_toggle', projcode=projcode) }}"
+                       hx-vals='{"user_id": {{ row.user.user_id }}, "resource_id": {{ cell.column.resource_id }}}'
+                       hx-include="#accessGridActiveOnly"
+                       hx-target="#accessGridContainer"
+                       hx-swap="innerHTML"
+                       hx-trigger="change"
+                     {% endif %}>
+            </td>
+            {% endfor %}
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
+  </div>
+</div>

--- a/src/webapp/templates/dashboards/admin/fragments/project_access_grid_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_access_grid_htmx.html
@@ -1,11 +1,15 @@
 {% from 'dashboards/fragments/form_fields.html' import form_errors_panel with context %}
 {#
   Operator-only User / Resource Access grid (site operators only — gated by the
-  container in edit_project.html on EDIT_PROJECTS + EDIT_PROJECT_MEMBERS).
+  collapsible card in edit_project.html on EDIT_PROJECTS + EDIT_PROJECT_MEMBERS).
 
-  Surfaces and repairs partial-access errors: a cell is checked when the member
-  has currently-active access to that resource's account. The whole card is the
-  swap target — every control posts back and re-renders #accessGridContainer.
+  Renders INTO #accessGridContainer (inside the collapsible card body), so this
+  fragment is just the controls bar + table — the card chrome lives in
+  edit_project.html. Every control posts back and re-renders #accessGridContainer.
+
+  A cell is checked when the member has currently-active access to that
+  resource's account. The Member column is sticky so usernames stay visible
+  while the (potentially many) resource columns scroll horizontally.
 
   Context:
     project       : Project
@@ -15,108 +19,100 @@
     active_only   : bool
     errors        : list[str]
 #}
-<div class="card">
-  <div class="card-header d-flex flex-wrap align-items-center justify-content-between gap-2">
-    <div>
-      <h5 class="mb-0 d-inline-block">
-        <i class="fas fa-user-shield text-primary"></i> User / Resource Access
-      </h5>
-      <span class="text-muted small ms-2">
-        Per-resource account access for each project member. All-checked is the
-        healthy state; gaps indicate partial access to repair.
-      </span>
+<div class="d-flex flex-wrap align-items-center justify-content-between gap-2 p-2 border-bottom bg-light">
+  <span class="text-muted small">
+    All-checked is the healthy state; gaps indicate partial access to repair.
+  </span>
+  <div class="d-flex align-items-center gap-3">
+    <div class="form-check form-switch mb-0">
+      <input type="checkbox" class="form-check-input"
+             id="accessGridActiveOnly"
+             name="active_only" value="1"
+             {% if active_only %}checked{% endif %}
+             hx-get="{{ url_for('admin_dashboard.htmx_access_grid', projcode=projcode) }}"
+             hx-trigger="change"
+             hx-target="#accessGridContainer"
+             hx-swap="innerHTML"
+             hx-include="this">
+      <label class="form-check-label small text-muted fw-normal"
+             for="accessGridActiveOnly">
+        Active only
+      </label>
     </div>
-    <div class="d-flex align-items-center gap-3">
-      <div class="form-check form-switch mb-0">
-        <input type="checkbox" class="form-check-input"
-               id="accessGridActiveOnly"
-               name="active_only" value="1"
-               {% if active_only %}checked{% endif %}
-               hx-get="{{ url_for('admin_dashboard.htmx_access_grid', projcode=projcode) }}"
-               hx-trigger="change"
-               hx-target="#accessGridContainer"
-               hx-swap="innerHTML"
-               hx-include="this">
-        <label class="form-check-label small text-muted fw-normal"
-               for="accessGridActiveOnly">
-          Active only
-        </label>
-      </div>
-      {% if member_rows and columns %}
-      <button type="button" class="btn btn-sm btn-warning"
-              hx-post="{{ url_for('admin_dashboard.htmx_access_grid_reconcile', projcode=projcode) }}"
-              hx-include="#accessGridActiveOnly"
-              hx-target="#accessGridContainer"
-              hx-swap="innerHTML"
-              hx-confirm="Give every member access to every resource shown on this project?">
-        <i class="fas fa-magic"></i> Reconcile all
-      </button>
-      {% endif %}
-    </div>
-  </div>
-
-  <div class="card-body">
-    {{ form_errors_panel() }}
-
-    {% if not columns %}
-    <p class="text-muted mb-0">
-      {% if active_only %}
-        This project has no resources with a currently-active allocation.
-        Turn off <em>Active only</em> to include expired resources.
-      {% else %}
-        This project has no resource accounts.
-      {% endif %}
-    </p>
-    {% elif not member_rows %}
-    <p class="text-muted mb-0">This project has no members.</p>
-    {% else %}
-    <div class="table-responsive">
-      <table class="table table-sm table-hover align-middle mb-0">
-        <thead>
-          <tr>
-            <th scope="col">Member</th>
-            {% for col in columns %}
-            <th scope="col" class="text-center {% if not col.has_active_alloc %}text-muted{% endif %}">
-              {{ col.resource_name }}
-              {% if not col.has_active_alloc %}
-              <span class="badge bg-secondary fw-normal ms-1" title="No currently-active allocation">expired</span>
-              {% endif %}
-            </th>
-            {% endfor %}
-          </tr>
-        </thead>
-        <tbody>
-          {% for row in member_rows %}
-          <tr>
-            <td>
-              {{ row.user.display_name }}
-              <span class="text-muted small">({{ row.user.username }})</span>
-              {% if row.is_lead %}
-              <span class="badge bg-info text-dark fw-normal ms-1">lead</span>
-              {% endif %}
-            </td>
-            {% for cell in row.cells %}
-            <td class="text-center">
-              <input type="checkbox" class="form-check-input"
-                     name="grant" value="1"
-                     {% if cell.checked %}checked{% endif %}
-                     {% if row.is_lead %}checked disabled
-                       title="The project lead always has access and cannot be revoked here."
-                     {% else %}
-                       hx-post="{{ url_for('admin_dashboard.htmx_access_grid_toggle', projcode=projcode) }}"
-                       hx-vals='{"user_id": {{ row.user.user_id }}, "resource_id": {{ cell.column.resource_id }}}'
-                       hx-include="#accessGridActiveOnly"
-                       hx-target="#accessGridContainer"
-                       hx-swap="innerHTML"
-                       hx-trigger="change"
-                     {% endif %}>
-            </td>
-            {% endfor %}
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
+    {% if member_rows and columns %}
+    <button type="button" class="btn btn-sm btn-warning"
+            hx-post="{{ url_for('admin_dashboard.htmx_access_grid_reconcile', projcode=projcode) }}"
+            hx-include="#accessGridActiveOnly"
+            hx-target="#accessGridContainer"
+            hx-swap="innerHTML"
+            hx-confirm="Give every member access to every resource shown on this project?">
+      <i class="fas fa-magic"></i> Reconcile all
+    </button>
     {% endif %}
   </div>
+</div>
+
+<div class="p-3">
+  {{ form_errors_panel() }}
+
+  {% if not columns %}
+  <p class="text-muted mb-0">
+    {% if active_only %}
+      This project has no resources with a currently-active allocation.
+      Turn off <em>Active only</em> to include expired resources.
+    {% else %}
+      This project has no resource accounts.
+    {% endif %}
+  </p>
+  {% elif not member_rows %}
+  <p class="text-muted mb-0">This project has no members.</p>
+  {% else %}
+  <div class="table-responsive">
+    <table class="table table-sm table-hover align-middle mb-0 access-grid">
+      <thead>
+        <tr>
+          <th scope="col" class="sticky-col">Member</th>
+          {% for col in columns %}
+          <th scope="col" class="text-center {% if not col.has_active_alloc %}text-muted{% endif %}">
+            {{ col.resource_name }}
+            {% if not col.has_active_alloc %}
+            <span class="badge bg-secondary fw-normal ms-1" title="No currently-active allocation">expired</span>
+            {% endif %}
+          </th>
+          {% endfor %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for row in member_rows %}
+        <tr>
+          <td class="sticky-col">
+            {{ row.user.display_name }}
+            <span class="text-muted small">({{ row.user.username }})</span>
+            {% if row.is_lead %}
+            <span class="badge bg-info text-dark fw-normal ms-1">lead</span>
+            {% endif %}
+          </td>
+          {% for cell in row.cells %}
+          <td class="text-center">
+            <input type="checkbox" class="form-check-input"
+                   name="grant" value="1"
+                   {% if cell.checked %}checked{% endif %}
+                   {% if row.is_lead %}checked disabled
+                     title="The project lead always has access and cannot be revoked here."
+                   {% else %}
+                     hx-post="{{ url_for('admin_dashboard.htmx_access_grid_toggle', projcode=projcode) }}"
+                     hx-vals='{"user_id": {{ row.user.user_id }}, "resource_id": {{ cell.column.resource_id }}}'
+                     hx-include="#accessGridActiveOnly"
+                     hx-target="#accessGridContainer"
+                     hx-swap="innerHTML"
+                     hx-trigger="change"
+                   {% endif %}>
+          </td>
+          {% endfor %}
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endif %}
 </div>

--- a/tests/unit/test_user_resource_access.py
+++ b/tests/unit/test_user_resource_access.py
@@ -1,0 +1,147 @@
+"""Tests for the operator User/Resource Access remediation functions:
+grant_user_resource_access, revoke_user_resource_access, and
+reconcile_project_access (sam.manage).
+
+Each test builds a fresh isolated graph (Layer-2 factories) so it does not
+depend on snapshot membership:
+  - make_project()                     → fresh Project + fresh lead User
+  - make_account(project=, resource=)  → Account.create() seeds the lead
+  - make_allocation(account=)          → currently-active allocation so the
+                                         resource counts as "active" for
+                                         get_user_inaccessible_resources()
+  - make_user()                        → fresh User, unambiguously off-project
+"""
+from datetime import datetime, timedelta
+
+import pytest
+
+from sam.accounting.accounts import AccountUser
+from sam.manage import (
+    add_user_to_project,
+    grant_user_resource_access,
+    reconcile_project_access,
+    revoke_user_resource_access,
+)
+
+from factories import make_account, make_allocation, make_project, make_user
+from factories import make_resource
+
+pytestmark = pytest.mark.unit
+
+
+def _membership_rows(session, account_id, user_id):
+    return session.query(AccountUser).filter(
+        AccountUser.account_id == account_id,
+        AccountUser.user_id == user_id,
+    ).all()
+
+
+class TestGrantUserResourceAccess:
+    def test_grant_adds_single_membership(self, session):
+        project = make_project(session)
+        account = make_account(session, project=project)
+        user = make_user(session)
+
+        grant_user_resource_access(
+            session, project.project_id, user.user_id, account.resource_id
+        )
+
+        rows = _membership_rows(session, account.account_id, user.user_id)
+        assert len(rows) == 1
+        assert rows[0].end_date is None
+
+    def test_grant_is_idempotent(self, session):
+        project = make_project(session)
+        account = make_account(session, project=project)
+        user = make_user(session)
+
+        grant_user_resource_access(
+            session, project.project_id, user.user_id, account.resource_id
+        )
+        grant_user_resource_access(
+            session, project.project_id, user.user_id, account.resource_id
+        )
+
+        rows = _membership_rows(session, account.account_id, user.user_id)
+        assert len(rows) == 1
+
+    def test_grant_raises_when_no_account_for_resource(self, session):
+        project = make_project(session)
+        make_account(session, project=project)
+        user = make_user(session)
+        # A resource the project has no account for.
+        orphan_resource = make_resource(session)
+
+        with pytest.raises(ValueError, match="no account for resource"):
+            grant_user_resource_access(
+                session, project.project_id, user.user_id,
+                orphan_resource.resource_id,
+            )
+
+
+class TestRevokeUserResourceAccess:
+    def test_revoke_removes_membership(self, session):
+        project = make_project(session)
+        account = make_account(session, project=project)
+        user = make_user(session)
+        grant_user_resource_access(
+            session, project.project_id, user.user_id, account.resource_id
+        )
+        assert _membership_rows(session, account.account_id, user.user_id)
+
+        revoke_user_resource_access(
+            session, project.project_id, user.user_id, account.resource_id
+        )
+
+        assert _membership_rows(session, account.account_id, user.user_id) == []
+
+    def test_revoke_lead_raises(self, session):
+        project = make_project(session)
+        account = make_account(session, project=project)
+        lead_id = project.project_lead_user_id
+
+        with pytest.raises(ValueError, match="lead"):
+            revoke_user_resource_access(
+                session, project.project_id, lead_id, account.resource_id
+            )
+
+
+class TestReconcileProjectAccess:
+    def test_reconcile_fills_partial_access(self, session):
+        project = make_project(session)
+        r1 = make_resource(session)
+        r2 = make_resource(session)
+        acct1 = make_account(session, project=project, resource=r1)
+        acct2 = make_account(session, project=project, resource=r2)
+        # Active allocations so both resources count as "active".
+        make_allocation(session, account=acct1)
+        make_allocation(session, account=acct2)
+
+        member = make_user(session)
+        # Backdate so is_active is independent of same-second DATETIME rounding.
+        past = datetime.now() - timedelta(days=1)
+        add_user_to_project(
+            session, project.project_id, member.user_id, start_date=past
+        )
+
+        # Simulate an out-of-band partial-access error: drop the member's
+        # access to r2 only.
+        bad = session.query(AccountUser).filter_by(
+            account_id=acct2.account_id, user_id=member.user_id
+        ).one()
+        session.delete(bad)
+        session.flush()
+        session.expire_all()
+
+        assert project.get_user_inaccessible_resources(member) == {r2.resource_name}
+
+        reconcile_project_access(session, project.project_id)
+
+        # Reconcile re-links the member to r2's account (deterministic).
+        assert session.query(AccountUser).filter_by(
+            account_id=acct2.account_id, user_id=member.user_id
+        ).count() == 1
+
+        # And the grid view agrees: no inaccessible resources remain.
+        session.expire_all()
+        assert project.get_user_inaccessible_resources(member) == set()


### PR DESCRIPTION
## Summary

Adds an operator-only **User / Resource Access** remediation card to the
project Edit page, and — surfaced while deploying it to prod — fixes a
pre-existing **app-pod ↔ database timezone skew** that affected any app-stamped
datetime, plus realigns the `system_status` subsystem to its naive-UTC
convention.

SAM models "a user on a project" as `AccountUser` links, one per
(project × resource) `Account`; adding a user seeds all resource-accounts and
adding a resource seeds all users. When an out-of-band DB edit leaves a user
with **partial** resource access, nothing in the web UI surfaced or repaired it
(only the CLI did). This PR adds a members × resources grid of checkmarks with
per-cell toggles and a **Reconcile all** button, visible only to site operators
holding both `EDIT_PROJECTS` and `EDIT_PROJECT_MEMBERS`.

## Part 1 — Feature: operator User/Resource Access card

- **New card** at the bottom of `/admin/project/<PROJCODE>/edit`, collapsible and
  collapsed by default (rare-use), lazy-loaded on expand.
- **Grid**: members (rows) × resources (columns). A cell is checked when the
  member has a currently-active `AccountUser` on that resource's account.
  Sticky Member column so usernames stay visible across many resource columns.
- **Active-only toggle** (default on): columns are resources with a
  currently-active allocation; off also shows expired/lapsed resources (badged).
- **Per-cell toggle**: grant/revoke one member's access to one resource. The
  project lead's row is locked (cannot be revoked).
- **Reconcile all**: gives every member access to every resource shown
  (fills the grid) via `Account._seed_members`.
- **RBAC**: new `require_project_operator_access` decorator — requires both
  system permissions, no project-lead/admin override.
- **Validation**: new `AccessGridToggleForm` (`sam.schemas.forms`) per CLAUDE.md §9.
- Backend ops co-located in `sam.manage`: `grant_user_resource_access`,
  `revoke_user_resource_access`, `reconcile_project_access` (no-commit; caller
  wraps in `management_transaction`).

Commits: `425f08f`, `4003d5a`.

## Part 2 — Prod timezone fixes (bundled intentionally)

Deploying Part 1 exposed that the prod pod runs **UTC** while the SAM DB
(`sam-sql.ucar.edu`) runs **Mountain**. The codebase assumes naive datetimes
with app-TZ == DB-TZ (CLAUDE.md), so this skew silently corrupted any
app-stamped datetime compared against the DB clock.

**2a. Access-grid writes not sticking (`f7cdede`)**
`AccountUser.is_active` compares `start_date <= func.now()` (DB/Mountain), but
writes stamped `datetime.now()` (pod/UTC) — landing new rows ~6h in the DB's
future, so just-granted access read back inactive for hours (and the insert
guard spawned duplicate rows). Fix: `TZ: "America/Denver"` on the webapp pod
(`helm/values.yaml`) to match the Mountain DB. This repairs the whole SAM/MySQL
class (access grid, web member-add, resource-add, expiration windows).

**2b. system_status realignment**
The `system_status` / collector subsystem stores naive **UTC** and was correct
only because the pod was UTC. Aligning the pod to Mountain would have skewed its
staleness/reservation/chart windows by 6h. New dependency-free helper
`system_status/timeutil.py::utcnow_naive()` now backs every status read, window
computation, write, and model default across three areas:
`system_status/` (queries, cli, model defaults),
`webapp/dashboards/status/blueprint.py`, and
`webapp/api/v1/status.py` (the collector ingest endpoint + API reservation reads).

- **Boot-crash fix (`82d6347`)**: the helper was initially placed in `sam.fmt`,
  which does `from config import SAMConfig`; importing it from the early-loading
  `system_status.base` pulled `config` into boot before it resolved and collided
  with `webapp/config.py` (`ImportError: cannot import name 'SAMConfig'`),
  crashing `samuel-webdev`. Moving it to dependency-free `system_status/timeutil.py`
  fixes the boot and decouples `system_status` from the `sam` package.
- **Reservations vanishing (`dc4d3fd`)**: the collector ingest
  (`webapp/api/v1/status.py`) still stamped `updated_at` with `datetime.now()`.
  After the pod moved to Mountain, a reservation's `created_at` was UTC (via the
  new model default) but `updated_at` was Mountain — 6h apart — so the dashboard
  staleness filter (`last_seen >= utcnow − 30min`) judged every reservation stale
  and hid them all. Converted the ingest writes and API-side reservation reads to
  `utcnow_naive()`. App-local timings (health latency, app uptime, config-inspect
  `gathered_at`) intentionally stay on local `datetime.now()`.

## Prod data cleanup (one-time, operator-run)

The original UTC-window bug left **212 future-dated open `AccountUser` rows**
(`start_date` stamped ~6h ahead) across 3 projects (SCSG0001: 145, NRAL0032: 60,
UCSD0074: 7). These also blocked **Reconcile all**: `_seed_members` treats a row
with `end_date IS NULL` as "already a member" (ignoring `start_date`), so it
skipped exactly the cells the grid showed as inactive — while per-cell toggle,
which guards on `is_active`, worked. Verified orphan-safe (every member kept ≥1
active row), then deleted the 212 rows (scoped: open + the 13:00–14:00 bug window
+ the 3 projects) and re-ran Reconcile all. No code change to `_seed_members`
was needed — with the pod on Mountain, no new future-dated rows are created.

## Validation

**Automated**
- Full suite green: **2457 passed, 23 skipped, 1 xfailed** (~68s), including
  status dashboard/endpoints, fmt, collector, and access-grid tiers.
- Reproduced `run.py`'s exact import order (`sam.session` → `system_status.session`
  → status blueprint) with `src/webapp` as `sys.path[0]` — boots cleanly.

**On prod (post-deploy)**
- New pod confirmed on Mountain (`date` → MDT, `TZ=America/Denver`).
- **Reservations**: after the deploy + one collector cycle, reservation
  `updated_at` is written in UTC (e.g. `17:00–17:01` vs `pg now 17:04`), so they
  are fresh (not filtered stale) — Derecho/Casper tabs populate again. `end_time`
  values are UTC-consistent with the query (no 6h drift on start/end either).
- **Access grid**: per-cell toggle persists across re-render and reload;
  newly-granted `account_user` rows have `start_date <= NOW()` (`is_active`)
  immediately.
- **Reconcile all** (post-cleanup), member × active-account gap cells:
  - SCSG0001: **141 → 0** (0 future-dated, 0 duplicate open rows)
  - NRAL0032: **59 → 0** (0 future-dated, 0 duplicate open rows)
  - UCSD0074: already 0 (its deleted rows were pure duplicates)
- RBAC: card + endpoints return 403 for non-operators; hidden for project leads.

## Files

- Feature: `webapp/templates/.../edit_project.html`,
  `.../fragments/project_access_grid_htmx.html`,
  `webapp/dashboards/admin/projects_routes.py`,
  `webapp/api/access_control.py`, `sam/manage/__init__.py`,
  `sam/schemas/forms/projects.py`, `webapp/static/css/admin.css`,
  `tests/unit/test_user_resource_access.py`.
- Timezone: `helm/values.yaml` (`TZ`), `system_status/timeutil.py` (new),
  `system_status/{base,cli,queries,models/lookups,models/outages}.py`,
  `webapp/dashboards/status/blueprint.py`, `webapp/api/v1/status.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
