### PR TITLE
Queue Cleanup: cross-check candidates against System Status PBS data

### DIFF
--- a/collectors/lib/base_collector.py
+++ b/collectors/lib/base_collector.py
@@ -68,8 +68,7 @@ class BaseCollector:
             job_stats = JobParser.parse_jobs(jobs_json)
             data.update(job_stats)
 
-            queue_summary = self.pbs.get_queue_summary()
-            data['queues'] = QueueParser.parse_queues(queue_summary, jobs_json)
+            data['queues'] = QueueParser.parse_queues(jobs_json)
             data['user_project_queues'] = QueueParser.parse_user_project_queues(jobs_json)
 
             self.logger.info(
@@ -78,6 +77,19 @@ class BaseCollector:
             self.logger.info(
                 f"  User/project rollups: {len(data['user_project_queues'])} rows"
             )
+
+            # Full qstat -Q roster (incl. routing/idle queues that never hold
+            # jobs) — its own try/except so a qstat -Q hiccup doesn't cost us
+            # the job-derived metrics above.
+            try:
+                queues_json = self.pbs.get_queues_json()
+                data['queue_definitions'] = QueueParser.parse_queue_definitions(queues_json)
+                self.logger.info(
+                    f"  Queue roster: {len(data['queue_definitions'])} defined queues"
+                )
+            except Exception as e:
+                self.logger.error(f"Failed to collect queue roster: {e}")
+                data['queue_definitions'] = []
         except Exception as e:
             self.logger.error(f"Failed to collect job data: {e}")
             data.update({
@@ -87,6 +99,7 @@ class BaseCollector:
                 'active_users': 0,
                 'queues': [],
                 'user_project_queues': [],
+                'queue_definitions': [],
             })
 
     def _collect_login_node_data(self, data: dict):

--- a/collectors/lib/parsers/queues.py
+++ b/collectors/lib/parsers/queues.py
@@ -33,12 +33,40 @@ class QueueParser:
         return account or QueueParser.UNKNOWN_PROJECT
 
     @staticmethod
-    def parse_queues(qstat_output: str, qstat_json: dict) -> List[dict]:
+    def parse_queue_definitions(qstat_q_json: dict) -> List[dict]:
         """
-        Parse queue summary and detailed job data.
+        Parse the queue roster from ``qstat -Q -f -F json``.
+
+        Unlike ``parse_queues`` (which is derived from *jobs* and therefore
+        only sees queues currently holding jobs), this captures every queue
+        PBS defines — including routing queues that drain instantly and
+        idle execution queues.
 
         Args:
-            qstat_output: Text output from qstat -Qa (not currently used)
+            qstat_q_json: JSON from qstat -Q -f -F json
+
+        Returns:
+            List of dicts: {queue_name, queue_type, enabled, started, total_jobs}
+        """
+        definitions = []
+        for name, attrs in (qstat_q_json.get('Queue') or {}).items():
+            if not isinstance(attrs, dict):
+                continue
+            definitions.append({
+                'queue_name': name,
+                'queue_type': attrs.get('queue_type'),      # 'Execution' / 'Route'
+                'enabled': str(attrs.get('enabled', '')).lower() == 'true',
+                'started': str(attrs.get('started', '')).lower() == 'true',
+                'total_jobs': int(attrs.get('total_jobs', 0) or 0),
+            })
+        return definitions
+
+    @staticmethod
+    def parse_queues(qstat_json: dict) -> List[dict]:
+        """
+        Parse per-queue rollups from detailed job data.
+
+        Args:
             qstat_json: JSON from qstat -f -F json (for per-queue breakdown)
 
         Returns:

--- a/collectors/lib/pbs_client.py
+++ b/collectors/lib/pbs_client.py
@@ -76,9 +76,9 @@ class PBSClient:
         """Execute qstat -f -F json"""
         return self.run_command("qstat -f -F json", json_output=True)
 
-    def get_queue_summary(self):
-        """Execute qstat -Qa"""
-        return self.run_command("qstat -Qa")
+    def get_queues_json(self):
+        """Execute qstat -Q -f -F json (full queue roster, incl. routing queues)"""
+        return self.run_command("qstat -Q -f -F json", json_output=True)
 
     def get_reservations(self):
         """Execute pbs_rstat -f"""

--- a/containers/sam-sql-dev/Makefile
+++ b/containers/sam-sql-dev/Makefile
@@ -13,6 +13,22 @@ clone:
 clean:
 	rm -rf dump/ *.sql.xz *~
 
+# system_status tables holding real identities/usage from local collector runs.
+# anonymize_sam_db.py only scrubs the `sam` database, so these must be dumped
+# schema-only or the "obfuscated" blob leaks real usernames + per-user activity.
+SENSITIVE_STATUS_TABLES := status_users project_codes user_proj_queue_status
+
+# The committed blob: everything, EXCEPT the sensitive status tables which are
+# appended schema-only (restore keeps working — FK checks are disabled inside
+# mysqldump output, and the mysql-test healthcheck only needs the DB present).
+backups/sam-obfuscated.sql.xz:
+	mkdir -p $$(dirname $@)
+	rm -f $@
+	{ docker compose -f $(COMPOSE_FILE) exec -T mysql sh -c 'exec mysqldump --all-databases --lock-all-tables --triggers --routines --events --set-gtid-purged=OFF $(foreach t,$(SENSITIVE_STATUS_TABLES),--ignore-table=system_status.$(t)) -uroot -p"root"'; \
+	  echo 'USE `system_status`;'; \
+	  docker compose -f $(COMPOSE_FILE) exec -T mysql sh -c 'exec mysqldump --no-data --skip-lock-tables --set-gtid-purged=OFF system_status $(SENSITIVE_STATUS_TABLES) -uroot -p"root"'; \
+	} | xz > $@
+
 %.sql.xz:
 	mkdir -p $$(dirname $@)
 	rm -f $@

--- a/containers/sam-sql-dev/backups/sam-obfuscated.sql.xz
+++ b/containers/sam-sql-dev/backups/sam-obfuscated.sql.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a47cd753dd3cce16c6b5eb1fbb1d224501bafbe3e390a440a8d3c49fc8b84dd4
-size 20466216
+oid sha256:1794f1c7cb8afb31f5ef6fc1f441c8fc58767df3be4c5c3de50ac1486cb752ac
+size 19456524

--- a/containers/sam-sql-dev/backups/sam-obfuscated.sql.xz
+++ b/containers/sam-sql-dev/backups/sam-obfuscated.sql.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1794f1c7cb8afb31f5ef6fc1f441c8fc58767df3be4c5c3de50ac1486cb752ac
-size 19456524
+oid sha256:4364364211ce9741351ef877371373c61618bb7dd003b02baab78a7433d963c2
+size 20274328

--- a/migrations/system_status/versions/0005_queue_def_roster_columns.py
+++ b/migrations/system_status/versions/0005_queue_def_roster_columns.py
@@ -1,0 +1,46 @@
+"""queues lookup: add PBS roster columns (queue_type, last_defined_at)
+
+The collectors now capture the `qstat -Q -f -F json` queue roster and the
+ingest path upserts it onto the write-once ``queues`` lookup. Snapshot rows
+in ``queue_status`` only exist while jobs sit in a queue, so a routing queue
+that drains instantly (e.g. casper's ``casper``) never appears there — the
+roster columns are the durable "PBS still defines this queue" signal used
+by the Admin Queue Cleanup cross-check.
+
+Both columns are nullable: queues that predate roster collection simply
+stay NULL. No data migration needed.
+
+Revision ID: 0005_queue_def_roster_columns
+Revises: 0004_user_proj_queue_last_seen
+Create Date: 2026-07-20
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0005_queue_def_roster_columns"
+down_revision: Union[str, Sequence[str], None] = "0004_user_proj_queue_last_seen"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("queues", schema=None) as batch_op:
+        batch_op.add_column(sa.Column(
+            "queue_type", sa.String(length=16), nullable=True,
+            comment="PBS queue type as reported ('Execution' / 'Route')",
+        ))
+        batch_op.add_column(sa.Column(
+            "last_defined_at", sa.DateTime(), nullable=True,
+            comment="Most recent collector tick whose qstat -Q roster included this queue (naive-UTC)",
+        ))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("queues", schema=None) as batch_op:
+        batch_op.drop_column("last_defined_at")
+        batch_op.drop_column("queue_type")

--- a/src/sam/queries/queue_access.py
+++ b/src/sam/queries/queue_access.py
@@ -145,7 +145,10 @@ def get_queue_cleanup_candidates(
     a routing queue, whereas one that was charged and then went quiet is far
     more likely genuinely dead. Callers should surface that distinction rather
     than treating every candidate the same; the admin UI pre-selects only
-    ``preselected`` rows for that reason.
+    ``preselected`` rows for that reason — and additionally cross-checks
+    candidates against the system_status PBS snapshots/roster (see
+    ``_annotate_pbs_activity`` in the admin resources routes), which is
+    deliberately kept out of this SAM-only query.
 
     Args:
         session:     SQLAlchemy session.

--- a/src/system_status/models/lookups.py
+++ b/src/system_status/models/lookups.py
@@ -63,6 +63,17 @@ class QueueDef(StatusBase, SessionMixin):
                         default=utcnow_naive,
                         server_default=text("CURRENT_TIMESTAMP"))
 
+    # PBS roster facts (from `qstat -Q -f -F json`), maintained by the
+    # ingest path's `update_queue_definitions`. Snapshot rows in
+    # `queue_status` only exist while jobs sit in a queue, so a routing
+    # queue that drains instantly never appears there — these columns are
+    # the durable "PBS still defines this queue" signal. Both stay NULL
+    # for queues that predate roster collection.
+    queue_type = Column(String(16), nullable=True,
+                        comment="PBS queue type as reported ('Execution' / 'Route')")
+    last_defined_at = Column(DateTime, nullable=True,
+                             comment='Most recent collector tick whose qstat -Q roster included this queue (naive-UTC)')
+
     system = relationship("System", back_populates="queues")
 
     def __str__(self):

--- a/src/system_status/queries/__init__.py
+++ b/src/system_status/queries/__init__.py
@@ -247,6 +247,50 @@ def get_latest_queue_status(session: Session, system: str, queue_name: str) -> O
     )
 
 
+def get_queue_last_seen(session: Session, system: str) -> Dict[str, datetime]:
+    """Map queue name → most recent ``queue_status`` tick for one system.
+
+    A queue appears in ``queue_status`` only while jobs sit in it, so this
+    answers "when did this queue last hold jobs?" — the full history is
+    returned (no window) so callers can also present a long-stale
+    last-seen as evidence of disuse. Returns ``{}`` for systems with no
+    snapshot coverage.
+    """
+    from sqlalchemy import func
+
+    rows = (
+        session.query(QueueDef.name, func.max(QueueStatus.timestamp))
+        .join(QueueStatus, QueueStatus.queue_id == QueueDef.queue_id)
+        .join(System, QueueDef.system_id == System.system_id)
+        .filter(System.name == system)
+        .group_by(QueueDef.name)
+        .all()
+    )
+    return {name: ts for name, ts in rows}
+
+
+def get_queue_definitions(session: Session, system: str) -> Dict[str, Dict[str, Any]]:
+    """Map queue name → PBS roster facts for one system.
+
+    Reads the ``queue_type`` / ``last_defined_at`` columns maintained on the
+    ``queues`` lookup by ``lookups.update_queue_definitions``. Only queues
+    with a recorded roster sighting are included — rows predating roster
+    collection (``last_defined_at`` NULL) are omitted, so absence of data
+    never masquerades as evidence. Returns ``{}`` for unknown systems.
+    """
+    rows = (
+        session.query(QueueDef.name, QueueDef.queue_type, QueueDef.last_defined_at)
+        .join(System, QueueDef.system_id == System.system_id)
+        .filter(System.name == system)
+        .filter(QueueDef.last_defined_at.isnot(None))
+        .all()
+    )
+    return {
+        name: {'queue_type': queue_type, 'last_defined_at': last_defined_at}
+        for name, queue_type, last_defined_at in rows
+    }
+
+
 def get_system_partition_history(
     session: Session,
     system: str,

--- a/src/system_status/queries/lookups.py
+++ b/src/system_status/queries/lookups.py
@@ -59,6 +59,46 @@ def get_or_create_queue(session: Session, system: System, name: str) -> QueueDef
     return obj
 
 
+def update_queue_definitions(session: Session, system_name: str,
+                             definitions: list, timestamp) -> int:
+    """Upsert PBS queue-roster facts onto the ``queues`` lookup.
+
+    Called from the status ingest path with the parsed ``qstat -Q -f``
+    roster (see ``QueueParser.parse_queue_definitions``). For each entry,
+    get-or-create the ``QueueDef`` row and stamp ``queue_type`` /
+    ``last_defined_at`` — the durable "PBS still defines this queue"
+    signal consumed by the Admin Queue Cleanup cross-check.
+
+    Args:
+        session:     SQLAlchemy session (system_status bind).
+        system_name: System the roster came from (e.g. ``'derecho'``).
+        definitions: List of dicts with ``queue_name`` and optionally
+                     ``queue_type``. Unknown extra keys are ignored.
+        timestamp:   The snapshot tick (naive-UTC datetime).
+
+    Returns:
+        Number of roster entries applied.
+    """
+    if not definitions:
+        return 0
+
+    system = get_or_create_system(session, system_name)
+    applied = 0
+    for entry in definitions:
+        name = (entry.get('queue_name') or '').strip()
+        if not name:
+            continue
+        queue = get_or_create_queue(session, system, name)
+        queue_type = entry.get('queue_type')
+        if queue_type:
+            queue.queue_type = str(queue_type)
+        # Never move last_defined_at backwards (out-of-order or replayed posts).
+        if queue.last_defined_at is None or timestamp > queue.last_defined_at:
+            queue.last_defined_at = timestamp
+        applied += 1
+    return applied
+
+
 def get_or_create_filesystem(session: Session, name: str) -> Filesystem:
     obj = session.query(Filesystem).filter(Filesystem.name == name).one_or_none()
     if obj is None:

--- a/src/webapp/api/v1/status.py
+++ b/src/webapp/api/v1/status.py
@@ -166,6 +166,10 @@ def _ingest_system_status(system_name, StatusSchema, id_mappers):
         # Extract reservations before loading (handled separately due to upsert logic)
         reservations = data.pop('reservations', [])
 
+        # Extract the qstat -Q queue roster (upserted onto the `queues`
+        # lookup, not stored as snapshot rows — see update_queue_definitions).
+        queue_definitions = data.pop('queue_definitions', [])
+
         # Schema loads EVERYTHING - main status + all nested objects
         data['timestamp'] = timestamp
         schema = StatusSchema()
@@ -200,6 +204,14 @@ def _ingest_system_status(system_name, StatusSchema, id_mappers):
         if reservations:
             result['reservation_ids'] = _handle_reservations(reservations, system_name)
 
+        # Stamp queue-roster facts (queue_type, last_defined_at) onto the
+        # queues lookup if the collector sent them.
+        if queue_definitions:
+            from system_status.queries.lookups import update_queue_definitions
+            result['queue_definitions_applied'] = update_queue_definitions(
+                db.session, system_name, queue_definitions, timestamp
+            )
+
         db.session.commit()
         return jsonify(result), 201
 
@@ -229,6 +241,7 @@ def ingest_derecho():
         - login_nodes (optional): List of login node status dicts
         - queues (optional): List of queue status dicts
         - user_project_queues (optional): List of per-user/project/queue rollup dicts
+        - queue_definitions (optional): qstat -Q roster dicts (upserted onto the queues lookup)
         - filesystems (optional): List of filesystem status dicts
         - reservations (optional): List of reservation dicts
 
@@ -266,6 +279,7 @@ def ingest_casper():
         - node_types (optional): List of node type status dicts
         - queues (optional): List of queue status dicts
         - user_project_queues (optional): List of per-user/project/queue rollup dicts
+        - queue_definitions (optional): qstat -Q roster dicts (upserted onto the queues lookup)
         - reservations (optional): List of reservation dicts
 
     Returns:

--- a/src/webapp/dashboards/admin/resources_routes.py
+++ b/src/webapp/dashboards/admin/resources_routes.py
@@ -696,6 +696,54 @@ def _cleanup_context(resource_id):
     return db.session.get(Resource, resource_id)
 
 
+def _annotate_pbs_activity(candidates, resource, days):
+    """Cross-check SAM cleanup candidates against system_status PBS snapshots.
+
+    SAM charging data is blind to routing queues and charging-exempt work,
+    so a queue can look dead while PBS is actively serving it. Two status
+    signals fill that gap, both matched by queue name against the system
+    derived from the resource ('Derecho GPU' → 'derecho'):
+
+    * ``queue_status`` — a queue appears there only while jobs sit in it,
+      giving "last held jobs at tick X".
+    * ``queues.last_defined_at`` — stamped from the collectors' qstat -Q
+      roster; covers routing queues that drain instantly and idle-but-live
+      execution queues.
+
+    Annotate-only, never drops rows: a queue seen in PBS within the window
+    is un-preselected (and badged in the template), but the admin can still
+    tick it deliberately. Absence of status data changes nothing — old
+    resources without snapshot coverage behave exactly as before.
+
+    Returns True when any status data existed for the system (template
+    hides the PBS column entirely otherwise).
+    """
+    from datetime import timedelta
+    from system_status.queries import get_queue_last_seen, get_queue_definitions
+    from system_status.timeutil import utcnow_naive
+
+    system_name = resource.resource_name.split()[0].lower()
+    try:
+        last_seen = get_queue_last_seen(db.session, system_name)
+        defined = get_queue_definitions(db.session, system_name)
+    except Exception:
+        last_seen, defined = {}, {}     # status DB unavailable → SAM-only view
+
+    cutoff = utcnow_naive() - timedelta(days=days)
+    for c in candidates:
+        name = c['queue'].queue_name
+        d = defined.get(name)
+        c['last_seen_pbs'] = last_seen.get(name)
+        c['pbs_queue_type'] = d['queue_type'] if d else None
+        c['defined_in_pbs'] = d is not None and d['last_defined_at'] >= cutoff
+        c['active_in_pbs'] = (c['last_seen_pbs'] is not None
+                              and c['last_seen_pbs'] >= cutoff)
+        if c['active_in_pbs'] or c['defined_in_pbs']:
+            c['preselected'] = False    # never pre-check a queue PBS still knows
+
+    return bool(last_seen) or bool(defined)
+
+
 @bp.route('/htmx/queue-cleanup-form/<int:resource_id>')
 @login_required
 @require_permission(Permission.DELETE_RESOURCES)
@@ -736,11 +784,13 @@ def htmx_queue_cleanup_preview(resource_id):
     candidates = get_queue_cleanup_candidates(
         db.session, resource_id, days=form_data['days']
     )
+    pbs_data_available = _annotate_pbs_activity(candidates, resource, form_data['days'])
     return render_template(
         'dashboards/admin/fragments/queue_cleanup_preview_htmx.html',
         resource=resource,
         days=form_data['days'],
         candidates=candidates,
+        pbs_data_available=pbs_data_available,
     )
 
 
@@ -771,6 +821,9 @@ def htmx_queue_cleanup(resource_id):
 
     days = form_data['days']
     candidates = get_queue_cleanup_candidates(db.session, resource_id, days=days)
+    # Annotate for the error-path re-renders below; PBS activity never
+    # disqualifies a candidate, so the admin's selection remains valid.
+    pbs_data_available = _annotate_pbs_activity(candidates, resource, days)
 
     # Honour the admin's selection, but only over queues that are still
     # candidates — a submitted id that no longer qualifies (or never did) is
@@ -785,6 +838,7 @@ def htmx_queue_cleanup(resource_id):
             resource=resource,
             days=days,
             candidates=candidates,
+            pbs_data_available=pbs_data_available,
             errors=['No queues selected — nothing to do.'],
         )
 
@@ -798,6 +852,7 @@ def htmx_queue_cleanup(resource_id):
             resource=resource,
             days=days,
             candidates=candidates,
+            pbs_data_available=pbs_data_available,
             errors=[f'Error expiring queues: {e}'],
         )
 

