### PR TITLE
collectors: surface collector stderr in the logfile (no more silent '✗ failed in 0s')

### DIFF
--- a/collectors/run_collectors.sh
+++ b/collectors/run_collectors.sh
@@ -88,7 +88,14 @@ while true; do
         echo "  - ${NAME}..."
 
         t0=$(date +%s)
-        if timeout "${TIMEOUT}" "./${COLLECTOR}" --log-file="${LOGFILE}" > /dev/null 2>&1; then
+        # Discard stdout (the collector's console handler duplicates the
+        # file-handler output already written to LOGFILE), but append stderr
+        # to LOGFILE.  Crashes that happen before setup_logging() runs — e.g.
+        # an import-time ZoneInfo/tzdata failure — only reach stderr; sending
+        # them to /dev/null previously turned a one-line traceback into a
+        # silent "✗ failed in 0s".  Now the traceback lands in the LOGFILE the
+        # failure message tells the user to check.
+        if timeout "${TIMEOUT}" "./${COLLECTOR}" --log-file="${LOGFILE}" > /dev/null 2>> "${LOGFILE}"; then
             elapsed=$(( $(date +%s) - t0 ))
             echo "    ✓ ${NAME} completed in ${elapsed}s"
         else


### PR DESCRIPTION
## Problem

`run_collectors.sh` runs each collector with `> /dev/null 2>&1`. Any failure that occurs **before** `setup_logging()` configures the file handler — most notably an import-time crash like `ZoneInfo('UTC')` failing when the conda env's `tzdata`/`share/zoneinfo` is missing — writes only to **stderr** and was therefore discarded. Operators saw an opaque:

```
✗ Derecho failed in 1s (see .../logs/Derecho.log)
```

…while the referenced logfile contained nothing about the actual failure. Diagnosing it required manually re-running a collector outside the loop to see the traceback.

## Fix

One line in `run_collectors.sh`:

- **stdout** is still discarded — the collector's console `StreamHandler` writes to `sys.stdout` and only duplicates what the `RotatingFileHandler` already writes to the logfile.
- **stderr** is now appended (`2>> "${LOGFILE}"`) to the same per-collector logfile the failure message tells the user to check.

So import-time tracebacks and the `setup_logging` fallback warning are preserved, right where operators already look.

## Verification

- `bash -n run_collectors.sh` — clean.
- Simulated pre-logging crash → full traceback now lands in the logfile.
- Normal Casper run → **no** duplicate INFO lines (SUCCESS/Posted appear once), collector still posts (`status_id` returned).

## Context

Surfaced while debugging the local collectors failing to post: the real cause was a rebuilt conda env with an empty `share/zoneinfo/` (conda hardlinks can't cross the `/glade/work` ↔ `/glade/derecho/scratch` filesystem boundary), which crashed every collector at import. That env issue is fixed separately (cache purge + `pkgs_dirs` on the same filesystem); this PR just makes the *next* such failure self-explanatory instead of silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)