### PR TITLE
Add host provisioning cross-check to sam-search user/project

### DIFF
--- a/src/cli/cmds/admin.py
+++ b/src/cli/cmds/admin.py
@@ -64,11 +64,16 @@ def cli(ctx: Context, verbose: bool, output_format: str):
 @click.option('--validate', is_flag=True, help='Validate user data integrity')
 @click.option('--list-projects', is_flag=True, help='List all projects')
 @click.option('--verbose', '-v', is_flag=True, help='Show detailed information')
+@click.option('--provisioning/--no-provisioning', default=None,
+              help='Cross-check host provisioning (auto-on on a provisioned host)')
 @pass_context
-def user(ctx: Context, username, validate, list_projects, verbose):
+def user(ctx: Context, username, validate, list_projects, verbose, provisioning):
     """Administrative user commands."""
     if verbose:
         ctx.verbose = True
+
+    if provisioning is not None:
+        ctx.check_provisioning = provisioning
 
     command = UserAdminCommand(ctx)
     exit_code = command.execute(username, validate=validate, list_projects=list_projects)
@@ -95,13 +100,18 @@ def user(ctx: Context, username, validate, list_projects, verbose):
 @click.option('--list-users', is_flag=True, help='List all users')
 @click.option('--facilities', '-F', multiple=True, default=['UNIV', 'WNA'], help='Facilities to include (default: UNIV, WNA). Use * for all facilities.')
 @click.option('--verbose', '-v', is_flag=True, help='Show detailed information')
+@click.option('--provisioning/--no-provisioning', default=None,
+              help='Cross-check host provisioning (auto-on on a provisioned host)')
 @pass_context
 def project(ctx: Context, projcode, validate, reconcile, audit_trees, audit_resource,
             upcoming_expirations, recent_expirations,
-            notify, dry_run, email_list, deactivate, force, since, list_users, facilities, verbose):
+            notify, dry_run, email_list, deactivate, force, since, list_users, facilities, verbose, provisioning):
     """Administrative project commands."""
     if verbose:
         ctx.verbose = True
+
+    if provisioning is not None:
+        ctx.check_provisioning = provisioning
 
     # Validate that --resource requires --audit-trees
     if audit_resource and not audit_trees:

--- a/src/cli/cmds/search.py
+++ b/src/cli/cmds/search.py
@@ -85,8 +85,10 @@ def process_result(result, **kwargs):
 @click.option('--limit', type=int, default=50, help='Maximum number of results for pattern search (default: 50)')
 @click.option('--verbose', '-v', is_flag=True, help='Show detailed information')
 @click.option('--very-verbose', '-vv', is_flag=True, help='Show full information (allocation end dates, timestamps)')
+@click.option('--provisioning/--no-provisioning', default=None,
+              help='Cross-check host provisioning (auto-on on a provisioned host)')
 @pass_context
-def user(ctx: Context, username, search, abandoned, has_active_project, list_projects, limit, verbose, very_verbose):
+def user(ctx: Context, username, search, abandoned, has_active_project, list_projects, limit, verbose, very_verbose, provisioning):
     """
     Search for users.
 
@@ -104,6 +106,9 @@ def user(ctx: Context, username, search, abandoned, has_active_project, list_pro
         ctx.verbose = True  # very_verbose implies verbose
     elif verbose:
         ctx.verbose = True
+
+    if provisioning is not None:
+        ctx.check_provisioning = provisioning
 
     if username:
         # Exact Search
@@ -145,8 +150,10 @@ def user(ctx: Context, username, search, abandoned, has_active_project, list_pro
 @click.option('--facilities', '-F', multiple=True, default=['UNIV', 'WNA'], help='Facilities to include (default: UNIV, WNA). Use * for all facilities.')
 @click.option('--verbose', '-v', is_flag=True, help='Show detailed information (truncated abstract, hierarchy)')
 @click.option('--very-verbose', '-vv', is_flag=True, help='Show full information (full abstract, timestamps, IDs, charge breakdown)')
+@click.option('--provisioning/--no-provisioning', default=None,
+              help='Cross-check host provisioning (auto-on on a provisioned host)')
 @pass_context
-def project(ctx: Context, projcode, search, upcoming_expirations, recent_expirations, since, list_users, limit, facilities, verbose, very_verbose):
+def project(ctx: Context, projcode, search, upcoming_expirations, recent_expirations, since, list_users, limit, facilities, verbose, very_verbose, provisioning):
     """
     Search for projects.
 
