### PR TITLE
Gate adhoc group members on the branch account set (legacy parity)

### DIFF
--- a/src/sam/queries/directory_access.py
+++ b/src/sam/queries/directory_access.py
@@ -10,9 +10,30 @@ The data is organized by access branch (hpc, hpc-data, hpc-dev) and includes:
 
 Group sources (in order of the legacy pipeline):
   1. Implicit project groups: active projects with allocations within grace period,
-     linked to access branches via account → resource → access_branch_resource
-  2. Explicit adhoc groups: AdhocGroup entries whose tags match access branch names
-  3. Global "ncar" group (gid=1000): every user per branch is injected as a member
+     linked to access branches via account → resource → access_branch_resource.
+     These member rows — and only these — establish the branch's *account set*,
+     the usernames that get a unixAccounts entry.
+  2. Explicit adhoc groups: AdhocGroup entries whose tags match access branch names.
+     The groups themselves are created unconditionally, but each
+     AdhocSystemAccountEntry is admitted **only if that username is already in
+     the branch's account set** — the dependent-account gate. See below.
+  3. Global "ncar" group (gid=1000): the branch's account set, verbatim
+
+The dependent-account gate (step 2) reproduces legacy
+``SystemDirectory.flatLoadDependentAccount()``::
+
+    void flatLoadDependentAccount(String branch, String group, String username) {
+        SystemAccount required = SystemAccount.create(branch, username);
+        if (accounts.contains(required)) {          // <-- the gate
+            flatLoadGroup(branch, group, username);
+        }
+    }
+
+Without it, a service account that is listed in an adhoc group but has no
+project membership (e.g. ``tomcat`` in ``sage``) is emitted as a group member
+with no corresponding unixAccounts entry — a dangling reference for the
+downstream LDAP provisioner. Legacy injects "ncar" *before* the adhoc stage
+for the same reason, so adhoc membership can never leak into it either.
 
 Constants matching legacy Java Constants.java:
   ACCESS_GRACE_PERIOD = 90  days
