### PR TITLE
UX polish: Manage Project rename, Reconcile-all popover, Used/Remaining columns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,15 @@ omit = [
     "*/migrations/*",
     "*/scripts/*",
 
+    # Jinja templates. Jinja compiles each template to a Python code object
+    # whose co_filename is the template's own path, so coverage's tracer
+    # records rendered *.html templates as "measured files". The HTML
+    # reporter then tries to syntax-highlight them as Python — harmless on
+    # some toolchains (skipped with a warning) but a hard INTERNALERROR on
+    # Python 3.14 + newer coverage, which calls ast.parse() on the CSS.
+    # Templates are never valid coverage targets; exclude them outright.
+    "*/templates/*",
+
     # Deferred workstream: admin HTMX dashboard routes. Tracked separately;
     # exercised via manual QA + smoke tests in tests/integration/.
     "src/webapp/dashboards/admin/blueprint.py",

--- a/src/webapp/templates/dashboards/admin/edit_project.html
+++ b/src/webapp/templates/dashboards/admin/edit_project.html
@@ -2,7 +2,7 @@
 {% from 'dashboards/admin/fragments/user_search_results_fk_htmx.html' import render_fk_search_results with context %}
 {% from 'dashboards/fragments/_breadcrumb.html' import breadcrumb %}
 
-{% block title %}Edit Project {{ project.projcode }} — SAM{% endblock %}
+{% block title %}Manage Project {{ project.projcode }} — SAM{% endblock %}
 
 {% block extra_css %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/admin.css') }}">
@@ -17,7 +17,7 @@
     {% set _ = _crumbs.append({'label': 'Admin',
                                'attrs': {'href': url_for('admin_dashboard.index')}}) %}
   {% endif %}
-  {% set _ = _crumbs.append({'label': 'Edit Project', 'active': True}) %}
+  {% set _ = _crumbs.append({'label': 'Manage Project', 'active': True}) %}
   {% set _ = _crumbs.append({'label': project.projcode, 'active': True}) %}
   {{ breadcrumb(_crumbs, classes='mb-0') }}
   {% if can_access_admin %}

--- a/src/webapp/templates/dashboards/admin/fragments/project_access_grid_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_access_grid_htmx.html
@@ -1,4 +1,5 @@
 {% from 'dashboards/fragments/form_fields.html' import form_errors_panel with context %}
+{% from 'dashboards/fragments/help.html' import help_icon with context %}
 {#
   Operator-only User / Resource Access grid (site operators only — gated by the
   collapsible card in edit_project.html on EDIT_PROJECTS + EDIT_PROJECT_MEMBERS).
@@ -48,6 +49,12 @@
             hx-confirm="Give every member access to every resource shown on this project?">
       <i class="fas fa-magic"></i> Reconcile all
     </button>
+    {{ help_icon(
+         'Approves every user for every resource on this project. This is typically '
+         'the intended state; partial user resource access is most typically a mistake.',
+         rich=True,
+         title='Reconcile all',
+         placement='left') }}
     {% endif %}
   </div>
 </div>

--- a/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
@@ -96,8 +96,24 @@
         <col style="width:110px;">   {# progress bar #}
         <col style="width:60px;">    {# % used #}
         <col style="width:90px;">    {# allocated amount #}
+        <col style="width:90px;">    {# used amount #}
+        <col style="width:90px;">    {# remaining amount #}
         <col style="width:110px;">   {# shared badge + edit button #}
       </colgroup>
+
+      {# Column labels for the three amount columns — bare numbers alone are
+         ambiguous. Rendered once per tab table, above all resource sections. #}
+      <thead>
+        <tr class="small text-muted">
+          <th></th>
+          <th></th>
+          <th></th>
+          <th class="text-end fw-normal">Allocated</th>
+          <th class="text-end fw-normal">Used</th>
+          <th class="text-end fw-normal">Remaining</th>
+          <th></th>
+        </tr>
+      </thead>
 
       {% for resource_name in tab_data.names %}
       {%- set resource_slug = resource_name | lower | replace(' ', '-') | replace('/', '-') | replace('_', '-') -%}
@@ -132,7 +148,17 @@
             {% if root_alloc %}{{ root_alloc.allocated | fmt_number }}{% endif %}
           </td>
 
-          {# Col 5: edit pencil (or shared badge for inherited allocations) #}
+          {# Col 5: used amount #}
+          <td class="text-end small text-muted" style="vertical-align:middle; white-space:nowrap;">
+            {% if root_alloc %}{{ root_alloc.used | fmt_number }}{% endif %}
+          </td>
+
+          {# Col 6: remaining amount #}
+          <td class="text-end small text-muted" style="vertical-align:middle; white-space:nowrap;">
+            {% if root_alloc %}{{ root_alloc.remaining | fmt_number }}{% endif %}
+          </td>
+
+          {# Col 7: edit pencil (or shared badge for inherited allocations) #}
           <td style="vertical-align:middle;">
             {% if can_modify_allocations and root_alloc and root_alloc.allocation_id and not root_alloc.is_inheriting %}
             <button class="btn btn-sm btn-outline-warning py-0 px-1"
@@ -188,7 +214,17 @@
             {% if root_alloc %}{{ root_alloc.allocated | fmt_number }}{% endif %}
           </td>
 
-          {# Col 5: shared badge #}
+          {# Col 5: used amount #}
+          <td class="text-end small text-muted" style="vertical-align:middle; white-space:nowrap;">
+            {% if root_alloc %}{{ root_alloc.used | fmt_number }}{% endif %}
+          </td>
+
+          {# Col 6: remaining amount #}
+          <td class="text-end small text-muted" style="vertical-align:middle; white-space:nowrap;">
+            {% if root_alloc %}{{ root_alloc.remaining | fmt_number }}{% endif %}
+          </td>
+
+          {# Col 7: shared badge #}
           <td style="vertical-align:middle;">
             {% if root_alloc and root_alloc.is_inheriting %}
             <span class="badge bg-secondary bg-opacity-25 text-dark border small">shared</span>

--- a/src/webapp/templates/dashboards/shared/project_tree.html
+++ b/src/webapp/templates/dashboards/shared/project_tree.html
@@ -144,6 +144,8 @@
         <col style="width:110px;">   (progress bar)
         <col style="width:50px;">    (% used)
         <col style="width:90px;">    (allocated amount)
+        <col style="width:90px;">    (used amount)
+        <col style="width:90px;">    (remaining amount)
         <col style="width:110px;">   (shared badge + edit button)
       </colgroup>
       <tbody>
@@ -231,7 +233,21 @@
     {%- endif %}
   </td>
 
-  {# ── Col 5: shared badge + edit button + exchange button ──────────── #}
+  {# ── Col 5: used amount ────────────────────────────────────────────── #}
+  <td class="text-end text-muted small" style="vertical-align:middle; white-space:nowrap;">
+    {%- if res %}{{ res.used | fmt_number }}
+    {%- elif alloc_by_projcode is not none %}<em>—</em>
+    {%- endif %}
+  </td>
+
+  {# ── Col 6: remaining amount ───────────────────────────────────────── #}
+  <td class="text-end text-muted small" style="vertical-align:middle; white-space:nowrap;">
+    {%- if res %}{{ res.remaining | fmt_number }}
+    {%- elif alloc_by_projcode is not none %}<em>—</em>
+    {%- endif %}
+  </td>
+
+  {# ── Col 7: shared badge + edit button + exchange button ──────────── #}
   <td style="vertical-align:middle; white-space:nowrap;">
     {%- if res and res.is_inheriting -%}
     <span class="badge bg-secondary bg-opacity-25 text-dark border small">shared</span>

--- a/src/webapp/templates/dashboards/user/partials/project_card.html
+++ b/src/webapp/templates/dashboards/user/partials/project_card.html
@@ -400,7 +400,7 @@
                 <div class="d-flex justify-content-end mt-3 pt-2 border-top">
                     <a href="{{ url_for('admin_dashboard.edit_project_page', projcode=project.projcode) }}"
                        class="btn  btn-primary">
-                        <i class="fas fa-edit"></i> Edit Project
+                        <i class="fas fa-edit"></i> Manage Project
                     </a>
                 </div>
                 {% endif %}

--- a/src/webapp/templates/dashboards/user/partials/project_details_modal.html
+++ b/src/webapp/templates/dashboards/user/partials/project_details_modal.html
@@ -16,7 +16,7 @@
         <div class="d-flex justify-content-end mb-2">
             <a href="{{ url_for('admin_dashboard.edit_project_page', projcode=project.projcode) }}"
                class="btn btn-primary">
-                <i class="fas fa-edit"></i> Edit Project
+                <i class="fas fa-edit"></i> Manage Project
             </a>
         </div>
         {% endif %}


### PR DESCRIPTION
## Summary

Three small UX improvements to the project Manage/Allocations screens:

- **Rename "Edit Project" → "Manage Project"** on the two buttons that route to `admin/project/<projcode>/edit`, plus the destination page `<title>` and breadcrumb — less confusing for project leads/admins who land on a constrained edit surface rather than a raw edit form.
- **Explanatory popover on the "Reconcile all" button** (operator-only User/Resource Access grid): _"Approves every user for every resource on this project. This is typically the intended state; partial user resource access is most typically a mistake."_ Reuses the existing `help_icon(rich=True)` macro.
- **Used / Remaining amount columns in the allocation tree** — the Allocations tab now shows Allocated / Used / Remaining on one row for both resource-header rows and expanded project-tree rows (with a labeled header row). No route/query change; the values were already in the resource dicts.

## Test Results

- Jinja2 parse-only syntax check passed on all edited templates.
- Verified visually in local `webdev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)