@@ -163,6 +170,9 @@ def project(ctx: Context, projcode, search, upcoming_expirations, recent_expirat
         ctx.verbose = True  # very_verbose implies verbose
     elif verbose:
         ctx.verbose = True
+
+    if provisioning is not None:
+        ctx.check_provisioning = provisioning
 
     # Handle facility filtering - '*' means all facilities
     facility_filter = None if '*' in facilities else list(facilities)

--- a/src/cli/core/context.py
+++ b/src/cli/core/context.py
@@ -17,6 +17,12 @@ class Context:
         self.inactive_projects: bool = False
         self.inactive_users: bool = False
         self.output_format: str = 'rich'
+
+        # Host provisioning cross-check: defaults on where the data is
+        # meaningful (NCAR_HOST / SAM_CHECK_PROVISIONING). The user/project
+        # commands may override this from their --provisioning flag.
+        from sam.provisioning import is_provisioned_host
+        self.check_provisioning: bool = is_provisioned_host()
         self.console = Console()
         self.stderr_console = Console(file=sys.stderr)
 

--- a/src/cli/project/builders.py
+++ b/src/cli/project/builders.py
@@ -2,6 +2,7 @@
 
 from sam import Project
 from sam.queries.rolling_usage import get_project_rolling_usage
+from sam.provisioning import check_project_provisioning
 
 
 def _user_brief(u) -> dict:
@@ -127,6 +128,17 @@ def build_project_users(project: Project) -> list:
             'inaccessible_resources': missing_by_user.get(u.user_id, []),
         })
     return out
+
+
+def build_project_provisioning(project: Project) -> dict:
+    """Host provisioning cross-check for a project.
+
+    Returns the dict from ``check_project_provisioning`` (group exists?, name
+    match, SAM roster vs OS group membership). Callers gate on
+    ``ctx.check_provisioning`` before invoking this — off-host it reads as
+    ``group_exists: False``, which the display renders as "unavailable here".
+    """
+    return check_project_provisioning(project)
 
 
 def build_project_search_results(projects: list, pattern: str, verbose: bool) -> dict:

--- a/src/cli/project/commands.py
+++ b/src/cli/project/commands.py
@@ -12,6 +12,7 @@ from cli.project.builders import (
     build_project_rolling,
     build_project_tree,
     build_project_users,
+    build_project_provisioning,
     build_project_search_results,
     build_expiring_projects,
 )
@@ -63,6 +64,8 @@ class ProjectSearchCommand(BaseProjectCommand):
                 data['tree'] = build_project_tree(project)
             if json_mode or list_users:
                 data['users'] = build_project_users(project)
+            if self.ctx.check_provisioning:
+                data['provisioning'] = build_project_provisioning(project)
 
             if json_mode:
                 output_json(data)

--- a/src/cli/project/display.py
+++ b/src/cli/project/display.py
@@ -297,9 +297,9 @@ def display_project_provisioning(ctx: Context, prov: dict, projcode: str):
 
     if not issues:
         ctx.console.print(
-            f"✅ Host provisioning consistent (unix group [bold]{prov['group_name']}[/] "
+            f"[green]✓[/] Host provisioning consistent (unix group [bold]{prov['group_name']}[/] "
             f"matches SAM roster, {prov['sam_member_count']} members).",
-            style="green",
+            style="dim",
         )
         return
 

