### PR TITLE
Add global cache-refresh API, Admin UX, and CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -780,6 +780,13 @@ sam-admin project SCSG0001 --validate
 # Project reconciliation
 sam-admin project SCSG0001 --reconcile
 
+# Cache refresh — HTTP client for POST /api/v1/admin/cache/refresh.
+# Caches live in the running webapp (+ shared Redis), NOT the DB, so this hits
+# the live endpoint. Needs SAM_API_USER / SAM_API_PASS (and SAM_API_BASE or
+# --base). Same Basic-auth creds as the systems-integration client.
+sam-admin cache --refresh                        # clear all cache categories
+sam-admin cache --refresh --category chart       # clear one (flask|chart|usage|scans)
+
 # Admin commands include all search functionality
 sam-admin user benkirk --list-projects  # Works like sam-search
 sam-admin project SCSG0001 --list-users  # Works like sam-search
@@ -999,6 +1006,8 @@ sam-search accounting --jobs --last 365d --job-id 6049117[28].desched1  # Exact 
 sam-admin user benkirk --validate                 # Validate user data
 sam-admin project SCSG0001 --validate             # Validate project
 sam-admin project SCSG0001 --reconcile            # Reconcile allocations
+sam-admin cache --refresh                         # Clear webapp caches (needs SAM_API_USER/PASS)
+sam-admin cache --refresh --category chart        # Clear one category (flask|chart|usage|scans)
 
 # CLI - JSON output (machine-readable)
 sam-search --format json user benkirk | jq        # User envelope (kind=user)

--- a/docs/apis/SYSTEMS_INTEGRATION_APIs.md
+++ b/docs/apis/SYSTEMS_INTEGRATION_APIs.md
@@ -745,6 +745,64 @@ roster of user overrides.
 
 ---
 
+## 6. Admin Cache Refresh API
+
+**Base URL**: `/api/v1/admin/`  
+**Permission required**: `SYSTEM_ADMIN` (session path; the Basic-auth token path
+authenticates by API key and bypasses the permission gate, like the other
+`/refresh` routes)  
+**Source**: `src/webapp/api/v1/admin.py`
+
+A single global cache-invalidation entry point on top of the unified caching
+facade (`webapp.caching.caching`). Unlike the per-resource `.../refresh` routes
+(which clear only the Flask HTTP-response cache), this can clear **any or all**
+of the four cache categories the webapp owns.
+
+### Endpoints
+
+#### `POST /api/v1/admin/cache/refresh`
+
+Clears caches and returns the number of entries cleared per category.
+
+**Query params**:
+
+| Param      | Values                          | Effect                        |
+|------------|---------------------------------|-------------------------------|
+| `category` | `flask` \| `chart` \| `usage` \| `scans` | Clear only that category |
+| *(omitted)*| —                               | Clear **all** categories      |
+
+**Response**:
+
+```json
+{"status": "ok", "cleared": {"flask": 12, "chart": 3, "usage": 0, "scans": 1}}
+```
+
+With `?category=chart`, only the `chart` key is present. An unrecognized
+`category` returns **400**.
+
+**Examples**:
+
+```bash
+# Clear everything
+curl -X POST -u "$SAM_API_USER:$SAM_API_PASS" \
+     "$SAM_API_BASE/api/v1/admin/cache/refresh"
+
+# Clear just the chart SVG caches
+curl -X POST -u "$SAM_API_USER:$SAM_API_PASS" \
+     "$SAM_API_BASE/api/v1/admin/cache/refresh?category=chart"
+```
+
+The `sam-admin cache --refresh [--category X]` CLI wraps this endpoint using the
+same `SAM_API_USER` / `SAM_API_PASS` / `SAM_API_BASE` env vars. Admins can also
+clear caches from **Admin > Configuration > Caching** via the "Clear…" dropdown
+(gated on `SYSTEM_ADMIN`).
+
+**Worker affinity**: with the in-process cache fallback (no Redis) and multiple
+gunicorn workers, a single call only clears the worker that served it. With
+Redis configured (production) the shared stores clear globally.
+
+---
+
 ## Common Design Notes
 
 ### Shared Infrastructure

--- a/docs/plans/GLOBAL_CACHE_REFRESH_API.md
+++ b/docs/plans/GLOBAL_CACHE_REFRESH_API.md
@@ -1,5 +1,16 @@
 # Global cache refresh API
 
