### PR TITLE
UX polish: project-modal edit pencil no-op + search-result scroll landing

### DIFF
--- a/src/webapp/static/js/actions.js
+++ b/src/webapp/static/js/actions.js
@@ -43,6 +43,37 @@
     document.addEventListener('input',  dispatch('data-action-input'));
     document.addEventListener('submit', dispatch('data-action-submit'));
 
+    /* ── Reveal a freshly-loaded card without scrolling past its header ──
+     *
+     * Two things made the old `scrollIntoView({block: 'start'})` land in
+     * the middle of the card:
+     *
+     *   1. It ran on htmx:afterSwap, *before* the sibling afterRequest
+     *      handler in form-helpers.js empties the search-results list.
+     *      That list sits above the card, so the page shrank by its height
+     *      after the scroll target was computed — the more matches were
+     *      listed, the deeper past the card title you ended up.
+     *   2. block:'start' pins the card's top edge to the viewport's top
+     *      edge, leaving the title flush against it with no margin.
+     *
+     * So: defer a frame (post-clear, post-layout), aim slightly above the
+     * card, and no-op when its header is already comfortably on screen so
+     * an in-place reload never yanks the page around. */
+    var CARD_REVEAL_OFFSET = 16;
+
+    window.revealCard = function (el) {
+        if (!el) { return; }
+        requestAnimationFrame(function () {
+            var top = el.getBoundingClientRect().top;
+            /* Header already visible in the top half — leave it alone. */
+            if (top >= 0 && top <= window.innerHeight / 2) { return; }
+            window.scrollTo({
+                top: Math.max(0, window.scrollY + top - CARD_REVEAL_OFFSET),
+                behavior: 'smooth'
+            });
+        });
+    };
+
     /* ── Generic built-ins ── */
 
     /* Clickable rows/elements that just navigate

--- a/src/webapp/static/js/dashboard-init.js
+++ b/src/webapp/static/js/dashboard-init.js
@@ -151,8 +151,10 @@
         var link = e.target.closest('.project-code-link');
         if (link && link.dataset.projcode) {
             e.preventDefault();
+            var card = document.getElementById('projectCardContainer');
             htmx.ajax('GET', '/admin/project/' + link.dataset.projcode,
-                      {target: '#projectCardContainer', swap: 'innerHTML'});
+                      {target: '#projectCardContainer', swap: 'innerHTML'})
+                .then(function () { revealCard(card); });
         }
     });
 
@@ -187,14 +189,27 @@
     });
 
     /* admin: switch to the Projects tab whenever a project card is loaded
-     * from any context (e.g. user card badges) */
+     * from any context (e.g. user card badges).
+     *
+     * Scrolling is NOT done here: this fires for every swap into the
+     * container, including the in-place reloads after an allocation edit
+     * (modals.js) — those must not yank the page back to the card top.
+     * The paths where the user asked for a different card call
+     * revealCard() themselves (form-helpers.js on a search hit,
+     * htmx-config.js after a create, data-reveal-on-load below). */
     document.body.addEventListener('htmx:afterSwap', function (e) {
         if (e.detail.target && e.detail.target.id === 'projectCardContainer') {
             var projectsTabBtn = document.getElementById('projects-tab');
             if (projectsTabBtn && !projectsTabBtn.classList.contains('active')) {
                 bootstrap.Tab.getOrCreateInstance(projectsTabBtn).show();
             }
-            e.detail.target.scrollIntoView({behavior: 'smooth', block: 'start'});
+        }
+        /* ?projcode= deep links auto-load a card on page load — reveal it
+         * once, then drop the flag so reloads of the same container stay
+         * put. */
+        if (e.detail.target && e.detail.target.hasAttribute('data-reveal-on-load')) {
+            e.detail.target.removeAttribute('data-reveal-on-load');
+            revealCard(e.detail.target);
         }
     });
 

