### PR TITLE
Expose project hierarchy in fstree API + audit the tree invariant

### DIFF
--- a/src/cli/cmds/admin.py
+++ b/src/cli/cmds/admin.py
@@ -15,7 +15,11 @@ from config import SAMConfig
 from cli.core.context import Context
 from cli.core.utils import EXIT_SUCCESS, EXIT_ERROR
 from cli.user.commands import UserAdminCommand
-from cli.project.commands import ProjectAdminCommand, ProjectExpirationCommand
+from cli.project.commands import (
+    ProjectAdminCommand,
+    ProjectExpirationCommand,
+    ProjectTreeAuditCommand,
+)
 from cli.accounting.commands import AccountingAdminCommand
 from cli.accounting.dates import _validate_accounting_dates, _resolve_accounting_dates
 
@@ -75,6 +79,10 @@ def user(ctx: Context, username, validate, list_projects, verbose):
 @click.argument('projcode', required=False)
 @click.option('--validate', is_flag=True, help='Validate project data')
 @click.option('--reconcile', is_flag=True, help='Reconcile allocations')
+@click.option('--audit-trees', 'audit_trees', is_flag=True,
+              help='Audit project allocation trees DB-wide (no projcode needed)')
+@click.option('--resource', 'audit_resource', type=str, default=None,
+              help='[audit-trees] Limit the audit to one resource (e.g. Derecho)')
 @click.option('--upcoming-expirations', is_flag=True, help='Search for upcoming project expirations')
 @click.option('--recent-expirations', is_flag=True, help='Show recently expired projects')
 @click.option('--notify', is_flag=True, help='Send email notifications (requires --upcoming-expirations)')
@@ -88,11 +96,17 @@ def user(ctx: Context, username, validate, list_projects, verbose):
 @click.option('--facilities', '-F', multiple=True, default=['UNIV', 'WNA'], help='Facilities to include (default: UNIV, WNA). Use * for all facilities.')
 @click.option('--verbose', '-v', is_flag=True, help='Show detailed information')
 @pass_context
