### PR TITLE
Fix inert "Active only" toggles on admin user/project/group search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -554,6 +554,37 @@ if 'end_date' in data:
 CSRF tokens, stray fields), `flatten_errors()` for template-friendly lists,
 and a clear separation from ORM serialization (`sam.schemas/` proper).
 
+### 10. "Active only" Toggles
+
+**Absent means OFF.** htmx omits an *unchecked* checkbox from the request
+entirely, so there is no "unchecked" value to test for — a missing
+`active_only` is how "include inactive rows" arrives over the wire. A route
+that defaults it to ON makes its checkbox inert in one direction (this is
+exactly how inactive users/projects went missing from the admin search
+boxes).
+
+Parse it with the shared helper — never a hand-rolled comparison, which is
+how the `'1'` vs `'true'` spelling split crept in:
+
+```python
+from webapp.utils.htmx import read_active_only
+
+active_only = read_active_only(request.args)                 # checkbox-backed
+active_only = read_active_only(request.args, default=True)   # FK picker, no checkbox
+```
+
+On the template side, emit `value="1"` and wire **both** directions —
+typing includes the checkbox, and toggling the checkbox re-runs the query:
+
+```jinja
+{% from 'dashboards/fragments/search_box.html' import active_toggle_search %}
+{{ active_toggle_search(search_url=..., input_id=..., results_id=...,
+                        label=..., toggle_id=..., toggle_label='Active only') }}
+```
+
+For a card (not a search box), copy the Resources/Organizations/Facilities
+pattern: `hx-trigger="change"` + `hx-include="this"` on the switch itself.
+
 ---
 
 ## Common ORM Patterns

--- a/src/webapp/api/v1/users.py
+++ b/src/webapp/api/v1/users.py
@@ -14,6 +14,7 @@ from flask import Blueprint, jsonify, request, abort
 from flask_login import login_required, current_user
 from webapp.utils.rbac import require_permission, Permission
 from webapp.extensions import db
+from webapp.utils.htmx import read_active_only
 from sam.schemas import UserSchema, UserListSchema, UserSummarySchema, ProjectListSchema
 from webapp.api.helpers import register_error_handlers, get_user_or_404, serialize_projects_by_role
 
@@ -189,7 +190,7 @@ def search_users():
         return jsonify([])
 
     limit = min(request.args.get('limit', 20, type=int), 50)
-    active_only = request.args.get('active_only', 'false').lower() == 'true'
+    active_only = read_active_only(request.args)
 
     # Get existing members to exclude if projcode provided
     exclude_ids = None

--- a/src/webapp/dashboards/admin/blueprint.py
+++ b/src/webapp/dashboards/admin/blueprint.py
@@ -11,7 +11,8 @@ Domain-specific routes are split into sub-modules imported at the bottom:
 """
 
 from flask import Blueprint, render_template, request, flash, redirect, url_for, session, Response, abort
-from webapp.utils.htmx import htmx_success, htmx_success_message, htmx_not_found
+from webapp.utils.htmx import (htmx_success, htmx_success_message, htmx_not_found,
+                               read_active_only)
 from flask_login import login_required, current_user, login_user
 from datetime import datetime, timedelta
 from webapp.api.helpers import parse_input_end_date
@@ -688,7 +689,11 @@ def htmx_search_users():
     }
     template = template_map.get(context, template_map['fk'])
 
-    active_only = request.args.get('active_only', 'true') == 'true'
+    # The 'impersonate' box drives this from a checkbox (absent = unchecked =
+    # include inactive). The fk/member pickers have no checkbox and never send
+    # the param, so they keep the active-only default.
+    active_only = read_active_only(request.args,
+                                   default=context != 'impersonate')
     exclude_ids = None
 
     if context == 'member':
@@ -728,7 +733,7 @@ def htmx_search_groups():
     if len(q) < 2:
         return ''
 
-    active_only = request.args.get('active_only', 'true') == 'true'
+    active_only = read_active_only(request.args)
     groups = search_groups_by_pattern(db.session, q, limit=20, active_only=active_only)
     return render_template(
         'dashboards/admin/fragments/group_search_results_htmx.html',
@@ -746,7 +751,7 @@ def htmx_search_users_impersonate():
     from sam.queries.users import search_users_by_pattern
 
     query = request.args.get('q', '').strip()
-    active_only = request.args.get('active_only', '') == 'true'
+    active_only = read_active_only(request.args)
 
     if len(query) < 2:
         return ''
@@ -772,7 +777,7 @@ def htmx_search_projects():
     from sam.queries.projects import search_projects_by_code_or_title
 
     query = request.args.get('q', '').strip()
-    active_only = request.args.get('active_only', '') == 'true'
+    active_only = read_active_only(request.args)
 
     if len(query) < 1:
         return ''

--- a/src/webapp/dashboards/admin/facilities_routes.py
+++ b/src/webapp/dashboards/admin/facilities_routes.py
@@ -13,6 +13,7 @@ from webapp.utils.htmx import (
     handle_htmx_soft_delete,
     htmx_not_found,
     htmx_success_message,
+    read_active_only,
 )
 from webapp.extensions import db
 from webapp.utils.rbac import (
@@ -44,7 +45,7 @@ def htmx_facilities_card():
     """
     from sam.resources.facilities import Facility
 