@@ -199,9 +220,14 @@ def group_populator(
     O(1) lookup of all groups a given username belongs to within a branch.
 
     Includes three group sources (matching legacy pipeline order):
-      1. Implicit project groups (projcode-based)
-      2. Explicit adhoc groups (AdhocGroup + AdhocSystemAccountEntry)
-      3. Global "ncar" group (every user per branch)
+      1. Implicit project groups (projcode-based) — these member rows define
+         the branch's account set
+      2. Explicit adhoc groups (AdhocGroup + AdhocSystemAccountEntry), whose
+         members are admitted only if already in the branch's account set
+      3. Global "ncar" group — the branch's account set
+
+    Every username in the returned ``groups`` is therefore guaranteed to have
+    a matching entry in :func:`user_populator`'s accounts for the same branch.
 
     Args:
         session: SQLAlchemy session
@@ -213,6 +239,12 @@ def group_populator(
     # --- 1. Implicit project groups ---
     branches: Dict[str, Dict] = {}
 
+    # Per-branch account set — the legacy SystemDirectory.accounts equivalent.
+    # Only *member* rows contribute (legacy flatLoad(branch, group, username)
+    # loads the group membership AND the account); _SQL_PROJECT_GROUPS creates
+    # groups without accounts and must not feed this.
+    branch_accounts: Dict[str, Set[str]] = {}
+
     rows = session.execute(_SQL_PROJECT_GROUPS, params).fetchall()
     for branch_name, group_name, gid in rows:
         b = branches.setdefault(branch_name, {'groups': {}})
@@ -223,6 +255,7 @@ def group_populator(
         b = branches.setdefault(branch_name, {'groups': {}})
         grp = b['groups'].setdefault(group_name, {'gid': None, 'usernames': set()})
         grp['usernames'].add(username)
+        branch_accounts.setdefault(branch_name, set()).add(username)
 
     # --- 2. Explicit adhoc groups (tags → access branch) ---
     rows = session.execute(_SQL_ADHOC_GROUPS, params).fetchall()
@@ -235,23 +268,29 @@ def group_populator(
 
     rows = session.execute(_SQL_ADHOC_MEMBERS, params).fetchall()
     for branch_name, group_name, username in rows:
+        # Dependent-account gate — legacy SystemDirectory.flatLoadDependentAccount().
+        # adhoc_system_account_entry.username is a bare string with no FK and no
+        # active check, so an entry can name a user who has no account on this
+        # branch (or none at all). Legacy drops those silently; so do we.
+        if username not in branch_accounts.get(branch_name, ()):
+            continue
         b = branches.setdefault(branch_name, {'groups': {}})
         grp = b['groups'].setdefault(group_name, {'gid': None, 'usernames': set()})
         grp['usernames'].add(username)
 
     # --- 3. Global "ncar" group ---
-    # Collect all usernames already in this branch (from project members + adhoc members)
-    for branch_name, branch_data in branches.items():
-        all_branch_usernames: Set[str] = set()
-        for grp_data in branch_data['groups'].values():
-            all_branch_usernames.update(grp_data['usernames'])
-
-        ncar_grp = branch_data['groups'].setdefault(DEFAULT_COMMON_GROUP, {
+    # Exactly the branch's account set. Legacy injects this *before* the adhoc
+    # stage (iterating SystemDirectory.accounts), so branches with adhoc groups
+    # but no accounts get no "ncar" group at all.
+    for branch_name, accounts in branch_accounts.items():
+        if not accounts:
+            continue
+        ncar_grp = branches[branch_name]['groups'].setdefault(DEFAULT_COMMON_GROUP, {
             'gid': DEFAULT_COMMON_GROUP_GID,
             'usernames': set(),
         })
         ncar_grp['gid'] = DEFAULT_COMMON_GROUP_GID
-        ncar_grp['usernames'].update(all_branch_usernames)
+        ncar_grp['usernames'].update(accounts)
 
     # --- 4. Symmetric username → groups index ---
     # Invert the groups dict so callers can quickly look up a user's memberships.

--- a/tests/unit/test_directory_access_queries.py
+++ b/tests/unit/test_directory_access_queries.py
@@ -1,17 +1,30 @@
 """Unit tests for sam.queries.directory_access.
 
-Ported verbatim from tests/unit/test_directory_access_queries.py. Structural
-tests only — no hardcoded identifiers, no writes. The one `.update()` call
-at line 70 is a `set.update()` (not ORM), so this entire file is pure-read.
+The `TestGroupPopulator` / `TestUserPopulator` / response-builder classes are
+structural tests over snapshot data — no hardcoded identifiers, no writes.
+(The `.update()` calls there are `set.update()`, not ORM.)
+
+`TestAdhocDependentAccountGate` is the exception: it uses Layer-2 factories to
+build an isolated access branch so the gate can be asserted on exact counts.
 """
 import pytest
 
+from sam import (
+    AccessBranch,
+    AccessBranchResource,
+    AdhocGroupTag,
+    AdhocSystemAccountEntry,
+)
 from sam.core.groups import DEFAULT_COMMON_GROUP, DEFAULT_COMMON_GROUP_GID
 from sam.queries.directory_access import (
     build_directory_access_response,
     group_populator,
     user_populator,
 )
+
+from factories.core import make_adhoc_group, make_user
+from factories.projects import make_account, make_allocation, make_project
+from factories.resources import make_resource
 
 
 pytestmark = pytest.mark.unit
@@ -129,6 +142,160 @@ class TestGroupPopulator:
                         f"Branch {branch_name}: user_groups[{username!r}] missing "
                         f"group {group_name!r}"
                     )
+
+    def test_no_dangling_group_members(self, session):
+        """Every group member must have a unixAccount on the same branch.
+
+        The dependent-account gate (legacy
+        ``SystemDirectory.flatLoadDependentAccount``) guarantees this. Without
+        it, adhoc entries for users with no project membership leak in as
+        members with no account — a dangling reference for the downstream LDAP
+        provisioner. Mirrors the `no dangling group members` parity check.
+        """
+        groups = group_populator(session)
+        accounts = user_populator(session)
+        for branch_name, branch_data in groups.items():
+            branch_accounts = set(accounts.get(branch_name, {}).get('accounts', {}))
+            members = set()
+            for grp in branch_data['groups'].values():
+                members.update(grp['usernames'])
+            dangling = members - branch_accounts
+            assert not dangling, (
+                f"Branch {branch_name}: {len(dangling)} group members have no "
+                f"unixAccount: {sorted(dangling)[:5]}"
+            )
+
+    def test_ncar_equals_account_set(self, session):
+        """ncar is exactly the branch's account set — no more, no less."""
+        groups = group_populator(session)
+        accounts = user_populator(session)
+        for branch_name, branch_data in groups.items():
+            branch_accounts = set(accounts.get(branch_name, {}).get('accounts', {}))
+            if not branch_accounts:
+                continue
+            ncar = branch_data['groups'].get(DEFAULT_COMMON_GROUP, {}).get('usernames', set())
+            assert ncar == branch_accounts, (
+                f"Branch {branch_name}: ncar has {len(ncar)} members, "
+                f"branch has {len(branch_accounts)} accounts "
+                f"(surplus: {sorted(ncar - branch_accounts)[:5]}, "
+                f"missing: {sorted(branch_accounts - ncar)[:5]})"
+            )
+
+
+# ============================================================================
+# Adhoc dependent-account gate (the `tomcat` case)
+# ============================================================================
+
+
+class TestAdhocDependentAccountGate:
+    """An adhoc entry is admitted only if the user already has an account.
+
+    Reproduces legacy ``SystemDirectory.flatLoadDependentAccount()``. The
+    real-world case that exposed this: service account ``tomcat`` sits in the
+    ``sage`` adhoc group on all three branches but has no project membership,
+    so legacy drops it while our ungated merge emitted it (in ``sage`` *and*
+    ``ncar``) with no matching unixAccounts entry.
+
+    Each test builds its own access branch so counts are exact and isolated
+    from whatever the snapshot happens to contain.
+    """
+
+    @pytest.fixture
+    def branch(self, session):
+        """An isolated access branch with one qualifying member.
+
+        Returns ``(branch_name, member_username, adhoc_group)`` where the
+        adhoc group is tagged onto the branch but has no entries yet.
+        """
+        resource = make_resource(session)          # configurable defaults True
+        assert resource.configurable, "gate test needs a configurable resource"
+
+        # The branch name must equal the resource name: user_populator's "key
+        # resource" join is `LOWER(ab.name) = LOWER(k.resource_name)`, so a
+        # branch that doesn't match a resource yields no unixAccounts at all.
+        branch_name = resource.resource_name
+        access_branch = AccessBranch(name=branch_name)
+        session.add(access_branch)
+        session.flush()
+        session.add(AccessBranchResource(
+            access_branch_id=access_branch.access_branch_id,
+            resource_id=resource.resource_id,
+        ))
+        session.flush()
+
+        # make_account seeds the project lead as an open-ended AccountUser,
+        # which is what puts them in the branch's account set; the allocation
+        # keeps the account inside the grace-period window.
+        project = make_project(session)
+        account = make_account(session, project=project, resource=resource)
+        make_allocation(session, account=account)
+
+        adhoc_group = make_adhoc_group(session)
+        session.add(AdhocGroupTag(group_id=adhoc_group.group_id, tag=branch_name))
+        session.flush()
+
+        return branch_name, project.lead.username, adhoc_group
+
+    def test_orphan_adhoc_entry_is_excluded(self, session, branch):
+        """A user with an adhoc entry but no account is dropped — the tomcat case."""
+        branch_name, member, adhoc_group = branch
+        orphan = make_user(session)
+        session.add(AdhocSystemAccountEntry(
+            group_id=adhoc_group.group_id,
+            access_branch_name=branch_name,
+            username=orphan.username,
+        ))
+        session.flush()
+
+        groups = group_populator(session, access_branch=branch_name)[branch_name]['groups']
+
+        assert orphan.username not in groups[adhoc_group.group_name]['usernames']
+        assert orphan.username not in groups[DEFAULT_COMMON_GROUP]['usernames']
+        # ...but the adhoc group itself is still published (legacy flatLoad is
+        # unconditional), and the qualifying member is unaffected.
+        assert adhoc_group.group_name in groups
+        assert groups[DEFAULT_COMMON_GROUP]['usernames'] == {member}
+
+    def test_qualifying_adhoc_entry_is_included(self, session, branch):
+        """Same shape, but the user has an account — so the entry is kept."""
+        branch_name, member, adhoc_group = branch
+        session.add(AdhocSystemAccountEntry(
+            group_id=adhoc_group.group_id,
+            access_branch_name=branch_name,
+            username=member,
+        ))
+        session.flush()
+
+        groups = group_populator(session, access_branch=branch_name)[branch_name]['groups']
+
+        assert member in groups[adhoc_group.group_name]['usernames']
+        assert member in groups[DEFAULT_COMMON_GROUP]['usernames']
+
+    def test_orphan_never_reaches_the_response(self, session, branch):
+        """End-to-end: the orphan appears in neither unixGroups nor unixAccounts."""
+        branch_name, _member, adhoc_group = branch
+        orphan = make_user(session)
+        session.add(AdhocSystemAccountEntry(
+            group_id=adhoc_group.group_id,
+            access_branch_name=branch_name,
+            username=orphan.username,
+        ))
+        session.flush()
+
+        response = build_directory_access_response(
+            group_populator(session, access_branch=branch_name),
+            user_populator(session, access_branch=branch_name),
+        )
+        directory = response['accessBranchDirectories'][0]
+        assert directory['accessBranchName'] == branch_name
+
+        members = set()
+        for grp in directory['unixGroups']:
+            members.update(grp['usernames'])
+        accounts = {a['username'] for a in directory['unixAccounts']}
+
+        assert orphan.username not in members
+        assert not members - accounts, 'response contains dangling group members'
 
 
 # ============================================================================

--- a/utils/parity/README.md
+++ b/utils/parity/README.md
@@ -19,8 +19,14 @@ production hosts and therefore requires the UCAR VPN.
 
 The response schemas are specified in
 [`docs/apis/SYSTEMS_INTEGRATION_APIs.md`](../../docs/apis/SYSTEMS_INTEGRATION_APIs.md).
-~37 comparison rules run across the five APIs, each returning a
+~40 comparison rules run across the five APIs, each returning a
 pass/fail `CheckResult` with sample mismatch lines.
+
+Most rules are one-directional (*legacy ⊆ new*) to absorb DB-mirror lag.
+`directory_access` additionally carries three checks in the reverse
+direction — surplus group members, surplus account usernames, and a
+"no dangling group members" self-consistency invariant asserted against
+each payload on its own. The other four APIs are still forward-only.
 
 ## Required environment variables
 

--- a/utils/parity/comparators.py
+++ b/utils/parity/comparators.py
@@ -109,7 +109,7 @@ def collect_resource_names(new_fstree_data: dict) -> list[str]:
 
 
 # ===========================================================================
-# Directory Access — 12 checks
+# Directory Access — 15 checks
 # ===========================================================================
 
 def compare_directory_access(legacy: dict, new: dict) -> list[CheckResult]:
@@ -295,6 +295,89 @@ def compare_directory_access(legacy: dict, new: dict) -> list[CheckResult]:
             mismatches=mismatches,
             compared=compared,
         ))
+
+    # -----------------------------------------------------------------------
+    # 13-15. Reverse direction (new − legacy).
+    #
+    # Checks 1-12 are all one-directional (legacy ⊆ new), so surplus rows in
+    # the new endpoint can never fail them. That blind spot is exactly how the
+    # ungated adhoc-member merge shipped: 3,959 group-member rows across 339
+    # groups that legacy drops, with all 12 checks green.
+    # -----------------------------------------------------------------------
+
+    # 13. No surplus group members — mirror of check 5, same ±5 per-group
+    #     tolerance (DB-mirror lag can legitimately add rows either way).
+    failures = []
+    compared = 0
+    for branch in shared_branches:
+        legacy_groups = {g['groupName']: set(g['usernames']) for g in legacy_idx[branch]['unixGroups']}
+        for grp in new_idx[branch]['unixGroups']:
+            name = grp['groupName']
+            if name not in legacy_groups:
+                continue
+            compared += 1
+            surplus, ok = subset_diff(set(grp['usernames']), legacy_groups[name], max_missing=5)
+            if not ok:
+                failures.append(
+                    f'{branch}/{name}: {len(surplus)} new members absent from legacy '
+                    f'(tolerance 5). Sample: {sorted(surplus)[:10]}'
+                )
+    results.append(CheckResult(
+        name='directory_access / no surplus group members',
+        passed=not failures,
+        summary=f'{compared} shared groups checked',
+        mismatches=failures,
+        compared=compared,
+    ))
+
+    # 14. No surplus account usernames — mirror of check 7, same ±10 tolerance.
+    mismatches = []
+    compared = 0
+    for branch in shared_branches:
+        legacy_users = {a['username'] for a in legacy_idx[branch]['unixAccounts']}
+        new_users = {a['username'] for a in new_idx[branch]['unixAccounts']}
+        compared += len(new_users)
+        surplus, ok = subset_diff(new_users, legacy_users, max_missing=10)
+        if not ok:
+            mismatches.append(
+                f'{branch}: {len(surplus)} new usernames absent from legacy '
+                f'(tolerance 10). Sample: {sorted(surplus)[:10]}'
+            )
+    results.append(CheckResult(
+        name='directory_access / no surplus account usernames',
+        passed=not mismatches,
+        summary=f'{compared} new usernames checked',
+        mismatches=mismatches,
+        compared=compared,
+    ))
+
+    # 15. No dangling group members. Unlike every other check this is a
+    #     self-consistency invariant of a single payload, not a comparison —
+    #     a group member with no unixAccounts entry is a dangling reference for
+    #     the downstream LDAP provisioner. No tolerance: it must be exactly 0.
+    #     Both payloads are checked; legacy is the control (already 0).
+    mismatches = []
+    compared = 0
+    for label, idx in (('legacy', legacy_idx), ('new', new_idx)):
+        for branch in sorted(idx):
+            accounts = {a['username'] for a in idx[branch]['unixAccounts']}
+            members = set()
+            for grp in idx[branch]['unixGroups']:
+                members.update(grp['usernames'])
+            compared += len(members)
+            dangling = members - accounts
+            if dangling:
+                mismatches.append(
+                    f'{label} {branch}: {len(dangling)} group members have no '
+                    f'unixAccounts entry. Sample: {sorted(dangling)[:10]}'
+                )
+    results.append(CheckResult(
+        name='directory_access / no dangling group members',
+        passed=not mismatches,
+        summary=f'{compared} group memberships checked across both payloads',
+        mismatches=mismatches,
+        compared=compared,
+    ))
 
     return results
 


### PR DESCRIPTION
Stacked on #367 (`sam_hpc_ucar_edu`). Review/merge that one first.

## The bug

User `tomcat` appears in our `GET /api/v1/directory_access/` output but not
in legacy's. It's a service account in the `sage` adhoc group with **no
project membership at all** — the legacy `sysAcctMembers` query returns zero
rows for it.

Legacy gates every `adhoc_system_account_entry` behind
`SystemDirectory.flatLoadDependentAccount()`:

```java
void flatLoadDependentAccount(String branch, String group, String username) {
    SystemAccount required = SystemAccount.create(branch, username);
    if (accounts.contains(required)) {          // <-- the gate
        flatLoadGroup(branch, group, username);
    }
}
```

An adhoc entry is admitted only if that username already has an account on
that branch from the project path. It's deliberate — the sole behaviour
asserted by `AdhocGroupInjectingSystemDirectoryReaderTest`. Legacy also
injects `ncar` *before* the adhoc stage, iterating the account set, so adhoc
membership can never leak into it either.

Our `_SQL_ADHOC_MEMBERS` had no gate — `adhoc_system_account_entry.username`
is a bare string with no FK and no active check. `ncar` was then built from
the union of all group usernames *after* the adhoc merge, compounding it.

## Measured impact (live prod, over VPN)

| branch | accounts L/N | groups L/N | surplus member rows | dangling |
|---|---|---|---|---|
| hpc | 4509 / 4509 | 1687 / 1687 | 444 | 154 |
| hpc-data | 4509 / 4509 | 1683 / 1683 | 347 | 110 |
| hpc-dev | 164 / 164 | 208 / 208 | 3168 | 874 |

`unixAccounts` and the group set were already byte-identical — the divergence
was entirely in `unixGroups[].usernames`, and **100% of the surplus members
were dangling** (no `unixAccounts` entry in the same payload — a dangling
reference for the downstream LDAP provisioner). `ncar` was the worst-hit
group; on `hpc-dev` a 6.3x inflation of a 164-account branch.

## Changes

- `group_populator()` accumulates a per-branch account set from
  `_SQL_PROJECT_MEMBERS` and gates the adhoc merge on it. Done in Python
  rather than SQL — mirrors legacy's in-memory `accounts.contains()` exactly
  and avoids duplicating the six-table join.
- `ncar` is now the account set verbatim.
- Adhoc *group* creation unchanged (legacy's `flatLoad` is unconditional, and
  the group set already matched). `user_populator()` unchanged — already faithful.

## Parity checks

All 12 existing `directory_access` comparators are one-directional
(legacy ⊆ new), which is exactly why this shipped green. Added three:

- `no surplus group members` — mirror of check 5, same ±5 tolerance
- `no surplus account usernames` — mirror of check 7, same ±10 tolerance
- `no dangling group members` — a self-consistency invariant of a *single*
  payload rather than a comparison. No tolerance, no legacy fetch needed.
  This is the one that would have caught it on day one.

Against the deployed (unfixed) stack the new checks report 13/15, with
`no surplus account usernames` rightly passing and legacy clean on the
dangling invariant. The other four APIs' comparators are still forward-only —
worth a follow-up.

## Verification

- Full suite: **2833 passed**, 25 skipped, 1 xfailed
- 5 new tests: dangling-member and `ncar == account set` invariants over
  snapshot data, plus a factory-built isolated access branch reproducing the
  `tomcat` case with its positive control. All 4 negative tests fail with the
  gate removed; the positive control passes either way.
- End-to-end via the running webapp: `hpc-dev` `ncar` 1039 → 165, dangling 0,
  `tomcat` absent from both sections, `sage` still published (5 qualifying
  members on `hpc`, 0 on `hpc-dev`).

After deploy, run `sam-admin cache --refresh` (the endpoint is Flask-cached)
then `python utils/parity/check_legacy_apis.py --api directory -v` — expect
15/15.

Note: `sam.queries.lookups.get_user_adhoc_groups()` is a separate consumer
(the user-dashboard "your groups" view) and still shows `tomcat`'s `sage`
membership, as it should.

🤖 Generated with [Claude Code](https://claude.com/claude-code)