### PR TITLE
Mobile polish round 2: table scrollboxes, fullscreen modals, stacked filters

### DIFF
--- a/docs/plans/MOBILE_FRIENDLY.md
+++ b/docs/plans/MOBILE_FRIENDLY.md
@@ -1,7 +1,15 @@
 # MOBILE_FRIENDLY — low-hanging mobile polish (handoff)
 
-**Status:** planned, not started. Written 2026-07-19 at the end of the
-`nav_polish` session, while the mobile survey was fresh.
+**Status:** IMPLEMENTED 2026-07-19 on branch `mobile_polish` (all six items).
+Item 1 went in as option (a), the global CSS rule, with two refinements found
+during Playwright verification: a `:not(.table-responsive) >` guard so
+deliberately-wrapped tables (access-grid sticky column) are untouched, and a
+wider `< 992px` breakpoint because the transactions table also overflowed
+iPad portrait (820px). The card-header rule (item 4) grew into a general
+"`.d-flex:not(.flex-column)` rows wrap below md" rule after the Manage
+Project allocations toolbar overflowed — flex-column stacks must stay
+unwrapped or align-items:stretch sizes children to fit-content. Survey notes
+below kept for reference.
 
 **Stacking:** branch off `nav_polish` (or `staging` once PRs #358 + #359 have
 merged). #358 made every top-level tab a routable page; #359 added navbar

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -423,6 +423,65 @@ body {
     .main-content .btn-group {
         flex-wrap: wrap;
     }
+
+    /* Any utility flex row wraps rather than squeezing or overflowing the
+       viewport: card headers with action buttons ("Search Projects" +
+       "Create Project"), tab-pane toolbars (date picker + Extend/Renew/Add
+       on Manage Project), etc. flex-wrap only engages when the row would
+       otherwise overflow, so fitting rows are untouched. Deliberately broad
+       — the precise per-container list kept growing (see #359's page-header
+       rule above, now one instance of this). Vertical stacks are excluded:
+       wrapping a flex-column makes align-items:stretch size children to
+       fit-content, which lets an inner table blow the card out to its
+       intrinsic width. */
+    .main-content .d-flex:not(.flex-column) {
+        flex-wrap: wrap;
+    }
+
+    .card-header.d-flex {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    /* Tab strips scroll horizontally by design; fade the right edge as a
+       "more tabs off-screen" affordance. Purely cosmetic — 2.5rem is narrow
+       enough not to obscure a strip that happens to fit exactly. */
+    .nav-tabs {
+        mask-image: linear-gradient(to right, #000 calc(100% - 2.5rem), transparent);
+        -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 2.5rem), transparent);
+    }
+
+    /* Tap targets: expandable drill-down rows and sortable column headers
+       are finger-hostile at desktop padding. */
+    .expandable-row td {
+        padding-top: 0.625rem;
+        padding-bottom: 0.625rem;
+    }
+
+    .main-content table.table th a {
+        display: inline-block;
+        padding: 0.25rem 0;
+    }
+
+    /* Slightly smaller table type on phones: trades a notch of size for a
+       lot less horizontal scrolling on data-heavy tables. */
+    .main-content .table {
+        font-size: 0.8125rem;
+    }
+}
+
+/* Below lg (phones AND portrait tablets — the widest data tables exceed even
+   an iPad's 820px): any table not already inside a .table-responsive scroller
+   gets its own horizontal scrollbox instead of widening the document. The
+   child-combinator guard leaves deliberately-wrapped tables (allocations
+   summary, admin access-grid with its sticky column) untouched. Known
+   tradeoff of display:block — a table narrower than the screen no longer
+   stretches to full width. */
+@media (max-width: 991.98px) {
+    .main-content :not(.table-responsive) > table.table {
+        display: block;
+        overflow-x: auto;
+    }
 }
 
 /* ============================================================================
@@ -1161,6 +1220,22 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
 
 .filter-sidebar input::placeholder {
     color: var(--ncar-gray);
+}
+
+/* On phones the horizontal filter rows wrap into a ragged multi-column mess:
+   stack every field full-width instead. !important is required to beat the
+   inline style="width:###px" attributes that size the fields on desktop
+   (audit_filters.html, allocations/projects.html, admin/projects.html). */
+@media (max-width: 575.98px) {
+    .filter-sidebar .d-flex.flex-wrap > div {
+        width: 100%;
+    }
+
+    .filter-sidebar input.form-control,
+    .filter-sidebar select.form-control,
+    .filter-sidebar select.form-select {
+        width: 100% !important;
+    }
 }
 
 /* ============================================================================

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -1186,6 +1186,41 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     margin: 0;
 }
 
+/* Collapsible filter panels: the "Filters" title is a collapse toggle.
+   The toggle is the title only — NOT the whole header row — because the
+   Bootstrap collapse data-api handles clicks in the capture phase, so the
+   sibling "Clear filters" link could never stopPropagation out of a
+   row-level toggle. Chevron tracks aria-expanded, which Bootstrap
+   maintains on the toggle. */
+.filter-sidebar-toggle {
+    background: none;
+    border: 0;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+    text-transform: inherit;
+    letter-spacing: inherit;
+    cursor: pointer;
+}
+
+.filter-sidebar-chevron {
+    font-size: 0.75rem;
+    transition: transform 0.2s ease;
+}
+
+.filter-sidebar-toggle[aria-expanded="false"] .filter-sidebar-chevron {
+    transform: rotate(-90deg);
+}
+
+/* Collapsed panel: drop the divider and reclaim the header's bottom
+   margin so the closed state reads as a tidy title bar rather than an
+   empty box. (During the .collapsing animation neither state matches —
+   the margin snaps when the transition ends, which reads fine.) */
+.filter-sidebar-header:has(+ .collapse:not(.show)) {
+    border-bottom: none;
+    margin-bottom: -0.75rem;
+}
+
 .filter-sidebar-clear {
     color: #fff;
     font-size: 0.875rem;

--- a/src/webapp/static/js/dashboard-init.js
+++ b/src/webapp/static/js/dashboard-init.js
@@ -204,4 +204,28 @@
     if (activeResourceTab) {
         showPieForResource(activeResourceTab.getAttribute('href').slice(1));
     }
+
+    /* ================= Collapsible filter panels ================= */
+
+    /* Filter panels ship expanded (class="collapse show") but default to
+     * collapsed on phones, where they can fill 1.5 screens. Markup can't be
+     * viewport-conditional, so the default is applied here: strip .show
+     * before first paint (script runs at end of body) and after htmx swaps
+     * that re-render a panel. Re-collapsing after a filter *submit* is
+     * deliberate — on a phone the results matter more than the form.
+     * The panels carry data-no-persist so nav-view-persistence.js does not
+     * re-expand them from a stale localStorage entry. */
+    function collapseFilterPanels(root) {
+        if (!window.matchMedia('(max-width: 767.98px)').matches) { return; }
+        root.querySelectorAll('.filter-fields-collapse.show').forEach(function (el) {
+            el.classList.remove('show');
+            var toggle = document.querySelector('[data-bs-target="#' + el.id + '"]');
+            if (toggle) { toggle.setAttribute('aria-expanded', 'false'); }
+        });
+    }
+
+    collapseFilterPanels(document);
+    document.body.addEventListener('htmx:afterSettle', function (e) {
+        if (e.detail.elt) { collapseFilterPanels(e.detail.elt); }
+    });
 })();

