### PR TITLE
Expose per-resource facility fair-share overrides in Admin > Resources

### DIFF
--- a/src/sam/resources/facilities.py
+++ b/src/sam/resources/facilities.py
@@ -115,8 +115,16 @@ class Facility(Base, TimestampMixin, ActiveFlagMixin, SessionMixin):
 
 
 #----------------------------------------------------------------------------
-class FacilityResource(Base):
-    """Maps facilities to resources with fair share percentages."""
+class FacilityResource(Base, SessionMixin):
+    """Per-(facility, resource) fair-share override.
+
+    When a row exists here for a given (facility, resource) pair, its
+    ``fair_share_percentage`` overrides the facility default
+    (``Facility.fair_share_percentage``) for that resource — see the
+    ``COALESCE(fr.fair_share_percentage, f.fair_share_percentage)`` in
+    ``sam/queries/fstree_access.py``. Deleting the row (or leaving it absent)
+    makes the facility default re-emerge.
+    """
     __tablename__ = 'facility_resource'
 
     __table_args__ = (
@@ -133,6 +141,92 @@ class FacilityResource(Base):
 
     facility = relationship('Facility', back_populates='facility_resources')
     resource = relationship('Resource', back_populates='facility_resources')
+
+    def update(self, *, fair_share_percentage: Optional[float] = None) -> 'FacilityResource':
+        """
+        Update this override's fair-share percentage.
+
+        NOTE: Does NOT commit. Caller must use management_transaction or commit manually.
+
+        Raises:
+            ValueError: If fair_share_percentage is out of the 0–100 range.
+        """
+        if fair_share_percentage is not None:
+            if not (0 <= fair_share_percentage <= 100):
+                raise ValueError("fair_share_percentage must be between 0 and 100")
+            self.fair_share_percentage = fair_share_percentage
+        self.session.flush()
+        return self
+
+    @classmethod
+    def create(
+        cls,
+        session,
+        *,
+        facility_id: int,
+        resource_id: int,
+        fair_share_percentage: Optional[float] = None,
+    ) -> 'FacilityResource':
+        """
+        Create a new per-resource fair-share override.
+
+        NOTE: Does NOT commit. Caller must use management_transaction or commit manually.
+        """
+        if fair_share_percentage is not None and not (0 <= fair_share_percentage <= 100):
+            raise ValueError("fair_share_percentage must be between 0 and 100")
+        obj = cls(
+            facility_id=facility_id,
+            resource_id=resource_id,
+            fair_share_percentage=fair_share_percentage,
+        )
+        session.add(obj)
+        session.flush()
+        return obj
+
+    @classmethod
+    def get_override(cls, session, facility_id: int, resource_id: int) -> Optional['FacilityResource']:
+        """Return the override row for (facility, resource), or None if absent."""
+        return (
+            session.query(cls)
+            .filter(cls.facility_id == facility_id, cls.resource_id == resource_id)
+            .one_or_none()
+        )
+
+    @classmethod
+    def set_override(
+        cls,
+        session,
+        *,
+        facility_id: int,
+        resource_id: int,
+        fair_share_percentage: float,
+    ) -> 'FacilityResource':
+        """Upsert the (facility, resource) override to the given percentage.
+
+        Updates the existing row if one exists, otherwise creates it.
+        """
+        existing = cls.get_override(session, facility_id, resource_id)
+        if existing is not None:
+            return existing.update(fair_share_percentage=fair_share_percentage)
+        return cls.create(
+            session,
+            facility_id=facility_id,
+            resource_id=resource_id,
+            fair_share_percentage=fair_share_percentage,
+        )
+
+    @classmethod
+    def clear_override(cls, session, *, facility_id: int, resource_id: int) -> bool:
+        """Delete the (facility, resource) override so the facility default re-emerges.
+
+        Returns True if a row was deleted, False if none existed (no-op).
+        """
+        existing = cls.get_override(session, facility_id, resource_id)
+        if existing is None:
+            return False
+        session.delete(existing)
+        session.flush()
+        return True
 
     def __str__(self):
         return f"<{self.facility.facility_name}/{self.resource.resource_name}>"

--- a/src/sam/schemas/forms/__init__.py
+++ b/src/sam/schemas/forms/__init__.py
@@ -161,6 +161,7 @@ from .facilities import (
 from .resources import (
     EditResourceForm,
     CreateResourceForm,
+    EditFacilityResourceForm,
     EditResourceTypeForm,
     CreateResourceTypeForm,
     EditMachineForm,
@@ -232,6 +233,7 @@ __all__ = [
     # Resources
     'EditResourceForm',
     'CreateResourceForm',
+    'EditFacilityResourceForm',
     'EditResourceTypeForm',
     'CreateResourceTypeForm',
     'EditMachineForm',

--- a/src/sam/schemas/forms/resources.py
+++ b/src/sam/schemas/forms/resources.py
@@ -36,6 +36,15 @@ class CreateResourceForm(HtmxFormSchema):
     commission_date = f.Date('%Y-%m-%d', load_default=None)
 
 
+class EditFacilityResourceForm(HtmxFormSchema):
+    """Per-(facility, resource) fair-share override.
+
+    fair_share_percentage is required for a Set/Edit; the Unset action
+    deletes the row via a separate DELETE route (no schema needed).
+    """
+    fair_share_percentage = f.Float(required=True, validate=v.Range(min=0, max=100))
+
+
 class EditResourceTypeForm(HtmxFormSchema):
     grace_period_days = f.Int(load_default=None, validate=v.Range(min=0))
 

--- a/src/webapp/dashboards/admin/resources_routes.py
+++ b/src/webapp/dashboards/admin/resources_routes.py
@@ -20,7 +20,7 @@ from webapp.utils.rbac import (
 )
 from sam.manage import management_transaction
 from sam.schemas.forms.resources import (
-    EditResourceForm, CreateResourceForm,
+    EditResourceForm, CreateResourceForm, EditFacilityResourceForm,
     EditResourceTypeForm, CreateResourceTypeForm,
     EditMachineForm, CreateMachineForm, EditQueueForm,
     CreateDiskResourceRootDirectoryForm, EditDiskResourceRootDirectoryForm,
@@ -61,6 +61,7 @@ def htmx_resources_card():
     """
     from sam.resources.resources import Resource, ResourceType
     from sam.resources.machines import Machine, Queue
+    from sam.resources.facilities import Facility
 
     active_only = request.args.get('active_only') == '1'
     now = datetime.now()
@@ -71,6 +72,16 @@ def htmx_resources_card():
     resources = resource_q.all()
 
     resource_types = db.session.query(ResourceType).order_by(ResourceType.resource_type).all()
+
+    # Active facilities drive the per-resource fair-share override table shown
+    # under each HPC/DAV resource row (defaults are shown where no override row
+    # exists — see fragments/resources_card.html).
+    facilities = (
+        db.session.query(Facility)
+        .filter(Facility.is_active)
+        .order_by(Facility.facility_name)
+        .all()
+    )
 
     machine_q = db.session.query(Machine).order_by(Machine.resource_id, Machine.name)
     if active_only:
@@ -113,6 +124,7 @@ def htmx_resources_card():
         'dashboards/admin/fragments/resources_card.html',
         resources=resources,
         resource_types=resource_types,
+        facilities=facilities,
         machines=machines,
         queues=queues,
         exemptions=exemptions,
@@ -230,6 +242,82 @@ def htmx_resource_delete(resource_id):
         return f'<div class="alert alert-danger">Error: {e}</div>', 500
 
     return ''
+
+
+# ── Per-resource Facility Fair-Share Override ──────────────────────────────
+# A row in `facility_resource` overrides the facility default fair-share for a
+# single resource (COALESCE(fr…, f…) in sam/queries/fstree_access.py). "Set"
+# upserts the row; "Unset" deletes it so the facility default re-emerges.
+
+
+@bp.route('/htmx/facility-resource-edit-form/<int:resource_id>/<int:facility_id>')
+@login_required
+@require_permission(Permission.EDIT_RESOURCES)
+def htmx_facility_resource_edit_form(resource_id, facility_id):
+    """Return the fair-share override edit form fragment (loaded into modal)."""
+    from sam.resources.resources import Resource
+    from sam.resources.facilities import Facility, FacilityResource
+
+    resource = db.session.get(Resource, resource_id)
+    facility = db.session.get(Facility, facility_id)
+    if not resource or not facility:
+        return '<div class="alert alert-warning">Resource or facility not found</div>'
+
+    override = FacilityResource.get_override(db.session, facility_id, resource_id)
+
+    return render_template(
+        'dashboards/admin/fragments/edit_facility_resource_form_htmx.html',
+        resource=resource,
+        facility=facility,
+        override=override,
+    )
+
+
+@bp.route('/htmx/facility-resource-edit/<int:resource_id>/<int:facility_id>', methods=['POST'])
+@login_required
+@require_permission(Permission.EDIT_RESOURCES)
+def htmx_facility_resource_edit(resource_id, facility_id):
+    """Set (upsert) a per-resource fair-share override for a facility."""
+    from sam.resources.resources import Resource
+    from sam.resources.facilities import Facility, FacilityResource
+
+    resource = db.session.get(Resource, resource_id)
+    facility = db.session.get(Facility, facility_id)
+    if not resource or not facility:
+        return htmx_not_found('Resource or facility')
+
+    return handle_htmx_form_post(
+        schema_cls=EditFacilityResourceForm,
+        template='dashboards/admin/fragments/edit_facility_resource_form_htmx.html',
+        success_triggers=_RESOURCES_TRIGGERS,
+        error_prefix='Error saving fair-share override',
+        extra_context={'resource': resource, 'facility': facility,
+                       'override': FacilityResource.get_override(db.session, facility_id, resource_id)},
+        do_action=lambda data: FacilityResource.set_override(
+            db.session,
+            facility_id=facility_id,
+            resource_id=resource_id,
+            fair_share_percentage=data['fair_share_percentage'],
+        ),
+    )
+
+
+@bp.route('/htmx/facility-resource-unset/<int:resource_id>/<int:facility_id>', methods=['DELETE'])
+@login_required
+@require_permission(Permission.DELETE_RESOURCES)
+def htmx_facility_resource_unset(resource_id, facility_id):
+    """Delete a per-resource fair-share override so the facility default re-emerges."""
+    from sam.resources.facilities import FacilityResource
+
+    try:
+        with management_transaction(db.session):
+            FacilityResource.clear_override(
+                db.session, facility_id=facility_id, resource_id=resource_id,
+            )
+    except Exception as e:  # noqa: BLE001 — surface to the user
+        return f'<div class="alert alert-danger">Error: {e}</div>', 500
+
+    return htmx_success_message(_RESOURCES_TRIGGERS, 'Override removed.')
 
 
 # ── Resource Type Edit ─────────────────────────────────────────────────────

--- a/src/webapp/static/js/admin-cards.js
+++ b/src/webapp/static/js/admin-cards.js
@@ -158,6 +158,7 @@
         if (has(root, '#resourcesTabsContent')) {
             document.querySelectorAll('#resourcesTabsContent table').forEach(attachSorting);
             SamCollapseChevron.attach('#resources-pane', '.res-type-collapse-icon');
+            SamCollapseChevron.attach('#resources-pane', '.facility-resource-collapse-icon');
             SamCollapseChevron.attach('#resources-pane', '.disk-root-collapse-icon');
             SamCollapseChevron.attach('#queues-pane',    '.queue-res-collapse-icon');
             SamCollapseChevron.attach('#queues-pane',    '.exemption-res-collapse-icon');

--- a/src/webapp/templates/dashboards/admin/fragments/edit_facility_resource_form_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/edit_facility_resource_form_htmx.html
@@ -1,0 +1,43 @@
+{% from 'dashboards/fragments/modal_form.html' import htmx_form with context %}
+{% from 'dashboards/fragments/form_fields.html' import number_field, readonly_display with context %}
+{#
+  htmx: Edit per-resource Facility Fair-Share Override
+  (loaded into #editFacilityResourceFormContainer)
+
+  Sets/updates the facility_resource row for (facility, resource). Clearing the
+  override is done via the separate "Unset" button on the row, which restores
+  the facility default.
+#}
+
+{% call htmx_form(
+    url_for('admin_dashboard.htmx_facility_resource_edit',
+            resource_id=resource.resource_id, facility_id=facility.facility_id),
+    '#editFacilityResourceFormContainer',
+    'Save Override',
+    is_edit=True
+) %}
+        <div class="row mb-3">
+            <div class="col-md-6">
+                {{ readonly_display('Resource', resource.resource_name, muted=False, strong=True) }}
+            </div>
+            <div class="col-md-6">
+                {{ readonly_display('Facility', facility.facility_name, muted=False, strong=True) }}
+            </div>
+        </div>
+
+        <p class="text-muted small mb-3">
+            Facility default fair share:
+            <strong>{{ facility.fair_share_percentage | fmt_pct(decimals=2) }}</strong>.
+            Setting an override here changes the fair share for
+            <strong>{{ resource.resource_name }}</strong> only. Use
+            <em>Unset</em> on the row to remove the override and fall back to the
+            facility default.
+        </p>
+
+        {{ number_field('fair_share_percentage', 'Override Fair Share %',
+                        required=True,
+                        min=0, max=100, step=0.01,
+                        default=override.fair_share_percentage if override and override.fair_share_percentage is not none else '',
+                        placeholder=facility.fair_share_percentage if facility.fair_share_percentage is not none else 'e.g. 31.00',
+                        id='editFacilityResourceFairShare') }}
+{% endcall %}

--- a/src/webapp/templates/dashboards/admin/fragments/resources_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/resources_card.html
@@ -138,20 +138,20 @@
                                                     <th class="text-end">Actions</th>
                                                 </tr>
                                             </thead>
+                                            {% set ns = namespace(total=0.0) %}
                                             <tbody>
                                                 {% for fac in facilities %}
                                                 {% set _matches = r.facility_resources | selectattr('facility_id', 'equalto', fac.facility_id) | list %}
                                                 {% set override = _matches[0] if _matches else none %}
                                                 {% set has_override = override is not none and override.fair_share_percentage is not none %}
+                                                {% set effective = override.fair_share_percentage if has_override else fac.fair_share_percentage %}
+                                                {% set ns.total = ns.total + (effective or 0) %}
                                                 <tr>
                                                     <td>
                                                         {% if fac.code %}<span class="badge bg-light text-dark border me-1">{{ fac.code }}</span>{% endif %}
                                                         {{ fac.facility_name }}
                                                     </td>
-                                                    <td>
-                                                        {% if has_override %}{{ override.fair_share_percentage | fmt_pct(decimals=2) }}
-                                                        {% else %}{{ fac.fair_share_percentage | fmt_pct(decimals=2) }}{% endif %}
-                                                    </td>
+                                                    <td>{{ effective | fmt_pct(decimals=2) }}</td>
                                                     <td>
                                                         {% if has_override %}
                                                         <span class="badge bg-warning text-dark">override</span>
@@ -181,6 +181,15 @@
                                                 <tr><td colspan="4" class="text-muted fst-italic">No active facilities.</td></tr>
                                                 {% endfor %}
                                             </tbody>
+                                            {% if facilities %}
+                                            <tfoot class="table-light fw-semibold" style="border-top: 2px solid var(--bs-border-color);">
+                                                <tr>
+                                                    <td>Total</td>
+                                                    <td>{{ ns.total | fmt_pct(decimals=2) }}</td>
+                                                    <td colspan="2"></td>
+                                                </tr>
+                                            </tfoot>
+                                            {% endif %}
                                         </table>
                                     </div>
                                 </div>

--- a/src/webapp/templates/dashboards/admin/fragments/resources_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/resources_card.html
@@ -49,6 +49,9 @@
                     {% if resource_types %}
                     {% for rt in resource_types %}
                     {% set type_resources = resources | selectattr('resource_type_id', 'equalto', rt.resource_type_id) | list | sort(attribute='resource_name') %}
+                    {# Per-resource facility fair-share overrides only apply to HPC/DAV
+                       resources (the only types the fstree query consults). #}
+                    {% set is_hpc_dav = rt.resource_type in ['HPC', 'DAV'] %}
                     {# ── Resource Type row (clickable trigger) ── #}
                     <tbody>
                         <tr class="cursor-pointer table-light fw-semibold"
@@ -85,8 +88,15 @@
                     {# ── Resource child rows (collapsed by default) ── #}
                     <tbody class="collapse" id="res-type-{{ rt.resource_type_id }}">
                         {% for r in type_resources %}
-                        <tr class="table-secondary{% if not r.is_active %} opacity-50{% endif %}">
-                            <td class="ps-4 fw-semibold">{{ r.resource_name }}</td>
+                        <tr class="table-secondary{% if not r.is_active %} opacity-50{% endif %}{% if is_hpc_dav %} cursor-pointer{% endif %}"
+                            {% if is_hpc_dav %}data-bs-toggle="collapse"
+                            data-bs-target="#res-fs-{{ r.resource_id }}"
+                            aria-expanded="false"{% endif %}>
+                            <td class="ps-4 fw-semibold">
+                                {% if is_hpc_dav %}<i class="fas fa-chevron-right small text-muted me-1 facility-resource-collapse-icon"
+                                   style="transition: transform 0.2s;"></i>{% endif %}
+                                {{ r.resource_name }}
+                            </td>
                             <td></td>
                             <td class="text-muted small">{{ r.description or '—' }}</td>
                             <td class="text-muted small text-nowrap">
@@ -98,14 +108,85 @@
                                     modal_id='editResourceModal',
                                     target_id='editResourceFormContainer',
                                     title='Edit resource',
+                                    stop_propagation=is_hpc_dav,
                                     permission=Permission.EDIT_RESOURCES) }}
                                 {{ delete_row_button(
                                     url_for('admin_dashboard.htmx_resource_delete', resource_id=r.resource_id),
                                     confirm="Decommission resource '" ~ r.resource_name ~ "'? This sets the decommission date to today.",
                                     title='Decommission resource',
+                                    stop_propagation=is_hpc_dav,
                                     permission=Permission.DELETE_RESOURCES) }}
                             </td>
                         </tr>
+                        {# ── Per-facility fair-share overrides (collapsed by default) ── #}
+                        {% if is_hpc_dav %}
+                        <tr class="table-secondary">
+                            <td colspan="5" class="p-0 border-0">
+                                <div class="collapse" id="res-fs-{{ r.resource_id }}">
+                                    <div class="ps-5 pt-1 pb-2">
+                                        <div class="text-muted small mb-1">
+                                            <i class="fas fa-balance-scale me-1"></i>
+                                            Fair-share by facility for {{ r.resource_name }}
+                                            <span class="fst-italic">(overrides the facility default; unset to restore it)</span>
+                                        </div>
+                                        <table class="table table-sm table-bordered mb-0 bg-white" style="font-size: 0.875em;">
+                                            <thead class="table-light">
+                                                <tr>
+                                                    <th>Facility</th>
+                                                    <th>Fair Share %</th>
+                                                    <th>Source</th>
+                                                    <th class="text-end">Actions</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {% for fac in facilities %}
+                                                {% set _matches = r.facility_resources | selectattr('facility_id', 'equalto', fac.facility_id) | list %}
+                                                {% set override = _matches[0] if _matches else none %}
+                                                {% set has_override = override is not none and override.fair_share_percentage is not none %}
+                                                <tr>
+                                                    <td>
+                                                        {% if fac.code %}<span class="badge bg-light text-dark border me-1">{{ fac.code }}</span>{% endif %}
+                                                        {{ fac.facility_name }}
+                                                    </td>
+                                                    <td>
+                                                        {% if has_override %}{{ override.fair_share_percentage | fmt_pct(decimals=2) }}
+                                                        {% else %}{{ fac.fair_share_percentage | fmt_pct(decimals=2) }}{% endif %}
+                                                    </td>
+                                                    <td>
+                                                        {% if has_override %}
+                                                        <span class="badge bg-warning text-dark">override</span>
+                                                        {% else %}
+                                                        <span class="badge bg-light text-muted border">default</span>
+                                                        {% endif %}
+                                                    </td>
+                                                    <td class="text-end text-nowrap">
+                                                        {{ edit_modal_button(
+                                                            url_for('admin_dashboard.htmx_facility_resource_edit_form',
+                                                                    resource_id=r.resource_id, facility_id=fac.facility_id),
+                                                            modal_id='editFacilityResourceModal',
+                                                            target_id='editFacilityResourceFormContainer',
+                                                            title='Set fair-share override',
+                                                            permission=Permission.EDIT_RESOURCES) }}
+                                                        {% if has_override %}
+                                                        {{ delete_row_button(
+                                                            url_for('admin_dashboard.htmx_facility_resource_unset',
+                                                                    resource_id=r.resource_id, facility_id=fac.facility_id),
+                                                            confirm="Unset the " ~ fac.facility_name ~ " fair-share override for " ~ r.resource_name ~ "? The facility default will apply.",
+                                                            title='Unset override (restore default)',
+                                                            permission=Permission.DELETE_RESOURCES) }}
+                                                        {% endif %}
+                                                    </td>
+                                                </tr>
+                                                {% else %}
+                                                <tr><td colspan="4" class="text-muted fst-italic">No active facilities.</td></tr>
+                                                {% endfor %}
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            </td>
+                        </tr>
+                        {% endif %}
                         {% else %}
                         <tr class="table-secondary">
                             <td colspan="5" class="ps-4 text-muted fst-italic">No resources of this type.</td>

--- a/src/webapp/templates/dashboards/admin/fragments/resources_modals.html
+++ b/src/webapp/templates/dashboards/admin/fragments/resources_modals.html
@@ -39,3 +39,6 @@
 
 {{ modal_scaffold('editDiskRootModal', 'Edit Disk Root Directory',
                   icon='folder-tree', container_id='editDiskRootFormContainer', variant='edit') }}
+
+{{ modal_scaffold('editFacilityResourceModal', 'Edit Fair-Share Override',
+                  icon='balance-scale', container_id='editFacilityResourceFormContainer', variant='edit') }}

--- a/tests/unit/test_facility_resource.py
+++ b/tests/unit/test_facility_resource.py
@@ -1,0 +1,154 @@
+"""Tests for FacilityResource write methods — the per-(facility, resource)
+fair-share override backing the Admin > Resources override UI.
+
+The override row is what the fstree query prefers over the facility default
+via ``COALESCE(fr.fair_share_percentage, f.fair_share_percentage)``. These
+tests cover the model-level create/update/delete/upsert/clear helpers; the
+end-to-end "unset restores the facility default" behavior through the query
+lives in test_fstree_queries.py::TestFacilityResourceOverride.
+"""
+import pytest
+
+from sam.resources.facilities import FacilityResource
+
+from factories import make_facility, make_resource
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestFacilityResourceCreate:
+
+    def test_create_sets_fields(self, session):
+        fac = make_facility(session, fair_share_percentage=31.0)
+        res = make_resource(session)
+        fr = FacilityResource.create(
+            session,
+            facility_id=fac.facility_id,
+            resource_id=res.resource_id,
+            fair_share_percentage=12.5,
+        )
+        assert fr.facility_resource_id is not None
+        assert fr.facility_id == fac.facility_id
+        assert fr.resource_id == res.resource_id
+        assert fr.fair_share_percentage == 12.5
+        session.rollback()
+
+    def test_create_rejects_out_of_range(self, session):
+        fac = make_facility(session)
+        res = make_resource(session)
+        with pytest.raises(ValueError, match="between 0 and 100"):
+            FacilityResource.create(
+                session,
+                facility_id=fac.facility_id,
+                resource_id=res.resource_id,
+                fair_share_percentage=150.0,
+            )
+        session.rollback()
+
+
+class TestFacilityResourceUpdate:
+
+    def test_update_changes_value(self, session):
+        fac = make_facility(session)
+        res = make_resource(session)
+        fr = FacilityResource.create(
+            session, facility_id=fac.facility_id, resource_id=res.resource_id,
+            fair_share_percentage=10.0,
+        )
+        fr.update(fair_share_percentage=42.0)
+        assert fr.fair_share_percentage == 42.0
+        session.rollback()
+
+    def test_update_rejects_out_of_range(self, session):
+        fac = make_facility(session)
+        res = make_resource(session)
+        fr = FacilityResource.create(
+            session, facility_id=fac.facility_id, resource_id=res.resource_id,
+            fair_share_percentage=10.0,
+        )
+        with pytest.raises(ValueError, match="between 0 and 100"):
+            fr.update(fair_share_percentage=-1.0)
+        session.rollback()
+
+
+class TestGetOverride:
+
+    def test_returns_none_when_absent(self, session):
+        fac = make_facility(session)
+        res = make_resource(session)
+        assert FacilityResource.get_override(session, fac.facility_id, res.resource_id) is None
+        session.rollback()
+
+    def test_returns_row_when_present(self, session):
+        fac = make_facility(session)
+        res = make_resource(session)
+        fr = FacilityResource.create(
+            session, facility_id=fac.facility_id, resource_id=res.resource_id,
+            fair_share_percentage=5.0,
+        )
+        found = FacilityResource.get_override(session, fac.facility_id, res.resource_id)
+        assert found is fr
+        session.rollback()
+
+
+class TestSetOverride:
+
+    def test_creates_when_absent(self, session):
+        fac = make_facility(session)
+        res = make_resource(session)
+        fr = FacilityResource.set_override(
+            session, facility_id=fac.facility_id, resource_id=res.resource_id,
+            fair_share_percentage=7.5,
+        )
+        assert fr.fair_share_percentage == 7.5
+        assert FacilityResource.get_override(session, fac.facility_id, res.resource_id) is fr
+        session.rollback()
+
+    def test_updates_when_present(self, session):
+        fac = make_facility(session)
+        res = make_resource(session)
+        first = FacilityResource.set_override(
+            session, facility_id=fac.facility_id, resource_id=res.resource_id,
+            fair_share_percentage=7.5,
+        )
+        second = FacilityResource.set_override(
+            session, facility_id=fac.facility_id, resource_id=res.resource_id,
+            fair_share_percentage=9.0,
+        )
+        # Upsert: same row, updated value — no duplicate created.
+        assert second.facility_resource_id == first.facility_resource_id
+        assert second.fair_share_percentage == 9.0
+        rows = (
+            session.query(FacilityResource)
+            .filter_by(facility_id=fac.facility_id, resource_id=res.resource_id)
+            .count()
+        )
+        assert rows == 1
+        session.rollback()
+
+
+class TestClearOverride:
+
+    def test_deletes_existing(self, session):
+        fac = make_facility(session)
+        res = make_resource(session)
+        FacilityResource.create(
+            session, facility_id=fac.facility_id, resource_id=res.resource_id,
+            fair_share_percentage=3.0,
+        )
+        removed = FacilityResource.clear_override(
+            session, facility_id=fac.facility_id, resource_id=res.resource_id,
+        )
+        assert removed is True
+        assert FacilityResource.get_override(session, fac.facility_id, res.resource_id) is None
+        session.rollback()
+
+    def test_noop_when_absent(self, session):
+        fac = make_facility(session)
+        res = make_resource(session)
+        removed = FacilityResource.clear_override(
+            session, facility_id=fac.facility_id, resource_id=res.resource_id,
+        )
+        assert removed is False
+        session.rollback()

--- a/tests/unit/test_fstree_queries.py
+++ b/tests/unit/test_fstree_queries.py
@@ -556,3 +556,60 @@ class TestGetUserFsdata:
 
     def test_at_least_one_user_present(self, user_fs_all):
         assert len(user_fs_all['users']) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Per-resource facility fair-share override (facility_resource) fallback
+# ---------------------------------------------------------------------------
+
+
+class TestFacilityResourceOverride:
+    """End-to-end: an override changes a facility node's fairSharePercentage for
+    one resource; clearing it restores the facility default (COALESCE fallback).
+
+    Uses the function-scoped `session` fixture (not the module-scoped throwaway
+    caches) so writes are visible to the query and rolled back afterward.
+    """
+
+    def _facility_fsp(self, session, resource_name, facility_name):
+        tree = get_fstree_data(session, resource_name=resource_name)
+        for fac in tree['facilities']:
+            if fac['name'] == facility_name:
+                return fac['fairSharePercentage']
+        return None
+
+    def test_override_wins_then_unset_restores_default(self, session, hpc_resource):
+        from sam.resources.facilities import Facility, FacilityResource
+
+        resource_name = hpc_resource.resource_name
+
+        # Pick a facility that actually appears in this resource's tree.
+        tree = get_fstree_data(session, resource_name=resource_name)
+        assert tree['facilities'], f'no facilities in fstree for {resource_name}'
+        facility_name = tree['facilities'][0]['name']
+        facility = session.query(Facility).filter_by(facility_name=facility_name).one()
+
+        default = facility.fair_share_percentage
+        sentinel = 3.5 if default != 3.5 else 6.5
+
+        # Set an override → the facility node reports the override value.
+        FacilityResource.set_override(
+            session,
+            facility_id=facility.facility_id,
+            resource_id=hpc_resource.resource_id,
+            fair_share_percentage=sentinel,
+        )
+        assert self._facility_fsp(session, resource_name, facility_name) == sentinel
+
+        # Unset the override → the facility default re-emerges via COALESCE.
+        removed = FacilityResource.clear_override(
+            session,
+            facility_id=facility.facility_id,
+            resource_id=hpc_resource.resource_id,
+        )
+        assert removed is True
+        restored = self._facility_fsp(session, resource_name, facility_name)
+        expected = float(default) if default is not None else 0.0
+        assert restored == expected
+
+        session.rollback()

--- a/tests/unit/test_htmx_facility_resource_override.py
+++ b/tests/unit/test_htmx_facility_resource_override.py
@@ -1,0 +1,144 @@
+"""HTTP-layer tests for the per-resource facility fair-share override routes
+under Admin > Resources.
+
+Scope (mirrors test_htmx_exemption_admin.py): auth, permission, validation,
+404, and render smoke. Happy-path DB writes are covered at the model layer in
+test_facility_resource.py and end-to-end in
+test_fstree_queries.py::TestFacilityResourceOverride.
+
+Endpoints tested:
+    GET    /admin/htmx/facility-resource-edit-form/<res>/<fac>
+    POST   /admin/htmx/facility-resource-edit/<res>/<fac>
+    DELETE /admin/htmx/facility-resource-unset/<res>/<fac>
+"""
+import os
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+_BOGUS = 99999999
+
+
+def _edit_form_url(res, fac):
+    return f'/admin/htmx/facility-resource-edit-form/{res}/{fac}'
+
+
+def _edit_url(res, fac):
+    return f'/admin/htmx/facility-resource-edit/{res}/{fac}'
+
+
+def _unset_url(res, fac):
+    return f'/admin/htmx/facility-resource-unset/{res}/{fac}'
+
+
+# ---------------------------------------------------------------------------
+# Resources card renders the override table (chevron + modal wiring)
+# ---------------------------------------------------------------------------
+
+
+class TestResourcesCardOverrideSection:
+
+    def test_admin_renders_override_wiring(self, auth_client):
+        resp = auth_client.get('/admin/htmx/resources')
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert 'facility-resource-collapse-icon' in html
+        assert 'editFacilityResourceModal' in html
+
+
+# ---------------------------------------------------------------------------
+# GET edit-form
+# ---------------------------------------------------------------------------
+
+
+class TestEditFormRoute:
+
+    def test_unauthenticated_redirects_or_401(self, client):
+        if os.getenv('DISABLE_AUTH') == '1':
+            pytest.skip("Auth disabled in dev environment")
+        resp = client.get(_edit_form_url(_BOGUS, _BOGUS))
+        assert resp.status_code in (302, 401)
+
+    def test_non_admin_denied(self, non_admin_client):
+        resp = non_admin_client.get(_edit_form_url(_BOGUS, _BOGUS))
+        assert resp.status_code == 403
+
+    def test_missing_pair_renders_not_found(self, auth_client):
+        resp = auth_client.get(_edit_form_url(_BOGUS, _BOGUS))
+        assert b'not found' in resp.data.lower()
+
+    def test_valid_pair_renders_form(self, auth_client, hpc_resource, any_facility):
+        resp = auth_client.get(
+            _edit_form_url(hpc_resource.resource_id, any_facility.facility_id)
+        )
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert 'Override Fair Share' in html
+        assert any_facility.facility_name in html
+
+
+# ---------------------------------------------------------------------------
+# POST edit (set / upsert)
+# ---------------------------------------------------------------------------
+
+
+class TestEditRoute:
+
+    def test_unauthenticated_redirects_or_401(self, client):
+        if os.getenv('DISABLE_AUTH') == '1':
+            pytest.skip("Auth disabled in dev environment")
+        resp = client.post(_edit_url(_BOGUS, _BOGUS), data={'fair_share_percentage': '10'})
+        assert resp.status_code in (302, 401)
+
+    def test_non_admin_denied(self, non_admin_client):
+        resp = non_admin_client.post(_edit_url(_BOGUS, _BOGUS), data={'fair_share_percentage': '10'})
+        assert resp.status_code == 403
+
+    def test_missing_pair_returns_404(self, auth_client):
+        resp = auth_client.post(_edit_url(_BOGUS, _BOGUS), data={'fair_share_percentage': '10'})
+        assert resp.status_code == 404
+
+    def test_missing_value_re_renders_with_error(self, auth_client, hpc_resource, any_facility):
+        resp = auth_client.post(
+            _edit_url(hpc_resource.resource_id, any_facility.facility_id), data={}
+        )
+        assert resp.status_code == 200
+        assert b'Override Fair Share' in resp.data  # form re-rendered
+
+    def test_out_of_range_re_renders_with_error(self, auth_client, hpc_resource, any_facility):
+        resp = auth_client.post(
+            _edit_url(hpc_resource.resource_id, any_facility.facility_id),
+            data={'fair_share_percentage': '150'},
+        )
+        assert resp.status_code == 200
+        assert b'Override Fair Share' in resp.data
+
+
+# ---------------------------------------------------------------------------
+# DELETE unset
+# ---------------------------------------------------------------------------
+
+
+class TestUnsetRoute:
+
+    def test_unauthenticated_redirects_or_401(self, client):
+        if os.getenv('DISABLE_AUTH') == '1':
+            pytest.skip("Auth disabled in dev environment")
+        resp = client.delete(_unset_url(_BOGUS, _BOGUS))
+        assert resp.status_code in (302, 401)
+
+    def test_non_admin_denied(self, non_admin_client):
+        resp = non_admin_client.delete(_unset_url(_BOGUS, _BOGUS))
+        assert resp.status_code == 403
+
+    def test_unset_absent_pair_is_ok(self, auth_client, hpc_resource, any_facility):
+        # No override exists for this (resource, facility) in the snapshot's
+        # default state → clear_override is a no-op but the route still
+        # succeeds and fires reloadResourcesCard.
+        resp = auth_client.delete(
+            _unset_url(hpc_resource.resource_id, any_facility.facility_id)
+        )
+        assert resp.status_code == 200

--- a/tests/unit/test_htmx_facility_resource_override.py
+++ b/tests/unit/test_htmx_facility_resource_override.py
@@ -48,6 +48,14 @@ class TestResourcesCardOverrideSection:
         assert 'facility-resource-collapse-icon' in html
         assert 'editFacilityResourceModal' in html
 
+    def test_admin_renders_totals_footer(self, auth_client):
+        """Each HPC/DAV override table has a Total footer row summing the shares."""
+        resp = auth_client.get('/admin/htmx/resources')
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert '<tfoot' in html
+        assert 'Total' in html
+
 
 # ---------------------------------------------------------------------------
 # GET edit-form


### PR DESCRIPTION
## Context

`GET /api/v1/fstree_access/Derecho` returns a fair-share of **1.0** for every
top-level facility (CSL, NCAR, UNIV, WNA…) instead of the facility defaults the
"Facilities & Allocation Types" card shows (CSL = 31%).

**Root cause:** the fstree query uses
`COALESCE(fr.fair_share_percentage, f.fair_share_percentage)` — preferring the
per-`(facility, resource)` `facility_resource` override over the facility
default. Derecho / Derecho GPU have stale placeholder override rows of `1.0`
(0.95 for ASD) that mask the real values. Casper's rows are `NULL`, so it
already falls back to the correct defaults — that asymmetry is the smoking gun.

The `facility_resource` table had **no in-app UI** (only the prod-disabled
Flask-Admin "Everything" view), so the stale data couldn't be seen or fixed.

## What this does

Makes the per-resource overrides a first-class, maintainable feature under
**Admin > Resources**. Each HPC/DAV resource row is now expandable to a
per-facility fair-share table:

- **Set/Edit** → upserts a `facility_resource` row for that (facility, resource).
- **Unset** → deletes the row so the facility default re-emerges (via the
  existing COALESCE fallback — no query change).

Each row shows the effective value and whether it is an `override` or inherited
`default`. The expander is limited to HPC/DAV — the only types the fstree query
consults `facility_resource` for.

## Implementation

- **Model** (`FacilityResource`): `SessionMixin` + `create` / `update` /
  `get_override` / `set_override` (upsert) / `clear_override` (delete).
- **Schema**: `EditFacilityResourceForm` (required `fair_share_percentage`, 0–100).
- **Routes** (`resources_routes.py`): three HTMX routes mirroring the facility
  CRUD pattern, reusing `handle_htmx_form_post` and firing `reloadResourcesCard`.
- **Template**: HPC/DAV resource rows become Bootstrap-collapse triggers over a
  nested facility-override table (mirrors the facility card's nested table);
  new form fragment, `editFacilityResourceModal`, and chevron wiring.

## Testing

- `test_facility_resource.py` — model create/update/get/set (upsert)/clear.
- `test_htmx_facility_resource_override.py` — auth / permission / 404 /
  validation / render smoke for the three routes.
- `test_fstree_queries.py::TestFacilityResourceOverride` — end-to-end: an
  override changes a facility node's `fairSharePercentage`; unsetting restores
  the facility default through the real query.
- **Playwright smoke test** (local, dev DB): expanded HPC > Derecho, confirmed
  the bug data (CSL/NCAR/UNIV/WNA = 1.00% override, Casper = defaults),
  **Unset** CSL → `31.00% default`, then **Set** back to `1.00%` — both round-trip
  through the real request/response cycle with card auto-reload.

## Follow-up (data cleanup, post-deploy)

This ships the UI, not the data fix. Once deployed, an admin **Unsets** the
Derecho + Derecho GPU overrides for CSL/NCAR/UNIV/WNA/CISL/ASD in the app.
The endpoint is double-cached (`@cache.memoize` + `@cache.cached`) — bust via
`POST /api/v1/fstree_access/refresh` or flush Redis when verifying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)