--- a/src/cli/project/display.py
+++ b/src/cli/project/display.py
@@ -265,6 +265,52 @@ def display_project(ctx: Context, data: dict, extra_title_info: str = "",
         ctx.console.print(Panel(tree, title="Project Hierarchy",
                                 border_style="blue", expand=False))
 
+    if data.get('provisioning') is not None:
+        display_project_provisioning(ctx, data['provisioning'], data['projcode'])
+
+
+def display_project_provisioning(ctx: Context, prov: dict, projcode: str):
+    """Render the host provisioning cross-check for a project.
+
+    `prov` is the dict from `sam.provisioning.check_project_provisioning`. Emits
+    a single green line when the OS group is faithful to the SAM roster,
+    otherwise a short table of the specific discrepancies.
+    """
+    if not prov['group_exists']:
+        ctx.console.print(
+            f"⚠️  Host provisioning: no unix group for [bold]{projcode}[/] "
+            f"(gid {prov['gid']}) on this host.",
+            style="red",
+        )
+        return
+
+    issues = []
+    if prov['name_matches'] is False:
+        issues.append(("Group name",
+                       f"{prov['group_name']} (does not match {projcode})"))
+    for username in prov['missing_from_group']:
+        issues.append(("Missing member",
+                       f"{username} — in SAM roster, not in unix group"))
+    for username in prov['extra_in_group']:
+        issues.append(("Ghost member",
+                       f"{username} — in unix group, no active SAM membership"))
+
+    if not issues:
+        ctx.console.print(
+            f"✅ Host provisioning consistent (unix group [bold]{prov['group_name']}[/] "
+            f"matches SAM roster, {prov['sam_member_count']} members).",
+            style="green",
+        )
+        return
+
+    ctx.console.print(f"\n[bold yellow]Host provisioning issues for {projcode}:[/]")
+    table = Table(box=box.SIMPLE, show_header=False)
+    table.add_column("Check", style="cyan")
+    table.add_column("Detail", style="yellow")
+    for label, detail in issues:
+        table.add_row(label, detail)
+    ctx.console.print(table)
+
 
 def display_project_users(ctx: Context, users: list, projcode: str):
     """Display users for a project from `build_project_users`."""

--- a/src/cli/user/builders.py
+++ b/src/cli/user/builders.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from typing import Optional
 from sam import User
+from sam.provisioning import check_user_provisioning
 
 
 def build_user_core(user: User) -> dict:
@@ -89,6 +90,17 @@ def build_user_projects(user: User, inactive: bool) -> list:
             'latest_allocation_end': latest_end,
         })
     return out
+
+
+def build_user_provisioning(user: User) -> dict:
+    """Host provisioning cross-check for a user.
+
+    Returns the dict from ``check_user_provisioning`` (recognized?, uid match,
+    shell/home, project-group coverage). Callers gate on
+    ``ctx.check_provisioning`` before invoking this — off-host it reads as
+    ``recognized: False``, which the display renders as "unavailable here".
+    """
+    return check_user_provisioning(user, user.active_projects())
 
 
 def build_user_search_results(users: list, pattern: str) -> dict:

