### PR TITLE
Add startDate/endDate to /api/v1/fstree_access resource entries

### DIFF
--- a/src/sam/queries/fstree_access.py
+++ b/src/sam/queries/fstree_access.py
@@ -23,7 +23,8 @@ Query 1 (skeleton): fast JOIN-based query returning only projects with a current
 Query 2 (lifecycle): targeted query for projects in the AllocationType tree that
   have no current active allocation — produces "Expired" (account exists, past
   allocation) and "No Account" (no account on this resource type) rows.  These are
-  the minority; they carry allocationAmount=0, adjustedUsage=0, no users.
+  the minority; they carry allocationAmount=0, adjustedUsage=0, no users, and
+  omit the startDate/endDate keys (no current allocation window to report).
 
 Query 3 (users): bulk active-user roster per account.
 
@@ -254,6 +255,11 @@ _SQL_FSTREE_EXPIRED_USERS = text("""
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _iso(value) -> Optional[str]:
+    """Render a datetime as an ISO-8601 string, passing through None."""
+    return value.isoformat() if value is not None else None
+
 
 def _alloc_type_name(facility_code: str, allocation_type: str) -> str:
     """
@@ -682,6 +688,8 @@ def get_fstree_data(
             'adjustedUsage':    int(round(adjusted_usage)),
             'balance':          int(round(balance)) if balance is not None else None,
             'allocationAmount': int(round(allocation_amount)) if allocation_amount is not None else None,
+            'startDate':        _iso(row.start_date),
+            'endDate':          _iso(row.end_date),
             'users':            user_map.get(account_id, []),
             'thresholds':       thresholds,
         }

--- a/src/webapp/api/v1/fstree_access.py
+++ b/src/webapp/api/v1/fstree_access.py
@@ -46,6 +46,8 @@ Response format (partial):
                                         "adjustedUsage": 48883597,
                                         "balance": 2616402,
                                         "allocationAmount": 51500000,
+                                        "startDate": "2025-01-01T00:00:00",
+                                        "endDate": "2025-12-31T23:59:59",
                                         "users": [
                                             {"username": "travisa", "uid": 29642}
                                         ]

--- a/tests/api/test_fstree_access.py
+++ b/tests/api/test_fstree_access.py
@@ -75,6 +75,27 @@ class TestFstreeSingleResource:
                         assert not missing, \
                             f'Resource {res.get("name")!r} missing: {missing}'
 
+    def test_active_rows_expose_iso_date_window(self, auth_client):
+        """Active rows carry ISO startDate/endDate through jsonify; lifecycle
+        rows (Expired / No Account) omit the keys."""
+        from datetime import datetime
+        data = auth_client.get('/api/v1/fstree_access/Derecho').get_json()
+        lifecycle = {'Expired', 'No Account'}
+        checked = 0
+        for fac in data['facilities']:
+            for at in fac['allocationTypes']:
+                for proj in at['projects']:
+                    for res in proj['resources']:
+                        if res['accountStatus'] in lifecycle:
+                            assert 'startDate' not in res and 'endDate' not in res
+                            continue
+                        assert res['startDate'] is not None
+                        datetime.fromisoformat(res['startDate'])
+                        if res['endDate'] is not None:
+                            datetime.fromisoformat(res['endDate'])
+                        checked += 1
+        assert checked > 0
+
     def test_threshold_key_present(self, auth_client):
         data = auth_client.get('/api/v1/fstree_access/Derecho').get_json()
         for fac in data['facilities'][:1]:

--- a/tests/unit/test_fstree_queries.py
+++ b/tests/unit/test_fstree_queries.py
@@ -20,6 +20,7 @@ Ported from tests/unit/test_fstree_queries.py. Transformations:
   drops the cost back to one call per module.
 """
 import re
+from datetime import datetime
 
 import pytest
 from sqlalchemy.orm import sessionmaker
@@ -200,6 +201,8 @@ class TestProjectStructure:
 
 class TestResourceStructure:
 
+    _LIFECYCLE = {'Expired', 'No Account'}
+
     @staticmethod
     def _first_resources(fstree, n=20):
         items = []
@@ -211,6 +214,13 @@ class TestResourceStructure:
                         if len(items) >= n:
                             return items
         return items
+
+    @staticmethod
+    def _all_resources(fstree):
+        for fac in fstree['facilities']:
+            for at in fac['allocationTypes']:
+                for proj in at['projects']:
+                    yield from proj['resources']
 
     def test_resource_has_required_fields(self, fstree_all):
         required = {'name', 'accountStatus', 'cutoffThreshold',
@@ -242,6 +252,31 @@ class TestResourceStructure:
     def test_users_is_list(self, fstree_all):
         for res in self._first_resources(fstree_all):
             assert isinstance(res['users'], list)
+
+    def test_active_resources_carry_iso_date_window(self, fstree_all):
+        """Rows with a current allocation expose ISO startDate/endDate so a
+        consumer can difference them for a burn rate. endDate may be null
+        (open-ended); when present it must not precede startDate."""
+        checked = 0
+        for res in self._all_resources(fstree_all):
+            if res['accountStatus'] in self._LIFECYCLE:
+                continue
+            assert 'startDate' in res and 'endDate' in res, res.get('name')
+            start = res['startDate']
+            assert start is not None
+            start_dt = datetime.fromisoformat(start)  # parseable ISO-8601
+            if res['endDate'] is not None:
+                end_dt = datetime.fromisoformat(res['endDate'])
+                assert end_dt >= start_dt
+            checked += 1
+        assert checked > 0, 'no active resources found to validate'
+
+    def test_lifecycle_rows_omit_date_keys(self, fstree_all):
+        """Expired / No Account rows have no current allocation, so they omit
+        the startDate/endDate keys entirely."""
+        for res in self._all_resources(fstree_all):
+            if res['accountStatus'] in self._LIFECYCLE:
+                assert 'startDate' not in res and 'endDate' not in res, res.get('name')
 
     def test_user_has_username_and_uid(self, fstree_all):
         for res in self._first_resources(fstree_all):


### PR DESCRIPTION
## Summary

Consumers of `GET /api/v1/fstree_access/` (and its `/projects/` and `/users/` remaps) get `allocationAmount` per resource but no allocation window, so they cannot compute an **allocation burn rate** (e.g. AU/year). This adds the current allocation's `startDate` and `endDate` alongside `allocationAmount` so a consumer can difference them for the duration.

The change is **purely additive** (new keys only) and ships on the **same API version** — existing consumers ignore unknown keys.

## Details

- The allocation dates are already fetched by `_SQL_FSTREE_SKELETON` (`al.start_date` / `al.end_date`) and sit on each row, so this is **assembly-side only**: no SQL change, no extra query, no perf impact.
- Format is **full ISO datetime** via a null-safe `_iso()` helper (mirrors the sibling `queue_access.py`), preserving the SAM convention of start floored to `00:00:00` and end pushed to `23:59:59` (`sam/base.py:normalize_end_date`). Differencing is therefore exact to the second — pure-date truncation was rejected because dropping the `23:59:59` undercounts every duration by one day. Open-ended allocations (`end_date IS NULL`) emit `endDate: null`.
- **Lifecycle rows** (Expired / No Account) have no current allocation (`allocationAmount` is already `0`), so they **omit both keys** entirely.
- The `/projects/` and `/users/` remaps copy the resource dict verbatim, so the new keys **propagate automatically**.

### Example (active row)

```json
"allocationAmount": 39000000,
"startDate": "2022-10-01T00:00:00",
"endDate": "2026-12-31T23:59:59"
```

## Test Results

- Added `test_active_resources_carry_iso_date_window` + `test_lifecycle_rows_omit_date_keys` (unit) and `test_active_rows_expose_iso_date_window` (api).
- Verified against the live DB: 1140 active Derecho rows carry ISO dates, 337 lifecycle rows omit them; sample duration (`2022-10-01` → `2026-12-31` = 1552 days) differences cleanly.
- Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)