--- a/src/webapp/static/js/modals.js
+++ b/src/webapp/static/js/modals.js
@@ -90,4 +90,25 @@
             }
         }
     });
+
+    /* ── Pinch-zoom scrollbar-compensation fix ──
+     * Bootstrap sizes its "hidden scrollbar" pad as
+     * abs(window.innerWidth - documentElement.clientWidth). Under pinch-zoom
+     * innerWidth tracks the *visual* viewport while clientWidth stays at
+     * layout width, so a 3x zoom on a 390px phone reads as a 260px
+     * scrollbar and the opening modal is padded down to a few characters
+     * wide (chart-link modals on the status pages were the visible victim).
+     * A zoomed viewport has no classic scrollbar to compensate for — strip
+     * the bogus padding as the modal opens. rAF: Bootstrap applies the
+     * padding synchronously right after dispatching show.bs.modal. Its
+     * hide-time restore still works — it resets to the saved original. */
+    document.addEventListener('show.bs.modal', function (e) {
+        if (!window.visualViewport || window.visualViewport.scale <= 1.01) { return; }
+        var modal = e.target;
+        requestAnimationFrame(function () {
+            modal.style.paddingRight = '';
+            modal.style.paddingLeft = '';
+            document.body.style.paddingRight = '';
+        });
+    });
 })();