-def project(ctx: Context, projcode, validate, reconcile, upcoming_expirations, recent_expirations,
+def project(ctx: Context, projcode, validate, reconcile, audit_trees, audit_resource,
+            upcoming_expirations, recent_expirations,
             notify, dry_run, email_list, deactivate, force, since, list_users, facilities, verbose):
     """Administrative project commands."""
     if verbose:
         ctx.verbose = True
+
+    # Validate that --resource requires --audit-trees
+    if audit_resource and not audit_trees:
+        ctx.console.print("Error: --resource requires --audit-trees", style="bold red")
+        sys.exit(1)
 
     # Validate that --notify requires --upcoming-expirations
     if notify and not upcoming_expirations:
@@ -113,6 +127,11 @@ def project(ctx: Context, projcode, validate, reconcile, upcoming_expirations, r
     if force and not deactivate:
         ctx.console.print("Error: --force requires --deactivate", style="bold red")
         sys.exit(1)
+
+    # DB-wide tree audit — no projcode (the invariant spans trees, not projects)
+    if audit_trees:
+        command = ProjectTreeAuditCommand(ctx)
+        sys.exit(command.execute(resource_name=audit_resource))
 
     # Handle facility filtering - '*' means all facilities
     facility_filter = None if '*' in facilities else list(facilities)
@@ -146,7 +165,8 @@ def project(ctx: Context, projcode, validate, reconcile, upcoming_expirations, r
     # Require projcode for other operations
     if not projcode:
         ctx.console.print(
-            "Error: projcode argument is required unless using --upcoming-expirations or --recent-expirations",
+            "Error: projcode argument is required unless using --upcoming-expirations, "
+            "--recent-expirations, or --audit-trees",
             style="bold red"
         )
         click.echo(click.get_current_context().get_help())

--- a/src/cli/project/commands.py
+++ b/src/cli/project/commands.py
@@ -21,7 +21,8 @@ from cli.project.display import (
     display_expiring_projects,
     display_abandoned_users_from_expired_projects,
     display_notification_results,
-    display_notification_preview
+    display_notification_preview,
+    display_tree_audit
 )
 from sam import Project, fmt
 from sam.enums import FacilityName
@@ -30,6 +31,7 @@ from sam.queries.expirations import (
     get_projects_with_expired_allocations,
     get_all_expiring_allocations
 )
+from sam.queries.tree_audit import audit_allocation_trees, audit_allocation_dates
 from rich.progress import track
 
 
@@ -407,6 +409,44 @@ class ProjectExpirationCommand(BaseProjectCommand):
             return EXIT_ERROR
 
         return EXIT_SUCCESS
+
+
+class ProjectTreeAuditCommand(BaseProjectCommand):
+    """Audit the project-tree allocation invariant across all projects.
+
+    Unlike the other admin project commands this is DB-wide, not scoped to a
+    single projcode: the invariant is a property of trees, not of any one
+    project.
+    """
+
+    def execute(self, resource_name: str = None) -> int:
+        try:
+            violations = audit_allocation_trees(self.session, resource_name)
+            bad_dates = audit_allocation_dates(self.session, resource_name)
+        except Exception as e:
+            self.console.print(f"Error auditing project trees: {e}", style="bold red")
+            return EXIT_ERROR
+
+        if self.ctx.output_format == 'json':
+            output_json({
+                'kind':          'tree_audit',
+                'resource':      resource_name,
+                'violations':    violations,
+                'invalid_dates': [{**d,
+                                   'start_date': d['start_date'].isoformat()
+                                   if d['start_date'] else None,
+                                   'end_date': d['end_date'].isoformat()
+                                   if d['end_date'] else None}
+                                  for d in bad_dates],
+            })
+        else:
+            scope = f" on {resource_name}" if resource_name else ""
+            self.console.print(
+                f"[dim]Auditing project allocation trees{scope}...[/dim]\n"
+            )
+            display_tree_audit(self.ctx, violations, bad_dates)
+
+        return EXIT_ERROR if (violations or bad_dates) else EXIT_SUCCESS
 
 
 class ProjectAdminCommand(ProjectSearchCommand):

--- a/src/cli/project/display.py
+++ b/src/cli/project/display.py
@@ -388,6 +388,83 @@ def display_abandoned_users_from_expired_projects(ctx: Context, abandoned_users)
     ctx.console.print(table)
 
 
+def display_tree_audit(ctx: Context, violations: list, bad_dates: list):
+    """Render the project-tree data-quality audit.
+
+    ``violations`` come from ``audit_allocation_trees()``, ``bad_dates`` from
+    ``audit_allocation_dates()``.  Both empty renders an all-clear.
+    """
+    if violations:
+        ctx.console.print(
+            f"⚠️  {len(violations)} parent allocation(s) do not cover their "
+            f"carve-out children:",
+            style="bold yellow",
+        )
+        table = Table(box=box.SIMPLE, show_header=True)
+        table.add_column("Parent")
+        table.add_column("Resource")
+        table.add_column("Parent amount", justify="right")
+        table.add_column("Carve-outs", justify="right")
+        table.add_column("Deficit", justify="right", style="red")
+        table.add_column("Raise parent to", justify="right", style="green")
+        for v in violations:
+            table.add_row(
+                v['parent_projcode'],
+                v['resource_name'],
+                fmt.number(v['parent_amount']),
+                fmt.number(v['carve_total']),
+                fmt.number(v['deficit']),
+                fmt.number(v['carve_total']),
+            )
+        ctx.console.print(table)
+
+        if ctx.verbose:
+            for v in violations:
+                ctx.console.print(
+                    f"[bold]{v['parent_projcode']}[/bold] on "
+                    f"{v['resource_name']} — {fmt.number(v['parent_amount'])}",
+                )
+                for c in sorted(v['carve_children'], key=lambda c: -c['amount']):
+                    ctx.console.print(
+                        f"    carve-out  {c['projcode']:12} "
+                        f"{fmt.number(c['amount']):>12}"
+                    )
+                for c in sorted(v['pool_children'], key=lambda c: c['projcode']):
+                    tag = "linked" if c['linked'] else "same amount"
+                    ctx.console.print(
+                        f"    [dim]pool ({tag:11}) {c['projcode']:12} "
+                        f"{fmt.number(c['amount']):>12}[/dim]"
+                    )
+    else:
+        ctx.console.print(
+            "✅ Every parent allocation covers its carve-out children",
+            style="green",
+        )
+
+    if bad_dates:
+        ctx.console.print(
+            f"\n⚠️  {len(bad_dates)} allocation(s) with impossible date windows:",
+            style="bold yellow",
+        )
+        table = Table(box=box.SIMPLE, show_header=True)
+        table.add_column("Project")
+        table.add_column("Resource")
+        table.add_column("Allocation", justify="right")
+        table.add_column("Start")
+        table.add_column("End")
+        for d in bad_dates:
+            table.add_row(
+                d['projcode'],
+                d['resource_name'],
+                str(d['allocation_id']),
+                fmt.date_str(d['start_date']),
+                fmt.date_str(d['end_date']),
+            )
+        ctx.console.print(table)
+    else:
+        ctx.console.print("✅ No impossible allocation date windows", style="green")
+
+
 def display_notification_results(ctx: Context, results: dict, total_projects: int):
     """Display notification results summary.
 

--- a/src/sam/queries/fstree_access.py
+++ b/src/sam/queries/fstree_access.py
@@ -40,6 +40,26 @@ accountStatus semantics (matching DefaultAccountStatusCalculator.java):
 
 Parent → child status propagation (pre-order): if a parent's accountStatus is
 non-Normal, that status cascades to all children on the same resource.
+
+Project trees
+-------------
+Each project entry carries ``parentProject`` — its direct parent's projcode
+(``None`` for roots and standalone projects), from SAM's project hierarchy
+(``project.parent_id``).  This lets a consumer reconstruct the tree; the PBS
+fairshare tool mirrors it into nested scheduler vertices.
+
+Amounts are reported **raw**, never deduplicated: NCAR runs two tree
+conventions and in both the root's ``allocationAmount`` is the subtree total
+(a shared pool is carried at full value by every member; a subdivided award
+has children carving out of the root's total).  Since PBS compares shares only
+among siblings, raw amounts + the hierarchy are sufficient and correct — a
+pool's members compare equal to each other, a subdivided award's children
+compare proportionally, and the root's own amount sets the subtree's weight
+against its peers.  So this module deliberately does **not** classify trees.
+
+That correctness rests on one data invariant — a parent's amount covers any
+child that isn't sharing its pool — which ``sam-admin project --audit-trees``
+enforces.
 """
 
 import re
@@ -472,6 +492,9 @@ def get_fstree_data(
         ``adjustedUsage`` is computed via MPTT subtree rollup.
         ``accountStatus`` follows the legacy Java priority chain.
         Parent non-Normal status propagates to children (pre-order walk).
+        ``parentProject`` exposes the project hierarchy (None for roots);
+        allocation amounts stay raw — see "Project trees" in the module
+        docstring for why no tree-level deduplication is applied.
         Projects with no current active allocation appear as "Expired" or
         "No Account" with zero usage/allocation/users (requires resource filter).
     """
@@ -525,10 +548,6 @@ def get_fstree_data(
                         row.start_date, row.end_date,
                     )
 
-    for row in skeleton_rows:
-        if row.projcode not in projcode_parent:
-            projcode_parent[row.projcode] = pid_to_projcode.get(row.parent_id) if row.parent_id else None
-
     # ------------------------------------------------------------------
     # Query 2 — Lifecycle rows (Expired / No Account)
     # Only meaningful when a specific resource is requested.
@@ -540,8 +559,16 @@ def get_fstree_data(
         lifecycle_rows = session.execute(_SQL_FSTREE_LIFECYCLE, params).fetchall()
         for row in lifecycle_rows:
             pid_to_projcode[row.project_id] = row.projcode
-            if row.projcode not in projcode_parent:
-                projcode_parent[row.projcode] = pid_to_projcode.get(row.parent_id) if row.parent_id else None
+
+    # Resolve parent_id → parent projcode only once *both* row sets have
+    # populated pid_to_projcode: neither query is ordered by tree depth, so
+    # resolving inline would miss any parent that happens to come later.
+    # A parent_id absent from the payload (inactive, or no account on this
+    # resource) resolves to None — such a project is a root of the tree we
+    # can see, which is what a consumer should act on.
+    for row in (*skeleton_rows, *lifecycle_rows):
+        if row.projcode not in projcode_parent:
+            projcode_parent[row.projcode] = pid_to_projcode.get(row.parent_id) if row.parent_id else None
 
     # ------------------------------------------------------------------
     # Charges — hybrid approach matching allocations.py:
@@ -765,9 +792,10 @@ def get_fstree_data(
                 resources_list.sort(key=lambda r: r['name'])
 
                 projects_list.append({
-                    'projectCode': projcode,
-                    'active':      proj_data['active'],
-                    'resources':   resources_list,
+                    'projectCode':   projcode,
+                    'parentProject': projcode_parent.get(projcode),
+                    'active':        proj_data['active'],
+                    'resources':     resources_list,
                 })
 
             alloc_types_list.append({
@@ -813,6 +841,7 @@ def _remap_fstree_by_project(fstree_data: Dict) -> Dict:
                 projcode = proj['projectCode']
                 projects[projcode] = {
                     'active':                    proj['active'],
+                    'parentProject':             proj.get('parentProject'),
                     'facility':                  fac['name'],
                     'allocationType':            at['name'],
                     'allocationTypeDescription': at['description'],
@@ -844,6 +873,7 @@ def _remap_fstree_by_user(fstree_data: Dict) -> Dict:
                 projcode  = proj['projectCode']
                 proj_meta = {
                     'active':                    proj['active'],
+                    'parentProject':             proj.get('parentProject'),
                     'facility':                  fac['name'],
                     'allocationType':            at['name'],
                     'allocationTypeDescription': at['description'],
@@ -896,7 +926,7 @@ def get_project_fsdata(
     Returns:
         Dict with ``name`` (``"projectFairShareData"``) and ``projects`` keys.
         ``projects`` is a dict keyed by projcode; each value contains
-        ``active``, ``facility``, ``allocationType``,
+        ``active``, ``parentProject``, ``facility``, ``allocationType``,
         ``allocationTypeDescription``, and ``resources`` (same fields as
         the fstree resource dict, sorted by resource name).
 
@@ -932,9 +962,10 @@ def get_user_fsdata(
         Dict with ``name`` (``"userFairShareData"``) and ``users`` keys.
         ``users`` is a dict keyed by username; each value contains ``uid``
         and ``projects``.  ``projects`` is a dict keyed by projcode; each
-        project entry contains ``active``, ``facility``, ``allocationType``,
-        ``allocationTypeDescription``, and ``resources`` (same fields as the
-        fstree resource dict minus ``users``, sorted by resource name).
+        project entry contains ``active``, ``parentProject``, ``facility``,
+        ``allocationType``, ``allocationTypeDescription``, and ``resources``
+        (same fields as the fstree resource dict minus ``users``, sorted by
+        resource name).
 
     Example::
 

--- a/src/sam/queries/tree_audit.py
+++ b/src/sam/queries/tree_audit.py
@@ -1,0 +1,227 @@
+"""
+Data-quality audits for project allocation trees.
+
+SAM runs two project-tree conventions, and downstream consumers (notably the
+PBS fairshare tree built from ``sam.queries.fstree_access``) rely on them being
+kept consistent:
+
+  * **shared pool** — every member of the tree carries an allocation row at the
+    *full* pool amount, ideally linked via ``allocation.parent_allocation_id``;
+  * **subdivided award** — children carve distinct amounts out of the root's
+    total.
+
+Both share one invariant: **a parent's allocation covers every child that is
+not sharing its pool.**  Hold that, and a tree root's raw ``amount`` is always
+its subtree total, which is what lets consumers weight a tree against its peers
+using raw amounts and the hierarchy alone — no tree classification needed.
+Break it, and the root is silently under-weighted against its peers.
+
+Nothing enforces the invariant at write time (allocations are entered per
+project), so it drifts as awards are made.  ``audit_allocation_trees()`` is the
+check; ``sam-admin project --audit-trees`` is the operator-facing front end.
+
+Note this module *does* classify pool-vs-carve children — that judgement lives
+here, in the audit, and deliberately nowhere else.
+"""
+
+from typing import Dict, List, Optional
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+
+# Current allocations on configurable HPC/DAV resources, one row per
+# (active project, resource).  Verified against production data: no
+# (project, resource) carries more than one current allocation, so joining
+# this CTE to itself cannot double-count.
+_CTE_CURRENT_ALLOCATIONS = """
+    WITH cur AS (
+        SELECT p.project_id,
+               p.projcode,
+               p.parent_id,
+               r.resource_name,
+               al.allocation_id,
+               al.parent_allocation_id,
+               al.amount
+        FROM project p
+        JOIN account        a  ON (a.project_id       = p.project_id
+                                    AND a.deleted      IS FALSE)
+        JOIN resources      r  ON (r.resource_id      = a.resource_id
+                                    AND r.configurable IS TRUE)
+        JOIN resource_type  rt ON (rt.resource_type_id = r.resource_type_id
+                                    AND rt.resource_type IN ('HPC', 'DAV'))
+        JOIN allocation     al ON (al.account_id      = a.account_id
+                                    AND al.deleted     IS FALSE
+                                    AND al.start_date <= NOW()
+                                    AND (al.end_date IS NULL OR al.end_date >= NOW()))
+        WHERE p.active IS TRUE
+    )
+"""
+
+# One row per (parent, child, resource) pair, flagging how the child relates to
+# its parent's allocation.
+#
+# `linked` guards the NULL: `parent_allocation_id = par.allocation_id` alone
+# would yield NULL (not FALSE) for unlinked children and poison the OR.
+_SQL_TREE_PAIRS = text(_CTE_CURRENT_ALLOCATIONS + """
+    SELECT par.projcode        AS parent_projcode,
+           par.resource_name   AS resource_name,
+           par.amount          AS parent_amount,
+           ch.projcode         AS child_projcode,
+           ch.amount           AS child_amount,
+           (ch.parent_allocation_id IS NOT NULL
+             AND ch.parent_allocation_id = par.allocation_id) AS linked,
+           (ch.amount = par.amount)                           AS equal_amount
+    FROM cur par
+    JOIN cur ch ON (ch.parent_id     = par.project_id
+                     AND ch.resource_name = par.resource_name)
+    WHERE (:resource IS NULL OR par.resource_name = :resource)
+    ORDER BY par.resource_name, par.projcode, ch.projcode
+""")
+
+# Impossible allocation windows — not merely unusual ones.  Long windows are
+# NOT an error: ~160 current allocations legitimately run 5-10 years (UNIV
+# awards with extended end dates), so only physically impossible values are
+# flagged.
+#
+# Scoped to configurable HPC/DAV resources — the population the fairshare tree
+# is built from, and the only one where a bogus window changes a burn rate.
+# Decommissioned machines (configurable IS FALSE) carry long-expired rows with
+# their own inconsistencies that nobody will fix; including them would leave
+# the audit permanently red and therefore ignored.
+#
+# Deliberately NOT restricted to *current* allocations: a current allocation
+# cannot have end < start (current implies start <= NOW() <= end), so that
+# check would be dead code under a current-only filter.
+_SQL_BAD_DATES = text("""
+    SELECT p.projcode        AS projcode,
+           r.resource_name   AS resource_name,
+           al.allocation_id  AS allocation_id,
+           al.start_date     AS start_date,
+           al.end_date       AS end_date,
+           al.amount         AS amount
+    FROM allocation al
+    JOIN account       a  ON (a.account_id        = al.account_id
+                               AND a.deleted      IS FALSE)
+    JOIN project       p  ON (p.project_id        = a.project_id
+                               AND p.active       IS TRUE)
+    JOIN resources     r  ON (r.resource_id       = a.resource_id
+                               AND r.configurable IS TRUE)
+    JOIN resource_type rt ON (rt.resource_type_id = r.resource_type_id
+                               AND rt.resource_type IN ('HPC', 'DAV'))
+    WHERE al.deleted IS FALSE
+      AND (:resource IS NULL OR r.resource_name = :resource)
+      AND (YEAR(al.start_date) < 1990
+           OR YEAR(al.end_date) > 2100
+           OR (al.end_date IS NOT NULL AND al.end_date < al.start_date))
+    ORDER BY p.projcode, r.resource_name
+""")
+
+
+def audit_allocation_trees(
+    session: Session,
+    resource_name: Optional[str] = None,
+) -> List[Dict]:
+    """
+    Find parents whose allocation fails to cover their carve-out children.
+
+    A child is a **pool member** (and so does not count against its parent) when
+    its allocation is linked into the parent's (``parent_allocation_id``, the
+    authoritative signal) *or* its amount equals the parent's — the fallback for
+    pools that were never formally linked, which are common.  Every other child
+    is a **carve-out** and consumes part of the parent's amount.
+
+    Args:
+        session:       SQLAlchemy session.
+        resource_name: Optional resource filter (e.g. ``"Derecho"``).
+                       ``None`` audits all HPC/DAV resources.
+
+    Returns:
+        One dict per violating (parent, resource), worst deficit first::
+
+            {
+                'parent_projcode': 'NCGD0006',
+                'resource_name':   'Derecho',
+                'parent_amount':   52000000.0,
+                'carve_total':     54000000.0,
+                'deficit':          2000000.0,   # always > 0
+                'carve_children':  [{'projcode': ..., 'amount': ...}, ...],
+                'pool_children':   [{'projcode': ..., 'amount': ...,
+                                     'linked': True}, ...],
+            }
+
+        Empty list means the invariant holds everywhere.
+    """
+    rows = session.execute(_SQL_TREE_PAIRS, {'resource': resource_name}).fetchall()
+
+    groups: Dict[tuple, Dict] = {}
+    for row in rows:
+        key = (row.parent_projcode, row.resource_name)
+        group = groups.setdefault(key, {
+            'parent_projcode': row.parent_projcode,
+            'resource_name':   row.resource_name,
+            'parent_amount':   float(row.parent_amount),
+            'carve_total':     0.0,
+            'carve_children':  [],
+            'pool_children':   [],
+        })
+
+        child_amount = float(row.child_amount)
+        if row.linked or row.equal_amount:
+            group['pool_children'].append({
+                'projcode': row.child_projcode,
+                'amount':   child_amount,
+                'linked':   bool(row.linked),
+            })
+        else:
+            group['carve_children'].append({
+                'projcode': row.child_projcode,
+                'amount':   child_amount,
+            })
+            group['carve_total'] += child_amount
+
+    violations = []
+    for group in groups.values():
+        deficit = group['carve_total'] - group['parent_amount']
+        if deficit > 0:
+            violations.append({**group, 'deficit': deficit})
+
+    violations.sort(key=lambda v: -v['deficit'])
+    return violations
+
+
+def audit_allocation_dates(
+    session: Session,
+    resource_name: Optional[str] = None,
+) -> List[Dict]:
+    """
+    Find allocations with impossible date windows.
+
+    Flags only values that cannot be real — a start year before 1990, an end
+    year after 2100, or an end that precedes its start (typically a mistyped
+    year, e.g. ``0006-05-08``).  Long-but-plausible windows are **not** flagged:
+    multi-year allocations are routine, and ~160 current ones legitimately run
+    5-10 years.
+
+    This matters to burn-rate consumers, which divide an amount by the window
+    length; a bogus year yields a nonsense rate.  Scoped to configurable
+    HPC/DAV resources for that reason — see the query comment.
+
+    Args:
+        session:       SQLAlchemy session.
+        resource_name: Optional resource filter.  ``None`` audits all
+                       configurable HPC/DAV resources.
+
+    Returns:
+        One dict per offending allocation with ``projcode``, ``resource_name``,
+        ``allocation_id``, ``start_date``, ``end_date``, ``amount``.
+    """
+    rows = session.execute(_SQL_BAD_DATES, {'resource': resource_name}).fetchall()
+    return [{
+        'projcode':      row.projcode,
+        'resource_name': row.resource_name,
+        'allocation_id': row.allocation_id,
+        'start_date':    row.start_date,
+        'end_date':      row.end_date,
+        'amount':        float(row.amount) if row.amount is not None else None,
+    } for row in rows]

--- a/src/webapp/api/v1/fstree_access.py
+++ b/src/webapp/api/v1/fstree_access.py
@@ -37,6 +37,7 @@ Response format (partial):
                         "projects": [
                             {
                                 "projectCode": "P93300041",
+                                "parentProject": null,
                                 "active": true,
                                 "resources": [
                                     {
@@ -110,7 +111,10 @@ def get_fstree():
     Returns:
         JSON with "name" and "facilities" keys, each facility containing
         allocationTypes, each with a projects list including per-resource
-        balance and user data.
+        balance and user data.  Each project carries "parentProject" (its
+        direct parent's projcode, or null) so callers can reconstruct SAM's
+        project hierarchy; allocation amounts are raw per-project values,
+        not deduplicated across a tree.
     """
     return jsonify(_fstree_data())
 

--- a/tests/api/test_fstree_access.py
+++ b/tests/api/test_fstree_access.py
@@ -96,6 +96,21 @@ class TestFstreeSingleResource:
                         checked += 1
         assert checked > 0
 
+    def test_projects_expose_parent_project(self, auth_client):
+        """parentProject survives jsonify and never dangles — a consumer
+        nesting these into a scheduler tree must be able to resolve every
+        parent it is told about."""
+        data = auth_client.get('/api/v1/fstree_access/Derecho').get_json()
+        projects = [proj
+                    for fac in data['facilities']
+                    for at in fac['allocationTypes']
+                    for proj in at['projects']]
+        codes = {p['projectCode'] for p in projects}
+        for proj in projects:
+            assert 'parentProject' in proj, proj['projectCode']
+            if proj['parentProject'] is not None:
+                assert proj['parentProject'] in codes
+
     def test_threshold_key_present(self, auth_client):
         data = auth_client.get('/api/v1/fstree_access/Derecho').get_json()
         for fac in data['facilities'][:1]:
@@ -115,6 +130,26 @@ class TestFstreeSingleResource:
                     for res in proj['resources']:
                         assert res['accountStatus'] in valid, \
                             f'accountStatus {res["accountStatus"]!r} is not valid'
+
+
+class TestFstreeProjectsRemap:
+    """Test GET /api/v1/fstree_access/projects/."""
+
+    def test_returns_200(self, auth_client):
+        response = auth_client.get('/api/v1/fstree_access/projects/?resource=Derecho')
+        assert response.status_code == 200
+
+    def test_parent_project_present_and_resolvable(self, auth_client):
+        """The project-keyed view carries the hierarchy through its own
+        dict rebuild (it doesn't copy the fstree project entry wholesale)."""
+        data = auth_client.get(
+            '/api/v1/fstree_access/projects/?resource=Derecho').get_json()
+        projects = data['projects']
+        assert projects
+        for projcode, proj in projects.items():
+            assert 'parentProject' in proj, projcode
+            if proj['parentProject'] is not None:
+                assert proj['parentProject'] in projects
 
 
 class TestFstreeAuth:

--- a/tests/unit/test_fstree_queries.py
+++ b/tests/unit/test_fstree_queries.py
@@ -195,6 +195,68 @@ class TestProjectStructure:
 
 
 # ============================================================================
+# Project hierarchy (parentProject)
+# ============================================================================
+
+
+def _all_projects(fstree):
+    """Yield every project entry in the tree."""
+    for fac in fstree['facilities']:
+        for at in fac['allocationTypes']:
+            yield from at['projects']
+
+
+class TestProjectHierarchy:
+    """`parentProject` exposes SAM's project tree so consumers (the PBS
+    fairshare tool) can nest projects instead of treating them as peers."""
+
+    def test_every_project_carries_the_key(self, fstree_all):
+        """Present on every entry — including lifecycle (Expired / No Account)
+        rows, since parentage is a project fact, not an allocation fact."""
+        for proj in _all_projects(fstree_all):
+            assert 'parentProject' in proj, proj.get('projectCode')
+
+    def test_parent_is_none_or_a_projcode_in_the_payload(self, fstree_all):
+        """A dangling parent would make a consumer emit a scheduler vertex
+        whose parent it never defines."""
+        codes = {p['projectCode'] for p in _all_projects(fstree_all)}
+        for proj in _all_projects(fstree_all):
+            parent = proj['parentProject']
+            if parent is not None:
+                assert isinstance(parent, str)
+                assert parent in codes, \
+                    f"{proj['projectCode']} -> unknown parent {parent!r}"
+
+    def test_snapshot_contains_at_least_one_tree(self, fstree_all):
+        """Guards the tests above from passing vacuously."""
+        parented = [p for p in _all_projects(fstree_all) if p['parentProject']]
+        assert parented, 'snapshot has no project trees to exercise'
+
+    def test_no_project_is_its_own_parent(self, fstree_all):
+        for proj in _all_projects(fstree_all):
+            assert proj['parentProject'] != proj['projectCode']
+
+    def test_parent_chains_terminate(self, fstree_all):
+        """Walking up must reach a root — a cycle would hang a consumer."""
+        parent_of = {p['projectCode']: p['parentProject']
+                     for p in _all_projects(fstree_all)}
+        for code in parent_of:
+            seen, cur = set(), code
+            while cur is not None:
+                assert cur not in seen, f'cycle through {code}'
+                seen.add(cur)
+                cur = parent_of.get(cur)
+
+    def test_hierarchy_survives_the_resource_filter(self, fstree_hpc):
+        fstree, _ = fstree_hpc
+        codes = {p['projectCode'] for p in _all_projects(fstree)}
+        for proj in _all_projects(fstree):
+            assert 'parentProject' in proj
+            if proj['parentProject'] is not None:
+                assert proj['parentProject'] in codes
+
+
+# ============================================================================
 # Resource level
 # ============================================================================
 
@@ -460,9 +522,17 @@ class TestGetProjectFsdata:
             assert len(projcode) > 0
 
     def test_project_has_required_fields(self, project_fs_all):
-        required = {'active', 'facility', 'allocationType', 'allocationTypeDescription', 'resources'}
+        required = {'active', 'parentProject', 'facility', 'allocationType',
+                    'allocationTypeDescription', 'resources'}
         for _projcode, proj in list(project_fs_all['projects'].items())[:20]:
             assert not (required - proj.keys())
+
+    def test_parent_project_matches_the_fstree(self, fstree_all, project_fs_all):
+        """The remap must carry the hierarchy through unchanged."""
+        expected = {p['projectCode']: p['parentProject']
+                    for p in _all_projects(fstree_all)}
+        for projcode, proj in project_fs_all['projects'].items():
+            assert proj['parentProject'] == expected[projcode]
 
     def test_project_active_is_bool(self, project_fs_all):
         for _projcode, proj in list(project_fs_all['projects'].items())[:20]:
@@ -536,7 +606,8 @@ class TestGetUserFsdata:
             assert isinstance(user['projects'], dict)
 
     def test_project_entry_has_required_fields(self, user_fs_all):
-        required = {'active', 'facility', 'allocationType', 'allocationTypeDescription', 'resources'}
+        required = {'active', 'parentProject', 'facility', 'allocationType',
+                    'allocationTypeDescription', 'resources'}
         for _username, user in list(user_fs_all['users'].items())[:10]:
             for _projcode, proj in list(user['projects'].items())[:5]:
                 assert not (required - proj.keys())

--- a/tests/unit/test_tree_audit.py
+++ b/tests/unit/test_tree_audit.py
@@ -1,0 +1,196 @@
+"""Unit tests for sam.queries.tree_audit.
+
+Each test builds an isolated tree on its own freshly-made HPC resource
+(Layer-2 factories) and audits filtered to that resource, so assertions are
+exact counts rather than "did my violation appear among the snapshot's".
+"""
+from datetime import datetime, timedelta
+
+import pytest
+
+from sam.queries.tree_audit import audit_allocation_trees, audit_allocation_dates
+from tests.factories.projects import make_project, make_account, make_allocation
+from tests.factories.resources import make_resource
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def hpc_type(session):
+    """The real 'HPC' ResourceType — the audit only looks at HPC/DAV."""
+    from sam import ResourceType
+    rt = session.query(ResourceType).filter_by(resource_type='HPC').first()
+    assert rt is not None, "snapshot has no 'HPC' resource type"
+    return rt
+
+
+@pytest.fixture
+def resource(session, hpc_type):
+    """A fresh configurable HPC resource, invisible to every other test."""
+    return make_resource(session, resource_type=hpc_type)
+
+
+def _alloc(session, resource, project, amount, parent_alloc=None):
+    """Give `project` a current allocation of `amount` on `resource`."""
+    account = make_account(session, project=project, resource=resource)
+    return make_allocation(session, account=account, amount=amount,
+                           parent=parent_alloc)
+
+
+# ============================================================================
+# The tree invariant
+# ============================================================================
+
+
+class TestCarveOutTrees:
+    """Children holding distinct amounts consume the parent's allocation."""
+
+    def test_covered_children_are_not_flagged(self, session, resource):
+        parent = make_project(session)
+        _alloc(session, resource, parent, 1_000_000)
+        for amount in (400_000, 400_000):
+            _alloc(session, resource, make_project(session, parent=parent), amount)
+
+        assert audit_allocation_trees(session, resource.resource_name) == []
+
+    def test_children_exceeding_parent_are_flagged(self, session, resource):
+        parent = make_project(session)
+        _alloc(session, resource, parent, 1_000_000)
+        for amount in (600_000, 600_000):
+            _alloc(session, resource, make_project(session, parent=parent), amount)
+
+        violations = audit_allocation_trees(session, resource.resource_name)
+
+        assert len(violations) == 1
+        v = violations[0]
+        assert v['parent_projcode'] == parent.projcode
+        assert v['resource_name'] == resource.resource_name
+        assert v['parent_amount'] == 1_000_000
+        assert v['carve_total'] == 1_200_000
+        assert v['deficit'] == 200_000
+        assert len(v['carve_children']) == 2
+        assert v['pool_children'] == []
+
+    def test_exactly_covered_is_not_flagged(self, session, resource):
+        """The invariant is 'covers', so equality is fine — a tree that spends
+        its parent's allocation to the last AU is not an error."""
+        parent = make_project(session)
+        _alloc(session, resource, parent, 1_000_000)
+        _alloc(session, resource, make_project(session, parent=parent), 1_000_000 - 1)
+        # (1_000_000 would be read as a pool member, not a carve-out)
+
+        assert audit_allocation_trees(session, resource.resource_name) == []
+
+
+class TestSharedPools:
+    """Pool members carry the pool's full amount and must not count against it."""
+
+    def test_equal_amount_children_are_pool_members(self, session, resource):
+        """The fallback signal: unlinked pools are common (in production only
+        3 of NMMM0003's 15 members are linked), so equal amounts must be read
+        as sharing, not as a 15x over-subscription."""
+        parent = make_project(session)
+        _alloc(session, resource, parent, 1_000_000)
+        for _ in range(3):
+            _alloc(session, resource, make_project(session, parent=parent), 1_000_000)
+
+        assert audit_allocation_trees(session, resource.resource_name) == []
+
+    def test_linked_children_are_pool_members_regardless_of_amount(
+            self, session, resource):
+        """Linkage is authoritative: parent_allocation_id says 'shares the
+        pool' even when the amounts disagree."""
+        parent = make_project(session)
+        parent_alloc = _alloc(session, resource, parent, 1_000_000)
+        _alloc(session, resource, make_project(session, parent=parent),
+               999_999, parent_alloc=parent_alloc)
+
+        assert audit_allocation_trees(session, resource.resource_name) == []
+
+    def test_pool_and_carve_children_coexist(self, session, resource):
+        """A node can mix conventions; only the carve-outs count."""
+        parent = make_project(session)
+        _alloc(session, resource, parent, 1_000_000)
+        _alloc(session, resource, make_project(session, parent=parent), 1_000_000)
+        _alloc(session, resource, make_project(session, parent=parent), 1_200_000)
+
+        violations = audit_allocation_trees(session, resource.resource_name)
+
+        assert len(violations) == 1
+        v = violations[0]
+        assert v['deficit'] == 200_000
+        assert len(v['pool_children']) == 1
+        assert len(v['carve_children']) == 1
+
+
+class TestAuditScope:
+
+    def test_violations_are_per_resource(self, session, hpc_type):
+        """A tree can be a pool on one resource and subdivided on another, so
+        the invariant is judged per (parent, resource)."""
+        res_a = make_resource(session, resource_type=hpc_type)
+        res_b = make_resource(session, resource_type=hpc_type)
+        parent = make_project(session)
+        child = make_project(session, parent=parent)
+
+        _alloc(session, res_a, parent, 1_000_000)
+        _alloc(session, res_a, child, 1_200_000)      # violation on A
+        _alloc(session, res_b, parent, 1_000_000)
+        _alloc(session, res_b, child, 500_000)        # fine on B
+
+        assert len(audit_allocation_trees(session, res_a.resource_name)) == 1
+        assert audit_allocation_trees(session, res_b.resource_name) == []
+
+    def test_deficits_sort_worst_first(self, session, hpc_type):
+        res = make_resource(session, resource_type=hpc_type)
+        for parent_amt, child_amt in ((1_000_000, 1_100_000),
+                                      (1_000_000, 3_000_000)):
+            parent = make_project(session)
+            _alloc(session, res, parent, parent_amt)
+            _alloc(session, res, make_project(session, parent=parent), child_amt)
+
+        deficits = [v['deficit'] for v in audit_allocation_trees(session,
+                                                                 res.resource_name)]
+        assert deficits == sorted(deficits, reverse=True)
+
+    def test_childless_projects_are_never_flagged(self, session, resource):
+        _alloc(session, resource, make_project(session), 1_000_000)
+        assert audit_allocation_trees(session, resource.resource_name) == []
+
+
+# ============================================================================
+# Allocation date windows
+# ============================================================================
+
+
+class TestDateAudit:
+
+    def test_impossible_start_year_is_flagged(self, session, resource):
+        """A mistyped year (production had 0006-05-08) yields a ~737,000-day
+        window, which wrecks any burn-rate consumer."""
+        project = make_project(session)
+        account = make_account(session, project=project, resource=resource)
+        make_allocation(session, account=account, amount=10_000,
+                        start_date=datetime(6, 5, 8),
+                        end_date=datetime.now() + timedelta(days=365))
+
+        bad = audit_allocation_dates(session, resource.resource_name)
+
+        assert len(bad) == 1
+        assert bad[0]['projcode'] == project.projcode
+        assert bad[0]['start_date'].year == 6
+
+    def test_normal_window_is_not_flagged(self, session, resource):
+        _alloc(session, resource, make_project(session), 1_000_000)
+        assert audit_allocation_dates(session, resource.resource_name) == []
+
+    def test_long_windows_are_not_flagged(self, session, resource):
+        """Regression: multi-year allocations are routine (~160 current ones
+        run 5-10 years), so length alone must never be an error."""
+        project = make_project(session)
+        account = make_account(session, project=project, resource=resource)
+        make_allocation(session, account=account, amount=1_000_000,
+                        start_date=datetime.now() - timedelta(days=365 * 4),
+                        end_date=datetime.now() + timedelta(days=365 * 5))
+
+        assert audit_allocation_dates(session, resource.resource_name) == []


### PR DESCRIPTION
## Summary

Adds `parentProject` to each project entry in `/api/v1/fstree_access/` (and its
`/projects/` and `/users/` remaps) so consumers can reconstruct SAM's project
tree, plus a `sam-admin` audit for the data invariant that makes the whole model
work.

**Why.** The PBS fairshare consumer ([hpc-scheduling-tools#1]) emits every
project as a peer, which badly distorts groups containing project trees. On
Derecho, project shares under `N_Divisional` summed to **3.2B flat vs 379M
nested (-88%)** and `C_CSL` to **1.16B vs 181M (-84%)** — those groups were
claiming many times their due against groups that have no trees. A shared pool
like NMMM0003 was counted once per member (~14x); a subdivided award like
CESM0002 was counted twice (root + children).

## The model — no tree classification anywhere

Amounts stay **raw**, deliberately not deduplicated. PBS compares shares only
among siblings, and under both NCAR conventions a root's `allocationAmount` is
already its subtree total (a shared pool is carried at full value by every
member; a subdivided award has children carving out of the root's total). So
hierarchy + raw amounts are sufficient, and neither the API nor the consumer
needs to classify trees.

## Changes

- **`parentProject`** — direct parent's projcode, `null` for roots. Purely
  additive, so it ships on the same API version. Sourced from the
  `projcode_parent` map the assembly already builds for status propagation:
  no SQL change, no extra query.
- **Fixed a latent ordering bug** in that map. The lifecycle loop populated
  `pid_to_projcode` and read it in the same pass, so a lifecycle row whose
  parent appeared later (the query orders by projcode, not tree depth) resolved
  its parent to `None`. Resolution now runs once, after both row sets load.
- **`sam.queries.tree_audit` + `sam-admin project --audit-trees [--resource X]`**
  — the correctness above rests on one invariant (*a parent's allocation covers
  every child not sharing its pool*) that nothing enforces at write time. The
  audit reports violations and exits 2. It is the **only** place pool-vs-carve
  classification lives: a child is a pool member when linked via
  `parent_allocation_id` (authoritative) or when its amount equals the parent's
  (the fallback — unlinked pools are common; only 3 of NMMM0003's 15 members are
  linked). Also flags impossible date windows (year <1990/>2100, end < start),
  scoped to configurable HPC/DAV resources. Long windows are explicitly **not**
  flagged: ~160 current allocations legitimately run 5-10 years.

## Verification

Against a production copy: 1,477 Derecho projects, 101 non-null parents, zero
dangling, no cycles; the multi-level CESM tree resolves correctly (CESM0027 →
CESM0028 → CESM0002, with P93300606 as an interior node).

The audit reports zero violations DB-wide. Injecting the historical NCGD0006
violation (52M root vs 54M children) in a rolled-back transaction reproduces it
exactly — including all 7 carve-out children — confirming the detector fires
rather than merely never complaining.

## Test Results

- `tests/unit/test_tree_audit.py` — 12 new tests: pool by equality, pool by
  linkage, mixed nodes, per-resource scope, and a long-window regression
- `tests/unit/test_fstree_queries.py` — 6 new hierarchy tests: no dangling
  parents, no cycles, survives the resource filter, remap parity
- `tests/api/test_fstree_access.py` — key survives `jsonify` on both the tree
  and the `/projects/` remap
- **Full suite: 2,591 passed, 22 skipped, 1 xfailed**

## Deploy

Ship before the consumer ([hpc-scheduling-tools#1] follow-up), though order is
not critical: a payload without `parentProject` makes the consumer emit its
previous flat tree byte-for-byte.

[hpc-scheduling-tools#1]: https://github.com/benkirk/hpc-scheduling-tools/pull/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)