### PR TITLE
Partial-access warning + one-click grant on the project member list

### DIFF
--- a/src/cli/project/builders.py
+++ b/src/cli/project/builders.py
@@ -109,15 +109,22 @@ def build_project_tree(project: Project) -> dict:
 
 
 def build_project_users(project: Project) -> list:
+    # Single call to the shared detector so the CLI, the web member-list
+    # warning, and the operator access grid all classify partial access
+    # identically (see Project.get_members_access_status).
+    status = project.get_members_access_status(active_only=True)
+    missing_by_user = {
+        row['user'].user_id: sorted(m['resource_name'] for m in row['missing'])
+        for row in status['members']
+    }
     out = []
     for u in sorted(project.users, key=lambda x: x.username):
-        inaccessible = project.get_user_inaccessible_resources(u)
         out.append({
             'username': u.username,
             'display_name': u.display_name,
             'primary_email': u.primary_email,
             'unix_uid': u.unix_uid,
-            'inaccessible_resources': sorted(inaccessible) if inaccessible else [],
+            'inaccessible_resources': missing_by_user.get(u.user_id, []),
         })
     return out
 

--- a/src/sam/projects/projects.py
+++ b/src/sam/projects/projects.py
@@ -481,18 +481,129 @@ class Project(Base, TimestampMixin, ActiveFlagMixin, SessionMixin, NestedSetMixi
         allocations_by_resource = self.get_all_allocations_by_resource()
         return allocations_by_resource.get(resource_name)
 
+    def get_members_access_status(self, active_only: bool = True) -> Dict[str, Any]:
+        """Per-member resource-access status for this project.
+
+        The single source of truth shared by the member-list warning
+        indicator, the CLI (``build_project_users``), and the operator
+        access grid (``_build_access_grid_context``) — so those surfaces
+        can never drift in how they classify partial access.
+
+        Columns are the resource "denominator":
+
+        - ``active_only=True`` (default) → resources with a currently-active
+          allocation (via :meth:`get_all_allocations_by_resource`). Used by
+          the member list and CLI.
+        - ``active_only=False`` → every non-deleted account's resource, so
+          lapsed resources are shown too (the grid's "show all" mode).
+
+        A member has *partial* access when they hold an active
+        ``AccountUser`` on some but not all columns, *none* when they hold
+        none, *full* otherwise. The project lead is flagged (``is_lead``) so
+        callers can apply the "lead always has access" business rule.
+
+        Returns a dict::
+
+            {
+              'columns': [
+                {account_id, resource_id, resource_name, has_active_alloc}, ...
+              ],                                          # sorted by resource_name
+              'members': [
+                {
+                  'user': User, 'is_lead': bool,
+                  'has': set[str],                        # resource_names with access
+                  'missing': [ {account_id, resource_id, resource_name}, ... ],
+                  'status': 'full' | 'partial' | 'none',
+                  'cells': [ {column, checked}, ... ],    # aligned with 'columns'
+                }, ...
+              ],
+            }
+        """
+        active_by_resource = self.get_all_allocations_by_resource()
+        active_resource_names = set(active_by_resource.keys())
+
+        columns = []
+        if active_only:
+            for resource_name, allocation in active_by_resource.items():
+                account = allocation.account
+                columns.append({
+                    'account_id': account.account_id,
+                    'resource_id': account.resource_id,
+                    'resource_name': resource_name,
+                    'has_active_alloc': True,
+                })
+        else:
+            for account in self.accounts:
+                if not account.is_active or not account.resource:
+                    continue
+                resource_name = account.resource.resource_name
+                columns.append({
+                    'account_id': account.account_id,
+                    'resource_id': account.resource_id,
+                    'resource_name': resource_name,
+                    'has_active_alloc': resource_name in active_resource_names,
+                })
+        columns.sort(key=lambda c: (c['resource_name'] or '').lower())
+
+        # One membership query for the whole grid — not per-cell lookups.
+        account_ids = [c['account_id'] for c in columns]
+        active_links = set()
+        if account_ids:
+            rows = self.session.query(
+                AccountUser.user_id, AccountUser.account_id
+            ).filter(
+                AccountUser.account_id.in_(account_ids),
+                AccountUser.is_active,
+            ).all()
+            active_links = {(uid, aid) for uid, aid in rows}
+
+        lead_user_id = self.project_lead_user_id
+        members = sorted(
+            self.users,
+            key=lambda u: (u.display_name or u.username or '').lower(),
+        )
+
+        member_rows = []
+        for user in members:
+            cells = []
+            has = set()
+            missing = []
+            for col in columns:
+                checked = (user.user_id, col['account_id']) in active_links
+                cells.append({'column': col, 'checked': checked})
+                if checked:
+                    has.add(col['resource_name'])
+                else:
+                    missing.append({
+                        'account_id': col['account_id'],
+                        'resource_id': col['resource_id'],
+                        'resource_name': col['resource_name'],
+                    })
+            if not missing:
+                status = 'full'
+            elif not has:
+                status = 'none'
+            else:
+                status = 'partial'
+            member_rows.append({
+                'user': user,
+                'is_lead': user.user_id == lead_user_id,
+                'has': has,
+                'missing': missing,
+                'status': status,
+                'cells': cells,
+            })
+
+        return {'columns': columns, 'members': member_rows}
+
     def get_user_inaccessible_resources(self, user: 'User') -> Set[str]:
         """
         Determine which resources with active allocations the user cannot access.
 
-        This method compares the resources available to this project (those with active
-        allocations) against the resources a specific user can access within this project.
-
-        Args:
-            user: User to check for resource access
-
-        Returns:
-            Set of resource names user cannot access. Empty set means full access.
+        Thin per-user wrapper over :meth:`get_members_access_status` (the
+        shared detector) so this convenience method and the grid/CLI cannot
+        disagree. Returns the set of resource names the user cannot access;
+        an empty set means full access.
 
         Example:
             >>> project = Project.get_by_projcode(session, 'UCSD0001')
@@ -501,27 +612,25 @@ class Project(Base, TimestampMixin, ActiveFlagMixin, SessionMixin, NestedSetMixi
             >>> if inaccessible:
             ...     print(f"User lacks access to: {', '.join(sorted(inaccessible))}")
         """
-        # Get all resources with active allocations
-        allocations_by_resource = self.get_all_allocations_by_resource()
-        project_resources = set(allocations_by_resource.keys())
+        status = self.get_members_access_status(active_only=True)
 
-        # If no active allocations, no restrictions apply
-        if not project_resources:
+        all_resources = {c['resource_name'] for c in status['columns']}
+        if not all_resources:
             return set()
 
-        # Find resources user CAN access in this project
-        user_resource_names = set()
-        for account_user in user.accounts:  # AccountUser objects
-            account = account_user.account
+        for row in status['members']:
+            if row['user'].user_id == user.user_id:
+                return {m['resource_name'] for m in row['missing']}
 
-            # Check: Same project + active date range + resource exists
-            if (account.project_id == self.project_id and
-                account_user.is_active and
-                account.resource):
-                user_resource_names.add(account.resource.resource_name)
-
-        # Return resources user CANNOT access
-        return project_resources - user_resource_names
+        # Caller passed a user who is not a listed project member — compute
+        # directly from their own AccountUser rows against the same column set.
+        accessible = {
+            au.account.resource.resource_name
+            for au in user.accounts
+            if (au.account.project_id == self.project_id and
+                au.is_active and au.account.resource)
+        }
+        return all_resources - accessible
 
     @hybrid_property
     def has_active_allocations(self) -> bool:

--- a/src/sam/schemas/forms/__init__.py
+++ b/src/sam/schemas/forms/__init__.py
@@ -204,6 +204,7 @@ from .projects import (
 )
 from .user import (
     AddMemberForm,
+    GrantMemberAccessForm,
     EditAllocationForm,
     ExchangeAllocationForm,
     AddAllocationForm,
@@ -276,6 +277,7 @@ __all__ = [
     'AccessGridToggleForm',
     # User
     'AddMemberForm',
+    'GrantMemberAccessForm',
     'EditAllocationForm',
     'ExchangeAllocationForm',
     'AddAllocationForm',

--- a/src/sam/schemas/forms/user.py
+++ b/src/sam/schemas/forms/user.py
@@ -62,6 +62,17 @@ class AddMemberForm(HtmxFormSchema):
         return data
 
 
+class GrantMemberAccessForm(HtmxFormSchema):
+    """Grant an existing project member access to all resources they are
+    currently missing (the member-list "Grant access" fix).
+
+    Only the username is submitted; the set of missing resources is derived
+    server-side from ``Project.get_members_access_status``. User existence /
+    membership checks require DB access and stay in the route per CLAUDE.md §9.
+    """
+    username = f.Str(required=True, validate=v.Length(min=1))
+
+
 class EditAllocationForm(HtmxFormSchema):
     amount = f.Float(required=True, validate=v.Range(min=0, min_inclusive=False))
     start_date = f.Date('%Y-%m-%d', load_default=None)

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -2782,75 +2782,19 @@ _ACCESS_GRID_TEMPLATE = 'dashboards/admin/fragments/project_access_grid_htmx.htm
 def _build_access_grid_context(project, active_only: bool) -> dict:
     """Build the member × resource access grid for *project*.
 
-    Columns are resources with a currently-active allocation when
-    ``active_only`` is True, otherwise every non-deleted account's resource
-    (so expired/lapsed resources are also shown). Each cell is checked when
-    the member has a currently-active AccountUser on that column's account —
-    computed from one membership query, not per-cell lookups.
+    Thin adapter over the shared detector
+    :meth:`Project.get_members_access_status` — the same computation that
+    backs the CLI and the member-list warning indicator, so the grid can
+    never disagree with them. Columns are resources with a currently-active
+    allocation when ``active_only`` is True, otherwise every non-deleted
+    account's resource (so expired/lapsed resources are also shown).
     """
-    from sam.accounting.accounts import AccountUser
-
-    active_by_resource = project.get_all_allocations_by_resource()
-    active_resource_names = set(active_by_resource.keys())
-
-    columns = []
-    if active_only:
-        for resource_name, allocation in active_by_resource.items():
-            account = allocation.account
-            columns.append({
-                'account_id': account.account_id,
-                'resource_id': account.resource_id,
-                'resource_name': resource_name,
-                'has_active_alloc': True,
-            })
-    else:
-        for account in project.accounts:
-            if not account.is_active or not account.resource:
-                continue
-            resource_name = account.resource.resource_name
-            columns.append({
-                'account_id': account.account_id,
-                'resource_id': account.resource_id,
-                'resource_name': resource_name,
-                'has_active_alloc': resource_name in active_resource_names,
-            })
-    columns.sort(key=lambda c: (c['resource_name'] or '').lower())
-
-    # One query for the whole grid: which (user, account) memberships are active.
-    account_ids = [c['account_id'] for c in columns]
-    active_links = set()
-    if account_ids:
-        rows = db.session.query(
-            AccountUser.user_id, AccountUser.account_id
-        ).filter(
-            AccountUser.account_id.in_(account_ids),
-            AccountUser.is_active,
-        ).all()
-        active_links = {(uid, aid) for uid, aid in rows}
-
-    lead_user_id = project.project_lead_user_id
-    members = sorted(
-        project.users,
-        key=lambda u: (u.display_name or u.username or '').lower(),
-    )
-
-    member_rows = []
-    for user in members:
-        cells = [{
-            'column': col,
-            'checked': (user.user_id, col['account_id']) in active_links,
-        } for col in columns]
-        member_rows.append({
-            'user': user,
-            'is_lead': user.user_id == lead_user_id,
-            'cells': cells,
-        })
-
+    status = project.get_members_access_status(active_only=active_only)
     return {
         'project': project,
         'projcode': project.projcode,
-        'columns': columns,
-        'member_rows': member_rows,
+        'columns': status['columns'],
+        'member_rows': status['members'],
         'active_only': active_only,
     }
 

--- a/src/webapp/dashboards/project_members.py
+++ b/src/webapp/dashboards/project_members.py
@@ -20,7 +20,7 @@ from flask_login import login_required, current_user
 from marshmallow import ValidationError
 
 from sam.queries.users import get_users_on_project
-from sam.schemas.forms.user import AddMemberForm
+from sam.schemas.forms.user import AddMemberForm, GrantMemberAccessForm
 from webapp.extensions import db
 from webapp.utils.htmx import htmx_success
 from webapp.api.access_control import (
@@ -56,14 +56,7 @@ def members_fragment(project):
     if not members:
         return '<p class="text-muted mb-0">No members found or project not accessible</p>'
 
-    return render_template(
-        'project_members/fragments/members_table.html',
-        members=sorted(members, key=lambda member: member["display_name"]),
-        projcode=project.projcode,
-        project=project,
-        can_manage=can_manage_project_members(current_user, project),
-        can_change_admin=can_change_admin(current_user, project)
-    )
+    return _render_members_table(project.projcode, project)
 
 
 @bp.route('/<projcode>/add-form')
@@ -213,6 +206,71 @@ def htmx_change_admin(project):
     return _render_members_table(projcode, project)
 
 
+@bp.route('/<projcode>/grant-access', methods=['POST'])
+@login_required
+@require_member_management
+def htmx_grant_access(project):
+    """Grant a member access to every project resource they are missing (htmx).
+
+    The member-list "Grant access" fix for a partial-access member. Derives
+    the member's missing resources from the shared detector
+    (``Project.get_members_access_status``) and loops the idempotent
+    ``grant_user_resource_access`` over them, then re-renders the table.
+    """
+    from sam.manage import grant_user_resource_access, management_transaction
+    from sam.core.users import User
+
+    projcode = project.projcode
+    try:
+        form_data = GrantMemberAccessForm().load(request.form)
+    except ValidationError as e:
+        errors = '; '.join(GrantMemberAccessForm.flatten_errors(e.messages))
+        return f'<div class="alert alert-danger">{errors}</div>', 400
+
+    username = form_data['username']
+    user = db.session.query(User).filter_by(username=username).first()
+    if not user:
+        return f'<div class="alert alert-danger">User "{username}" not found</div>', 404
+
+    # Derive this member's missing resources from the shared detector.
+    status = project.get_members_access_status()
+    missing = next(
+        (row['missing'] for row in status['members']
+         if row['user'].user_id == user.user_id),
+        [],
+    )
+
+    try:
+        with management_transaction(db.session):
+            for gap in missing:
+                grant_user_resource_access(
+                    db.session, project.project_id, user.user_id, gap['resource_id']
+                )
+    except (ValueError, Exception) as e:
+        return f'<div class="alert alert-danger">{e}</div>', 400
+
+    return _render_members_table(projcode, project)
+
+
+def _members_access_by_username(project):
+    """Map ``username -> {status, missing_names, is_lead}`` for the member
+    list's partial-access warning.
+
+    Uses the shared detector ``Project.get_members_access_status`` so the
+    card indicator, the CLI, and the operator access grid classify partial
+    access identically.
+    """
+    status = project.get_members_access_status()
+    return {
+        row['user'].username: {
+            'status': row['status'],
+            'missing_names': sorted(m['resource_name'] for m in row['missing']),
+            'is_lead': row['is_lead'],
+        }
+        for row in status['members']
+    }
+
+
 def _render_members_table(projcode, project):
     """Render the members table fragment for a project (shared by htmx routes)."""
     members = get_users_on_project(db.session, projcode)
@@ -222,5 +280,6 @@ def _render_members_table(projcode, project):
         projcode=projcode,
         project=project,
         can_manage=can_manage_project_members(current_user, project),
-        can_change_admin=can_change_admin(current_user, project)
+        can_change_admin=can_change_admin(current_user, project),
+        access_by_username=_members_access_by_username(project),
     )

--- a/src/webapp/templates/project_members/fragments/members_table.html
+++ b/src/webapp/templates/project_members/fragments/members_table.html
@@ -30,10 +30,45 @@
         </thead>
         <tbody>
             {% for member in members %}
+            {% set acc = access_by_username.get(member.username) if access_by_username else None %}
             <tr>
                 <td>
                     <i class="fas fa-user text-muted me-1"></i>
                     <strong>{{ member.display_name }}</strong>
+                    {% if acc and acc.status != 'full' and not acc.is_lead %}
+                        {% set missing_str = acc.missing_names | join(', ') %}
+                        {% if can_manage %}
+                        {# Actionable partial-access warning: click to grant the missing resources. #}
+                        <button type="button"
+                                class="btn btn-link p-0 border-0 align-baseline text-warning ms-1"
+                                data-bs-toggle="tooltip"
+                                data-bs-title="No access to {{ missing_str }} — click to grant"
+                                hx-post="{{ url_for('project_members.htmx_grant_access', projcode=projcode) }}"
+                                hx-vals='{"username": "{{ member.username }}"}'
+                                hx-target="#htmx-members-{{ projcode }}"
+                                hx-swap="innerHTML"
+                                hx-confirm="Grant {{ member.display_name }} access to {{ missing_str }}?"
+                                data-confirm-title="Grant resource access"
+                                data-confirm-variant="warning"
+                                data-confirm-label="Grant access"
+                                data-confirm-body="#confirm-grant-{{ member.username }}">
+                            <i class="fas fa-triangle-exclamation" aria-hidden="true"></i>
+                            <span class="visually-hidden">Partial access: no access to {{ missing_str }}. Grant access.</span>
+                        </button>
+                        <template id="confirm-grant-{{ member.username }}">
+                            <p>Grant <strong>{{ member.display_name }}</strong> access to the project resources they are currently missing?</p>
+                            <p class="mb-0 text-muted small">Missing: {{ missing_str }}. This adds them to each resource's account; existing access is unchanged.</p>
+                        </template>
+                        {% else %}
+                        {# Read-only indicator for viewers who cannot manage members. #}
+                        <span class="text-warning ms-1" tabindex="0"
+                              data-bs-toggle="tooltip"
+                              data-bs-title="No access to {{ missing_str }}">
+                            <i class="fas fa-triangle-exclamation" aria-hidden="true"></i>
+                            <span class="visually-hidden">Partial access: no access to {{ missing_str }}.</span>
+                        </span>
+                        {% endif %}
+                    {% endif %}
                 </td>
                 <td><code>{{ member.username }}</code></td>
                 <td>

--- a/tests/unit/test_cli_json_builders.py
+++ b/tests/unit/test_cli_json_builders.py
@@ -203,6 +203,18 @@ class TestProjectBuilders:
             }
             assert isinstance(u['inaccessible_resources'], list)
 
+    def test_build_project_users_matches_shared_detector(self, active_project):
+        """CLI partial-access output is sourced from Project.get_members_access_status,
+        so it must agree resource-for-resource with the detector (no drift)."""
+        users = build_project_users(active_project)
+        status = active_project.get_members_access_status(active_only=True)
+        expected = {
+            row['user'].username: sorted(m['resource_name'] for m in row['missing'])
+            for row in status['members']
+        }
+        for u in users:
+            assert u['inaccessible_resources'] == expected.get(u['username'], [])
+
     def test_build_project_search_results_brief(self, active_project):
         data = build_project_search_results([active_project], 'pat', verbose=False)
         assert data['kind'] == 'project_search_results'

--- a/tests/unit/test_user_resource_access.py
+++ b/tests/unit/test_user_resource_access.py
@@ -106,6 +106,138 @@ class TestRevokeUserResourceAccess:
             )
 
 
+class TestGetMembersAccessStatus:
+    """Tests for Project.get_members_access_status — the shared detector that
+    backs the member-list warning, the CLI, and the operator access grid."""
+
+    def _project_two_active_resources(self, session):
+        project = make_project(session)
+        r1 = make_resource(session)
+        r2 = make_resource(session)
+        acct1 = make_account(session, project=project, resource=r1)
+        acct2 = make_account(session, project=project, resource=r2)
+        make_allocation(session, account=acct1)
+        make_allocation(session, account=acct2)
+        return project, r1, r2, acct1, acct2
+
+    def _add_member(self, session, project):
+        member = make_user(session)
+        past = datetime.now() - timedelta(days=1)
+        add_user_to_project(
+            session, project.project_id, member.user_id, start_date=past
+        )
+        session.expire_all()
+        return member
+
+    def _row_for(self, status, user_id):
+        return next(r for r in status['members'] if r['user'].user_id == user_id)
+
+    def test_full_access_member(self, session):
+        project, r1, r2, _, _ = self._project_two_active_resources(session)
+        member = self._add_member(session, project)
+
+        row = self._row_for(project.get_members_access_status(), member.user_id)
+        assert row['status'] == 'full'
+        assert row['missing'] == []
+        assert row['has'] == {r1.resource_name, r2.resource_name}
+        assert row['is_lead'] is False
+
+    def test_partial_access_carries_resource_id(self, session):
+        project, r1, r2, _, acct2 = self._project_two_active_resources(session)
+        member = self._add_member(session, project)
+
+        # Drop the member's access to r2 only (out-of-band partial error).
+        bad = session.query(AccountUser).filter_by(
+            account_id=acct2.account_id, user_id=member.user_id
+        ).one()
+        session.delete(bad)
+        session.flush()
+        session.expire_all()
+
+        row = self._row_for(project.get_members_access_status(), member.user_id)
+        assert row['status'] == 'partial'
+        assert [m['resource_name'] for m in row['missing']] == [r2.resource_name]
+        # The grant loop needs a usable resource_id.
+        assert row['missing'][0]['resource_id'] == acct2.resource_id
+
+    def test_no_access_member(self, session):
+        # jpereira's real shape: the member still belongs to the project (via
+        # a resource with no active allocation) but has lost access to every
+        # active-allocation resource. r1 has an active allocation, r2 does not.
+        project = make_project(session)
+        r1 = make_resource(session)
+        r2 = make_resource(session)
+        acct1 = make_account(session, project=project, resource=r1)
+        make_account(session, project=project, resource=r2)
+        make_allocation(session, account=acct1)  # only r1 is active
+        member = self._add_member(session, project)
+
+        # Drop the member's r1 (active) access; keep r2 so they remain a member.
+        bad = session.query(AccountUser).filter_by(
+            account_id=acct1.account_id, user_id=member.user_id
+        ).one()
+        session.delete(bad)
+        session.flush()
+        session.expire_all()
+
+        row = self._row_for(project.get_members_access_status(), member.user_id)
+        assert row['status'] == 'none'
+        assert row['has'] == set()
+        assert {m['resource_name'] for m in row['missing']} == {r1.resource_name}
+
+    def test_lead_is_flagged(self, session):
+        project, *_ = self._project_two_active_resources(session)
+        row = self._row_for(
+            project.get_members_access_status(), project.project_lead_user_id
+        )
+        assert row['is_lead'] is True
+
+    def test_active_only_denominator(self, session):
+        # r2's account has no active allocation → excluded when active_only,
+        # included when active_only=False.
+        project = make_project(session)
+        r1 = make_resource(session)
+        r2 = make_resource(session)
+        make_allocation(session, account=make_account(session, project=project, resource=r1))
+        make_account(session, project=project, resource=r2)  # no allocation
+        session.expire_all()
+
+        cols_active = {
+            c['resource_name']
+            for c in project.get_members_access_status(active_only=True)['columns']
+        }
+        cols_all = {
+            c['resource_name']
+            for c in project.get_members_access_status(active_only=False)['columns']
+        }
+        assert r1.resource_name in cols_active
+        assert r2.resource_name not in cols_active
+        assert {r1.resource_name, r2.resource_name} <= cols_all
+
+    def test_grant_over_missing_restores_full(self, session):
+        """End-to-end: the exact loop the grant route runs makes a member whole."""
+        project, r1, r2, _, acct2 = self._project_two_active_resources(session)
+        member = self._add_member(session, project)
+        bad = session.query(AccountUser).filter_by(
+            account_id=acct2.account_id, user_id=member.user_id
+        ).one()
+        session.delete(bad)
+        session.flush()
+        session.expire_all()
+
+        status = project.get_members_access_status()
+        missing = self._row_for(status, member.user_id)['missing']
+        for gap in missing:
+            grant_user_resource_access(
+                session, project.project_id, member.user_id, gap['resource_id']
+            )
+        session.expire_all()
+
+        row = self._row_for(project.get_members_access_status(), member.user_id)
+        assert row['status'] == 'full'
+        assert row['missing'] == []
+
+
 class TestReconcileProjectAccess:
     def test_reconcile_fills_partial_access(self, session):
         project = make_project(session)


### PR DESCRIPTION
## Problem

Partial project access — a member holding an `account_user` row on only *some* of a project's active-allocation resources (exactly the state the recent add-member no-op bug produced for jpereira: access to retired resources but not the live Derecho/Casper) — was **invisible in the web member list**. Only the site-operator reconcile grid and the CLI (`sam-search project … --list-users --verbose`) exposed it, and those two computed it with **different** code paths that could disagree.

## What this does

Adds a muted-yellow ⚠ next to any non-lead member with missing resource access:

- **Hover** → "No access to Casper, Casper GPU, …" (the specific gaps).
- **Click** (for anyone who can manage members — project lead/admin **or** operator) → a confirm dialog listing the gaps, then a one-click **Grant access** that fills them.

## Unified detection (kills CLI/web drift)

New single source of truth `Project.get_members_access_status(active_only)` → per member `{has, missing[{resource_id,resource_name}], status: full|partial|none, cells, is_lead}`. All three surfaces now consume it:

| Surface | Change |
|---|---|
| Member list (new warning) | `project_members.py` + `members_table.html` |
| CLI `build_project_users` | rewired to the detector — output shape unchanged |
| Operator access grid | `_build_access_grid_context` is now a thin adapter over the detector (template/behavior unchanged) |

`get_user_inaccessible_resources` becomes a thin wrapper over the same method.

## Grant action

`POST /project-members/<projcode>/grant-access` (htmx), gated `@require_member_management` (same audience as Add/Remove Member). Loops the existing **idempotent** `grant_user_resource_access` over the member's missing resources; old end-dated rows are preserved as history. New `GrantMemberAccessForm` per CLAUDE.md §9. The operator reconcile grid is unchanged functionally — only its computation is unified.

## Tests

- `TestGetMembersAccessStatus` — full/partial/none classification, lead flag, `active_only` denominator, `resource_id` present in `missing`, and the grant-loop-restores-full path.
- CLI parity test: `build_project_users` matches the detector resource-for-resource.
- **Full suite green: 2828 passed, 25 skipped, 1 xfailed.**

## Manual smoke test (Playwright, project `NWCA0001`)

A project with 10 members / 4 active resources where 3 non-lead members (incl. one **Admin**) have Derecho-only access:

1. **Render** — Members tab shows the ⚠ on exactly Danny Hogan, Debasish Mishra, and Ryan Cabell (Admin); the **Lead** and the 6 fully-provisioned members show nothing. The operator grid below cross-confirms the same gaps.
2. **Explain** — the icon's label/tooltip reads "No access to Casper, Casper GPU, Derecho GPU."
3. **Confirm** — clicking it opens the confirm dialog naming the member and listing the missing resources.
4. **Grant** — confirming grants **only that member**: Danny Hogan's warning clears while Debasish Mishra and Ryan Cabell keep theirs (per-user scope, not whole-project reconcile). DB verified: three fresh open `account_user` rows for dlhogan on Casper/Casper GPU/Derecho GPU, the other two members untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)