--- a/src/webapp/templates/dashboards/admin/edit_project.html
+++ b/src/webapp/templates/dashboards/admin/edit_project.html
@@ -224,7 +224,7 @@
 
 <!-- Extend Allocations Modal (lazy-loaded) -->
 <div class="modal fade" id="extendAllocationsModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-lg">
+  <div class="modal-dialog modal-lg modal-fullscreen-sm-down">
     <div class="modal-content">
       <div class="modal-header bg-warning text-dark">
         <h5 class="modal-title"><i class="fas fa-calendar-plus"></i> Extend Allocations</h5>
@@ -242,7 +242,7 @@
 
 <!-- Renew Allocations Modal (lazy-loaded) -->
 <div class="modal fade" id="renewAllocationsModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-lg">
+  <div class="modal-dialog modal-lg modal-fullscreen-sm-down">
     <div class="modal-content">
       <div class="modal-header bg-primary text-white">
         <h5 class="modal-title"><i class="fas fa-sync-alt"></i> Renew Allocations</h5>

--- a/src/webapp/templates/dashboards/admin/fragments/institution_filters.html
+++ b/src/webapp/templates/dashboards/admin/fragments/institution_filters.html
@@ -34,13 +34,22 @@
     <input type="hidden" name="active_only" value="{{ 1 if active_only else 0 }}">
 
     <div class="filter-sidebar-header">
-        <h2 class="filter-sidebar-title">Filters</h2>
+        <h2 class="filter-sidebar-title">
+            <button class="filter-sidebar-toggle" type="button"
+                    data-bs-toggle="collapse" data-bs-target="#{{ form_id }}-fields"
+                    aria-expanded="true" aria-controls="{{ form_id }}-fields">
+                Filters <i class="fas fa-chevron-down filter-sidebar-chevron ms-1"></i>
+            </button>
+        </h2>
         {# CSP-clean reset: form-reset-submit (static/js/actions.js) resets the
            form and re-triggers its htmx submit — no inline onclick. #}
         <a class="filter-sidebar-clear" style="cursor: pointer;"
            data-action="form-reset-submit" data-form-id="{{ form_id }}">Clear filters</a>
     </div>
 
+    {# Collapsed by default on phones (dashboard-init.js strips .show below
+       md). data-no-persist: the responsive default owns the initial state. #}
+    <div id="{{ form_id }}-fields" class="collapse show filter-fields-collapse" data-no-persist>
     <div class="d-flex flex-wrap align-items-start gap-3">
 
         <div>
@@ -125,6 +134,7 @@
             <i class="fas fa-rotate-left"></i> Reset
         </button>
 
+    </div>
     </div>
 </form>
 {% endmacro %}

--- a/src/webapp/templates/dashboards/allocations/adjustments.html
+++ b/src/webapp/templates/dashboards/allocations/adjustments.html
@@ -46,7 +46,7 @@
 {% if has_permission(Permission.EDIT_ALLOCATIONS) %}
 <!-- Create Adjustment modal ("Create Adjustment" button above) -->
 <div class="modal fade" id="createAdjustmentModal" tabindex="-1" role="dialog" aria-hidden="true">
-    <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-dialog modal-lg modal-fullscreen-sm-down" role="document">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title"><i class="fas fa-plus"></i> Create Charge Adjustment</h5>

--- a/src/webapp/templates/dashboards/allocations/partials/audit_details_modal.html
+++ b/src/webapp/templates/dashboards/allocations/partials/audit_details_modal.html
@@ -3,7 +3,7 @@
      so e.g. a transaction row shows "Allocation Transaction Details" and an
      adjustment row shows "Charge Adjustment Details". -->
 <div class="modal fade" id="auditDetailsModal" tabindex="-1" role="dialog" aria-hidden="true">
-    <div class="modal-dialog modal-lg modal-dialog-scrollable" role="document">
+    <div class="modal-dialog modal-lg modal-fullscreen-sm-down modal-dialog-scrollable" role="document">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="auditDetailsModalTitle">Details</h5>

--- a/src/webapp/templates/dashboards/allocations/projects.html
+++ b/src/webapp/templates/dashboards/allocations/projects.html
@@ -109,11 +109,20 @@
      filter); form fields arranged horizontally for top-of-page placement. -->
 <div class="filter-sidebar mb-3">
     <div class="filter-sidebar-header">