--- a/src/cli/user/commands.py
+++ b/src/cli/user/commands.py
@@ -7,6 +7,7 @@ from cli.user.builders import (
     build_user_core,
     build_user_detail,
     build_user_projects,
+    build_user_provisioning,
     build_user_search_results,
     build_abandoned_users,
     build_users_with_projects,
@@ -45,6 +46,8 @@ class UserSearchCommand(BaseUserCommand):
                 data['projects'] = build_user_projects(
                     user, inactive=self.ctx.inactive_projects
                 )
+            if self.ctx.check_provisioning:
+                data['provisioning'] = build_user_provisioning(user)
 
             if json_mode:
                 output_json(data)

--- a/src/cli/user/display.py
+++ b/src/cli/user/display.py
@@ -107,9 +107,9 @@ def display_user_provisioning(ctx: Context, prov: dict, username: str):
 
     if not issues:
         ctx.console.print(
-            "✅ Host provisioning consistent "
+            "[green]✓[/] Host provisioning consistent "
             "(recognized, uid matches, all project groups present).",
-            style="green",
+            style="dim",
         )
         return
 

--- a/src/cli/user/display.py
+++ b/src/cli/user/display.py
@@ -74,6 +74,53 @@ def display_user(ctx: Context, data: dict, list_projects: bool = False):
     if list_projects and 'projects' in data:
         display_user_projects(ctx, data['projects'], data['username'])
 
+    if data.get('provisioning') is not None:
+        display_user_provisioning(ctx, data['provisioning'], data['username'])
+
+
+def display_user_provisioning(ctx: Context, prov: dict, username: str):
+    """Render the host provisioning cross-check for a user.
+
+    `prov` is the dict from `sam.provisioning.check_user_provisioning`. Emits a
+    single green line when everything is consistent, otherwise a short table of
+    the specific gaps.
+    """
+    if not prov['recognized']:
+        ctx.console.print(
+            f"⚠️  Host provisioning: user [bold]{username}[/] is not recognized "
+            "on this host.",
+            style="red",
+        )
+        return
+
+    issues = []
+    if prov['uid_matches'] is False:
+        issues.append(("UID mismatch",
+                       f"host reports {prov['uid']} (SAM unix_uid differs)"))
+    if prov['shell_ok'] is False:
+        issues.append(("Login shell", f"{prov['shell']} (no-login)"))
+    if prov['home_exists'] is False:
+        issues.append(("Home directory", f"{prov['home']} (missing)"))
+    for m in prov['missing_project_groups']:
+        issues.append(("Missing group",
+                       f"{m['projcode']} (gid {m['unix_gid']}) — not a member"))
+
+    if not issues:
+        ctx.console.print(
+            "✅ Host provisioning consistent "
+            "(recognized, uid matches, all project groups present).",
+            style="green",
+        )
+        return
+
+    ctx.console.print(f"\n[bold yellow]Host provisioning issues for {username}:[/]")
+    table = Table(box=box.SIMPLE, show_header=False)
+    table.add_column("Check", style="cyan")
+    table.add_column("Detail", style="yellow")
+    for label, detail in issues:
+        table.add_row(label, detail)
+    ctx.console.print(table)
+
 
 def display_user_projects(ctx: Context, projects: list, username: str):
     """Display projects for a user."""

--- a/src/sam/provisioning.py
+++ b/src/sam/provisioning.py
@@ -1,0 +1,215 @@
+"""Host provisioning cross-checks.
+
+On a provisioned NCAR host (Casper/Derecho) the local NSS layer resolves users
+and groups against LDAP — the same source `getent` reads. This module compares
+what SAM (the database) believes against what the host actually provisions,
+using the Python `pwd` / `grp` / `os.getgrouplist` primitives (no shelling out).
+
+Everything here is read-only and side-effect free: no Rich, no DB writes. The
+CLI builders call the ``check_*`` functions and hand the resulting plain dicts
+to display / JSON. When the host cannot answer (not provisioned, user/group
+absent), lookups degrade to ``None`` / ``[]`` rather than raising.
+
+The single primitive behind both checks is :func:`user_group_gids`, which wraps
+``os.getgrouplist``. Unlike ``grp.getgrnam().gr_mem`` it includes a group that
+is the user's *primary* group, so "is user U in project group G" is answered
+correctly whether G is a primary or supplementary group.
+"""
+
+import os
+import pwd
+import grp
+
+# Shells that mean "this account cannot log in" — flagged for an active user.
+NOLOGIN_SHELLS = frozenset({
+    '/sbin/nologin',
+    '/usr/sbin/nologin',
+    '/bin/false',
+    '/usr/bin/false',
+    '/bin/true',
+})
+
+
+def is_provisioned_host() -> bool:
+    """Whether host provisioning data is meaningful here (the gate).
+
+    ``SAM_CHECK_PROVISIONING`` (if set) wins outright — ``true/1/yes`` forces
+    the check on, anything else forces it off. Otherwise the gate follows the
+    presence of ``NCAR_HOST``, which is defined on provisioned NCAR systems.
+    """
+    override = os.getenv('SAM_CHECK_PROVISIONING')
+    if override is not None:
+        return override.strip().lower() in ('true', '1', 'yes')
+    return bool(os.getenv('NCAR_HOST'))
+
+
+# ---------------------------------------------------------------- NSS primitives
+
+def _getpwnam(username: str):
+    """`pwd.getpwnam`, returning None instead of raising KeyError."""
+    try:
+        return pwd.getpwnam(username)
+    except KeyError:
+        return None
+
+
+def _getgrgid(gid):
+    """`grp.getgrgid`, returning None instead of raising KeyError."""
+    if gid is None:
+        return None
+    try:
+        return grp.getgrgid(gid)
+    except KeyError:
+        return None
+
+
+def _getgrnam(name: str):
+    """`grp.getgrnam`, returning None instead of raising KeyError."""
+    try:
+        return grp.getgrnam(name)
+    except KeyError:
+        return None
+
+
+def user_group_gids(username: str, pw_gid: int) -> set:
+    """Full set of GIDs (primary + supplementary) the host assigns to a user.
+
+    Wraps ``os.getgrouplist`` so a project group counts whether it is the
+    user's primary or a supplementary group. Returns an empty set if the host
+    cannot resolve the user.
+    """
+    try:
+        return set(os.getgrouplist(username, pw_gid))
+    except (KeyError, OSError):
+        return set()
+
+
+# ----------------------------------------------------------------- user check
+
+def check_user_provisioning(user, projects) -> dict:
+    """Compare a SAM user against host provisioning.
+
+    Args:
+        user: SAM ``User`` (uses ``username``, ``unix_uid``).
+        projects: iterable of SAM ``Project`` the user should have host group
+            membership for (typically ``user.active_projects()``). Each needs
+            ``projcode`` and ``unix_gid``.
+
+    Returns a plain dict::
+
+        {recognized, uid, uid_matches, home, home_exists, shell, shell_ok,
+         missing_project_groups: [{projcode, unix_gid}], ok}
+
+    ``ok`` is True when the host recognizes the user, the uid matches, the
+    account can log in, and every project group is present. ``home_exists`` /
+    ``shell_ok`` surface softer warnings and do not gate ``ok``.
+    """
+    pw = _getpwnam(user.username)
+    if pw is None:
+        return {
+            'recognized': False,
+            'uid': None,
+            'uid_matches': None,
+            'home': None,
+            'home_exists': None,
+            'shell': None,
+            'shell_ok': None,
+            'missing_project_groups': [],
+            'ok': False,
+        }
+
+    gids = user_group_gids(user.username, pw.pw_gid)
+    missing = [
+        {'projcode': p.projcode, 'unix_gid': p.unix_gid}
+        for p in projects
+        if p.unix_gid is not None and p.unix_gid not in gids
+    ]
+    missing.sort(key=lambda m: m['projcode'])
+
+    uid_matches = (user.unix_uid == pw.pw_uid)
+    shell_ok = pw.pw_shell not in NOLOGIN_SHELLS
+    home_exists = bool(pw.pw_dir) and os.path.isdir(pw.pw_dir)
+
+    return {
+        'recognized': True,
+        'uid': pw.pw_uid,
+        'uid_matches': uid_matches,
+        'home': pw.pw_dir,
+        'home_exists': home_exists,
+        'shell': pw.pw_shell,
+        'shell_ok': shell_ok,
+        'missing_project_groups': missing,
+        'ok': uid_matches and not missing,
+    }
+
+
+# --------------------------------------------------------------- project check
+
+def check_project_provisioning(project) -> dict:
+    """Compare a SAM project's roster against its host group.
+
+    Args:
+        project: SAM ``Project`` (uses ``projcode``, ``unix_gid``, ``users``).
+
+    Returns a plain dict::
+
+        {group_exists, gid, group_name, name_matches, os_member_count,
+         sam_member_count, missing_from_group: [usernames],
+         extra_in_group: [usernames], ok}
+
+    ``missing_from_group`` = SAM roster members whose host group set lacks the
+    project's gid (per-user ``getgrouplist``, so a primary-group membership
+    counts). ``extra_in_group`` = group members with no active SAM membership
+    (ghosts). ``ok`` is True when the group exists and both lists are empty.
+    """
+    group = _getgrgid(project.unix_gid)
+    # Fall back to name lookup if the gid is unset/unresolvable. Host group
+    # names are the lowercased projcode (scsg0001 ↔ SCSG0001), and getgrnam is
+    # case-sensitive, so look up the lowercased form.
+    if group is None:
+        group = _getgrnam(project.projcode.lower())
+
+    if group is None:
+        return {
+            'group_exists': False,
+            'gid': project.unix_gid,
+            'group_name': None,
+            'name_matches': None,
+            'os_member_count': 0,
+            'sam_member_count': len(project.users),
+            'missing_from_group': [],
+            'extra_in_group': [],
+            'ok': False,
+        }
+
+    sam_users = {u.username: u for u in project.users}
+    os_members = set(group.gr_mem)
+
+    missing_from_group = sorted(
+        username for username, u in sam_users.items()
+        if group.gr_gid not in user_group_gids(username, _primary_gid(u))
+    )
+    extra_in_group = sorted(os_members - set(sam_users))
+
+    return {
+        'group_exists': True,
+        'gid': group.gr_gid,
+        'group_name': group.gr_name,
+        # Host group names are the lowercased projcode (scsg0001 ↔ SCSG0001).
+        'name_matches': group.gr_name.lower() == project.projcode.lower(),
+        'os_member_count': len(os_members),
+        'sam_member_count': len(sam_users),
+        'missing_from_group': missing_from_group,
+        'extra_in_group': extra_in_group,
+        'ok': not missing_from_group and not extra_in_group,
+    }
+
+
+def _primary_gid(user) -> int:
+    """Host primary gid for a SAM user, needed as the ``getgrouplist`` seed.
+
+    Falls back to the SAM ``unix_uid`` (a harmless non-match) if the host does
+    not recognize the user, so ``getgrouplist`` still returns the empty set.
+    """
+    pw = _getpwnam(user.username)
+    return pw.pw_gid if pw else (user.unix_uid or 0)

--- a/tests/unit/test_provisioning.py
+++ b/tests/unit/test_provisioning.py
@@ -1,0 +1,208 @@
+"""Unit tests for sam.provisioning — host NSS cross-checks.
+
+These are host-independent: the NSS layer (`pwd` / `grp` / `os.getgrouplist`)
+is monkeypatched with in-memory fakes, and the SAM user/project objects are
+lightweight stand-ins (only the attributes the checks read). Nothing here
+touches the database or the real host, so it runs anywhere including CI.
+"""
+import os
+import types
+import pytest
+
+from sam import provisioning
+
+
+# --------------------------------------------------------------- fake objects
+
+def _pw(uid, gid, home='/home/x', shell='/bin/bash'):
+    return types.SimpleNamespace(
+        pw_uid=uid, pw_gid=gid, pw_dir=home, pw_shell=shell
+    )
+
+
+def _gr(gid, name, members):
+    return types.SimpleNamespace(gr_gid=gid, gr_name=name, gr_mem=list(members))
+
+
+def _user(username, unix_uid):
+    return types.SimpleNamespace(username=username, unix_uid=unix_uid)
+
+
+def _project(projcode, unix_gid, users):
+    return types.SimpleNamespace(projcode=projcode, unix_gid=unix_gid, users=users)
+
+
+@pytest.fixture
+def nss(monkeypatch):
+    """In-memory NSS. Populate `.passwd` (name→pw) and `.groups` (gid→gr);
+    `.grouplist` maps username→set(gids). Missing lookups raise KeyError like
+    the real modules, exercising the module's swallowing logic."""
+    state = types.SimpleNamespace(passwd={}, groups={}, grouplist={})
+
+    def getpwnam(name):
+        try:
+            return state.passwd[name]
+        except KeyError:
+            raise KeyError(name)
+
+    def getgrgid(gid):
+        try:
+            return state.groups[gid]
+        except KeyError:
+            raise KeyError(gid)
+
+    def getgrnam(name):
+        for gr in state.groups.values():
+            if gr.gr_name == name:
+                return gr
+        raise KeyError(name)
+
+    def getgrouplist(username, pw_gid):
+        if username not in state.grouplist:
+            raise KeyError(username)
+        return list(state.grouplist[username] | {pw_gid})
+
+    monkeypatch.setattr(provisioning.pwd, 'getpwnam', getpwnam)
+    monkeypatch.setattr(provisioning.grp, 'getgrgid', getgrgid)
+    monkeypatch.setattr(provisioning.grp, 'getgrnam', getgrnam)
+    monkeypatch.setattr(provisioning.os, 'getgrouplist', getgrouplist)
+    # home_exists check — default everything to "exists" unless a test overrides
+    monkeypatch.setattr(provisioning.os.path, 'isdir', lambda p: True)
+    return state
+
+
+# ------------------------------------------------------------ is_provisioned_host
+
+def test_gate_ncar_host(monkeypatch):
+    monkeypatch.delenv('SAM_CHECK_PROVISIONING', raising=False)
+    monkeypatch.setenv('NCAR_HOST', 'casper')
+    assert provisioning.is_provisioned_host() is True
+
+
+def test_gate_no_ncar_host(monkeypatch):
+    monkeypatch.delenv('SAM_CHECK_PROVISIONING', raising=False)
+    monkeypatch.delenv('NCAR_HOST', raising=False)
+    assert provisioning.is_provisioned_host() is False
+
+
+@pytest.mark.parametrize('val,expected', [
+    ('1', True), ('true', True), ('YES', True),
+    ('0', False), ('false', False), ('', False),
+])
+def test_gate_override_wins(monkeypatch, val, expected):
+    # Override beats NCAR_HOST in both directions.
+    monkeypatch.setenv('NCAR_HOST', 'casper')
+    monkeypatch.setenv('SAM_CHECK_PROVISIONING', val)
+    assert provisioning.is_provisioned_host() is expected
+
+
+# --------------------------------------------------------- check_user_provisioning
+
+def test_user_consistent(nss):
+    nss.passwd['jdoe'] = _pw(1001, 500)
+    nss.grouplist['jdoe'] = {500, 68283}
+    proj = _project('SCSG0001', 68283, [])
+    r = provisioning.check_user_provisioning(_user('jdoe', 1001), [proj])
+    assert r['recognized'] and r['uid_matches'] and r['shell_ok']
+    assert r['home_exists'] and r['missing_project_groups'] == [] and r['ok']
+
+
+def test_user_not_recognized(nss):
+    r = provisioning.check_user_provisioning(_user('ghost', 1), [])
+    assert r['recognized'] is False and r['ok'] is False
+    assert r['uid'] is None and r['missing_project_groups'] == []
+
+
+def test_user_uid_mismatch(nss):
+    nss.passwd['jdoe'] = _pw(9999, 500)   # host uid ≠ SAM unix_uid
+    nss.grouplist['jdoe'] = {500}
+    r = provisioning.check_user_provisioning(_user('jdoe', 1001), [])
+    assert r['uid'] == 9999 and r['uid_matches'] is False and r['ok'] is False
+
+
+def test_user_nologin_shell(nss):
+    nss.passwd['svc'] = _pw(1001, 500, shell='/sbin/nologin')
+    nss.grouplist['svc'] = {500}
+    r = provisioning.check_user_provisioning(_user('svc', 1001), [])
+    assert r['shell_ok'] is False
+    # shell_ok is a soft warning — does not gate ok
+    assert r['ok'] is True
+
+
+def test_user_missing_home(nss, monkeypatch):
+    nss.passwd['jdoe'] = _pw(1001, 500, home='/home/gone')
+    nss.grouplist['jdoe'] = {500}
+    monkeypatch.setattr(provisioning.os.path, 'isdir', lambda p: False)
+    r = provisioning.check_user_provisioning(_user('jdoe', 1001), [])
+    assert r['home_exists'] is False and r['ok'] is True  # soft warning
+
+
+def test_user_missing_project_group(nss):
+    nss.passwd['jdoe'] = _pw(1001, 500)
+    nss.grouplist['jdoe'] = {500}          # NOT in 68283
+    proj = _project('SCSG0001', 68283, [])
+    r = provisioning.check_user_provisioning(_user('jdoe', 1001), [proj])
+    assert r['missing_project_groups'] == [{'projcode': 'SCSG0001', 'unix_gid': 68283}]
+    assert r['ok'] is False
+
+
+def test_user_primary_group_counts(nss):
+    # Project group is the user's PRIMARY group — getgrouplist includes it
+    # via the pw_gid seed even though it's not a supplementary membership.
+    nss.passwd['jdoe'] = _pw(1001, 68283)
+    nss.grouplist['jdoe'] = set()          # no supplementary groups
+    proj = _project('SCSG0001', 68283, [])
+    r = provisioning.check_user_provisioning(_user('jdoe', 1001), [proj])
+    assert r['missing_project_groups'] == [] and r['ok']
+
+
+# ------------------------------------------------------ check_project_provisioning
+
+def test_project_consistent(nss):
+    members = [_user('a', 1), _user('b', 2)]
+    nss.passwd['a'] = _pw(1, 500)
+    nss.passwd['b'] = _pw(2, 500)
+    nss.grouplist['a'] = {68283}
+    nss.grouplist['b'] = {68283}
+    nss.groups[68283] = _gr(68283, 'scsg0001', ['a', 'b'])
+    r = provisioning.check_project_provisioning(_project('SCSG0001', 68283, members))
+    # case-insensitive name match
+    assert r['group_exists'] and r['name_matches'] is True
+    assert r['missing_from_group'] == [] and r['extra_in_group'] == [] and r['ok']
+
+
+def test_project_group_missing(nss):
+    r = provisioning.check_project_provisioning(_project('SCSG0001', 68283, []))
+    assert r['group_exists'] is False and r['ok'] is False
+    assert r['gid'] == 68283
+
+
+def test_project_member_missing_from_group(nss):
+    members = [_user('a', 1), _user('b', 2)]
+    nss.passwd['a'] = _pw(1, 500)
+    nss.passwd['b'] = _pw(2, 500)
+    nss.grouplist['a'] = {68283}
+    nss.grouplist['b'] = set()                 # b lacks the project gid
+    nss.groups[68283] = _gr(68283, 'scsg0001', ['a'])
+    r = provisioning.check_project_provisioning(_project('SCSG0001', 68283, members))
+    assert r['missing_from_group'] == ['b'] and r['ok'] is False
+
+
+def test_project_ghost_member(nss):
+    members = [_user('a', 1)]
+    nss.passwd['a'] = _pw(1, 500)
+    nss.grouplist['a'] = {68283}
+    # group lists a stale member 'z' with no active SAM membership
+    nss.groups[68283] = _gr(68283, 'scsg0001', ['a', 'z'])
+    r = provisioning.check_project_provisioning(_project('SCSG0001', 68283, members))
+    assert r['extra_in_group'] == ['z'] and r['ok'] is False
+
+
+def test_project_name_lookup_fallback(nss):
+    # gid unresolvable, but projcode names a real group → found by name.
+    members = [_user('a', 1)]
+    nss.passwd['a'] = _pw(1, 500)
+    nss.grouplist['a'] = {70000}
+    nss.groups[70000] = _gr(70000, 'scsg0001', ['a'])
+    r = provisioning.check_project_provisioning(_project('SCSG0001', None, members))
+    assert r['group_exists'] and r['gid'] == 70000 and r['ok']


### PR DESCRIPTION
## Summary

On a provisioned NCAR host (where `NCAR_HOST` is defined and NSS resolves users/groups against LDAP), `sam-search user` and `sam-search project` now cross-check what SAM (the database) believes against what the host actually provisions — a read-only consistency audit surfaced inline in the existing views.

- **user**: host recognizes the active user, SAM `unix_uid` matches the host `pw_uid`, the account has a real login shell + home dir, and the user is a member of the unix group of every project they can access in SAM.
- **project**: the projcode's unix group exists, its name matches (case-insensitive: `scsg0001` ↔ `SCSG0001`), and its membership is faithful to the SAM roster — flags SAM members missing from the group and stale/ghost group members with no active SAM membership.

The single primitive behind both checks is `os.getgrouplist`, which counts a project group whether it is a user's primary or supplementary group (unlike `grp.getgrnam().gr_mem`). No shelling out to `getent`.

## Gating

Auto-runs when on a provisioned host (`NCAR_HOST` set); `--provisioning` / `--no-provisioning` and the `SAM_CHECK_PROVISIONING` env var force on/off anywhere. `sam-admin user/project` inherit the section for free (they extend the search commands).

```bash
sam-search project SCSG0001            # ✅ consistent, or a discrepancy table
sam-search user benkirk --no-provisioning   # section suppressed
sam-search --format json project SCSG0001 | jq .provisioning
```

## Design

- New pure module `src/sam/provisioning.py`: `is_provisioned_host()` gate, NSS primitives, and `check_user_provisioning` / `check_project_provisioning` returning plain dicts. No Rich, no DB writes.
- Wired through the existing builder → display/JSON layering, mirroring `build_project_users`. `ctx.check_provisioning` (Context) is the single source of truth, defaulting to the gate and overridable by the flag.

## Test Results

- New `tests/unit/test_provisioning.py` (20 tests) mocks `pwd`/`grp`/`os.getgrouplist` so it runs host-independently in CI — all pass.
- Verified live on Casper: consistent user/project render a green line; `SSSG0001` (a real roster/group mismatch) renders the discrepancy table; `--no-provisioning` and `SAM_CHECK_PROVISIONING=0` suppress the section; JSON envelopes carry a `provisioning` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)