### PR TITLE
Fix returning-member re-add no-op + show membership status in CLI

### DIFF
--- a/src/cli/user/builders.py
+++ b/src/cli/user/builders.py
@@ -1,5 +1,6 @@
 """Data extraction for user CLI output. No Rich, no I/O."""
 
+from datetime import datetime
 from typing import Optional
 from sam import User
 
@@ -43,8 +44,29 @@ def build_user_detail(user: User) -> dict:
 
 
 def build_user_projects(user: User, inactive: bool) -> list:
-    """List of projects for a user (active or all)."""
+    """List of projects for a user (active or all).
+
+    Each row carries both the project's own active flag (``active``) and
+    whether *this user's* membership window is still open
+    (``membership_active``). The two diverge for someone who has been
+    removed from a still-active project: the project reads Active but the
+    membership has ended. Only the ``inactive`` path (``all_projects``)
+    surfaces such rows, since ``active_projects()`` already filters on the
+    membership window — so without ``membership_active`` the "All projects"
+    listing would render an ex-member's rows as "Active" and contradict the
+    "Active Projects: 0" count and the web UI.
+    """
     projects = user.all_projects if inactive else user.active_projects()
+
+    # Projcodes where this user's membership window is currently open.
+    now = datetime.now()
+    active_membership_codes = {
+        au.account.project.projcode
+        for au in user.accounts
+        if au.account and au.account.project
+        and (au.end_date is None or au.end_date >= now)
+    }
+
     out = []
     for p in projects:
         if p.lead == user:
@@ -63,6 +85,7 @@ def build_user_projects(user: User, inactive: bool) -> list:
             'title': p.title,
             'role': role,
             'active': p.active,
+            'membership_active': p.projcode in active_membership_codes,
             'latest_allocation_end': latest_end,
         })
     return out

--- a/src/cli/user/display.py
+++ b/src/cli/user/display.py
@@ -85,11 +85,18 @@ def display_user_projects(ctx: Context, projects: list, username: str):
 
     ctx.console.print(f"\n{label} projects for {username}:", style="bold underline")
 
+    # In the "All" view a project can be Active while the user's membership
+    # in it has ended; surface that with a Membership column so the listing
+    # doesn't contradict the "Active Projects" count / the web UI.
+    show_membership = ctx.inactive_projects
+
     table = Table(box=box.SIMPLE_HEAD)
     table.add_column("#", style="dim", width=4)
     table.add_column("Code", style="cyan bold")
     table.add_column("Title")
     table.add_column("Role", style="magenta")
+    if show_membership:
+        table.add_column("Membership")
     table.add_column("Status")
     if ctx.very_verbose:
         table.add_column("Alloc End", style="yellow")
@@ -98,8 +105,15 @@ def display_user_projects(ctx: Context, projects: list, username: str):
         status_style = "green" if p['active'] else "red"
         status_str = "Active" if p['active'] else "Inactive"
 
-        row = [str(i), p['projcode'], p['title'], p['role'],
-               f"[{status_style}]{status_str}[/]"]
+        row = [str(i), p['projcode'], p['title'], p['role']]
+
+        if show_membership:
+            m_active = p.get('membership_active', True)
+            m_style = "green" if m_active else "red"
+            m_str = "Active" if m_active else "Ended"
+            row.append(f"[{m_style}]{m_str}[/]")
+
+        row.append(f"[{status_style}]{status_str}[/]")
 
         if ctx.very_verbose:
             row.append(fmt.date_str(p['latest_allocation_end'], null='—'))

--- a/src/sam/manage/__init__.py
+++ b/src/sam/manage/__init__.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from typing import Optional
 
 from sqlalchemy.orm import Session
-from sqlalchemy import select
+from sqlalchemy import select, or_
 
 from sam.accounting.accounts import Account, AccountUser
 from sam.projects.projects import Project