--- a/src/webapp/static/js/form-helpers.js
+++ b/src/webapp/static/js/form-helpers.js
@@ -17,7 +17,9 @@
     /* ── Search-select result buttons (user/group/project searches) ──
      * Replaces hx-on::after-request attributes (htmx evaluates those via
      * Function(), which needs 'unsafe-eval'). After the button's request,
-     * clear the result list and the search input. */
+     * clear the result list and the search input, then scroll the card the
+     * click just loaded into view — revealCard() runs a frame later, so it
+     * measures the page *after* the result list above it is gone. */
     document.body.addEventListener('htmx:afterRequest', function (e) {
         var el = e.detail.elt;
         if (!el.dataset || !el.dataset.clearResults) { return; }
@@ -25,6 +27,8 @@
         if (results) { results.innerHTML = ''; }
         var input = document.getElementById(el.dataset.clearInput);
         if (input) { input.value = ''; }
+        var target = el.getAttribute('hx-target');
+        if (target) { revealCard(document.querySelector(target)); }
     });
 
     /* ── Single-option auto-select after cascading dropdown loads ──

--- a/src/webapp/static/js/htmx-config.js
+++ b/src/webapp/static/js/htmx-config.js
@@ -157,7 +157,8 @@ document.body.addEventListener('loadNewProject', function(evt) {
     if (baseUrl && projcode) {
         setTimeout(function() {
             htmx.ajax('GET', baseUrl + projcode,
-                      {target: '#projectCardContainer', swap: 'innerHTML'});
+                      {target: '#projectCardContainer', swap: 'innerHTML'})
+                .then(function() { revealCard(container); });
         }, 300);
     }
 });

--- a/src/webapp/templates/dashboards/admin/base_admin.html
+++ b/src/webapp/templates/dashboards/admin/base_admin.html
@@ -46,9 +46,6 @@
 <!-- Member Management Modals (shared — used by user, admin, and edit-project pages) -->
 {% include 'project_members/fragments/member_modals_htmx.html' %}
 
-<!-- Allocation Management Modals (reused from user dashboard) -->
-{% include 'dashboards/user/fragments/allocation_modals.html' %}
-
 {% include 'dashboards/user/fragments/user_details_modal.html' %}
 
 {% include 'dashboards/shared/project_details_modal.html' %}

--- a/src/webapp/templates/dashboards/admin/edit_project.html
+++ b/src/webapp/templates/dashboards/admin/edit_project.html
@@ -294,24 +294,8 @@
   </div>
 </div>
 
-<!-- Edit Allocation Modal (lazy-loaded) -->
-<div class="modal fade" id="editAllocationModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header bg-warning text-dark">
-        <h5 class="modal-title"><i class="fas fa-edit"></i> Edit Allocation</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-      </div>
-      <div id="editAllocationFormContainer">
-        <div class="modal-body text-center text-muted py-3">
-          <i class="fas fa-spinner fa-spin fa-2x"></i>
-          <p class="mt-2">Loading…</p>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
+{# Also brings in the lazy-loaded #editAllocationModal used by the allocation
+   tree's edit pencils. #}
 {% include 'dashboards/shared/project_details_modal.html' %}
 
 {# Member rows in the Members tab open user cards here (this page extends

--- a/src/webapp/templates/dashboards/admin/projects.html
+++ b/src/webapp/templates/dashboards/admin/projects.html
@@ -47,6 +47,9 @@
              hx-get="{{ url_for('admin_dashboard.project_card', projcode=auto_load_projcode) }}"
              hx-trigger="load"
              hx-swap="innerHTML"
+             {# One-shot scroll to the card a ?projcode= back-link asked for
+                (dashboard-init.js); later reloads of this container don't. #}
+             data-reveal-on-load
              {% endif %}></div>
     </div>
 </div>

--- a/src/webapp/templates/dashboards/allocations/projects.html
+++ b/src/webapp/templates/dashboards/allocations/projects.html
@@ -426,7 +426,8 @@
     </div>
 </div>
 
-{% include 'dashboards/user/fragments/allocation_modals.html' %}
+{# Allocation management modals arrive with dashboards/shared/project_details_modal.html
+   (included by base_allocations.html). #}
 
 {% endblock %}
 

--- a/src/webapp/templates/dashboards/shared/project_details_modal.html
+++ b/src/webapp/templates/dashboards/shared/project_details_modal.html
@@ -17,3 +17,11 @@
         </div>
     </div>
 </div>
+
+{# The modal body (user/partials/project_details_modal.html → project_card's
+   render_project_resources) renders per-allocation edit pencils that target
+   #editAllocationModal / #editAllocationFormContainer. Those live in the
+   fragment below, so include it here — otherwise the pencils are a silent
+   no-op (htmx:targetError + no Bootstrap target) on any page that shows the
+   project details modal without also remembering this second include. #}
+{% include 'dashboards/user/fragments/allocation_modals.html' %}

--- a/src/webapp/templates/dashboards/user/accounts.html
+++ b/src/webapp/templates/dashboards/user/accounts.html
@@ -39,7 +39,7 @@
 <!-- Member Management Modals (htmx version — form loaded dynamically) -->
 {% include 'project_members/fragments/member_modals_htmx.html' %}
 
-<!-- Allocation Management Modals -->
-{% include 'dashboards/user/fragments/allocation_modals.html' %}
+{# Allocation management modals arrive with dashboards/shared/project_details_modal.html
+   (included by base_user.html). #}
 
 {% endblock %}

--- a/tests/unit/test_dashboard_routes.py
+++ b/tests/unit/test_dashboard_routes.py
@@ -97,3 +97,20 @@ class TestAdminConfigurationPage:
         })
         assert auth_client.get('/admin/projects').status_code == 200
         assert auth_client.get('/admin/configuration').status_code == 403
+
+
+class TestProjectCardAutoLoad:
+    """``?projcode=`` back-links auto-load the card and flag it for a
+    one-shot scroll into view (``data-reveal-on-load``, consumed by
+    dashboard-init.js). Without the parameter the container stays inert —
+    otherwise every in-place card reload would yank the page to its top."""
+
+    def test_flag_present_with_projcode(self, auth_client, active_project):
+        html = auth_client.get(
+            f'/admin/projects?projcode={active_project.projcode}'
+        ).get_data(as_text=True)
+        assert 'data-reveal-on-load' in html
+
+    def test_flag_absent_without_projcode(self, auth_client):
+        html = auth_client.get('/admin/projects').get_data(as_text=True)
+        assert 'data-reveal-on-load' not in html

--- a/tests/unit/test_modal_shell_pairing.py
+++ b/tests/unit/test_modal_shell_pairing.py
@@ -1,0 +1,60 @@
+"""Every page that ships the project-details modal must also ship the
+allocation-edit modal it links to.
+
+The project-details modal body renders a per-allocation edit pencil
+(``user/partials/project_card.html`` → ``render_project_resources``) whose
+``data-bs-target``/``hx-target`` point at ``#editAllocationModal`` /
+``#editAllocationFormContainer``. Those ids live in a *separate* fragment
+(``user/fragments/allocation_modals.html``). When a page included only the
+first fragment the pencil was a silent no-op — Bootstrap found no modal and
+htmx aborted on a target error, with nothing in the network tab.
+
+``shared/project_details_modal.html`` now pulls the allocation fragment in
+itself, so the pairing holds by construction. These tests pin that, and pin
+that the shells are not double-included anywhere (duplicate DOM ids).
+"""
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+PROJECT_MODAL_ID = 'id="projectDetailsModal"'
+EDIT_MODAL_ID = 'id="editAllocationModal"'
+EDIT_CONTAINER_ID = 'id="editAllocationFormContainer"'
+
+# Pages that render the project-details modal shell. Kept explicit rather
+# than derived from the route map: the point is to catch a new page that
+# includes one fragment and forgets the other.
+PAGES_WITH_PROJECT_MODAL = [
+    '/user/accounts',
+    '/admin/projects',
+    '/allocations/projects',
+    '/allocations/transactions',
+    '/allocations/adjustments',
+    '/status/derecho',
+]
+
+
+@pytest.mark.parametrize('url', PAGES_WITH_PROJECT_MODAL)
+def test_project_modal_pages_ship_the_allocation_modal(auth_client, url):
+    """The pencil inside the project-details modal needs its target shell."""
+    resp = auth_client.get(url)
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert html.count(PROJECT_MODAL_ID) == 1, f'{url}: project modal shell'
+    assert html.count(EDIT_MODAL_ID) == 1, f'{url}: edit-allocation shell'
+    assert html.count(EDIT_CONTAINER_ID) == 1, f'{url}: htmx target container'
+
+
+def test_edit_project_page_ships_one_of_each(auth_client, active_project):
+    """/admin/project/<projcode>/edit assembles its own modal set (it extends
+    dashboards/base, not base_admin) — it used to carry an inline copy of the
+    edit-allocation modal alongside the shared include."""
+    resp = auth_client.get(f'/admin/project/{active_project.projcode}/edit')
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert html.count(PROJECT_MODAL_ID) == 1
+    assert html.count(EDIT_MODAL_ID) == 1
+    assert html.count(EDIT_CONTAINER_ID) == 1


### PR DESCRIPTION
Two independent UX fixes on the admin/status dashboards.

---

## 1. Edit pencil in the project details modal was a silent no-op

On `/status/derecho`, clicking a project code in the queue-load chart legend opens the project details modal — but the per-allocation **edit pencil** inside it did nothing. No modal, no network request, no console error.

**Root cause:** the modal body renders pencils targeting `#editAllocationModal` / `#editAllocationFormContainer`, which live in a *second* fragment (`user/fragments/allocation_modals.html`). Pages had to remember to include **both** shells. Bootstrap found no modal target and htmx aborted on `htmx:targetError` before issuing the GET.

Pages that shipped the project modal without the allocation modal:

| Page | Before |
|---|---|
| `/status/<system>` (`base_status.html`) | broken |
| `/status/queue-history/<system>/<queue>` | broken |
| `/allocations/transactions` | broken |
| `/allocations/adjustments` | broken |

**Fix:** `shared/project_details_modal.html` now includes the allocation fragment itself, so the pairing holds **by construction**. Redundant standalone includes are dropped to avoid duplicate DOM ids:

- `admin/base_admin.html`, `user/accounts.html`, `allocations/projects.html` — their base already pulls the project modal.
- `admin/edit_project.html` — drops its **inline copy**. Its header loses the local `bg-warning` styling and now matches the shared `bg-primary` shell used everywhere else. (Only intentional visual change in this PR.)

`user/resource_details.html` keeps its standalone include — it has page-level pencils but no project details modal.

---

## 2. Search results scrolled past the loaded card's title

Picking a project from the admin Projects search scrolled *past* the card's title and its **Manage Project** button, by a distance that varied with the number of matches.

**Root cause (two parts):**

1. The scroll ran on `htmx:afterSwap`, which fires **before** the sibling `htmx:afterRequest` handler in `form-helpers.js` empties the results list. That list sits above the card, so the page shrank by its height right after the scroll target was computed — a 2-match list overshot by ~90px, longer lists by more.
2. `scrollIntoView({block: 'start'})` pins the card's top edge flush against the viewport's, leaving the title no breathing room.

The **user and group** searches on `/admin/users-groups` had the opposite problem: no scroll at all, leaving their card ~640px down the page, below the fold.

**Fix:** new shared `revealCard(el)` helper (`actions.js`, alongside `registerAction`) — defers a frame so it measures after the results list is gone, aims 16px above the card, and no-ops when the card header is already in the top half of the viewport.

It is called from the paths where the user asked for a *different* card — search hit (all three searches), project creation, `.project-code-link` badges, and the one-shot `?projcode=` deep-link auto-load — rather than from the blanket afterSwap hook. In-place reloads of an already-visible card (after an allocation edit, after an exemption change) consequently **no longer yank the page back to the card top**.

---

## Test Results

Verified in the browser at `:5050`:

- `/status/derecho` → legend project code → project modal → pencil now loads the edit-allocation form.
- `/admin/project/<code>/edit` → Allocations tab → tree pencil still opens the form after its inline modal was removed.
- Every affected page renders exactly **one** `#projectDetailsModal`, `#editAllocationModal`, and `#editAllocationFormContainer`.
- Project, user, and group searches all land with the card header 16px below the viewport top (title + Manage Project button visible).
- `?projcode=` deep link reveals once and consumes its flag; a subsequent in-place swap into the same container leaves the scroll position untouched. No console errors.

New `tests/unit/test_modal_shell_pairing.py` pins the modal-shell invariant; `test_dashboard_routes.py` gains coverage for the `data-reveal-on-load` flag. The scroll behavior itself is JS — no harness in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)