--- a/src/webapp/templates/dashboards/admin/fragments/queue_cleanup_preview_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/queue_cleanup_preview_htmx.html
@@ -6,11 +6,19 @@
   are pre-checked, while queues that were never charged are listed unchecked
   (they may be routing queues, which never accrue charges by design).
 
+  Candidates are cross-checked against the system_status PBS snapshots
+  (see _annotate_pbs_activity): a queue seen holding jobs — or still present
+  in the qstat -Q roster — within the window is badged and never pre-checked,
+  but stays in the list so the admin can still expire it deliberately.
+
   Context:
-    resource   : Resource
-    days       : int (the window from step 1)
-    candidates : list of {queue, last_charged, ever_charged, preselected}
-    errors     : optional list[str]
+    resource           : Resource
+    days               : int (the window from step 1)
+    candidates         : list of {queue, last_charged, ever_charged, preselected,
+                         last_seen_pbs, active_in_pbs, defined_in_pbs, pbs_queue_type}
+    pbs_data_available : bool — False hides the PBS column (no snapshot
+                         coverage for this resource's system)
+    errors             : optional list[str]
 #}
 
 <form hx-post="{{ url_for('admin_dashboard.htmx_queue_cleanup', resource_id=resource.resource_id) }}"
@@ -24,6 +32,8 @@
         {% if candidates %}
         {% set preselected = candidates | selectattr('preselected') | list %}
         {% set never = candidates | rejectattr('ever_charged') | list %}
+        {% set in_pbs_count = (candidates | selectattr('active_in_pbs') | list | length)
+                            + (candidates | rejectattr('active_in_pbs') | selectattr('defined_in_pbs') | list | length) %}
 
         <p class="mb-2">
             <strong>{{ candidates|length }} queue{{ 's' if candidates|length != 1 else '' }}</strong>
@@ -32,6 +42,10 @@
             {% if preselected %}
             {{ preselected|length }} previously-used
             queue{{ 's are' if preselected|length != 1 else ' is' }} pre-selected.
+            {% endif %}
+            {% if in_pbs_count %}
+            {{ in_pbs_count }} {{ 'are' if in_pbs_count != 1 else 'is' }} still
+            known to PBS and left unchecked.
             {% endif %}
         </p>
 
@@ -59,6 +73,9 @@
                         <th>Queue</th>
                         <th>Started</th>
                         <th>Last charged</th>
+                        {% if pbs_data_available %}
+                        <th>Last seen in PBS</th>
+                        {% endif %}
                     </tr>
                 </thead>
                 <tbody>
@@ -75,6 +92,14 @@
                                    for="cleanupQueue{{ c.queue.queue_id }}">
                                 {{ c.queue.queue_name }}
                             </label>
+                            {% if c.active_in_pbs %}
+                            <span class="badge bg-success ms-1">active in PBS</span>
+                            {% elif c.defined_in_pbs %}
+                            <span class="badge bg-info text-dark ms-1">defined in PBS</span>
+                            {% endif %}
+                            {% if c.pbs_queue_type == 'Route' %}
+                            <span class="badge bg-secondary ms-1">routing queue</span>
+                            {% endif %}
                             {% if not c.ever_charged %}
                             <span class="badge bg-warning text-dark ms-1">never charged</span>
                             {% endif %}
@@ -88,11 +113,24 @@
                         <td class="text-muted small text-nowrap">
                             {{ c.last_charged | fmt_date }}
                         </td>
+                        {% if pbs_data_available %}
+                        <td class="text-muted small text-nowrap">
+                            {{ c.last_seen_pbs | fmt_date }}
+                        </td>
+                        {% endif %}
                     </tr>
                     {% endfor %}
                 </tbody>
             </table>
         </div>
+
+        {% if not pbs_data_available %}
+        <div class="text-muted small mt-1">
+            <i class="fas fa-info-circle"></i>
+            No PBS snapshot data covers this resource — the system-status
+            cross-check was skipped.
+        </div>
+        {% endif %}
 
         <div class="alert alert-danger mt-2 mb-0">
             <i class="fas fa-exclamation-triangle"></i>

--- a/tests/api/test_status_endpoints.py
+++ b/tests/api/test_status_endpoints.py
@@ -134,6 +134,67 @@ class TestDerechoPost:
         assert len(json_data['queue_ids']) == 1
         assert len(json_data['filesystem_ids']) == 1
 
+    def test_post_derecho_with_queue_definitions(self, api_key_client, status_session):
+        """The qstat -Q roster is upserted onto the queues lookup (not stored
+        as snapshot rows) — covering routing queues that never hold jobs."""
+        from system_status.models.lookups import QueueDef, System
+
+        data = {
+            'timestamp': '2026-07-20 12:00:00',
+            'cpu_nodes_total': 100,
+            'cpu_nodes_available': 80,
+            'cpu_nodes_down': 5,
+            'cpu_nodes_reserved': 15,
+            'gpu_nodes_total': 10,
+            'gpu_nodes_available': 8,
+            'gpu_nodes_down': 0,
+            'gpu_nodes_reserved': 2,
+            'cpu_cores_total': 12800,
+            'cpu_cores_allocated': 10000,
+            'cpu_cores_idle': 2800,
+            'gpu_count_total': 80,
+            'gpu_count_allocated': 60,
+            'gpu_count_idle': 20,
+            'memory_total_gb': 25600.0,
+            'memory_allocated_gb': 20000.0,
+            'running_jobs': 150,
+            'pending_jobs': 30,
+            'active_users': 50,
+            'queue_definitions': [
+                {'queue_name': 'main', 'queue_type': 'Route',
+                 'enabled': True, 'started': True, 'total_jobs': 12},
+                {'queue_name': 'cpu', 'queue_type': 'Execution',
+                 'enabled': True, 'started': True, 'total_jobs': 340},
+            ],
+        }
+
+        response = api_key_client.post(
+            '/api/v1/status/derecho', json=data,
+            content_type='application/json',
+        )
+
+        assert response.status_code == 201
+        json_data = response.get_json()
+        assert json_data['success'] is True
+        assert json_data['queue_definitions_applied'] == 2
+        # No snapshot rows were created for the roster.
+        assert json_data['queue_ids'] == []
+
+        from datetime import datetime
+        expected_ts = datetime(2026, 7, 20, 12, 0, 0)
+        rows = (
+            status_session.query(QueueDef)
+            .join(System, QueueDef.system_id == System.system_id)
+            .filter(System.name == 'derecho')
+            .all()
+        )
+        by_name = {q.name: q for q in rows}
+        assert set(by_name) == {'main', 'cpu'}
+        assert by_name['main'].queue_type == 'Route'
+        assert by_name['cpu'].queue_type == 'Execution'
+        assert by_name['main'].last_defined_at == expected_ts
+        assert by_name['cpu'].last_defined_at == expected_ts
+
     def test_post_derecho_with_user_project_queues(self, api_key_client, status_session):
         """Per-user/project rollups round-trip through the ingest path,
         creating denormalized UserDef / ProjectCodeDef rows on demand and

--- a/tests/unit/test_collector_queue_parser.py
+++ b/tests/unit/test_collector_queue_parser.py
@@ -120,7 +120,7 @@ class TestParseUserProjectQueues:
             _make_job("Q", "benkirk@d", "OTHER001", "main", ncpus=32),
         ])
         per_user = QueueParser.parse_user_project_queues(qstat)
-        per_queue = QueueParser.parse_queues("", qstat)
+        per_queue = QueueParser.parse_queues(qstat)
 
         assert len(per_queue) == 1
         q = per_queue[0]
@@ -128,3 +128,49 @@ class TestParseUserProjectQueues:
         assert sum(r["pending_jobs"] for r in per_user) == q["pending_jobs"]
         assert sum(r["cores_allocated"] for r in per_user) == q["cores_allocated"]
         assert sum(r["cores_pending"] for r in per_user) == q["cores_pending"]
+
+
+class TestParseQueueDefinitions:
+    """qstat -Q -f -F json roster parsing — the source of the 'PBS still
+    defines this queue' signal, which covers routing queues that never
+    appear in job-derived rollups."""
+
+    QSTAT_Q = {
+        "timestamp": 1752624000,
+        "pbs_version": "2022.1.1",
+        "pbs_server": "casper-pbs",
+        "Queue": {
+            "casper": {
+                "queue_type": "Route",
+                "total_jobs": 0,
+                "enabled": "True",
+                "started": "True",
+                "route_destinations": "htc,vis,largemem",
+            },
+            "htc": {
+                "queue_type": "Execution",
+                "total_jobs": 371,
+                "enabled": "True",
+                "started": "False",
+                "state_count": "Transit:0 Queued:12 Held:3 Running:356",
+            },
+        },
+    }
+
+    def test_parses_roster_including_routing_queues(self):
+        defs = {d["queue_name"]: d
+                for d in QueueParser.parse_queue_definitions(self.QSTAT_Q)}
+
+        assert set(defs) == {"casper", "htc"}
+        assert defs["casper"]["queue_type"] == "Route"
+        assert defs["casper"]["enabled"] is True
+        assert defs["casper"]["started"] is True
+        assert defs["casper"]["total_jobs"] == 0
+        assert defs["htc"]["queue_type"] == "Execution"
+        assert defs["htc"]["started"] is False
+        assert defs["htc"]["total_jobs"] == 371
+
+    def test_empty_or_missing_roster_returns_empty(self):
+        assert QueueParser.parse_queue_definitions({}) == []
+        assert QueueParser.parse_queue_definitions({"Queue": {}}) == []
+        assert QueueParser.parse_queue_definitions({"Queue": None}) == []

--- a/tests/unit/test_htmx_queue_admin.py
+++ b/tests/unit/test_htmx_queue_admin.py
@@ -249,6 +249,208 @@ class TestQueueCleanupCommit:
 
 
 # ---------------------------------------------------------------------------
+# Cleanup — PBS cross-check (_annotate_pbs_activity + preview rendering)
+# ---------------------------------------------------------------------------
+
+
+class _StubQueue:
+    """Just enough of a Queue for _annotate_pbs_activity (name access only)."""
+
+    def __init__(self, name):
+        self.queue_name = name
+
+
+def _candidate(name, preselected):
+    return {'queue': _StubQueue(name), 'last_charged': None,
+            'ever_charged': preselected, 'preselected': preselected}
+
+
+def _seed_tick(status_session, system, queue, ts):
+    from system_status import QueueStatus
+
+    status_session.add(QueueStatus(timestamp=ts, system_name=system,
+                                   queue_name=queue))
+    status_session.commit()
+
+
+class TestAnnotatePbsActivity:
+    """Direct tests of the scrub/annotate step. status_session guarantees a
+    clean SQLite status DB and provides the app context the helper's
+    db.session usage needs."""
+
+    def test_recent_snapshot_unpreselects_and_flags(self, status_session):
+        from datetime import timedelta
+        from system_status.timeutil import utcnow_naive
+        from webapp.dashboards.admin.resources_routes import _annotate_pbs_activity
+
+        class R:
+            resource_name = 'Derecho'
+
+        _seed_tick(status_session, 'derecho', 'develop',
+                   utcnow_naive() - timedelta(days=3))
+
+        cands = [_candidate('develop', preselected=True),
+                 _candidate('preempt', preselected=True)]
+        available = _annotate_pbs_activity(cands, R, days=90)
+
+        assert available is True
+        develop, preempt = cands
+        assert develop['active_in_pbs'] is True
+        assert develop['preselected'] is False          # rescued
+        assert preempt['active_in_pbs'] is False
+        assert preempt['preselected'] is True           # untouched
+        assert preempt['last_seen_pbs'] is None
+
+    def test_stale_snapshot_annotates_but_does_not_rescue(self, status_session):
+        from datetime import timedelta
+        from system_status.timeutil import utcnow_naive
+        from webapp.dashboards.admin.resources_routes import _annotate_pbs_activity
+
+        class R:
+            resource_name = 'Casper'
+
+        stale = utcnow_naive() - timedelta(days=200)
+        _seed_tick(status_session, 'casper', 'rda', stale)
+
+        cands = [_candidate('rda', preselected=True)]
+        _annotate_pbs_activity(cands, R, days=90)
+
+        assert cands[0]['active_in_pbs'] is False
+        assert cands[0]['preselected'] is True          # still recommended
+        assert cands[0]['last_seen_pbs'] == stale       # negative evidence shown
+
+    def test_roster_definition_rescues_routing_queue(self, status_session):
+        """The casper case: never holds jobs, but the qstat -Q roster still
+        defines it — must be un-preselected and typed as a routing queue."""
+        from datetime import timedelta
+        from system_status.timeutil import utcnow_naive
+        from system_status.queries.lookups import update_queue_definitions
+        from webapp.dashboards.admin.resources_routes import _annotate_pbs_activity
+
+        class R:
+            resource_name = 'Casper'
+
+        update_queue_definitions(
+            status_session, 'casper',
+            [{'queue_name': 'casper', 'queue_type': 'Route'}],
+            utcnow_naive() - timedelta(days=1))
+        status_session.commit()
+
+        cands = [_candidate('casper', preselected=True)]
+        available = _annotate_pbs_activity(cands, R, days=90)
+
+        assert available is True
+        assert cands[0]['defined_in_pbs'] is True
+        assert cands[0]['pbs_queue_type'] == 'Route'
+        assert cands[0]['preselected'] is False
+
+    def test_gpu_resource_maps_to_base_system(self, status_session):
+        from datetime import timedelta
+        from system_status.timeutil import utcnow_naive
+        from webapp.dashboards.admin.resources_routes import _annotate_pbs_activity
+
+        class R:
+            resource_name = 'Derecho GPU'
+
+        _seed_tick(status_session, 'derecho', 'hybrid',
+                   utcnow_naive() - timedelta(days=3))
+
+        cands = [_candidate('hybrid', preselected=False)]
+        _annotate_pbs_activity(cands, R, days=90)
+        assert cands[0]['active_in_pbs'] is True
+
+    def test_other_system_activity_does_not_rescue(self, status_session):
+        """'cpu' on derecho must not vouch for 'cpu' on a Casper resource."""
+        from datetime import timedelta
+        from system_status.timeutil import utcnow_naive
+        from webapp.dashboards.admin.resources_routes import _annotate_pbs_activity
+
+        class R:
+            resource_name = 'Casper'
+
+        _seed_tick(status_session, 'derecho', 'cpu',
+                   utcnow_naive() - timedelta(days=1))
+
+        cands = [_candidate('cpu', preselected=True)]
+        _annotate_pbs_activity(cands, R, days=90)
+        assert cands[0]['active_in_pbs'] is False
+        assert cands[0]['preselected'] is True
+
+    def test_no_status_data_changes_nothing(self, status_session):
+        """Old resources without snapshot coverage behave exactly as before."""
+        from webapp.dashboards.admin.resources_routes import _annotate_pbs_activity
+
+        class R:
+            resource_name = 'Cheyenne'
+
+        cands = [_candidate('regular', preselected=True),
+                 _candidate('share', preselected=False)]
+        available = _annotate_pbs_activity(cands, R, days=90)
+
+        assert available is False
+        assert cands[0]['preselected'] is True
+        assert cands[1]['preselected'] is False
+
+
+class TestQueueCleanupPreviewPbsColumn:
+
+    def test_no_status_data_hides_column_and_notes_skip(
+            self, auth_client, status_session, snapshot_resource_id):
+        resp = auth_client.post(
+            f'/admin/htmx/queue-cleanup-preview/{snapshot_resource_id}',
+            data={'days': '90'})
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert 'Last seen in PBS' not in html
+        if 'cleanupQueue' in html:               # only shown with candidates
+            assert 'cross-check was skipped' in html
+
+    def test_seeded_status_data_badges_candidate(
+            self, auth_client, session, status_session):
+        """End-to-end: a committed snapshot candidate seen in PBS renders the
+        badge, the PBS column, and an unchecked checkbox."""
+        from datetime import timedelta
+
+        from sam.queries.queue_access import get_queue_cleanup_candidates
+        from sam.resources.machines import Queue
+        from sam.resources.resources import Resource
+        from system_status.timeutil import utcnow_naive
+
+        # Find any committed resource with a cleanup candidate (route + this
+        # query both see only committed snapshot rows).
+        target = None
+        resource_ids = [r[0] for r in session.query(Queue.resource_id)
+                        .group_by(Queue.resource_id).all()]
+        for rid in resource_ids:
+            cands = get_queue_cleanup_candidates(session, rid, days=90)
+            if cands:
+                target = (session.get(Resource, rid), cands[0])
+                break
+        if target is None:
+            pytest.skip('snapshot has no cleanup candidates')
+
+        resource, cand = target
+        system = resource.resource_name.split()[0].lower()
+        _seed_tick(status_session, system, cand['queue'].queue_name,
+                   utcnow_naive() - timedelta(days=1))
+
+        resp = auth_client.post(
+            f'/admin/htmx/queue-cleanup-preview/{resource.resource_id}',
+            data={'days': '90'})
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+
+        assert 'Last seen in PBS' in html
+        assert 'active in PBS' in html
+        # The badged queue's checkbox must not be pre-checked ('checked'
+        # renders after the id attribute in the template, so inspect the
+        # remainder of the <input> tag).
+        qid = cand['queue'].queue_id
+        tag_rest = html.split(f'id="cleanupQueue{qid}"', 1)[1].split('>', 1)[0]
+        assert 'checked' not in tag_rest
+
+
+# ---------------------------------------------------------------------------
 # Resources card — the new buttons render
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_queue_cleanup_queries.py
+++ b/tests/unit/test_queue_cleanup_queries.py
@@ -153,3 +153,116 @@ class TestOrdering:
 
         names = [c['queue'].queue_name for c in _candidates(session, resource)]
         assert names == sorted(names)
+
+
+# ---------------------------------------------------------------------------
+# system_status cross-check helpers
+#
+# These run on the per-worker SQLite system_status bind (status_session),
+# not the SAM MySQL snapshot — they back the PBS cross-check the admin
+# cleanup routes layer on top of get_queue_cleanup_candidates.
+# ---------------------------------------------------------------------------
+
+
+def _tick(status_session, system, queue, ts):
+    """Insert one QueueStatus snapshot row (string setters resolve lookups)."""
+    from system_status import QueueStatus
+
+    row = QueueStatus(timestamp=ts, system_name=system, queue_name=queue)
+    status_session.add(row)
+    status_session.flush()
+    return row
+
+
+class TestGetQueueLastSeen:
+
+    def test_returns_max_tick_per_queue(self, status_session):
+        from system_status.queries import get_queue_last_seen
+
+        _tick(status_session, 'derecho', 'main', NOW - timedelta(days=30))
+        _tick(status_session, 'derecho', 'main', NOW - timedelta(days=2))
+        _tick(status_session, 'derecho', 'develop', NOW - timedelta(days=150))
+
+        seen = get_queue_last_seen(status_session, 'derecho')
+        assert seen == {
+            'main': NOW - timedelta(days=2),
+            'develop': NOW - timedelta(days=150),
+        }
+
+    def test_is_system_scoped(self, status_session):
+        """'cpu' exists on both derecho and casper — never cross the streams."""
+        from system_status.queries import get_queue_last_seen
+
+        _tick(status_session, 'derecho', 'cpu', NOW - timedelta(days=1))
+        _tick(status_session, 'casper', 'cpu', NOW - timedelta(days=400))
+
+        assert get_queue_last_seen(status_session, 'derecho') == {
+            'cpu': NOW - timedelta(days=1)}
+        assert get_queue_last_seen(status_session, 'casper') == {
+            'cpu': NOW - timedelta(days=400)}
+
+    def test_unknown_system_returns_empty(self, status_session):
+        from system_status.queries import get_queue_last_seen
+
+        _tick(status_session, 'derecho', 'main', NOW)
+        assert get_queue_last_seen(status_session, 'cheyenne') == {}
+
+
+class TestQueueDefinitions:
+
+    def test_update_then_get_roundtrip(self, status_session):
+        from system_status.queries import get_queue_definitions
+        from system_status.queries.lookups import update_queue_definitions
+
+        applied = update_queue_definitions(status_session, 'casper', [
+            {'queue_name': 'casper', 'queue_type': 'Route'},
+            {'queue_name': 'htc', 'queue_type': 'Execution'},
+        ], NOW)
+
+        assert applied == 2
+        defs = get_queue_definitions(status_session, 'casper')
+        assert defs['casper'] == {'queue_type': 'Route', 'last_defined_at': NOW}
+        assert defs['htc'] == {'queue_type': 'Execution', 'last_defined_at': NOW}
+
+    def test_last_defined_at_never_moves_backwards(self, status_session):
+        """Replayed / out-of-order collector posts must not rewind the stamp."""
+        from system_status.queries import get_queue_definitions
+        from system_status.queries.lookups import update_queue_definitions
+
+        update_queue_definitions(
+            status_session, 'casper',
+            [{'queue_name': 'casper', 'queue_type': 'Route'}], NOW)
+        update_queue_definitions(
+            status_session, 'casper',
+            [{'queue_name': 'casper', 'queue_type': 'Route'}],
+            NOW - timedelta(hours=1))
+
+        defs = get_queue_definitions(status_session, 'casper')
+        assert defs['casper']['last_defined_at'] == NOW
+
+    def test_blank_names_are_skipped(self, status_session):
+        from system_status.queries.lookups import update_queue_definitions
+
+        applied = update_queue_definitions(status_session, 'casper', [
+            {'queue_name': ''},
+            {'queue_name': '   '},
+            {'queue_type': 'Route'},           # no name at all
+        ], NOW)
+        assert applied == 0
+
+    def test_queues_without_roster_sighting_are_omitted(self, status_session):
+        """Pre-roster QueueDef rows (last_defined_at NULL) must not appear —
+        absence of data is not evidence the queue is defined."""
+        from system_status.queries import get_queue_definitions
+
+        _tick(status_session, 'casper', 'vis', NOW)   # lookup row, no roster stamp
+        assert get_queue_definitions(status_session, 'casper') == {}
+
+    def test_unknown_system_returns_empty(self, status_session):
+        from system_status.queries import get_queue_definitions
+        from system_status.queries.lookups import update_queue_definitions
+
+        update_queue_definitions(
+            status_session, 'casper',
+            [{'queue_name': 'casper', 'queue_type': 'Route'}], NOW)
+        assert get_queue_definitions(status_session, 'derecho') == {}

--- a/utils/sample_collector_commands.sh
+++ b/utils/sample_collector_commands.sh
@@ -5,8 +5,8 @@ set -e
 #-----------------------------------
 # Derecho sample collection commands
 
-# summary listing of queues
-ssh derecho "qstat -Qa"
+# full queue roster (incl. routing queues), JSON
+ssh derecho "qstat -Q -f -F json"
 
 # full listing of all compute nodes and status
 ssh derecho "pbsnodes -aj -F json"
@@ -28,8 +28,8 @@ ssh derecho "pbs_rstat -f"
 #----------------------------------
 # Casper sample collection commands
 
-# summary listing of queues
-ssh casper "qstat -Qa"
+# full queue roster (incl. routing queues), JSON
+ssh casper "qstat -Q -f -F json"
 
 # full listing of all compute nodes and status
 ssh casper "pbsnodes -aj -F json"


### PR DESCRIPTION
## Summary

PR #355's Queue Cleanup flags active queues with no recent charging activity — a signal that is blind to **routing queues** (never charged by design) and **charging-exempt work** (charged-then-quiet). This layers a system_status cross-check on top of the *unchanged* SAM-side candidate query, in two parts:

### Part 1 — snapshot cross-check (works immediately on deploy)
- New `get_queue_last_seen()` (system-scoped: `'cpu'` on derecho never vouches for `'cpu'` on casper) maps queue name → most recent `queue_status` tick.
- The preview annotates every candidate with a **Last seen in PBS** column; a queue seen holding jobs inside the window gets an **active in PBS** badge and is never pre-checked.
- Real save on today's data: `derecho/develop` (last charged 2026-02-05 → was pre-checked for expiry) has jobs in queue right now.
- Stale sightings work the other way: `casper/rda` shows "last seen 2026-02-22", strengthening the cleanup case.

### Part 2 — qstat -Q roster capture (needs collector rollout)
The collectors ran `qstat -Qa` every tick and **discarded the output**. They now collect `qstat -Q -f -F json` and post a `queue_definitions` list; ingest upserts `queue_type` / `last_defined_at` onto the write-once `queues` lookup — one small UPDATE per queue per tick, no snapshot-row growth, immune to snapshot pruning.

A candidate still in the roster is badged **defined in PBS** (+ **routing queue** when `queue_type='Route'`) and un-preselected. **This is what fixes the motivating case**: casper's `casper` routing queue drains instantly, so it never appears in job-derived snapshots — only the roster sees it.

### Design notes
- **Annotate-only, never drop**: the admin keeps override power; preview/commit validation stays symmetric; badged rows just aren't pre-checked.
- Resources without status coverage (Cheyenne, Yellowstone, …) render exactly as before; a status-DB outage degrades silently to the SAM-only view.
- Compatibility both directions: old collector → new API is a no-op; new collector → old API is ignored (`unknown=EXCLUDE`). Deploy webapp first, then the collector cron host.
- `sam.queries.queue_access` stays SAM-pure; the cross-check lives in the webapp layer + `system_status.queries`.

### Schema / migrations
- Alembic `0005_queue_def_roster_columns`: two nullable columns on `queues`. Verified upgrade **and** downgrade on scratch SQLite.
- **Already applied** to local dev MySQL and prod CNPG Postgres (2026-07-20, pre-migration pg_dump retained) — columns sit unused until this code deploys, old ingest never touches them.

### Test Results
- ~20 new tests: status query helpers on the SQLite bind; `_annotate_pbs_activity` unit coverage (rescue, stale-annotation, GPU-resource→base-system mapping, cross-system isolation, no-data regression guard); preview rendering incl. unchecked-checkbox assertion; `queue_definitions` ingest round-trip; collector roster parser.
- Full suite run twice locally — passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)