@@ -66,6 +66,12 @@ def add_user_to_project(
     NOTE: This function does NOT commit the session. The caller is responsible
     for calling session.commit() or session.flush() as appropriate.
 
+    A returning member is re-added: accounts where the user has only an
+    expired (end-dated) membership get a fresh open row. Only a currently
+    live membership causes the account to be skipped, so the operation is
+    idempotent for active members but never a silent no-op for someone
+    whose prior rows have all lapsed.
+
     Args:
         session: SQLAlchemy session
         project_id: Project ID
@@ -74,11 +80,13 @@ def add_user_to_project(
         end_date: End date for membership (optional, defaults to None/no end date)
 
     Raises:
-        ValueError: If user is already a member of any account
+        ValueError: If the project has no accounts
     """
     # Default start_date to now if not provided
     if start_date is None:
         start_date = datetime.now()
+
+    now = datetime.now()
 
     accounts = session.query(Account).filter(
         Account.project_id == project_id,
@@ -89,13 +97,20 @@ def add_user_to_project(
         raise ValueError(f"No accounts found for project {project_id}")
 
     for account in accounts:
-        # Check if already exists
-        existing = session.query(AccountUser).filter(
+        # Skip only if the user already has a LIVE membership on this account —
+        # one that is open-ended or not yet expired (a future start_date still
+        # counts). A stale end-dated row must NOT block the add, otherwise
+        # re-adding a returning member is a silent no-op on every account they
+        # previously held. We test end_date directly rather than
+        # AccountUser.is_active because is_active also excludes not-yet-started
+        # rows, which we still want to treat as an existing membership.
+        existing_open = session.query(AccountUser).filter(
             AccountUser.account_id == account.account_id,
-            AccountUser.user_id == user_id
+            AccountUser.user_id == user_id,
+            or_(AccountUser.end_date.is_(None), AccountUser.end_date >= now),
         ).first()
 
-        if not existing:
+        if not existing_open:
             account_user = AccountUser(
                 account_id=account.account_id,
                 user_id=user_id,

--- a/tests/unit/test_cli_json_builders.py
+++ b/tests/unit/test_cli_json_builders.py
@@ -105,9 +105,15 @@ class TestUserBuilders:
         projects = build_user_projects(multi_project_user, inactive=False)
         for p in projects:
             assert set(p.keys()) == {
-                'projcode', 'title', 'role', 'active', 'latest_allocation_end',
+                'projcode', 'title', 'role', 'active', 'membership_active',
+                'latest_allocation_end',
             }
             assert p['role'] in {'Lead', 'Admin', 'Member'}
+            assert isinstance(p['membership_active'], bool)
+            # A 'Member' row can only come from an open account_user window,
+            # so its membership is necessarily active here.
+            if p['role'] == 'Member':
+                assert p['membership_active'] is True
 
     def test_build_user_search_results(self, multi_project_user):
         data = build_user_search_results([multi_project_user], 'pattern')

--- a/tests/unit/test_management_functions.py
+++ b/tests/unit/test_management_functions.py
@@ -118,6 +118,73 @@ class TestAddUserToProject:
         ).count()
         assert count == 1
 
+    def test_readds_member_whose_prior_rows_all_expired(self, session):
+        """A returning member with only end-dated rows gets a fresh open row.
+
+        Regression: the existence check used to match on (account_id,
+        user_id) alone, so a stale end-dated row made the account look
+        "already a member" and the re-add was a silent no-op — leaving the
+        user with no live access on that account.
+        """
+        project, account = _project_with_account(session)
+        new_user = make_user(session)
+
+        # First add → one open membership.
+        add_user_to_project(session, project.project_id, new_user.user_id)
+        rows = session.query(AccountUser).filter_by(
+            account_id=account.account_id, user_id=new_user.user_id
+        ).all()
+        assert len(rows) == 1
+
+        # Expire it in the past.
+        expired_at = datetime(2020, 1, 1, 12, 0, 0)
+        rows[0].end_date = expired_at
+        session.flush()
+
+        # Re-add → a NEW open row; the expired row is preserved as history.
+        add_user_to_project(session, project.project_id, new_user.user_id)
+
+        rows = session.query(AccountUser).filter_by(
+            account_id=account.account_id, user_id=new_user.user_id
+        ).order_by(AccountUser.account_user_id).all()
+        assert len(rows) == 2
+        assert rows[0].end_date == expired_at            # history kept
+        assert sum(1 for r in rows if r.end_date is None) == 1  # one live membership
+
+    def test_readd_is_per_account_partial(self, session):
+        """Re-add fills only the accounts lacking a live row (the prod bug).
+
+        Accounts where the user still has an open row are not duplicated;
+        accounts where the only row is expired get a fresh open row.
+        """
+        project, account_a = _project_with_account(session)
+        account_b = make_account(session, project=project)
+        new_user = make_user(session)
+
+        add_user_to_project(session, project.project_id, new_user.user_id)
+
+        # Expire the user's row on account_a only; account_b stays open.
+        a_row = session.query(AccountUser).filter_by(
+            account_id=account_a.account_id, user_id=new_user.user_id
+        ).one()
+        a_row.end_date = datetime(2020, 1, 1, 12, 0, 0)
+        session.flush()
+
+        add_user_to_project(session, project.project_id, new_user.user_id)
+
+        a_rows = session.query(AccountUser).filter_by(
+            account_id=account_a.account_id, user_id=new_user.user_id
+        ).all()
+        b_rows = session.query(AccountUser).filter_by(
+            account_id=account_b.account_id, user_id=new_user.user_id
+        ).all()
+        # account_a: expired + fresh open = 2 rows, exactly one live.
+        assert len(a_rows) == 2
+        assert sum(1 for r in a_rows if r.end_date is None) == 1
+        # account_b: still exactly one open row, not duplicated.
+        assert len(b_rows) == 1
+        assert b_rows[0].end_date is None
+
 
 class TestRemoveUserFromProject:
     """Tests for remove_user_from_project()."""


### PR DESCRIPTION
Two related fixes surfaced while investigating a user (jpereira) who showed projects in the CLI but none in the web UI.

---

## Fix 1 — silent no-op when re-adding a returning project member (`src/sam/manage/__init__.py`)

`add_user_to_project()` matched existing membership on `(account_id, user_id)` **alone** — date-insensitive — so a stale, end-dated `account_user` row made an account look "already a member" and it was skipped. A returning member whose prior rows had all lapsed got **no** new membership: the Add-Member UI (and the parallel REST endpoint `POST /api/v1/projects/<projcode>/members`, which shares this function) closed with no error while creating zero rows — despite promising "access to all resources."

Observed in prod: a user re-added to four projects only "took" on the two that had gained new accounts since she left; the two where every current account carried a stale end-dated row were complete no-ops.

**Fix:** the skip check now counts only a **live** membership (`end_date IS NULL OR end_date >= now`); accounts whose only rows are expired get a fresh open row (start=today), old rows preserved as history. `end_date` is tested directly (not `AccountUser.is_active`) so future-dated rows also count as existing. Stale docstring corrected.

Reproduced the no-op live via Manage Project → Add Member, then confirmed the fix through the same UI (roster grew; four new open `account_user` rows created across all accounts). Regression tests `test_readds_member_whose_prior_rows_all_expired` and `test_readd_is_per_account_partial` both fail pre-fix.

## Fix 2 — show membership status in `sam-search user --list-projects` (`src/cli/user/`)

The `--inactive-projects` list rendered each row's **Status** from the *project's* active flag only, so a project a user was removed from still read "Active" — contradicting the "Active Projects: 0" count and the web UI. Added a **Membership** column (Active/Ended) to the "All projects" view and a `membership_active` field to JSON output. Default active-only view unchanged.

---

## Tests
- `tests/unit/test_management_functions.py` — two new regression tests for Fix 1.
- `tests/unit/test_cli_json_builders.py` — updated row-keys assertion for Fix 2.
- Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)