+> **Status: implemented** on branch `cache_mgmt` (PR → `staging`). This doc
+> is the original design; the shipped work refined it in three ways:
+> 1. **Five** bypass routes were consolidated, not three — PR #346 added
+>    `queue.py` and `wallclock_exemption.py` after this doc was written.
+> 2. Added an **Admin UX**: a `SYSTEM_ADMIN`-gated "Clear…" dropdown on the
+>    Configuration tab's Caching card (`POST /admin/htmx/cache/clear`,
+>    re-rendering the extracted `caching_card_body.html` fragment).
+> 3. The CLI reuses the existing `SAM_API_USER` / `SAM_API_PASS` /
+>    `SAM_API_BASE` env vars (from the systems-integration client), not a new
+>    `SAM_WEBAPP_URL`. It stays a pure HTTP client (no webapp import).
+
 ## Context
 
 SAM has several per-resource `/refresh` endpoints (`project_access`, `fstree_access`,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,7 +11,8 @@ scripts/
 ├── cirrus_weblog_audit.sh       # CIRRUS/k8s traffic + rate-limit + abuse audit
 ├── zap_probe_docker.sh          # Dockerized OWASP ZAP scan of the webapp
 ├── apis/                        # Public-API worked examples / smoke tests
-│   └── systems_integration_apis.sh  # Download→refresh→re-download over the 5 SI APIs
+│   ├── systems_integration_apis.sh  # Download→refresh→re-download over the 5 SI APIs
+│   └── clear_caches.sh              # Clear webapp caches via the Admin Cache Refresh API
 ├── lib/                         # Sourceable shell helpers (see below)
 │   ├── common.sh               # Generic: colors, log/verdict helpers, usage
 │   ├── cirrus_common.sh        # CIRRUS layer: release names, KCTL, arg parse
@@ -89,6 +90,23 @@ idioms as the cluster tools (colored PASS/WARN/FAIL, exit `0`/`1`/`2`,
   scripts/apis/systems_integration_apis.sh            # all five, against prod
   scripts/apis/systems_integration_apis.sh -v queue   # one API, verbose
   scripts/apis/systems_integration_apis.sh -o ./out   # keep the downloaded JSON
+  ```
+
+- **`apis/clear_caches.sh`** — worked example + smoke test for the Admin Cache
+  Refresh API (`POST /api/v1/admin/cache/refresh`). Clears any or all of the
+  four cache categories (`flask`, `chart`, `usage`, `scans`), asserting the
+  `{"status":"ok","cleared":{…}}` shape and that scoping via `?category=` works,
+  plus a negative test that an unknown category is rejected with HTTP 400. Same
+  API-key Basic-auth env vars. Unlike the SI script this is **not read-only** —
+  its purpose is the side effect of invalidating live caches. Documented in
+  [../docs/apis/SYSTEMS_INTEGRATION_APIs.md](../docs/apis/SYSTEMS_INTEGRATION_APIs.md)
+  (§6 Admin Cache Refresh API).
+
+  ```bash
+  export SAM_API_USER='my-api-user' SAM_API_PASS='...'
+  scripts/apis/clear_caches.sh                        # clear all + each category
+  scripts/apis/clear_caches.sh -v chart               # just the chart caches, verbose
+  scripts/apis/clear_caches.sh --base http://localhost:5050   # against local webdev
   ```
 
 ### Shared Library (`lib/`)

--- a/scripts/apis/clear_caches.sh
+++ b/scripts/apis/clear_caches.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+# clear_caches.sh — worked example + smoke test for the SAM Admin Cache
+# Refresh API (POST /api/v1/admin/cache/refresh).
+#
+# SAM's webapp fronts four cache categories behind one facade — the Flask
+# HTTP-response cache (flask), the matplotlib chart SVG caches (chart), the
+# allocation-usage cache (usage), and the filesystem-scan cache (scans). This
+# single endpoint invalidates any one of them, or all at once. Read it
+# top-to-bottom to see exactly how an operator / cron / deploy hook is expected
+# to call it, authenticating with an API key over HTTP Basic Auth.
+#
+# Unlike scripts/apis/systems_integration_apis.sh (read-only apart from the
+# idempotent per-resource /refresh), this script's WHOLE PURPOSE is the side
+# effect: it clears live caches. On a shared/production deployment that briefly
+# raises cache-miss latency until the caches warm again. It is safe (caches are
+# derived state) but not read-only — run it deliberately.
+#
+# Credentials come from the environment (keep them out of shell history):
+#   SAM_API_USER   API-key username (required)
+#   SAM_API_PASS   API-key password (required)
+#   SAM_API_BASE   Base URL (optional; default https://samuel.k8s.ucar.edu)
+#
+# Generate a key with `python scripts/gen_api_key.py` and add its bcrypt hash to
+# the deployment's API_KEYS config. (Note: the Basic-auth token path clears the
+# cache regardless of the key's role; the SYSTEM_ADMIN permission gate applies
+# only to the browser/session path — the Admin > Configuration "Clear…" button.)
+#
+# Usage:
+#   SAM_API_USER=... SAM_API_PASS=... scripts/apis/clear_caches.sh [options] [category ...]
+#
+# Arguments:
+#   category ...          One or more categories to clear (default: all of them,
+#                         each demonstrated as a separate scoped call).
+#                         Choices: all flask chart usage scans
+#                         'all' issues the unscoped call that clears everything.
+#
+# Options:
+#       --base URL        Override SAM_API_BASE
+#       --no-negative     Skip the invalid-category (HTTP 400) negative test
+#       --no-color        Disable ANSI color
+#   -v, --verbose         Echo the (password-redacted) curl commands + bodies
+#   -h, --help            Show this help
+#
+# Exit codes: 0 all pass · 1 ≥1 warn · 2 ≥1 fail (or a precondition error)
+
+set -euo pipefail
+
+# Shared presentation/control-flow helpers (colors, section/pass/warn/fail,
+# require_cmd, usage_from_header, verdict_exit). Lives one level up in ../lib.
+_LIBDIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../lib" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${_LIBDIR}/common.sh"
+
+# Precondition failures exit 2 to match this script's documented ladder
+# (0 pass / 1 warn / 2 fail); the lib's die() exits 1, which would read as "warn".
+die2() { echo -e "${RED}ERROR:${NC} $*" >&2; exit 2; }
+
+# The four categories the facade understands, in the order stats() reports them.
+CATEGORIES=(flask chart usage scans)
+# The demonstration targets: 'all' (unscoped) plus each category (scoped).
+ALL_TARGETS=(all "${CATEGORIES[@]}")
+
+# --- defaults + arg parsing -------------------------------------------------
+SAM_API_BASE="${SAM_API_BASE:-https://samuel.k8s.ucar.edu}"
+RUN_NEGATIVE=1
+SELECTED=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --base)         SAM_API_BASE="$2"; shift 2 ;;
+        --no-negative)  RUN_NEGATIVE=0; shift ;;
+        --no-color)     USE_COLOR=0; shift ;;
+        -v|--verbose)   VERBOSE=1; shift ;;
+        -h|--help)      usage_from_header "$0"; exit 0 ;;
+        -*)             echo "Unknown option: $1" >&2; exit 2 ;;
+        *)              SELECTED+=("$1"); shift ;;
+    esac
+done
+
+setup_colors
+
+# Validate/normalize the requested target list (default: all).
+if [[ ${#SELECTED[@]} -eq 0 ]]; then
+    SELECTED=("${ALL_TARGETS[@]}")
+else
+    for want in "${SELECTED[@]}"; do
+        ok=0
+        for known in "${ALL_TARGETS[@]}"; do [[ "$want" == "$known" ]] && ok=1 && break; done
+        [[ $ok -eq 1 ]] || die2 "unknown category '$want' (choices: ${ALL_TARGETS[*]})"
+    done
+fi
+
+SAM_API_BASE="${SAM_API_BASE%/}"   # trim trailing slash for clean concatenation
+REFRESH_URL="${SAM_API_BASE}/api/v1/admin/cache/refresh"
+
+# ============================================================================
+section "0. Prerequisites"
+# ============================================================================
+
+require_cmd curl
+require_cmd jq
+
+[[ -n "${SAM_API_USER:-}" ]] || die2 "SAM_API_USER is not set (export your API-key username)"
+[[ -n "${SAM_API_PASS:-}" ]] || die2 "SAM_API_PASS is not set (export your API-key password)"
+
+info "base URL : $SAM_API_BASE"
+info "endpoint : POST /api/v1/admin/cache/refresh"
+info "auth     : Basic (-u \"\$SAM_API_USER:***\") as '${SAM_API_USER}'"
+info "targets  : ${SELECTED[*]}"
+pass "prerequisites OK — curl + jq present, credentials set"
+explain "Each call authenticates with HTTP Basic Auth; curl's -u sends the
+  Authorization: Basic header. The password is read from \$SAM_API_PASS and never
+  printed. An unscoped POST clears everything; ?category=X scopes the clear."
+
+# --------------------------------------------------------------------------
+# http_post URL   → prints "<body> <code>" (JSON body, then space, then the
+# HTTP status). Credentials go via curl -u; the password never appears in argv
+# echoes. Trailing `|| true` keeps a hard curl failure (timeout, DNS) from
+# aborting under `set -e` — it yields a "000" status the caller treats as FAIL.
+# --------------------------------------------------------------------------
+http_post() {
+    local url="$1"
+    local errsink=/dev/null; [[ $VERBOSE -eq 1 ]] && errsink=/dev/stderr
+    [[ $VERBOSE -eq 1 ]] && note "curl -sS -X POST -u \"\$SAM_API_USER:***\" \"$url\"" >&2
+    curl -sS -m 60 -X POST -u "${SAM_API_USER}:${SAM_API_PASS}" \
+         -H 'Accept: application/json' \
+         -w ' %{http_code}' "$url" 2>"$errsink" || true
+}
+
+# --------------------------------------------------------------------------
+# clear_one TARGET — issue one clear ('all' → unscoped; else ?category=TARGET),
+# validate {"status":"ok"} + that .cleared holds exactly the expected keys, and
+# print a per-category count summary. Never aborts the whole run.
+# --------------------------------------------------------------------------
+clear_one() {
+    local target="$1" url expected
+    if [[ "$target" == "all" ]]; then
+        url="$REFRESH_URL"
+        expected="$(printf '%s\n' "${CATEGORIES[@]}" | sort | paste -sd, -)"
+    else
+        url="${REFRESH_URL}?category=${target}"
+        expected="$target"
+    fi
+
+    section "clear: ${target}"
+    explain "POST /api/v1/admin/cache/refresh$([[ "$target" != all ]] && echo "?category=${target}")"
+
+    local resp code body
+    resp="$(http_post "$url")"
+    code="${resp##* }"     # trailing " <code>"
+    body="${resp% *}"
+
+    if [[ "$code" != "200" ]]; then
+        fail "${target}: refresh POST returned HTTP ${code}"
+        [[ $VERBOSE -eq 1 && -n "$body" ]] && run bash -c "echo '$body' | head -c 300"
+        return
+    fi
+    if [[ "$(echo "$body" | jq -r '.status // empty' 2>/dev/null)" != "ok" ]]; then
+        fail "${target}: did not return {\"status\":\"ok\"} (got: ${body})"
+        return
+    fi
+
+    local got
+    got="$(echo "$body" | jq -r '.cleared | keys | sort | join(",")' 2>/dev/null || echo '')"
+    if [[ "$got" != "$expected" ]]; then
+        fail "${target}: cleared categories {${got}} != expected {${expected}}"
+        return
+    fi
+
+    # One-line per-category count summary, e.g. "flask=12 chart=3 usage=0 scans=1".
+    local counts
+    counts="$(echo "$body" | jq -r '.cleared | to_entries | map("\(.key)=\(.value)") | join(" ")')"
+    pass "cleared OK — HTTP 200, {${counts}}"
+}
+
+for target in "${SELECTED[@]}"; do
+    clear_one "$target"
+done
+
+# --------------------------------------------------------------------------
+# Negative test: an unrecognized category must be rejected with HTTP 400
+# rather than silently clearing everything. Demonstrates the endpoint's input
+# validation. Skip with --no-negative.
+# --------------------------------------------------------------------------
+if [[ $RUN_NEGATIVE -eq 1 ]]; then
+    section "invalid category (negative test)"
+    explain "POST /api/v1/admin/cache/refresh?category=bogus  →  expect HTTP 400"
+    resp="$(http_post "${REFRESH_URL}?category=bogus")"
+    code="${resp##* }"
+    if [[ "$code" == "400" ]]; then
+        pass "rejected as expected — HTTP 400 on unknown category"
+    else
+        fail "unknown category returned HTTP ${code} (expected 400)"
+    fi
+fi
+
+# ============================================================================
+section "Summary"
+# ============================================================================
+verdict_exit

--- a/src/cli/cmds/admin.py
+++ b/src/cli/cmds/admin.py
@@ -5,6 +5,7 @@ SAM Admin CLI - Administrative commands.
 Administrative commands for SAM database management and validation.
 """
 
+import os
 import sys
 import click
 from datetime import date as _date, datetime
@@ -12,10 +13,15 @@ from sqlalchemy.orm import Session
 
 from config import SAMConfig
 from cli.core.context import Context
+from cli.core.utils import EXIT_SUCCESS, EXIT_ERROR
 from cli.user.commands import UserAdminCommand
 from cli.project.commands import ProjectAdminCommand, ProjectExpirationCommand
 from cli.accounting.commands import AccountingAdminCommand
 from cli.accounting.dates import _validate_accounting_dates, _resolve_accounting_dates
+
+# Default base URL for the running webapp (matches the systems-integration
+# shell client, scripts/apis/systems_integration_apis.sh).
+_DEFAULT_API_BASE = 'https://samuel.k8s.ucar.edu'
 
 
 pass_context = click.make_pass_decorator(Context, ensure=True)
@@ -475,6 +481,86 @@ def accounting(ctx: Context, comp, disk, archive, reconcile_quotas, resource,
         epoch=epoch_date,
     )
     sys.exit(exit_code)
+
+
+@cli.command()
+@click.option('--refresh', is_flag=True,
+              help='Invalidate the running webapp\'s caches')
+@click.option('--category', type=click.Choice(['flask', 'chart', 'usage', 'scans']),
+              default=None,
+              help='Scope the refresh to one cache category (default: all)')
+@click.option('--base', 'base_url', type=str, default=None,
+              help=f'Webapp base URL (default: $SAM_API_BASE or {_DEFAULT_API_BASE})')
+@pass_context
+def cache(ctx: Context, refresh: bool, category, base_url):
+    """Manage the running webapp's caches.
+
+    \b
+    Thin HTTP client for POST /api/v1/admin/cache/refresh — the caches live
+    inside the webapp worker process (and shared Redis), not the DB, so this
+    hits the live endpoint rather than clearing anything locally.
+
+    Credentials (HTTP Basic Auth, same as the systems-integration client):
+      SAM_API_USER   API-key username (required)
+      SAM_API_PASS   API-key password (required)
+      SAM_API_BASE   Base URL (optional; --base overrides)
+
+    \b
+    Examples:
+      sam-admin cache --refresh
+      sam-admin cache --refresh --category chart
+    """
+    if not refresh:
+        ctx.console.print(
+            "Error: specify an action (currently only --refresh)",
+            style="bold red",
+        )
+        sys.exit(EXIT_ERROR)
+
+    base = (base_url or os.getenv('SAM_API_BASE') or _DEFAULT_API_BASE).rstrip('/')
+    user = os.getenv('SAM_API_USER')
+    password = os.getenv('SAM_API_PASS')
+    if not user or not password:
+        ctx.console.print(
+            "Error: SAM_API_USER and SAM_API_PASS must be set (API-key credentials).",
+            style="bold red",
+        )
+        sys.exit(EXIT_ERROR)
+
+    import requests
+
+    url = f"{base}/api/v1/admin/cache/refresh"
+    params = {'category': category} if category else {}
+    try:
+        resp = requests.post(url, auth=(user, password), params=params, timeout=60)
+    except requests.RequestException as e:
+        ctx.console.print(f"Error: could not reach {url}: {e}", style="bold red")
+        sys.exit(EXIT_ERROR)
+
+    if resp.status_code != 200:
+        body = resp.text.strip()
+        ctx.console.print(
+            f"Error: cache refresh failed (HTTP {resp.status_code}): {body}",
+            style="bold red",
+        )
+        sys.exit(EXIT_ERROR)
+
+    payload = resp.json()
+    cleared = payload.get('cleared', {})
+
+    if ctx.output_format == 'json':
+        import json
+        click.echo(json.dumps(payload, indent=2, sort_keys=False))
+        sys.exit(EXIT_SUCCESS)
+
+    from rich.table import Table
+    table = Table(title=f"Cache refreshed via {base}", title_style="bold")
+    table.add_column("Category", style="cyan")
+    table.add_column("Entries cleared", justify="right", style="green")
+    for cat, count in cleared.items():
+        table.add_row(cat, str(count))
+    ctx.console.print(table)
+    sys.exit(EXIT_SUCCESS)
 
 
 if __name__ == '__main__':

--- a/src/webapp/api/v1/admin.py
+++ b/src/webapp/api/v1/admin.py
@@ -1,0 +1,60 @@
+"""
+Admin API endpoints (v1).
+
+Operational endpoints for sysadmins and machine-to-machine tooling that
+mutate or invalidate runtime state (as opposed to the read-only
+Configuration dashboard). Gated on ``Permission.SYSTEM_ADMIN``.
+
+  POST /api/v1/admin/cache/refresh              — clear every cache
+  POST /api/v1/admin/cache/refresh?category=X   — clear one category
+
+``category`` is one of ``flask|chart|usage|scans`` and is passed straight
+through to the caching facade's ``clear()``.
+
+Response format::
+
+    {"status": "ok", "cleared": {"flask": 12, "chart": 3, "usage": 0, "scans": 1}}
+
+Worker affinity: with the in-process cache fallback (no Redis) and multiple
+gunicorn workers, this only clears the worker that handled the request. With
+Redis configured (production) the shared stores clear globally. See
+``webapp.caching`` for the fallback semantics.
+"""
+
+from flask import Blueprint, jsonify, request, abort
+
+from webapp.utils.rbac import Permission
+from webapp.utils.api_auth import login_or_token_required
+from webapp.extensions import csrf
+from webapp.api.helpers import register_error_handlers
+from webapp.caching import caching
+
+bp = Blueprint('api_admin', __name__)
+register_error_handlers(bp)
+
+# Categories understood by caching.clear(); None (omitted) clears all.
+_VALID_CATEGORIES = {'flask', 'chart', 'usage', 'scans'}
+
+
+@bp.route('/cache/refresh', methods=['POST'])
+@csrf.exempt          # token path is Basic-auth (no cookies); the session
+                      # path losing CSRF on an idempotent cache refresh is
+                      # an accepted trade-off, matching the per-resource
+                      # /refresh routes.
+@login_or_token_required(Permission.SYSTEM_ADMIN)
+def refresh_cache():
+    """
+    Invalidate caches, optionally scoped to a single category.
+
+    Query params:
+        category: one of ``flask|chart|usage|scans``. Omit to clear all.
+
+    Returns:
+        JSON ``{"status": "ok", "cleared": {category: count_cleared}}``.
+        400 if ``category`` is present but not recognized.
+    """
+    category = request.args.get('category')
+    if category is not None and category not in _VALID_CATEGORIES:
+        abort(400, f"Invalid category {category!r}; "
+                   f"must be one of {sorted(_VALID_CATEGORIES)}")
+    return jsonify({'status': 'ok', 'cleared': caching.clear(category)})

--- a/src/webapp/api/v1/directory_access.py
+++ b/src/webapp/api/v1/directory_access.py
@@ -16,6 +16,7 @@ from flask import Blueprint, jsonify, abort
 from webapp.utils.rbac import Permission
 from webapp.utils.api_auth import login_or_token_required
 from webapp.extensions import db, cache, csrf
+from webapp.caching import caching
 from webapp.api.helpers import register_error_handlers
 from sam.queries.directory_access import (
     group_populator,
@@ -96,5 +97,5 @@ def refresh_cache():
     cache.delete_memoized(get_directory_access)
     cache.delete_memoized(get_directory_access_branch)
     # Also clear any cached versions by key pattern
-    cache.clear()
+    caching.clear('flask')
     return jsonify({'status': 'ok'})

--- a/src/webapp/api/v1/fstree_access.py
+++ b/src/webapp/api/v1/fstree_access.py
@@ -64,6 +64,7 @@ from flask import Blueprint, jsonify, abort, request
 from webapp.utils.rbac import Permission
 from webapp.utils.api_auth import login_or_token_required
 from webapp.extensions import db, cache, csrf
+from webapp.caching import caching
 from webapp.api.helpers import register_error_handlers
 from sam.queries.fstree_access import get_fstree_data, get_project_fsdata, get_user_fsdata
 
@@ -245,5 +246,5 @@ def refresh_cache():
     cache.delete_memoized(_fstree_data)
     cache.delete_memoized(_project_fstree_data)
     cache.delete_memoized(_user_fstree_data)
-    cache.clear()
+    caching.clear('flask')
     return jsonify({'status': 'ok'})

--- a/src/webapp/api/v1/project_access.py
+++ b/src/webapp/api/v1/project_access.py
@@ -37,6 +37,7 @@ from flask import Blueprint, jsonify, abort
 from webapp.utils.rbac import Permission
 from webapp.utils.api_auth import login_or_token_required
 from webapp.extensions import db, cache, csrf
+from webapp.caching import caching
 from webapp.api.helpers import register_error_handlers
 from sam.queries.project_access import get_project_group_status, ACCESS_GRACE_PERIOD
 
@@ -102,5 +103,5 @@ def refresh_cache():
     """
     cache.delete_memoized(get_project_access)
     cache.delete_memoized(get_project_access_branch)
-    cache.clear()
+    caching.clear('flask')
     return jsonify({'status': 'ok'})

--- a/src/webapp/api/v1/queue.py
+++ b/src/webapp/api/v1/queue.py
@@ -38,6 +38,7 @@ from flask import Blueprint, jsonify, abort, request
 from webapp.utils.rbac import Permission
 from webapp.utils.api_auth import login_or_token_required
 from webapp.extensions import db, cache, csrf
+from webapp.caching import caching
 from webapp.api.helpers import register_error_handlers
 from sam.queries.queue_access import get_queue_data
 
@@ -111,5 +112,5 @@ def refresh_cache():
     cache.delete_memoized(get_queues)
     cache.delete_memoized(get_queues_for_resource)
     cache.delete_memoized(_queue_data)
-    cache.clear()
+    caching.clear('flask')
     return jsonify({'status': 'ok'})

--- a/src/webapp/api/v1/wallclock_exemption.py
+++ b/src/webapp/api/v1/wallclock_exemption.py
@@ -38,6 +38,7 @@ from flask import Blueprint, jsonify, abort, request
 from webapp.utils.rbac import Permission
 from webapp.utils.api_auth import login_or_token_required
 from webapp.extensions import db, cache, csrf
+from webapp.caching import caching
 from webapp.api.helpers import register_error_handlers
 from sam.queries.wallclock_exemption_access import get_wallclock_exemption_data
 
@@ -111,5 +112,5 @@ def refresh_cache():
     cache.delete_memoized(get_wallclock_exemptions)
     cache.delete_memoized(get_wallclock_exemptions_for_resource)
     cache.delete_memoized(_wallclock_exemption_data)
-    cache.clear()
+    caching.clear('flask')
     return jsonify({'status': 'ok'})

--- a/src/webapp/audit/events.py
+++ b/src/webapp/audit/events.py
@@ -199,8 +199,8 @@ def init_audit_events(app, db, logfile_path, stdout=True):
         from flask import current_app
         try:
             current_app._get_current_object()  # raises RuntimeError outside app context
-            from webapp.extensions import cache
-            cache.clear()
+            from webapp.caching import caching
+            caching.clear('flask')
         except RuntimeError:
             pass  # No app context — CLI, test teardown, etc.
 

--- a/src/webapp/dashboards/admin/configuration_routes.py
+++ b/src/webapp/dashboards/admin/configuration_routes.py
@@ -16,14 +16,19 @@ sole place that reads from ``app.config`` / ``os.environ`` /
 extensions; secrets are masked there before reaching the template.
 """
 
-from flask import render_template, current_app
+from flask import render_template, current_app, request
 from flask_login import login_required
 
 from webapp.extensions import db
+from webapp.caching import caching
 from webapp.utils.rbac import require_permission, Permission
 from webapp.utils.config_inspect import gather_runtime_state, gather_server_info
 
 from .blueprint import bp
+
+# Categories accepted by caching.clear(); mirrors the JSON API's set
+# (webapp.api.v1.admin). None (omitted) clears everything.
+_VALID_CACHE_CATEGORIES = {'flask', 'chart', 'usage', 'scans'}
 
 
 @bp.route('/htmx/configuration', methods=['GET'])
@@ -52,4 +57,32 @@ def htmx_server_card():
     return render_template(
         'dashboards/admin/fragments/server_card_body.html',
         server=gather_server_info(),
+    )
+
+
+@bp.route('/htmx/cache/clear', methods=['POST'])
+@login_required
+@require_permission(Permission.SYSTEM_ADMIN)
+def htmx_clear_cache():
+    """Clear caches from the Configuration tab's Caching card and re-render
+    just that card body with fresh stats + a summary of what was cleared.
+
+    Gated one tier above the read-only card (SYSTEM_ADMIN vs
+    VIEW_SYSTEM_CONFIG) because it mutates runtime state. ``?category=`` (one
+    of flask|chart|usage|scans) scopes the clear; omit it to clear everything.
+
+    Runs in-process, so it clears *this* worker's caches directly (no HTTP
+    round-trip). With Redis configured the shared stores clear globally; with
+    the in-process fallback only the worker that served this POST is cleared —
+    same worker-affinity caveat as the Server card's refresh button.
+    """
+    category = request.args.get('category') or None
+    if category is not None and category not in _VALID_CACHE_CATEGORIES:
+        category = None  # ignore a bad param rather than 500 the fragment
+    cleared = caching.clear(category)
+    state = gather_runtime_state(current_app, db)
+    return render_template(
+        'dashboards/admin/fragments/caching_card_body.html',
+        cache_state=state['caching'],
+        cleared=cleared,
     )

--- a/src/webapp/run.py
+++ b/src/webapp/run.py
@@ -37,6 +37,7 @@ from webapp.api.v1.project_access import bp as api_project_access_bp
 from webapp.api.v1.fstree_access import bp as api_fstree_access_bp
 from webapp.api.v1.queue import bp as api_queue_bp
 from webapp.api.v1.wallclock_exemption import bp as api_wallclock_exemption_bp
+from webapp.api.v1.admin import bp as api_admin_bp
 from webapp.config import get_webapp_config
 from webapp.logging_config import configure_logging
 
@@ -391,6 +392,7 @@ def create_app(*, config_overrides: dict | None = None):
     app.register_blueprint(api_fstree_access_bp, url_prefix='/api/v1/fstree_access')
     app.register_blueprint(api_queue_bp, url_prefix='/api/v1/queue')
     app.register_blueprint(api_wallclock_exemption_bp, url_prefix='/api/v1/wallclock_exemption')
+    app.register_blueprint(api_admin_bp, url_prefix='/api/v1/admin')
 
     # Register centralized formatting filters (fmt_number, fmt_pct, fmt_date, fmt_size)
     import sam.fmt as fmt

--- a/src/webapp/templates/dashboards/admin/fragments/_config_macros.html
+++ b/src/webapp/templates/dashboards/admin/fragments/_config_macros.html
@@ -1,0 +1,53 @@
+{#
+  Shared macros for the Admin > Configuration card and its sub-fragments.
+
+  Imported (not included) so the macros are reusable across the full
+  configuration_card.html and the standalone card-body fragments that HTMX
+  re-renders on their own (e.g. caching_card_body.html). Macros here rely
+  only on their arguments + global filters (fmt_size) — never on caller
+  context — so `{% from ... import ... %}` without `with context` is safe.
+#}
+
+{% macro stat(label, value, value_class='') %}
+    <dt class="fw-normal text-muted">{{ label }}</dt>
+    <dd class="fw-semibold {{ value_class }}">
+        {{ value if value not in (None, '') else '—' }}
+    </dd>
+{% endmacro %}
+
+{% macro mask_badge(state) %}
+    {% if state == 'set' %}
+        <span class="badge bg-success-subtle text-success">set</span>
+    {% else %}
+        <span class="badge bg-secondary-subtle text-muted">unset</span>
+    {% endif %}
+{% endmacro %}
+
+{#  All cache adapters return a uniform info() dict — see CacheBase in
+    src/sam/caching/base.py. cache_row renders any of them: flask, chart,
+    usage, or scans. #}
+{% macro cache_row(info) %}
+    <dl class="config-stats mb-0 small">
+        {% if info.enabled is not none %}
+            {{ stat('Enabled', 'Yes' if info.enabled else 'No') }}
+        {% endif %}
+        {% if info.ttl is not none %}
+            {{ stat('TTL (s)', info.ttl) }}
+        {% endif %}
+        {% if info.currsize is not none %}
+            {{ stat('Size',
+                    '%d / %s' | format(info.currsize,
+                                        info.maxsize if info.maxsize is not none else '∞')) }}
+        {% endif %}
+        {% if info.hits is not none or info.misses is not none %}
+            {{ stat('Hits / Misses',
+                    '%d / %d' | format(info.hits or 0, info.misses or 0)) }}
+        {% endif %}
+        {% if info.bytes_approx is not none %}
+            {{ stat('Memory (approx)', info.bytes_approx | fmt_size) }}
+        {% endif %}
+        {% if info.extras and info.extras.message %}
+            {{ stat('Note', info.extras.message) }}
+        {% endif %}
+    </dl>
+{% endmacro %}

--- a/src/webapp/templates/dashboards/admin/fragments/caching_card_body.html
+++ b/src/webapp/templates/dashboards/admin/fragments/caching_card_body.html
@@ -1,0 +1,118 @@
+{#
+  Admin > Configuration: Caching card body.
+
+  Extracted from configuration_card.html so the "Clear…" dropdown can
+  re-render *just* this body via HTMX (admin_dashboard.htmx_clear_cache)
+  without rebuilding the whole Configuration tab — mirroring the Server
+  Information card's refresh pattern.
+
+  Context in:
+    cache_state  — state.caching dict from config_inspect.gather_runtime_state
+    cleared      — (optional) {category: count} dict returned by caching.clear(),
+                   set only when this fragment is rendered as a clear response.
+
+  Worker affinity: with the in-process cache fallback (no Redis) and multiple
+  gunicorn workers, a clear only invalidates the worker that served the POST.
+  With Redis configured (production) the shared stores clear globally.
+#}
+{% from 'dashboards/admin/fragments/_config_macros.html' import stat, cache_row %}
+
+{% if cleared is defined and cleared %}
+    <div class="alert alert-success alert-dismissible fade show py-2 small mb-3" role="alert">
+        <i class="fas fa-check-circle me-1"></i>
+        Cleared:
+        {% for category, count in cleared.items() %}
+            <strong>{{ category }}</strong> {{ count }}{% if not loop.last %} · {% endif %}
+        {% endfor %}
+        <button type="button" class="btn-close btn-close-sm py-2" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+{% endif %}
+
+<dl class="config-stats mb-0 small">
+    {{ stat('Flask-Cache backend',   cache_state.flask_cache_backend) }}
+    {{ stat('Default timeout (s)',   cache_state.cache_default_timeout) }}
+</dl>
+
+{% if cache_state.usage %}
+<hr class="my-3">
+<div class="text-muted small mb-2"><strong>Allocation usage cache</strong></div>
+{{ cache_row(cache_state.usage) }}
+{% endif %}
+
+{% if cache_state.scans %}
+<hr class="my-3">
+<div class="text-muted small mb-2"><strong>Filesystem-scan cache</strong></div>
+{# Two buckets: the long-lived default (passive/landing + tab pill) and the
+   short-TTL explorer (filtered) bucket. Looping surfaces each bucket's TTL so
+   the 30-min explorer TTL is visible next to the 8-day default. #}
+{% for _b in cache_state.scans %}
+  <div class="text-muted small mb-1">
+    {{ 'Explorer (filtered)' if _b.name == 'fs_scans_filtered'
+       else 'Default (passive)' }}
+    <code class="ms-1">{{ _b.name }}</code>
+  </div>
+  {{ cache_row(_b) }}
+  {% if not loop.last %}<div class="mb-2"></div>{% endif %}
+{% endfor %}
+{% endif %}
+
+{% if cache_state.flask %}
+<hr class="my-3">
+<div class="text-muted small mb-2"><strong>Flask-Cache (HTTP-level)</strong></div>
+{{ cache_row(cache_state.flask) }}
+{% if cache_state.flask.extras and cache_state.flask.extras.groups %}
+<details class="mt-2">
+    <summary class="small text-muted">By API group</summary>
+    <dl class="config-stats mb-0 small mt-2">
+        {% for prefix, g in cache_state.flask.extras.groups.items() %}
+            {% if g.entries %}
+            {{ stat(prefix,
+                    '%d entries · %s' | format(g.entries, g.bytes_approx | fmt_size)) }}
+            {% endif %}
+        {% endfor %}
+    </dl>
+</details>
+{% endif %}
+{% endif %}
+
+{% if cache_state.chart %}
+<hr class="my-3">
+<div class="text-muted small mb-2"><strong>Chart SVG caches</strong></div>
+{# `selectattr` filters out items whose attr is falsy (None, 0).
+   Redis-backed RedisChartCache reports maxsize=None — the boundless
+   cache is Redis-wide allkeys-lru, not per-cache. #}
+{% set _ns = namespace(currsize=0, maxsize=0, hits=0, misses=0, bytes=0, unbounded=false) %}
+{% for c in cache_state.chart %}
+{% set _ns.currsize = _ns.currsize + (c.currsize or 0) %}
+{% set _ns.hits     = _ns.hits     + (c.hits     or 0) %}
+{% set _ns.misses   = _ns.misses   + (c.misses   or 0) %}
+{% set _ns.bytes    = _ns.bytes    + (c.bytes_approx or 0) %}
+{% if c.maxsize is none %}
+{% set _ns.unbounded = true %}
+{% else %}
+{% set _ns.maxsize = _ns.maxsize + c.maxsize %}
+{% endif %}
+{% endfor %}
+<dl class="config-stats mb-0 small">
+    {% if _ns.unbounded %}
+    {{ stat('Total size',
+            '%d entries (shared, Redis LRU)' | format(_ns.currsize)) }}
+    {% else %}
+    {{ stat('Total size',
+            '%d / %d entries' | format(_ns.currsize, _ns.maxsize)) }}
+    {% endif %}
+    {{ stat('Hits / Misses',
+            '%d / %d' | format(_ns.hits, _ns.misses)) }}
+    {{ stat('Memory (approx)', _ns.bytes | fmt_size) }}
+</dl>
+<details class="mt-2">
+    <summary class="small text-muted">Per-chart breakdown ({{ cache_state.chart | length }})</summary>
+    <dl class="config-stats mb-0 small mt-2">
+        {% for c in cache_state.chart %}
+        {% set cap = c.maxsize if c.maxsize is not none else '∞' %}
+        {{ stat(c.name,
+                '%s/%s · %d hits · %s' | format(c.currsize, cap, c.hits or 0, c.bytes_approx | fmt_size)) }}
+        {% endfor %}
+    </dl>
+</details>
+{% endif %}

--- a/src/webapp/templates/dashboards/admin/fragments/configuration_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/configuration_card.html
@@ -16,21 +16,9 @@
   cards.
 #}
 {# styles extracted to static/css/components.css (CSP) #}
-
-{% macro stat(label, value, value_class='') %}
-    <dt class="fw-normal text-muted">{{ label }}</dt>
-    <dd class="fw-semibold {{ value_class }}">
-        {{ value if value not in (None, '') else '—' }}
-    </dd>
-{% endmacro %}
-
-{% macro mask_badge(state) %}
-    {% if state == 'set' %}
-        <span class="badge bg-success-subtle text-success">set</span>
-    {% else %}
-        <span class="badge bg-secondary-subtle text-muted">unset</span>
-    {% endif %}
-{% endmacro %}
+{# stat / mask_badge / cache_row live in a shared partial so the caching
+   card body can re-render standalone on HTMX clear (see caching_card_body.html). #}
+{% from 'dashboards/admin/fragments/_config_macros.html' import stat, mask_badge %}
 
 <div class="card-body">
 
@@ -208,130 +196,68 @@
         </div>
 
         {# ── Caching ──────────────────────────────────────────────────── #}
-        {#  All cache adapters return a uniform info() dict — see CacheBase
-            in src/sam/caching/base.py. The cache_row macro renders any of
-            them: flask, chart, or usage. #}
-        {% macro cache_row(info) %}
-            <dl class="config-stats mb-0 small">
-                {% if info.enabled is not none %}
-                    {{ stat('Enabled', 'Yes' if info.enabled else 'No') }}
-                {% endif %}
-                {% if info.ttl is not none %}
-                    {{ stat('TTL (s)', info.ttl) }}
-                {% endif %}
-                {% if info.currsize is not none %}
-                    {{ stat('Size',
-                            '%d / %s' | format(info.currsize,
-                                                info.maxsize if info.maxsize is not none else '∞')) }}
-                {% endif %}
-                {% if info.hits is not none or info.misses is not none %}
-                    {{ stat('Hits / Misses',
-                            '%d / %d' | format(info.hits or 0, info.misses or 0)) }}
-                {% endif %}
-                {% if info.bytes_approx is not none %}
-                    {{ stat('Memory (approx)', info.bytes_approx | fmt_size) }}
-                {% endif %}
-                {% if info.extras and info.extras.message %}
-                    {{ stat('Note', info.extras.message) }}
-                {% endif %}
-            </dl>
-        {% endmacro %}
-
+        {#  Card body lives in a standalone fragment so the "Clear…" dropdown
+            can re-render just it via HTMX (admin_dashboard.htmx_clear_cache),
+            mirroring the Server Information card's refresh pattern above.
+            All cache adapters return a uniform info() dict — see CacheBase in
+            src/sam/caching/base.py; cache_row (in _config_macros.html) renders
+            any of them. #}
         <div class="col-12 col-xl-6">
             <div class="card inner-card h-100">
-                <div class="card-header mb-4">
-                    <h5><i class="fas fa-bolt me-1"></i> Caching</h5>
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0"><i class="fas fa-bolt me-1"></i> Caching</h5>
+                    {# Clearing is write-shaped, so it's gated one tier above the
+                       read-only card (SYSTEM_ADMIN vs VIEW_SYSTEM_CONFIG). #}
+                    {% if has_permission(Permission.SYSTEM_ADMIN) %}
+                    <div class="d-flex align-items-center">
+                        <span id="caching-card-spinner"
+                              class="htmx-indicator spinner-border spinner-border-sm me-2"
+                              role="status" aria-hidden="true"></span>
+                        <div class="dropdown">
+                            <button type="button"
+                                    class="btn btn-sm btn-outline-danger py-0 px-2 dropdown-toggle"
+                                    data-bs-toggle="dropdown" aria-expanded="false"
+                                    title="Invalidate caches">
+                                <i class="fas fa-trash-alt"></i>
+                                <span class="d-none d-sm-inline ms-1">Clear…</span>
+                            </button>
+                            {% set _clear_url = url_for('admin_dashboard.htmx_clear_cache') %}
+                            <ul class="dropdown-menu dropdown-menu-end shadow-sm">
+                                <li>
+                                    <button type="button" class="dropdown-item"
+                                            hx-post="{{ _clear_url }}"
+                                            hx-target="#caching-card-body" hx-swap="innerHTML"
+                                            hx-indicator="#caching-card-spinner"
+                                            hx-confirm="Clear ALL caches?">
+                                        <i class="fas fa-broom me-2 text-danger"></i>All caches
+                                    </button>
+                                </li>
+                                <li><hr class="dropdown-divider"></li>
+                                <li><h6 class="dropdown-header py-1">By category</h6></li>
+                                {% for cat, label in [
+                                        ('flask', 'Flask (HTTP)'),
+                                        ('chart', 'Chart SVG'),
+                                        ('usage', 'Allocation usage'),
+                                        ('scans', 'Filesystem scans')] %}
+                                <li>
+                                    <button type="button" class="dropdown-item"
+                                            hx-post="{{ _clear_url }}?category={{ cat }}"
+                                            hx-target="#caching-card-body" hx-swap="innerHTML"
+                                            hx-indicator="#caching-card-spinner"
+                                            hx-confirm="Clear the {{ label }} cache?">
+                                        {{ label }}
+                                    </button>
+                                </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    </div>
+                    {% endif %}
                 </div>
-                <div class="card-body">
-                    <dl class="config-stats mb-0 small">
-                        {{ stat('Flask-Cache backend',   state.caching.flask_cache_backend) }}
-                        {{ stat('Default timeout (s)',   state.caching.cache_default_timeout) }}
-                    </dl>
-
-                    {% if state.caching.usage %}
-                    <hr class="my-3">
-                    <div class="text-muted small mb-2"><strong>Allocation usage cache</strong></div>
-                    {{ cache_row(state.caching.usage) }}
-                    {% endif %}
-
-                    {% if state.caching.scans %}
-                    <hr class="my-3">
-                    <div class="text-muted small mb-2"><strong>Filesystem-scan cache</strong></div>
-                    {# Two buckets: the long-lived default (passive/landing +
-                       tab pill) and the short-TTL explorer (filtered) bucket.
-                       Looping surfaces each bucket's TTL so the 30-min explorer
-                       TTL is visible next to the 8-day default. #}
-                    {% for _b in state.caching.scans %}
-                      <div class="text-muted small mb-1">
-                        {{ 'Explorer (filtered)' if _b.name == 'fs_scans_filtered'
-                           else 'Default (passive)' }}
-                        <code class="ms-1">{{ _b.name }}</code>
-                      </div>
-                      {{ cache_row(_b) }}
-                      {% if not loop.last %}<div class="mb-2"></div>{% endif %}
-                    {% endfor %}
-                    {% endif %}
-
-                    {% if state.caching.flask %}
-                    <hr class="my-3">
-                    <div class="text-muted small mb-2"><strong>Flask-Cache (HTTP-level)</strong></div>
-                    {{ cache_row(state.caching.flask) }}
-                    {% if state.caching.flask.extras and state.caching.flask.extras.groups %}
-                    <details class="mt-2">
-                        <summary class="small text-muted">By API group</summary>
-                        <dl class="config-stats mb-0 small mt-2">
-                            {% for prefix, g in state.caching.flask.extras.groups.items() %}
-                                {% if g.entries %}
-                                {{ stat(prefix,
-                                        '%d entries · %s' | format(g.entries, g.bytes_approx | fmt_size)) }}
-                                {% endif %}
-                            {% endfor %}
-                        </dl>
-                    </details>
-                    {% endif %}
-                    {% endif %}
-
-                    {% if state.caching.chart %}
-                    <hr class="my-3">
-                    <div class="text-muted small mb-2"><strong>Chart SVG caches</strong></div>
-                    {# `selectattr` filters out items whose attr is falsy (None, 0).
-                       Redis-backed RedisChartCache reports maxsize=None — the boundless
-                       cache is Redis-wide allkeys-lru, not per-cache. #}
-                    {% set _ns = namespace(currsize=0, maxsize=0, hits=0, misses=0, bytes=0, unbounded=false) %}
-                    {% for c in state.caching.chart %}
-                    {% set _ns.currsize = _ns.currsize + (c.currsize or 0) %}
-                    {% set _ns.hits     = _ns.hits     + (c.hits     or 0) %}
-                    {% set _ns.misses   = _ns.misses   + (c.misses   or 0) %}
-                    {% set _ns.bytes    = _ns.bytes    + (c.bytes_approx or 0) %}
-                    {% if c.maxsize is none %}
-                    {% set _ns.unbounded = true %}
-                    {% else %}
-                    {% set _ns.maxsize = _ns.maxsize + c.maxsize %}
-                    {% endif %}
-                    {% endfor %}
-                    <dl class="config-stats mb-0 small">
-                        {% if _ns.unbounded %}
-                        {{ stat('Total size',
-                                '%d entries (shared, Redis LRU)' | format(_ns.currsize)) }}
-                        {% else %}
-                        {{ stat('Total size',
-                                '%d / %d entries' | format(_ns.currsize, _ns.maxsize)) }}
-                        {% endif %}
-                        {{ stat('Hits / Misses',
-                                '%d / %d' | format(_ns.hits, _ns.misses)) }}
-                        {{ stat('Memory (approx)', _ns.bytes | fmt_size) }}
-                    </dl>
-                    <details class="mt-2">
-                        <summary class="small text-muted">Per-chart breakdown ({{ state.caching.chart | length }})</summary>
-                        <dl class="config-stats mb-0 small mt-2">
-                            {% for c in state.caching.chart %}
-                            {% set cap = c.maxsize if c.maxsize is not none else '∞' %}
-                            {{ stat(c.name,
-                                    '%s/%s · %d hits · %s' | format(c.currsize, cap, c.hits or 0, c.bytes_approx | fmt_size)) }}
-                            {% endfor %}
-                        </dl>
-                    </details>
-                    {% endif %}
+                <div class="card-body" id="caching-card-body">
+                    {% with cache_state = state.caching %}
+                        {% include 'dashboards/admin/fragments/caching_card_body.html' %}
+                    {% endwith %}
                 </div>
             </div>
         </div>

--- a/tests/api/test_admin_cache.py
+++ b/tests/api/test_admin_cache.py
@@ -1,0 +1,51 @@
+"""
+API endpoint tests for the admin cache-refresh endpoint.
+
+Tests POST /api/v1/admin/cache/refresh — the global cache-invalidation
+entry point on top of the webapp.caching facade. Gated on
+Permission.SYSTEM_ADMIN (session path); the Basic-auth token path is
+exercised elsewhere and intentionally bypasses the permission gate.
+"""
+
+import pytest
+
+
+class TestAdminCacheRefreshAuth:
+    """Permission gating on the session path."""
+
+    def test_unauthenticated_rejected(self, client):
+        response = client.post('/api/v1/admin/cache/refresh')
+        assert response.status_code in (302, 401)
+
+    def test_non_admin_forbidden(self, non_admin_client):
+        response = non_admin_client.post('/api/v1/admin/cache/refresh')
+        assert response.status_code == 403
+
+    def test_system_admin_allowed(self, auth_client):
+        response = auth_client.post('/api/v1/admin/cache/refresh')
+        assert response.status_code == 200
+
+
+class TestAdminCacheRefreshBehavior:
+    """Response shape + category scoping."""
+
+    def test_clear_all_returns_status_ok(self, auth_client):
+        data = auth_client.post('/api/v1/admin/cache/refresh').get_json()
+        assert data['status'] == 'ok'
+        assert isinstance(data['cleared'], dict)
+
+    def test_clear_all_covers_every_category(self, auth_client):
+        data = auth_client.post('/api/v1/admin/cache/refresh').get_json()
+        assert set(data['cleared'].keys()) == {'flask', 'chart', 'usage', 'scans'}
+
+    @pytest.mark.parametrize('category', ['flask', 'chart', 'usage', 'scans'])
+    def test_single_category_scopes_the_clear(self, auth_client, category):
+        data = auth_client.post(
+            f'/api/v1/admin/cache/refresh?category={category}'
+        ).get_json()
+        assert data['status'] == 'ok'
+        assert set(data['cleared'].keys()) == {category}
+
+    def test_invalid_category_returns_400(self, auth_client):
+        response = auth_client.post('/api/v1/admin/cache/refresh?category=bogus')
+        assert response.status_code == 400

--- a/tests/unit/test_admin_cache_cli.py
+++ b/tests/unit/test_admin_cache_cli.py
@@ -1,0 +1,101 @@
+"""
+CliRunner tests for `sam-admin cache --refresh`.
+
+The command is a thin HTTP client for POST /api/v1/admin/cache/refresh —
+the caches live in the webapp worker (and shared Redis), not the DB, so it
+hits the live endpoint. These tests mock `requests.post` and assert the URL,
+auth, params, and exit-code handling.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from cli.cmds.admin import cli
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_db_session(session):
+    """Neutralize the CLI group's DB connect (cache command doesn't use it)."""
+    with patch('sam.session.create_sam_engine') as mock_engine, \
+         patch('cli.cmds.admin.Session') as mock_session_cls:
+        mock_engine.return_value = (MagicMock(), None)
+        mock_session_cls.return_value = session
+        yield session
+
+
+@pytest.fixture
+def api_creds(monkeypatch):
+    monkeypatch.setenv('SAM_API_USER', 'collector')
+    monkeypatch.setenv('SAM_API_PASS', 'secret')
+    monkeypatch.setenv('SAM_API_BASE', 'http://webapp.test')
+
+
+def _ok_response(cleared):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {'status': 'ok', 'cleared': cleared}
+    return resp
+
+
+class TestCacheCli:
+
+    def test_refresh_all_posts_to_endpoint(self, runner, mock_db_session, api_creds):
+        with patch('requests.post',
+                   return_value=_ok_response({'flask': 5, 'chart': 2,
+                                              'usage': 0, 'scans': 1})) as mock_post:
+            result = runner.invoke(cli, ['cache', '--refresh'])
+        assert result.exit_code == 0, result.output
+        args, kwargs = mock_post.call_args
+        assert args[0] == 'http://webapp.test/api/v1/admin/cache/refresh'
+        assert kwargs['auth'] == ('collector', 'secret')
+        assert kwargs['params'] == {}
+
+    def test_refresh_category_passes_param(self, runner, mock_db_session, api_creds):
+        with patch('requests.post',
+                   return_value=_ok_response({'chart': 2})) as mock_post:
+            result = runner.invoke(cli, ['cache', '--refresh', '--category', 'chart'])
+        assert result.exit_code == 0, result.output
+        assert mock_post.call_args.kwargs['params'] == {'category': 'chart'}
+
+    def test_json_output(self, runner, mock_db_session, api_creds):
+        with patch('requests.post', return_value=_ok_response({'flask': 5})):
+            result = runner.invoke(cli, ['--format', 'json', 'cache', '--refresh'])
+        assert result.exit_code == 0, result.output
+        assert '"cleared"' in result.output
+        assert '"flask": 5' in result.output
+
+    def test_missing_action_errors(self, runner, mock_db_session, api_creds):
+        result = runner.invoke(cli, ['cache'])
+        assert result.exit_code == 2
+        assert '--refresh' in result.output
+
+    def test_missing_credentials_errors(self, runner, mock_db_session, monkeypatch):
+        monkeypatch.delenv('SAM_API_USER', raising=False)
+        monkeypatch.delenv('SAM_API_PASS', raising=False)
+        result = runner.invoke(cli, ['cache', '--refresh'])
+        assert result.exit_code == 2
+        assert 'SAM_API_USER' in result.output
+
+    def test_http_error_reported(self, runner, mock_db_session, api_creds):
+        bad = MagicMock()
+        bad.status_code = 401
+        bad.text = 'Unauthorized'
+        with patch('requests.post', return_value=bad):
+            result = runner.invoke(cli, ['cache', '--refresh'])
+        assert result.exit_code == 2
+        assert '401' in result.output
+
+    def test_unreachable_webapp_reported(self, runner, mock_db_session, api_creds):
+        import requests
+        with patch('requests.post',
+                   side_effect=requests.RequestException('connection refused')):
+            result = runner.invoke(cli, ['cache', '--refresh'])
+        assert result.exit_code == 2
+        assert 'could not reach' in result.output

--- a/tests/unit/test_admin_cache_ui.py
+++ b/tests/unit/test_admin_cache_ui.py
@@ -1,0 +1,52 @@
+"""
+Tests for the Admin > Configuration Caching-card "Clear…" HTMX route.
+
+POST /admin/htmx/cache/clear re-renders just the caching card body with a
+"cleared" summary alert. Gated on Permission.SYSTEM_ADMIN — one tier above
+the read-only Configuration card (VIEW_SYSTEM_CONFIG).
+"""
+
+from unittest.mock import patch
+
+
+class TestClearCacheRouteAuth:
+
+    def test_unauthenticated_rejected(self, client):
+        response = client.post('/admin/htmx/cache/clear')
+        assert response.status_code in (302, 401)
+
+    def test_non_admin_forbidden(self, non_admin_client):
+        response = non_admin_client.post('/admin/htmx/cache/clear')
+        assert response.status_code == 403
+
+    def test_system_admin_allowed(self, auth_client):
+        response = auth_client.post('/admin/htmx/cache/clear')
+        assert response.status_code == 200
+
+
+class TestClearCacheRouteBehavior:
+
+    def test_renders_cleared_alert(self, auth_client):
+        html = auth_client.post('/admin/htmx/cache/clear').get_data(as_text=True)
+        assert 'Cleared:' in html
+
+    def test_clear_all_calls_facade_with_none(self, auth_client):
+        with patch('webapp.dashboards.admin.configuration_routes.caching.clear',
+                   return_value={'flask': 0}) as mock_clear:
+            resp = auth_client.post('/admin/htmx/cache/clear')
+        assert resp.status_code == 200
+        mock_clear.assert_called_once_with(None)
+
+    def test_category_passed_through_to_facade(self, auth_client):
+        with patch('webapp.dashboards.admin.configuration_routes.caching.clear',
+                   return_value={'chart': 3}) as mock_clear:
+            resp = auth_client.post('/admin/htmx/cache/clear?category=chart')
+        assert resp.status_code == 200
+        mock_clear.assert_called_once_with('chart')
+
+    def test_bad_category_falls_back_to_clear_all(self, auth_client):
+        with patch('webapp.dashboards.admin.configuration_routes.caching.clear',
+                   return_value={'flask': 0}) as mock_clear:
+            resp = auth_client.post('/admin/htmx/cache/clear?category=bogus')
+        assert resp.status_code == 200
+        mock_clear.assert_called_once_with(None)


### PR DESCRIPTION
## Summary

Adds a real "refresh everything" entry point on top of SAM's existing unified caching facade (`webapp.caching.caching`), consolidates the uncoordinated per-site `cache.clear()` bypasses onto it, and exposes it three ways: a JSON API, an Admin dashboard control, and a CLI command. Refines the plan from #348.

## What's included

**New JSON API** — `POST /api/v1/admin/cache/refresh[?category=flask|chart|usage|scans]` (`src/webapp/api/v1/admin.py`), gated on `SYSTEM_ADMIN`; thin wrapper over `caching.clear(category)`. Returns `{"status":"ok","cleared":{cat:count}}`.

**Facade consolidation (5 routes + audit hook)** — swapped blunt `cache.clear()` → `caching.clear('flask')` in the `project_access`, `fstree_access`, `directory_access`, `queue`, and `wallclock_exemption` refresh routes plus the `after_commit` audit hook. The `queue`/`wallclock_exemption` routes arrived in #346 *after* the plan doc was written, so the original "3 routes" grew to 5. No `cache.clear()` calls remain in the webapp.

**Admin UX** — a `SYSTEM_ADMIN`-gated "Clear…" dropdown (All + per-category) on the Configuration tab's Caching card. Extracted the card body into a standalone `caching_card_body.html` fragment + shared `_config_macros.html` so a new `POST /admin/htmx/cache/clear` route re-renders just the body with a "Cleared: …" summary, mirroring the Server card's refresh pattern. CSRF flows via the existing global `hx-headers`.

**CLI** — `sam-admin cache --refresh [--category X]`, a pure HTTP client (no webapp import) reusing the existing `SAM_API_USER`/`SAM_API_PASS`/`SAM_API_BASE` Basic-auth convention.

**Demo script** — `scripts/apis/clear_caches.sh`, a worked example / smoke test mirroring `systems_integration_apis.sh`.

## Test Results

- `tests/api/test_admin_cache.py`, `tests/unit/test_admin_cache_ui.py`, `tests/unit/test_admin_cache_cli.py` — green locally.
- `scripts/apis/clear_caches.sh` verified live against local webdev: **7 PASS, 0 FAIL** (the "all" call cleared real entries — chart=3, usage=2).
- Regression check on the 5 modified refresh routes + audit hook via existing suites.

## Notes / decisions

- The Basic-auth **token path intentionally bypasses** the `SYSTEM_ADMIN` gate (existing behavior across all `/refresh` routes); the gate applies to the browser/session path — the Admin dashboard button.
- CLI reuses `SAM_API_*` (systems-integration convention) rather than a new `SAM_WEBAPP_URL` — reuse over sprawl.
- **Worker affinity**: with the in-process fallback (no Redis) + multiple gunicorn workers, one call clears only the serving worker; with Redis (prod) the shared stores clear globally. Documented inline and in the API doc.
- `shellcheck` isn't installed locally, so `clear_caches.sh` was validated with `bash -n` only — CI's mega-linter will be its first shellcheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)