-        <h2 class="filter-sidebar-title">Filters</h2>
+        <h2 class="filter-sidebar-title">
+            <button class="filter-sidebar-toggle" type="button"
+                    data-bs-toggle="collapse" data-bs-target="#allocations-filter-fields"
+                    aria-expanded="true" aria-controls="allocations-filter-fields">
+                Filters <i class="fas fa-chevron-down filter-sidebar-chevron ms-1"></i>
+            </button>
+        </h2>
         <a href="{{ url_for('allocations_dashboard.projects') }}"
            class="filter-sidebar-clear">Clear filters</a>
     </div>
 
+    {# Collapsed by default on phones (dashboard-init.js strips .show below
+       md). data-no-persist: the responsive default owns the initial state. #}
+    <div id="allocations-filter-fields" class="collapse show filter-fields-collapse" data-no-persist>
     <form method="GET" class="d-flex flex-wrap align-items-start gap-3 mb-0"
           id="allocations-facility-filter-form">
         <div>
@@ -150,6 +159,7 @@
 
         <button type="submit" class="btn btn-outline-white align-self-end">Update</button>
     </form>
+    </div>
 </div>
 
 <!-- Resource Tabs -->

--- a/src/webapp/templates/dashboards/allocations/projects.html
+++ b/src/webapp/templates/dashboards/allocations/projects.html
@@ -399,7 +399,7 @@
 
 <!-- Usage Modal -->
 <div class="modal fade" id="usageModal" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-dialog modal-lg modal-fullscreen-sm-down" role="document">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">Allocation Usage Details</h5>

--- a/src/webapp/templates/dashboards/fragments/audit_filters.html
+++ b/src/webapp/templates/dashboards/fragments/audit_filters.html
@@ -34,13 +34,22 @@
       hx-swap="innerHTML"
       hx-trigger="submit">
     <div class="filter-sidebar-header">