-    active_only = request.args.get('active_only') == '1'
+    active_only = read_active_only(request.args)
 
     facility_q = db.session.query(Facility).order_by(Facility.facility_name)
     if active_only:

--- a/src/webapp/dashboards/admin/orgs_routes.py
+++ b/src/webapp/dashboards/admin/orgs_routes.py
@@ -14,6 +14,7 @@ from webapp.utils.htmx import (
     handle_htmx_soft_delete,
     htmx_not_found,
     htmx_success_message,
+    read_active_only,
 )
 from webapp.extensions import db, cache, user_aware_cache_key
 from webapp.utils.rbac import (
@@ -109,7 +110,7 @@ def htmx_organizations_card():
     from sam.core.organizations import Organization, MnemonicCode
     from sam.projects.contracts import ContractSource
 
-    active_only = request.args.get('active_only') == '1'
+    active_only = read_active_only(request.args)
     now = datetime.now()
 
     organizations = get_organizations_with_members(db.session, active_only=active_only)
@@ -199,7 +200,7 @@ def htmx_institutions_fragment():
 
     country_id = _int_or_none(request.args.get('country_id'))
     state_prov_id = _int_or_none(request.args.get('state_prov_id')) if country_id else None
-    active_only = request.args.get('active_only') == '1'
+    active_only = read_active_only(request.args)
     show_users_projects = request.args.get('show_users_projects') == '1'
     active_users_projects = request.args.get('active_users_projects') == '1'
 

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -7,7 +7,8 @@ Covers: Project creation (Phase A).  Edit/allocation management (Phase B).
 from datetime import datetime
 
 from flask import render_template, request, redirect, url_for
-from webapp.utils.htmx import htmx_success, htmx_success_message, handle_htmx_form_post
+from webapp.utils.htmx import (htmx_success, htmx_success_message,
+                               handle_htmx_form_post, read_active_only)
 from webapp.utils.fk_validation import FKValidationError, validate_fk_existence
 from flask_login import login_required, current_user
 
@@ -2467,11 +2468,7 @@ def htmx_admin_project_directories():
     without the on-load 403 that the old system-wide EDIT_PROJECTS gate
     produced for them.
     """
-    # Match the canonical "Active only" toggle pattern used by the
-    # Resources / Organizations / Facilities cards: when the checkbox is
-    # checked, hx-include sends active_only=1; when unchecked, no param,
-    # so we treat absence as False ("show all").
-    active_only = request.args.get('active_only') == '1'
+    active_only = read_active_only(request.args)
     return _render_project_directories_card(active_only=active_only)
 
 
@@ -2868,12 +2865,12 @@ def _render_access_grid(project, active_only: bool, errors=None):
 def _access_grid_active_only(source) -> bool:
     """Read the Active-Only flag from a request args/form mapping.
 
-    Follows the project-directories card convention: the checkbox sends
-    ``active_only=1`` only when checked, so an absent value means OFF. The
-    initial container load passes ``active_only=1`` explicitly to default ON,
-    and every control hx-includes the switch so the current mode rides along.
+    Thin alias for ``read_active_only`` kept because the grid's POST
+    handlers read it off ``request.form`` as well as ``request.args``. The
+    initial container load passes ``active_only=1`` explicitly to default
+    ON, and every control hx-includes the switch so the mode rides along.
     """
-    return source.get('active_only') == '1'
+    return read_active_only(source)
 
 
 @bp.route('/htmx/access-grid/<projcode>')

--- a/src/webapp/dashboards/admin/resources_routes.py
+++ b/src/webapp/dashboards/admin/resources_routes.py
@@ -13,6 +13,7 @@ from webapp.utils.htmx import (
     handle_htmx_soft_delete,
     htmx_not_found,
     htmx_success_message,
+    read_active_only,
 )
 from webapp.extensions import db
 from webapp.utils.rbac import (
@@ -84,7 +85,7 @@ def htmx_resources_card():
     from sam.resources.machines import Machine, Queue
     from sam.resources.facilities import Facility
 
-    active_only = request.args.get('active_only') == '1'
+    active_only = read_active_only(request.args)
     now = datetime.now()
 
     resource_q = db.session.query(Resource).order_by(Resource.resource_name)

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -17,6 +17,7 @@ from sam.schemas.forms.user import (
 )
 
 from webapp.extensions import db
+from webapp.utils.htmx import read_active_only
 from sam.queries.dashboard import get_user_dashboard_data, get_resource_detail_data, get_project_dashboard_data
 from sam.queries.disk_usage import (
     build_disk_subtree,
@@ -1316,7 +1317,7 @@ def tree_fragment(project):
     """
     from webapp.api.access_control import _user_can_access_project, _get_sam_user
 
-    active_only = request.args.get('active_only') == '1'
+    active_only = read_active_only(request.args)
     root = project.get_root() if hasattr(project, 'get_root') else project
     sam_user = _get_sam_user()
     can_view = (

--- a/src/webapp/templates/dashboards/admin/projects.html
+++ b/src/webapp/templates/dashboards/admin/projects.html
@@ -1,4 +1,5 @@
 {% extends 'dashboards/admin/base_admin_projects.html' %}
+{% from 'dashboards/fragments/search_box.html' import active_toggle_search %}
 
 {% block title %}Admin: Projects - SAM{% endblock %}
 
@@ -24,27 +25,14 @@
                 {% endif %}
             </div>
             <div class="card-body">
-                <div class="mb-3">
-                    <label for="projectSearchInput">Search by project code or title</label>
-                    <input type="search" class="form-control" id="projectSearchInput"
-                           name="q"
-                           placeholder="Start typing a project code or title..."
-                           autocomplete="off"
-                           hx-get="{{ url_for('admin_dashboard.htmx_search_projects') }}"
-                           hx-trigger="input changed delay:300ms"
-                           hx-target="#projectSearchResults"
-                           hx-swap="innerHTML"
-                           hx-params="q,active_only"
-                           hx-include="#activeProjectsOnly">
-                    <div id="projectSearchResults" class="list-group mt-2"></div>
-                </div>
-                <div class="form-check mb-0">
-                    <input type="checkbox" class="form-check-input" id="activeProjectsOnly"
-                           name="active_only" value="true" checked>
-                    <label class="form-check-label" for="activeProjectsOnly">
-                        Active projects only
-                    </label>
-                </div>
+                {{ active_toggle_search(
+                    search_url=url_for('admin_dashboard.htmx_search_projects'),
+                    input_id='projectSearchInput',
+                    results_id='projectSearchResults',
+                    label='Search by project code or title',
+                    placeholder='Start typing a project code or title...',
+                    toggle_id='activeProjectsOnly',
+                    toggle_label='Active projects only') }}
             </div>
         </div>
     </div>

--- a/src/webapp/templates/dashboards/admin/users_groups.html
+++ b/src/webapp/templates/dashboards/admin/users_groups.html
@@ -1,4 +1,5 @@
 {% extends 'dashboards/admin/base_admin.html' %}
+{% from 'dashboards/fragments/search_box.html' import active_toggle_search %}
 
 {% block title %}Admin: Users &amp; Groups - SAM{% endblock %}
 
@@ -12,27 +13,14 @@
                 <h5><i class="fas fa-users"></i> Search Users</h5>
             </div>
             <div class="card-body">
-                <div class="mb-3">
-                    <label for="userSearchInput">Search by username, first, or last name</label>
-                    <input type="search" class="form-control" id="userSearchInput"
-                           name="q"
-                           placeholder="Start typing a username, first, or last name..."
-                           autocomplete="off"
-                           hx-get="{{ url_for('admin_dashboard.htmx_search_users', context='impersonate') }}"
-                           hx-trigger="input changed delay:300ms"
-                           hx-target="#userSearchResults"
-                           hx-swap="innerHTML"
-                           hx-params="q,active_only"
-                           hx-include="#activeUsersOnly">
-                    <div id="userSearchResults" class="list-group mt-2"></div>
-                </div>
-                <div class="form-check mb-0">
-                    <input type="checkbox" class="form-check-input" id="activeUsersOnly"
-                           name="active_only" value="true" checked>
-                    <label class="form-check-label" for="activeUsersOnly">
-                        Active users only
-                    </label>
-                </div>
+                {{ active_toggle_search(
+                    search_url=url_for('admin_dashboard.htmx_search_users', context='impersonate'),
+                    input_id='userSearchInput',
+                    results_id='userSearchResults',
+                    label='Search by username, first, or last name',
+                    placeholder='Start typing a username, first, or last name...',
+                    toggle_id='activeUsersOnly',
+                    toggle_label='Active users only') }}
             </div>
         </div>
     </div>
@@ -44,27 +32,14 @@
                 <h5><i class="fas fa-users-cog"></i> Search Groups</h5>
             </div>
             <div class="card-body">
-                <div class="mb-3">
-                    <label for="groupSearchInput">Search by group name or GID</label>
-                    <input type="search" class="form-control" id="groupSearchInput"
-                           name="q"
-                           placeholder="Start typing a group name or GID..."
-                           autocomplete="off"
-                           hx-get="{{ url_for('admin_dashboard.htmx_search_groups') }}"
-                           hx-trigger="input changed delay:300ms"
-                           hx-target="#groupSearchResults"
-                           hx-swap="innerHTML"
-                           hx-params="q,active_only"
-                           hx-include="#activeGroupsOnly">
-                    <div id="groupSearchResults" class="list-group mt-2"></div>
-                </div>
-                <div class="form-check mb-0">
-                    <input type="checkbox" class="form-check-input" id="activeGroupsOnly"
-                           name="active_only" value="true" checked>
-                    <label class="form-check-label" for="activeGroupsOnly">
-                        Active groups only
-                    </label>
-                </div>
+                {{ active_toggle_search(
+                    search_url=url_for('admin_dashboard.htmx_search_groups'),
+                    input_id='groupSearchInput',
+                    results_id='groupSearchResults',
+                    label='Search by group name or GID',
+                    placeholder='Start typing a group name or GID...',
+                    toggle_id='activeGroupsOnly',
+                    toggle_label='Active groups only') }}
             </div>
         </div>
     </div>

--- a/src/webapp/templates/dashboards/fragments/search_box.html
+++ b/src/webapp/templates/dashboards/fragments/search_box.html
@@ -1,0 +1,57 @@
+{# ─── search-as-you-type box with an "active only" toggle ───────────────── #}
+{#
+  Both controls hit the same endpoint: typing includes the checkbox state,
+  and toggling the checkbox re-runs the current query. Without the second
+  wiring the toggle looks inert — results only changed on the next keystroke.
+
+  htmx omits an unchecked checkbox from the request entirely, so the route
+  behind `search_url` must treat an absent `active_only` as OFF (i.e.
+  include inactive rows) — parse it with webapp.utils.htmx.read_active_only,
+  never a hand-rolled `== '1'` comparison.
+
+  Required:
+    search_url   - endpoint returning the results fragment
+    input_id     - id of the text input (result rows target it via
+                   data-clear-input)
+    results_id   - id of the results container (data-clear-results)
+    label        - visible label above the input
+    toggle_id    - id of the "active only" checkbox
+    toggle_label - label for the checkbox
+
+  Optional:
+    placeholder    - input placeholder text
+    toggle_checked - initial checkbox state (default True)
+    delay          - hx-trigger debounce for typing (default '300ms')
+#}
+{% macro active_toggle_search(search_url, input_id, results_id, label,
+                              toggle_id, toggle_label,
+                              placeholder='Start typing…',
+                              toggle_checked=True, delay='300ms') %}
+<div class="mb-3">
+    <label for="{{ input_id }}">{{ label }}</label>
+    <input type="search" class="form-control" id="{{ input_id }}"
+           name="q"
+           placeholder="{{ placeholder }}"
+           autocomplete="off"
+           hx-get="{{ search_url }}"
+           hx-trigger="input changed delay:{{ delay }}"
+           hx-target="#{{ results_id }}"
+           hx-swap="innerHTML"
+           hx-params="q,active_only"
+           hx-include="#{{ toggle_id }}">
+    <div id="{{ results_id }}" class="list-group mt-2"></div>
+</div>
+<div class="form-check mb-0">
+    <input type="checkbox" class="form-check-input" id="{{ toggle_id }}"
+           name="active_only" value="1" {% if toggle_checked %}checked{% endif %}
+           hx-get="{{ search_url }}"
+           hx-trigger="change"
+           hx-target="#{{ results_id }}"
+           hx-swap="innerHTML"
+           hx-params="q,active_only"
+           hx-include="#{{ input_id }}">
+    <label class="form-check-label" for="{{ toggle_id }}">
+        {{ toggle_label }}
+    </label>
+</div>
+{% endmacro %}

--- a/src/webapp/utils/htmx.py
+++ b/src/webapp/utils/htmx.py
@@ -7,6 +7,39 @@ from webapp.utils.fk_validation import FKValidationError
 from sam.manage import management_transaction
 
 
+#: Values an "Active only" checkbox may arrive as. Templates emit ``1``
+#: (see the ``active_toggle_search`` macro and the admin card toggles) but
+#: the set is deliberately permissive: a checkbox copy-pasted with the
+#: wrong spelling should still work rather than silently fail open.
+_TRUTHY = frozenset({'1', 'true', 'on', 'yes'})
+
+
+def read_active_only(args, default=False):
+    """Read an ``active_only`` filter flag off a request args/form mapping.
+
+    **Absent means OFF.** htmx omits an unchecked checkbox from the request
+    entirely, so a missing value is how "show me inactive rows too" arrives
+    over the wire — there is no distinct "unchecked" value to look for. A
+    route that defaults this to ON makes its checkbox inert in one
+    direction, which is exactly how inactive users/projects went missing
+    from the admin search boxes.
+
+    Pass ``default=True`` only for endpoints with no checkbox behind them
+    (the FK pickers), where active-only is the intended fixed behaviour.
+
+    Args:
+        args:    ``request.args`` or ``request.form`` (anything with .get).
+        default: value to use when the key is absent entirely.
+
+    Returns:
+        bool
+    """
+    raw = args.get('active_only')
+    if raw is None:
+        return default
+    return str(raw).strip().lower() in _TRUTHY
+
+
 def htmx_success(template, triggers, *, toast=None, toast_variant='success', **ctx):
     """Render a success fragment with HX-Trigger response headers.
 

--- a/tests/unit/test_htmx_search_active_toggle.py
+++ b/tests/unit/test_htmx_search_active_toggle.py
@@ -1,0 +1,155 @@
+"""The "Active … only" checkbox on the admin search boxes.
+
+htmx omits an unchecked checkbox from the request entirely, so every
+search endpoint behind one of these boxes must read an *absent*
+``active_only`` as OFF — i.e. include inactive rows. Reading an absent
+value as ON makes the checkbox inert: unchecking it changed nothing and
+inactive users/projects stayed invisible in the UI even though
+``sam-search --inactive-users`` found them.
+
+The FK/member user pickers never send the param and must stay
+active-only, so the users endpoint keys its default off ``context``.
+
+These are HTTP-layer tests, so they read snapshot rows rather than
+factory-built ones: Flask routes go through Flask-SQLAlchemy's
+``db.session``, which has its own connection and cannot see uncommitted
+rows written on the raw test ``session`` (see ``non_admin_client`` in
+conftest for the same constraint).
+"""
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestReadActiveOnlyHelper:
+    """`read_active_only` is the single parser every route shares — it exists
+    so the `'1'` vs `'true'` spelling split can't silently reappear.
+    """
+
+    @pytest.mark.parametrize('raw', ['1', 'true', 'True', 'TRUE', 'on', 'yes', ' 1 '])
+    def test_truthy_spellings(self, raw):
+        from webapp.utils.htmx import read_active_only
+        assert read_active_only({'active_only': raw}) is True
+
+    @pytest.mark.parametrize('raw', ['0', 'false', 'off', 'no', ''])
+    def test_falsy_spellings(self, raw):
+        from webapp.utils.htmx import read_active_only
+        assert read_active_only({'active_only': raw}) is False
+
+    def test_absent_is_off(self):
+        """The core invariant: htmx drops unchecked checkboxes entirely."""
+        from webapp.utils.htmx import read_active_only
+        assert read_active_only({}) is False
+
+    def test_absent_honors_explicit_default(self):
+        from webapp.utils.htmx import read_active_only
+        assert read_active_only({}, default=True) is True
+
+    def test_explicit_value_beats_default(self):
+        from webapp.utils.htmx import read_active_only
+        assert read_active_only({'active_only': '0'}, default=True) is False
+
+
+USERS_URL = '/admin/htmx/search/users'
+PROJECTS_URL = '/admin/htmx/search-projects'
+GROUPS_URL = '/admin/htmx/search/groups'
+
+
+def _any_inactive(session, model, order_col):
+    """First inactive snapshot row of `model`, or skip if the snapshot has none."""
+    row = session.query(model).filter(~model.is_active).order_by(order_col).first()
+    if row is None:
+        pytest.skip(f'snapshot has no inactive {model.__name__} rows')
+    return row
+
+
+@pytest.fixture
+def inactive_user(session):
+    from sam import User
+    return _any_inactive(session, User, User.user_id)
+
+
+@pytest.fixture
+def inactive_project(session):
+    from sam import Project
+    return _any_inactive(session, Project, Project.project_id)
+
+
+@pytest.fixture
+def inactive_group(session):
+    from sam.core.groups import AdhocGroup
+    return _any_inactive(session, AdhocGroup, AdhocGroup.group_name)
+
+
+class TestUserSearchActiveToggle:
+
+    def test_inactive_user_found_when_unchecked(self, auth_client, inactive_user):
+        resp = auth_client.get(
+            f'{USERS_URL}?q={inactive_user.username}&context=impersonate')
+        assert resp.status_code == 200
+        assert inactive_user.username in resp.get_data(as_text=True)
+
+    def test_inactive_user_hidden_when_checked(self, auth_client, inactive_user):
+        resp = auth_client.get(
+            f'{USERS_URL}?q={inactive_user.username}'
+            f'&context=impersonate&active_only=true')
+        assert inactive_user.username not in resp.get_data(as_text=True)
+
+    def test_active_user_found_either_way(self, auth_client):
+        """`benkirk` is preserved verbatim by the obfuscated snapshot."""
+        for suffix in ('', '&active_only=true'):
+            resp = auth_client.get(
+                f'{USERS_URL}?q=benkirk&context=impersonate{suffix}')
+            assert 'benkirk' in resp.get_data(as_text=True), suffix
+
+    @pytest.mark.parametrize('context', ['fk', 'bogus'])
+    def test_picker_contexts_stay_active_only(self, auth_client, inactive_user, context):
+        """FK pickers have no checkbox — an absent param must NOT open them up."""
+        resp = auth_client.get(
+            f'{USERS_URL}?q={inactive_user.username}&context={context}')
+        assert inactive_user.username not in resp.get_data(as_text=True)
+
+
+class TestProjectSearchActiveToggle:
+
+    def test_inactive_project_found_when_unchecked(self, auth_client, inactive_project):
+        resp = auth_client.get(f'{PROJECTS_URL}?q={inactive_project.projcode}')
+        assert resp.status_code == 200
+        assert inactive_project.projcode in resp.get_data(as_text=True)
+
+    def test_inactive_project_hidden_when_checked(self, auth_client, inactive_project):
+        resp = auth_client.get(
+            f'{PROJECTS_URL}?q={inactive_project.projcode}&active_only=true')
+        assert inactive_project.projcode not in resp.get_data(as_text=True)
+
+
+class TestGroupSearchActiveToggle:
+
+    def test_inactive_group_found_when_unchecked(self, auth_client, inactive_group):
+        resp = auth_client.get(f'{GROUPS_URL}?q={inactive_group.group_name}')
+        assert resp.status_code == 200
+        assert inactive_group.group_name in resp.get_data(as_text=True)
+
+    def test_inactive_group_hidden_when_checked(self, auth_client, inactive_group):
+        resp = auth_client.get(
+            f'{GROUPS_URL}?q={inactive_group.group_name}&active_only=true')
+        assert inactive_group.group_name not in resp.get_data(as_text=True)
+
+
+class TestToggleRefiresSearch:
+    """The checkbox itself must re-run the query — otherwise the server-side
+    default is invisible until the user retypes the search term.
+    """
+
+    @pytest.mark.parametrize('page,toggle_id,results_id', [
+        ('/admin/users-groups', 'activeUsersOnly', 'userSearchResults'),
+        ('/admin/users-groups', 'activeGroupsOnly', 'groupSearchResults'),
+        ('/admin/projects', 'activeProjectsOnly', 'projectSearchResults'),
+    ])
+    def test_checkbox_is_htmx_wired(self, auth_client, page, toggle_id, results_id):
+        html = auth_client.get(page).get_data(as_text=True)
+        start = html.index(f'id="{toggle_id}"')
+        block = html[start:start + 600]
+        assert 'hx-get=' in block
+        assert 'hx-trigger="change"' in block
+        assert f'hx-target="#{results_id}"' in block


### PR DESCRIPTION
## The bug

`sam-search --inactive-users --inactive-projects user mauricio` finds an inactive user. The Admin > **Users & Groups** search box could not surface that user no matter how the "Active users only" checkbox was set.

Two independent defects, either one sufficient to break the toggle:

**1. An absent param was read as ON.** `htmx_search_users` and `htmx_search_groups` used `request.args.get('active_only', 'true')`. htmx omits an *unchecked* checkbox from the request entirely, so unchecking the box sent no `active_only` at all — and the `'true'` default kicked back in. The toggle was a no-op in the ON direction.

**2. The checkbox never re-ran the search.** All three search boxes gave `hx-get` to the text input only; the checkbox was inert markup pulled in via `hx-include`. Even with (1) fixed, toggling changed nothing until the user retyped the query. Project search was affected by this half only — its server-side default was already correct, which is why it presented the same symptom from a different cause.

## The fix

- **`read_active_only(args, default=False)`** in `webapp/utils/htmx.py` — one parser, all 12 call sites. Absent means OFF; `default=True` is reserved for the FK pickers, which have no checkbox and intentionally stay active-only.
- **Normalized the spelling split that let this hide.** Search boxes emitted `active_only=true`, cards emitted `active_only=1`, and each route understood only its own spelling — a checkbox copy-pasted across families would silently fail open or closed. Templates now emit `1` uniformly, and the helper accepts `1`/`true`/`on`/`yes` as a backstop.
- **New `active_toggle_search` macro** (`dashboards/fragments/search_box.html`) replaces three hand-rolled copies and wires both directions: typing includes the checkbox, toggling includes the query.
- **CLAUDE.md § 9.10** documents the invariant for the next person.

## Sweep

Audited every "Active"-adjacent control in the webapp:

| Control | Absent → | Toggle re-fires? | |
|---|---|---|---|
| Users & Groups → Active users only | ~~ON~~ → **OFF** | ~~no~~ → **yes** | **fixed** |
| Users & Groups → Active groups only | ~~ON~~ → **OFF** | ~~no~~ → **yes** | **fixed** |
| Projects → Active projects only | OFF ✅ | ~~no~~ → **yes** | **fixed (client)** |
| Resources / Organizations / Facilities cards | OFF ✅ | yes ✅ | ok |
| Project Directories, access grid, institutions | OFF ✅ | yes ✅ | ok |
| User dashboard project tree | OFF ✅ | yes ✅ | ok |
| API `/api/v1/users/search` | OFF ✅ | n/a | ok |

The three search boxes were the only broken ones — notably the only three that didn't use the cards' `hx-trigger="change"` + `hx-include="this"` pattern. All now route through the shared helper.

## Testing

- **New:** `tests/unit/test_htmx_search_active_toggle.py`, 27 tests — both toggle directions per entity, FK-context guard, helper spelling matrix, and a markup assertion that each checkbox carries `hx-trigger="change"`.
- **Full suite:** 2819 passed, 25 skipped, 1 xfailed (64s).
- **Manual, against the running webapp:** `mauricio` appears with the box unchecked, disappears with it checked; card toggles still filter (resources 1.24MB → 442KB, facilities 76.8KB → 70.5KB).

These are HTTP-layer tests, so they read snapshot rows rather than factory-built ones — Flask routes go through `db.session`, which can't see uncommitted rows on the raw test session (same constraint `non_admin_client` documents).

## Deliberately out of scope

Two FK-picker searches hard-filter to `active=True` with no escape hatch —
`htmx_project_search_for_parent` and `htmx_project_search_for_adjustment`.
Surfaced by the sweep and **confirmed intended**: a parent project must be
active, and no charge adjustments may be posted against an expired project.
No toggle belongs on either. Noted here so the next audit doesn't re-raise
them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