-        <h2 class="filter-sidebar-title">Filters</h2>
+        <h2 class="filter-sidebar-title">
+            <button class="filter-sidebar-toggle" type="button"
+                    data-bs-toggle="collapse" data-bs-target="#{{ form_id }}-fields"
+                    aria-expanded="true" aria-controls="{{ form_id }}-fields">
+                Filters <i class="fas fa-chevron-down filter-sidebar-chevron ms-1"></i>
+            </button>
+        </h2>
         {# CSP-clean reset: form-reset-submit (static/js/actions.js) resets the
            form and re-triggers its htmx submit — no inline onclick. #}
         <a class="filter-sidebar-clear" style="cursor: pointer;"
            data-action="form-reset-submit" data-form-id="{{ form_id }}">Clear filters</a>
     </div>
 
+    {# Collapsed by default on phones (dashboard-init.js strips .show below
+       md). data-no-persist: the responsive default owns the initial state. #}
+    <div id="{{ form_id }}-fields" class="collapse show filter-fields-collapse" data-no-persist>
     <div class="d-flex flex-wrap align-items-start gap-3">
 
         <div>
@@ -102,6 +111,7 @@
         {% endif %}
 
         <button type="submit" class="btn btn-outline-white align-self-end">Search</button>
+    </div>
     </div>
 </form>
 {% endmacro %}

--- a/src/webapp/templates/dashboards/fragments/modals.html
+++ b/src/webapp/templates/dashboards/fragments/modals.html
@@ -75,7 +75,9 @@
   {%- set _header_class = 'bg-success text-white' -%}
   {%- set _close_class = 'btn-close btn-close-white' -%}
 {%- endif -%}
-{%- set _dialog_class = 'modal-dialog' + (' modal-' ~ size if size else '') -%}
+{#- Sized (lg/xl) modals go fullscreen on phones — a modal-lg squeezed into a
+    390px viewport is unusable. Default-size modals already fit. -#}
+{%- set _dialog_class = 'modal-dialog' + (' modal-' ~ size ~ ' modal-fullscreen-sm-down' if size else '') -%}
 <div class="modal fade" id="{{ modal_id }}" tabindex="-1"
      aria-labelledby="{{ modal_id }}Label" aria-hidden="true">
     <div class="{{ _dialog_class }}">

--- a/src/webapp/templates/dashboards/shared/project_details_modal.html
+++ b/src/webapp/templates/dashboards/shared/project_details_modal.html
@@ -1,7 +1,7 @@
 {# Project Details Modal — body filled via HTMX GET /project-details-modal/<projcode>
    Triggered by buttons / SVG anchors with hx-get → #projectDetailsModalBody. #}
 <div class="modal fade" id="projectDetailsModal" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-xl" role="document">
+    <div class="modal-dialog modal-xl modal-fullscreen-sm-down" role="document">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="projectDetailsModalTitle">Project Details</h5>

--- a/src/webapp/templates/dashboards/status/partials/filesystem_scans.html
+++ b/src/webapp/templates/dashboards/status/partials/filesystem_scans.html
@@ -4,10 +4,11 @@
    the project disk page shows, but in resource mode — rooted over the whole
    filesystem (VIEW_ALL_FILESYSTEM_DATA-gated routes).
 
-   Lazy-load: the active first subtab gets no shown.bs.tab when the parent
-   "Filesystem Scans" tab opens, so its card's first inner tab listens to the
-   parent tab (#filesystem-scans-tab). Other subtabs load when their own
-   subtab nav-link is shown. Bind to the shown event, not click
+   Lazy-load: since the routable-pages refactor (#358) this partial renders
+   only on its own /status/filesystem-scans page, where the first subtab's
+   pane is visible immediately — so its card's first inner tab fires on
+   `load` (same pattern as my_data_scans.html). Other subtabs load when
+   their own subtab nav-link is shown. Bind to the shown event, not click
    (feedback_persisted_collapse_htmx). Closed subtabs cost nothing.
 
    This partial is only included when fs_scan_resources is non-empty AND the
@@ -30,7 +31,7 @@
     <div class="tab-pane fade {% if loop.first %}show active{% endif %}"
          id="fs-scan-pane-{{ loop.index }}" role="tabpanel">
         {% if loop.first %}
-            {% set _trigger = 'shown.bs.tab once from:#filesystem-scans-tab' %}
+            {% set _trigger = 'load once' %}
         {% else %}
             {% set _trigger = 'shown.bs.tab once from:#fs-scan-subtab-' ~ loop.index %}
         {% endif %}

--- a/src/webapp/templates/dashboards/user/fragments/user_details_modal.html
+++ b/src/webapp/templates/dashboards/user/fragments/user_details_modal.html
@@ -1,6 +1,6 @@
 {# User Details Modal — loaded via hx-get to user_card endpoint, target #userDetailsModalBody #}
 <div class="modal fade" id="userDetailsModal" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-xl" role="document">
+    <div class="modal-dialog modal-xl modal-fullscreen-sm-down" role="document">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">User Details</h5>

--- a/src/webapp/templates/dashboards/user/partials/_disk_scans_dir_filters.html
+++ b/src/webapp/templates/dashboards/user/partials/_disk_scans_dir_filters.html
@@ -28,13 +28,26 @@
       hx-swap="innerHTML"
       hx-trigger="submit">
   <div class="filter-sidebar-header">
-    <h2 class="filter-sidebar-title">Filters</h2>
+    <h2 class="filter-sidebar-title">
+      <button class="filter-sidebar-toggle" type="button"
+              data-bs-toggle="collapse" data-bs-target="#{{ form_id }}-fields"
+              aria-expanded="true" aria-controls="{{ form_id }}-fields">
+        Filters <i class="fas fa-chevron-down filter-sidebar-chevron ms-1"></i>
+      </button>
+    </h2>
     {# CSP-clean reset: form-reset-submit (static/js/actions.js) resets the form
        and re-triggers its htmx submit. fk-picker.js also clears its badge on
        the native reset event, so the user picker clears too. #}
     <a class="filter-sidebar-clear" style="cursor: pointer;"
        data-action="form-reset-submit" data-form-id="{{ form_id }}">Clear filters</a>
   </div>
+
+  {# Collapsed by default on phones (dashboard-init.js strips .show below md).
+     data-no-persist: the responsive default owns the initial state. The hidden
+     scope inputs live inside so the header keeps the collapse as its next
+     sibling (the collapsed-state CSS relies on the adjacency); htmx reads
+     them regardless of visibility. #}
+  <div id="{{ form_id }}-fields" class="collapse show filter-fields-collapse" data-no-persist>
 
   {# Scope context — submitted alongside the visible filter controls. #}
   <input type="hidden" name="resource" value="{{ resource_name }}">
@@ -94,6 +107,7 @@
     <button type="submit" class="btn btn-outline-white mb-2">
       <i class="fas fa-filter me-1"></i> Apply
     </button>
+  </div>
   </div>
 </form>
 {% endmacro %}

--- a/src/webapp/templates/dashboards/user/partials/user_card.html
+++ b/src/webapp/templates/dashboards/user/partials/user_card.html
@@ -315,7 +315,7 @@
 
 {# Group-members modal — populated by user_dashboard.htmx_group_members #}
 <div class="modal fade" id="groupMembersModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-dialog modal-lg modal-fullscreen-sm-down modal-dialog-scrollable">
         <div class="modal-content" id="groupMembersContainer">
             <div class="modal-body text-center py-4">
                 <div class="spinner-border text-primary" role="status">


### PR DESCRIPTION
## Summary

Implements `docs/plans/MOBILE_FRIENDLY.md` (all six items) plus collapsible filter panels — the low-hanging mobile fixes surveyed at the end of the nav_polish (#359) session. CSS, small template edits, and ~15 lines of JS; **desktop rendering is unchanged** (verified at 1280/1024) except that filter panels gain an optional collapse toggle.

### Mobile polish (commit 1)

- **Wide tables** (the main remaining overflow source): below 992px, any `table.table` not already inside a `.table-responsive` scroller becomes its own horizontal scrollbox instead of widening the document. Covers all 14 unwrapped fragment tables — `/allocations/transactions` was 1304px wide with no scrollable ancestor, scrolling the whole document to 1316px at 390px. The `:not(.table-responsive) >` guard leaves deliberately-wrapped tables (allocations summary, admin access-grid with its sticky first column) untouched. `<992px` rather than `<768px` because the transactions table also overflows iPad portrait (820px).
- **Modals**: `modal_scaffold` now appends `modal-fullscreen-sm-down` whenever a size (`lg`/`xl`) is set — covering every admin modal fragment at once — and the same class is added to the 8 hand-rolled `modal-lg`/`modal-xl` dialogs.
- **Filter forms**: below 576px, `.filter-sidebar` fields stack full-width (`!important` beats the inline desktop `style="width:###px"` attributes, which are intentionally left in place).
- **Flex rows wrap below md**: generalized from #359's page-header rule to `.main-content .d-flex:not(.flex-column)` — fixes the admin "Search Projects / Create Project" card-header squeeze and the Manage Project allocations toolbar (724px overflow). The `:not(.flex-column)` exclusion is load-bearing: wrapping a column stack makes `align-items: stretch` size children to fit-content, letting inner tables blow cards out to their intrinsic width.
- **Tab strips**: right-edge fade below md as a "more tabs off-screen" affordance (pure CSS mask).
- **Tap targets + type**: roomier expandable-row / sort-link hit areas and `0.8125rem` table font below md (fits full project codes where 1rem clips them).

### Collapsible filter panels (commit 2)

The `.filter-sidebar` panels are large — on a phone the transactions filter form alone fills ~1.5 screens before the first table row. Every panel's "Filters" title is now a collapse toggle (accordion-style button in the `h2`, chevron tracks `aria-expanded` via CSS), **collapsed by default below md**, expanded by default on desktop.

- Collapsed-by-default is applied in `dashboard-init.js` (markup can't be viewport-conditional): `.show` is stripped at end-of-body script run (no flash) and on `htmx:afterSettle`, so fragment-delivered panels (admin Institutions tab) arrive collapsed too. Re-collapsing after a filter submit on a phone is deliberate — results beat form.
- The toggle is the title only, not the whole header row: the collapse data-api handles clicks in the capture phase, so the sibling "Clear filters" link could never `stopPropagation` out of a row-level toggle.
- `data-no-persist` keeps `nav-view-persistence.js` from re-expanding panels from stale localStorage.
- Panels converted: `audit_filters` macro (Transactions + Adjustments), Allocations Projects, admin Institutions, disk-scans directory filters. Admin Project Expirations skipped — already inside a collapsed card.

### Pinch-zoom modal fix (commit 3)

Bootstrap's modal scrollbar compensation reads `abs(window.innerWidth − documentElement.clientWidth)`; under pinch-zoom `innerWidth` tracks the *visual* viewport, so a 3× zoom on a 390px phone computes a "260px scrollbar" and pads the opening modal down to a few characters wide (chart-link modals on the status pages were the visible victim). `modals.js` now strips the bogus padding on `show.bs.modal` when `visualViewport.scale > 1` — a zoomed viewport has no classic scrollbar to compensate for. Un-zoomed desktop keeps Bootstrap's legitimate compensation (verified: 15px body pad intact).

### Filesystem Scans spinner fix (commit 4, drive-by)

The first subtab's "Large directories" fragment on `/status/filesystem-scans` never loaded: its htmx trigger (`shown.bs.tab from:#filesystem-scans-tab`) referenced the old Bootstrap top-level tab that #358's routable-pages refactor removed, so the event never fired. First subtab now uses `load once` — the same pattern `my_data_scans.html` (written post-#358) already uses. All other `from:#…` triggers audited; the remaining seven reference elements that still exist.

Explicit non-goals per the plan: no chart refactors, no data-view redesigns.

## Test plan

- [x] Full pytest suite green (local, both commits).
- [x] Playwright at 390 / 820 / 1280 as benkirk + bdobbins: `scrollWidth == clientWidth` on all four sections' pages **after htmx fragments settle and drill-downs expand** (allocations facility → type → project table, Manage Project tabs, status node tables, user-dashboard project cards).
- [x] Converted modals (extend allocations, create adjustment, audit details) open fullscreen at 390 and dismiss cleanly.
- [x] Filter panels at 390: collapsed by default (72px title bar vs 875px expanded on transactions), toggle round-trips, "Clear filters" doesn't toggle, filter submit returns correct rows, htmx-loaded institutions filters arrive collapsed, no localStorage persistence keys written.
- [x] Desktop regression: tables back to `display:table` + 16px font, inline filter widths, filter panels expanded by default with `aria-expanded` in sync, access-grid sticky column, expandable-row toggles all intact.
- [x] Pinch-zoom repro (CDP scale 3 + mobile-style `innerWidth`): chart modal opens full-width, no bogus padding; un-zoomed desktop compensation unchanged.
- [x] `/status/filesystem-scans`: Campaign_Store directories load on page render; Destor subtab still lazy-loads on first show.
- [ ] Flush Redis (or cachebust) when eyeballing `/allocations/projects` after deploy — it's cached per-user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

