### PR TITLE
Job History dashboard: 5-tab card, explorer, Status tab, My Jobs

### DIFF
--- a/docs/plans/JOB_HISTORY_DASHBOARD.md
+++ b/docs/plans/JOB_HISTORY_DASHBOARD.md
@@ -2,7 +2,10 @@
 
 **Status (2026-07-26):** plugin side DONE and pushed; SAM side NOT STARTED.
 This doc is the restart brief for a fresh session: everything needed to execute
-the SAM work is here or referenced by exact path.
+the SAM work is here or referenced by exact path. The approved plan of record
+(full rationale, plugin-side commit details) is
+[`JOB_HISTORY_DRILLDOWN.md`](JOB_HISTORY_DRILLDOWN.md); where the two differ,
+THIS doc reflects what actually landed.
 
 ## How to resume
 

--- a/docs/plans/JOB_HISTORY_DASHBOARD.md
+++ b/docs/plans/JOB_HISTORY_DASHBOARD.md
@@ -334,3 +334,10 @@ Personas via Quick Login: `benkirk` (full operator), a plain project user,
 - Explorer inputs for elapsed/reqmem bounds (`min/max_elapsed`,
   `min/max_reqmem` are already accepted by the service normalizer; only
   panel fields + roundtrip keys are missing).
+- **Pre-existing, discovered via CI**: `RedisTTLAdapter` namespaces keys
+  and `clear()`/`info()` scans by `prefix` only, and the usage cache AND
+  both fs_scans buckets all sit on the default `'usage:'` prefix — so on
+  Redis, `clear('usage')` / `clear('scans')` wipe each other's entries
+  and their `info()` counts merge. The jobs buckets now pass distinct
+  `prefix=<name>:` values; migrating fs_scans/usage the same way is a
+  separate PR (existing 'usage:' keys orphan until TTL at cutover).

--- a/docs/plans/JOB_HISTORY_DASHBOARD.md
+++ b/docs/plans/JOB_HISTORY_DASHBOARD.md
@@ -1,11 +1,37 @@
 # Job History Dashboard — SAM-side implementation (Session 2 handoff)
 
-**Status (2026-07-26):** plugin side DONE and pushed; SAM side NOT STARTED.
-This doc is the restart brief for a fresh session: everything needed to execute
-the SAM work is here or referenced by exact path. The approved plan of record
+**Status (2026-07-27): IMPLEMENTED.** Plugin side landed on PR #99 (tip
+`24a35ed`); SAM Commits 1–7 are on `job_history_expansion` as planned, with
+the deltas recorded in *As-built notes* below. The approved plan of record
 (full rationale, plugin-side commit details) is
 [`JOB_HISTORY_DRILLDOWN.md`](JOB_HISTORY_DRILLDOWN.md); where the two differ,
 THIS doc reflects what actually landed.
+
+## As-built notes (deltas from the plan below)
+
+- **Metric pills landed on ALL aggregation tabs**, not just By User: the
+  three histogram tabs also toggle Jobs / CPU-hours / GPU-hours (the chart
+  generator already supported it; one shared partial).
+- The card carries the resource-details page's **date window** (`start`/
+  `end`) into every tab so aggregations stay bounded by default.
+- `?scope=` subtree re-rooting is honored by **every** project fragment
+  (table + all aggregations + explorer) via `_tree_projcodes` →
+  `_scope_project`, not only the explorer.
+- The per-job fragment's hidden filter form now round-trips the **full**
+  extended filter set (`roundtrip_params`) so explorer pagination/sort
+  keeps name-glob/bounds/wait filters; the fk-picker's `user_id` resolves
+  to a username in `_resolve_user_filter`.
+- The jobs table body is one shared `_jobs_table_response(mode=…)`
+  (project | machine | user) rather than three copies.
+- The By User table appends an inert **"Other (beyond top N)"** row from
+  the pre-truncation totals (limit = 25 rows; pie keeps ≤ 9 + Other).
+- Machine-wide count uses the plugin's `jobs_count` (no SAM-summary fast
+  path — that table is per-project and the operator surfaces are gated +
+  low-volume).
+- `sam-admin cache --category` and the API/HTMX category sets gained
+  `jobs`; `tests/api/test_admin_cache.py`'s pinned category set updated.
+- Histogram bucket tables render inside a collapsed `<details>` under the
+  SVG ("Bucket counts").
 
 ## How to resume
 
@@ -294,12 +320,17 @@ Personas via Quick Login: `benkirk` (full operator), a plain project user,
 6. `docker compose exec` psql: `pg_stat_activity` shows
    `sam-webapp:…:job_history:<machine>` tagging and `statement_timeout`.
 
-## Deferred follow-ups (record outcomes in Commit 8)
+## Deferred follow-ups (confirmed deferred as of 2026-07-27)
 
 - `jobs_facets` filter chips in the explorer (cost: self-exclusion plan
   flips measured 4.5×; needs a default window policy first).
 - By-Project tab in user mode (needs nothing new server-side —
   `jobs_usage_by('account', user=<me>)` — UI decision only).
 - Clickable histogram bars (drill via `min_param`/`max_param` envelope,
-  mirroring the disk band-drill).
+  mirroring the disk band-drill; the envelope's self-describing
+  min/max_param fields are already threaded through to the template
+  context, so this is chart + JS work only).
 - `memory_used` histogram dimension upstream if ever asked (one spec row).
+- Explorer inputs for elapsed/reqmem bounds (`min/max_elapsed`,
+  `min/max_reqmem` are already accepted by the service normalizer; only
+  panel fields + roundtrip keys are missing).

--- a/docs/plans/JOB_HISTORY_DASHBOARD.md
+++ b/docs/plans/JOB_HISTORY_DASHBOARD.md
@@ -1,0 +1,302 @@
+# Job History Dashboard — SAM-side implementation (Session 2 handoff)
+
+**Status (2026-07-26):** plugin side DONE and pushed; SAM side NOT STARTED.
+This doc is the restart brief for a fresh session: everything needed to execute
+the SAM work is here or referenced by exact path.
+
+## How to resume
+
+1. Branch: `job_history_expansion` (this repo). Plugin repo:
+   `~/codes/hpc-usage-queries/devel`, branch `jobs_plugin_search_drilldown`
+   = PR #99, **tip `24a35edffd4f1cea633ccebee7c9fdd5308ec1a3`**.
+2. Rebuild against the pinned sha (both, before any webapp/pytest work):
+   ```bash
+   HPC_USAGE_QUERIES_REF=24a35edffd4f1cea633ccebee7c9fdd5308ec1a3 docker compose build webdev
+   HPC_USAGE_QUERIES_REF=24a35edffd4f1cea633ccebee7c9fdd5308ec1a3 source etc/config_env.sh
+   make print-env-hash   # confirm the hash-keyed conda-env rebuilt
+   ```
+3. Webapp: `docker compose up webdev --watch` → http://localhost:5050 (stub
+   Quick Login). Tests: `docker compose --profile test up -d mysql-test`,
+   `export SAM_TEST_DB_URL='mysql+pymysql://root:root@127.0.0.1:3307/sam'`.
+   **Running pytest directly is authorized for this track** (both repos).
+4. Merge order at the end: plugin PR #99 → staging (then #98 staging→main);
+   SAM PR (this branch → staging) only after.
+
+## As-landed plugin contract (verified, tip 24a35ed)
+
+Everything importable from the package root: `COLUMNS`, `DEFAULT_COLUMNS`,
+`VERBOSE_COLUMNS`, `project_row`, `JobQueries`, `get_engine`, `get_session`.
+
+**Shared filter kwargs** on `jobs_search` / `jobs_count` / `jobs_facets` /
+`jobs_histogram` / `jobs_usage_by` (all keyword-only, all `Optional`):
+`start, end` (site-local dates, filter `Job.end`), `user`, `account`
+(str | Sequence — sequence → `IN`; `[]` means NO ROWS), `queue`, `qos`,
+`exit_status` (PBS exit CODE as text, `'0'` = success), `job_id`,
+`name` (str | Sequence glob, `[]` means NO FILTER), `ignore_case`,
+`min/max_eligible_secs`, `min/max_nodes`, `min/max_cpus`, `min/max_gpus`,
+`min/max_elapsed` (seconds), `min/max_reqmem` (bytes). All range bounds
+inclusive + NULL-strict.
+
+- `jobs_search(..., columns, limit, offset, sort_by, sort_dir)` → `list[dict]`
+- `jobs_count(...)` → `int`
+- `jobs_facets(..., facets=('queue','qos','exit_status'), self_exclude=True,
+  limit=None)` → `{dim: [{'value','count'}]}` (v1 UI defers facet chips)
+- `jobs_histogram(dimension, ...)` → dimension ∈
+  `wait | nodes | cpus | gpus | memory | duration` (`memory` = REQUESTED
+  bytes, `reqmem`):
+  ```python
+  {"dimension": "wait", "column": "eligible_secs", "unit": "seconds",
+   "min_param": "min_eligible_secs", "max_param": "max_eligible_secs",
+   "buckets": [{"label": "<1m", "lo": 0, "hi": 59,
+                "job_count": 12, "cpu_hours": 190.0, "gpu_hours": 0.0}, ...],
+   "null_count": 2481,      # rows matching filters with NULL column
+   "total_count": 40213}    # == jobs_count(**filters), guaranteed
+  ```
+  Full bucket vector in band order, zeros included → stable chart x-axes.
+  Bar drill-down: `jobs_search(**{min_param: lo, max_param: hi})`, omit max
+  when `hi is None`. **Never hardcode the dimension→kwarg map** — use
+  `min_param`/`max_param` from the envelope.
+- `jobs_usage_by(dimension, ..., limit=None)`:
+  ```python
+  {"dimension": "user",
+   "rows": [{"value": "alice", "job_count": 812,
+             "cpu_hours": 91234.5, "gpu_hours": 120.0}, ...],  # hours desc
+   "totals": {"job_count": ..., "cpu_hours": ..., "gpu_hours": ...}}
+  ```
+  `totals` is pre-truncation → pie "Other" slice = totals − Σ rows.
+  No self-exclusion; `account` scoping always applies (security boundary).
+
+**Costs (dev PG, 308k-row month, machine-wide, warm):** histogram ~570 ms,
+usage_by ~545 ms, facets ~150 ms, unbounded window ~200 s. Always bound the
+window; the SAM cache layer (below) is mandatory for the card fragments.
+
+**Wait-data facts for UI copy:** use `eligible_secs` (never start−submit);
+NULL = unmeasured, not zero; Derecho waits recorded only from
+**2025-01-07 17:47:50 UTC** (Casper complete). Caption when
+`null_count > 0`: "N jobs in this range have no wait measurement (queued
+before eligible-time collection began, early 2025 on Derecho) and are
+excluded."
+
+## Breaking renames SAM must absorb (Commit 1, same deploy as plugin)
+
+1. `COLUMNS` import — `job_history.cli.search.columns` is GONE:
+   `from job_history import COLUMNS` at `src/webapp/jobs/routes.py:312`
+   (`_load_column_specs`).
+2. `has_gpus` kwarg REMOVED → `min_gpus`/`max_gpus`:
+   `src/webapp/jobs/service.py` (~6 sites incl. the fast-path predicate at
+   :195 — switch it, never drop it). Do NOT touch the unrelated `has_gpus`
+   in `system_status/`, `dashboards/charts.py`, `status/` blueprint+templates.
+3. `status` → `exit_status` (kwarg AND row/COLUMNS key):
+   `service.py:137`, `routes.py:68` (`_VERBOSE_EXTRAS`) and `:172`,
+   `src/cli/accounting/commands.py:1788` (`JOB_COLUMNS`), plus the
+   `jobs_fragment.html` filter field. DB column/ORM attr unchanged upstream.
+
+Newly surfaceable columns: `queued`, `eligible_secs`, `run_count`.
+
+## Decisions already made (do not re-litigate)
+
+- Card = **5 tabs**: Jobs · By User (usage pie; hidden in user mode) ·
+  Wait Times · Job Sizes (nodes/cpus/gpus/memory pills) · Durations.
+- New global permission `VIEW_ALL_JOB_DATA` (mirrors
+  `VIEW_ALL_FILESYSTEM_DATA`; auto-joins operator bundles via `ALL_VIEW`;
+  NOT facility-scoped).
+- Machine-wide routes say `machine/<machine>` (plugin machines `derecho`,
+  `casper`), not `resource/` — `derecho` covers SAM's Derecho + Derecho GPU.
+- ONE SAM PR to staging, ordered commits below.
+- Facet chips, By-Project user-mode tab, clickable histogram bars: deferred
+  (record in this doc's follow-ups on completion).
+
+## Commit series (structural template = `src/webapp/disk_scans/` throughout)
+
+### Commit 1 — absorb plugin breaking renames (mechanical, UI-identical)
+Files: `src/webapp/jobs/routes.py`, `src/webapp/jobs/service.py`,
+`src/cli/accounting/commands.py`, `templates/dashboards/user/partials/jobs_fragment.html`,
+`tests/unit/test_webapp_jobs.py` (mock kwargs), `tests/unit/test_sam_search_jobs_cli.py`.
+
+### Commit 2 — RBAC + config + session
+- `src/webapp/utils/rbac.py`: `VIEW_ALL_JOB_DATA = "view_all_job_data"`
+  right after `VIEW_ALL_FILESYSTEM_DATA` (:110), mirrored comment block.
+- `src/webapp/config.py`: `JOB_HISTORY_STATEMENT_TIMEOUT_MS` (default 60000).
+- `src/webapp/jobs/session.py`: `_attach_application_name` →
+  `_apply_connection_settings(engine, app_name, *, statement_timeout_ms)`
+  (copy the autocommit-toggle body from `disk_scans/session.py:184-221`).
+- `src/webapp/jobs/service.py`: `job_history_machines()` → sorted engine
+  keys when enabled (analogue of `scan_capable_resources()`).
+- Tests: `test_view_all_job_data_grants` (in nusd/csg/ssg bundles, NOT in
+  sureshm's WNA facility set — mirror `test_webapp_disk_scans.py:1594`),
+  statement-timeout listener, machines helper.
+
+### Commit 3 — service mode families + extended filters + TTL cache
+- `service.py`: one `_plugin_filter_kwargs` normalizer (wraps
+  `_resolve_queue_and_qos` + flat passthrough of the full filter set);
+  `search_jobs`/`count_jobs` keep project pinning and gain the extended
+  filters (SAM-summary count fast path ONLY when every extended filter is
+  None: qos, exit_status, name, all min/max bounds);
+  `search_jobs_machine`/`count_jobs_machine` (NO account filter — docstring
+  warns caller must be VIEW_ALL_JOB_DATA-gated);
+  `search_jobs_user`/`count_jobs_user` (hard-pin `user=username`, raise on
+  empty username, reject a user kwarg in filters);
+  cached `jobs_histogram(machine, dimension, *, account_projcodes=None,
+  username=None, **filters)` and `jobs_usage_by_user(machine, *, limit=50,
+  **filters)` (plugin `jobs_usage_by('user', …)`; "Other" = totals − Σrows).
+- NEW `src/webapp/jobs/cache.py` — clone `disk_scans/cache.py` minus the
+  scan-date signature (pure TTL): bucket `historical` (`JOBS_CACHE_TTL`
+  21600 s / 256 entries; windows with `end < today`) and `recent`
+  (`JOBS_RECENT_CACHE_TTL` 900 s / 128; window touches today). Cache ONLY
+  the aggregations; paged search + counts stay uncached.
+  Key: `(query_type, machine, sorted(normalized opts))`.
+- `src/webapp/caching/__init__.py`: register in `adapters()`,
+  `stats()['jobs']`, `clear('jobs')`; admin configuration card category.
+- NEW `tests/unit/test_webapp_jobs_cache.py`.
+
+### Commit 4 — chart generators + sentinel handler
+- `src/webapp/dashboards/charts.py` (near the disk pie section):
+  `generate_jobs_histogram(hist, *, metric='jobs')` — single-series bars
+  from `hist['buckets']` (metric picks `job_count`/`cpu_hours`/`gpu_hours`),
+  `@caching.chart_cached(name='jobs_histogram', maxsize=128, key_fn=...)`
+  hashing (labels, metric values, dimension, null_count, metric),
+  `_empty_state('No jobs in this range')` when all-zero;
+  `generate_jobs_user_pie_chart(entity_data, metric='cpu_hours')` — reuse
+  `_pie_cumulative_keep` (0.90 share / 9 cap), wedge+legend
+  `set_url(f'#job-user-{username}')`, inert "Other" slice built from
+  totals − Σ rows.
+- `src/webapp/static/js/svg-chart-links.js`: `#job-user-` prefix →
+  existing `openEntityRow` with `data-job-user` rows scoped to `.tab-pane`.
+- NEW `tests/unit/test_webapp_jobs_charts.py`.
+
+### Commit 5 — 5-tab card (project mode) on resource details
+- NEW templates under `templates/dashboards/user/partials/`:
+  `jobs_card.html` (mode-parameterized `project|machine|user`, params
+  `mode, cid, tablist_id, machine, load_trigger` + project-only
+  `projcode, scope`; structural clone of `disk_scans_card.html:25-43`
+  URL-resolution block + tab strip; "Open full view ↗" per mode; By User
+  omitted when `mode == 'user'`);
+  `_jobs_macros.html` (`jobs_disabled/error/empty`, `mode_badge`,
+  `exit_status_badge`: 0 → green "Success", N → red "Failed (N)", None →
+  muted em-dash, raw code in title=);
+  `jobs_by_user.html` (metric pills Jobs/CPU-h/GPU-h via `?metric=`,
+  `{{ pie_svg | safe }}`, rows `tr[data-job-user=…]` with collapse drill →
+  mode's Jobs fragment filtered `?user=…`, hidden params form);
+  `jobs_histogram.html` (shared by Wait Times / Job Sizes / Durations;
+  dimension pills nodes/cpus/gpus/memory on Sizes only; Wait pins
+  `dimension='wait'`, Durations pins `'duration'`; bucket table under the
+  SVG; the null_count caption).
+- `src/webapp/jobs/routes.py`: project fragments `by_user_fragment` /
+  `wait_times_fragment` / `job_sizes_fragment` / `durations_fragment`;
+  `_parse_job_filters()` (whitelisted GET parse, wait-hours→secs at the
+  boundary); shared `_render_by_user` / `_render_histogram` helpers taking
+  explicit scope args (model: `disk_scans/routes.py` ctx helpers). Jobs tab
+  reuses `jobs.jobs_fragment` unchanged.
+- `templates/dashboards/user/resource_details.html`: collapsible "Job
+  History" card after Usage by User (~:511), `{% if jobs_machine %}`, with
+  `{% with mode='project', cid='jobs-hist', tablist_id='jobsCardTabs',
+  machine=jobs_machine, load_trigger='shown.bs.tab once,
+  shown.bs.collapse once from:#collapseJobs' %}`.
+- `src/webapp/dashboards/user/blueprint.py`: delete the inline machine
+  resolution at :617-623 in favor of `_resolve_jobs_machine` (:686).
+
+### Commit 6 — explorer full view + machine mode + Status tab
+- NEW `templates/dashboards/user/jobs_explore_page.html` +
+  `partials/_jobs_filters.html` (macro `jobs_filters(form_id, fragment_url,
+  target_id, filters, user_search_url, machine, scope, per_page_options,
+  mode)`; sidebar: date range, `fk_search_field` user picker (project/
+  machine modes only), queue text, QoS select from `list_qos_names`, exit
+  code text ("0 = success" hint), name glob + ignore-case switch,
+  min/max nodes/cpus/gpus, wait-hours range, rows selector; wrapped in
+  `.filter-sidebar`; clone of `disk_scans_directories_page.html` +
+  `_disk_scans_dir_filters.html`). Project mode: `?scope=<child>` re-root
+  with the same same-tree_root validation as `disk_scans/routes.py:70-84`.
+- `jobs/routes.py`: `explore_page` (project) + machine family
+  `/machine/<machine>/{jobs,by-user,wait-times,job-sizes,durations,explore}`
+  gated `@require_permission(Permission.VIEW_ALL_JOB_DATA)`; `<machine>`
+  validated against `job_history_machines()` → 404 unknown.
+- `jobs_fragment.html`: tolerate `project=None` (machine/user modes).
+- Status tab: `dashboards/status/blueprint.py` route `job_history`
+  (mirror `filesystem_scans` :203-212) + `_page_context` gains
+  `job_history_machines`; `templates/dashboards/status/job_history_page.html`
+  + `partials/job_history.html` (nav-pill per machine, card mode='machine',
+  first pane `load once`, clones of the filesystem_scans pair);
+  `base_status.html` page_tabs entry (icon `fas fa-list-check`, visible =
+  machines AND `has_permission(VIEW_ALL_JOB_DATA)`); `utils/nav.py`
+  `_can_view_job_history` + status-section item.
+- Route-map snapshot regen: `ROUTE_MAP_REGEN=1 pytest
+  tests/unit/test_route_map_parity.py` (adds `status_dashboard.job_history`).
+
+### Commit 7 — My Jobs (user mode)
+- `jobs/routes.py`: user family
+  `/user/<machine>/{jobs,wait-times,job-sizes,durations,explore}`,
+  `@login_required` ONLY; `_user_ctx` pins
+  `forced_user=current_user.username`; render helpers overwrite any
+  client-supplied `user` (mirror `disk_scans/routes.py:361-377,392-395`).
+- `dashboards/user/blueprint.py`: `my_jobs` route at `/user/jobs` (404
+  unless machines; mirror `my_data` :155-162) + `_page_context` keys
+  `my_jobs_available`, `job_history_machines`.
+- NEW `templates/dashboards/user/my_jobs.html` + `partials/my_jobs_card.html`
+  (machine nav-pills, card mode='user'; clones of my_data pair);
+  `base_user.html` "My Jobs" tab (icon `fas fa-list-check`, visible:
+  `my_jobs_available`); `nav.py` `_my_jobs_available`.
+- Route-map regen (adds `user_dashboard.my_jobs`).
+- Tests: client `?user=` ignored in ALL user fragments (mirror
+  `test_user_directories_pins_owner_ignoring_query`), 404 when no machines,
+  tab visibility, explorer omits user picker.
+
+### Commit 8 — docs
+Update THIS file to as-built status (final route table, contract drift,
+deferred follow-ups); `src/webapp/README.md` `jobs/` line.
+
+## Route table (all new; `jobs` bp prefix `/dashboards/user/jobs`, all `@login_required`)
+
+| Endpoint | Rule | Extra gate |
+|---|---|---|
+| `jobs.{by_user,wait_times,job_sizes,durations}_fragment`, `jobs.explore_page` | `/<projcode>/{by-user,wait-times,job-sizes,durations,explore}` | `@require_project_access` |
+| `jobs.{jobs,by_user,wait_times,job_sizes,durations}_machine_fragment`, `jobs.explore_machine_page` | `/machine/<machine>/{jobs,by-user,wait-times,job-sizes,durations,explore}` | `@require_permission(VIEW_ALL_JOB_DATA)` |
+| `jobs.{jobs,wait_times,job_sizes,durations}_user_fragment`, `jobs.explore_user_page` | `/user/<machine>/{jobs,wait-times,job-sizes,durations,explore}` | user pinned server-side |
+| `status_dashboard.job_history` | `/status/job-history` | `VIEW_ALL_JOB_DATA` (+ tab visible w/ machines) |
+| `user_dashboard.my_jobs` | `/user/jobs` | 404 unless machines available |
+
+Only the last two touch the route-map parity snapshot (the `jobs` blueprint
+is not pinned).
+
+## Test inventory
+
+Extend `tests/unit/test_webapp_jobs.py` (TestingConfig keeps
+`JOB_HISTORY_MACHINES=[]`; mock via the file's existing monkeypatch
+patterns). New: `test_webapp_jobs_cache.py`, `test_webapp_jobs_charts.py`.
+Per-commit lists are embedded above. Full sweep before the PR:
+`pytest tests/unit/test_webapp_jobs.py tests/unit/test_webapp_jobs_cache.py
+tests/unit/test_webapp_jobs_charts.py tests/unit/test_webapp_disk_scans.py
+tests/unit/test_rbac.py tests/unit/test_route_map_parity.py`, then full
+`pytest`.
+
+## Playwright smoke checklist (Session 2, webdev :5050)
+
+Personas via Quick Login: `benkirk` (full operator), a plain project user,
+`sureshm` (WNA facility-scoped — must NOT see operator surfaces),
+`dlawren` (PROJ_TREE_LEAD).
+
+1. Resource details (`/user/resource-details/SCSG0001?resource=Derecho`):
+   Job History card present, collapsed; expand → 5 tabs lazy-load on first
+   show only; Jobs tab pagination/sort; By User pie wedge click expands the
+   matching user row; Wait/Sizes/Durations pills re-fetch; Sizes dimension
+   pills switch; wait caption absent post-2025 (Derecho) — check a 2024
+   Casper window shows counts, and a 2024 Derecho window shows the caption.
+2. "Open full view ↗" lands on the explorer with filters carried; project
+   mode `?scope=<child>` re-roots; deep-link with filters reloads state.
+3. `/status/job-history`: visible+working for benkirk (derecho/casper
+   pills); tab hidden AND direct URL 403 for plain user and for sureshm.
+4. `/user/jobs`: shows own jobs only; appending `?user=<other>` to fragment
+   URLs changes nothing; tab hidden when no unix identity is irrelevant
+   here (username always exists) but hidden when machines unavailable.
+5. Admin → Configuration: `jobs` cache buckets listed; clear works.
+6. `docker compose exec` psql: `pg_stat_activity` shows
+   `sam-webapp:…:job_history:<machine>` tagging and `statement_timeout`.
+
+## Deferred follow-ups (record outcomes in Commit 8)
+
+- `jobs_facets` filter chips in the explorer (cost: self-exclusion plan
+  flips measured 4.5×; needs a default window policy first).
+- By-Project tab in user mode (needs nothing new server-side —
+  `jobs_usage_by('account', user=<me>)` — UI decision only).
+- Clickable histogram bars (drill via `min_param`/`max_param` envelope,
+  mirroring the disk band-drill).
+- `memory_used` histogram dimension upstream if ever asked (one spec row).

--- a/docs/plans/JOB_HISTORY_DRILLDOWN.md
+++ b/docs/plans/JOB_HISTORY_DRILLDOWN.md
@@ -1,0 +1,240 @@
+# Job History Dashboard — bring job history to fs_scans feature parity
+
+## Context
+
+SAM's disk-scans (fs_scans plugin) feature set — tabbed resource-details card, standalone
+"Open Full View" explorer, operator-gated Status tab, and per-user "My Data" tab — proved
+out a clean architecture: a mode-parameterized card partial (`project` / `resource` /
+`user`), matplotlib→inline-SVG charts with click-through sentinels, TTL/Redis caching,
+and a single global `view_*` operator permission. Job history today has only a single
+project-scoped collapse-drawer fragment (`jobs.jobs_fragment`) inside the resource-details
+usage tables.
+
+Goal: replicate the full fs_scans surface for job history on Derecho + Casper, backed by
+the `job_history` plugin from hpc-usage-queries. The peer repo's open **PR #99**
+(`jobs_plugin_search_drilldown`, head `a3ca191`, targets `staging`) is explicitly the
+plugin-side groundwork (name globs, wait/resource range filters, `jobs_facets()`, plus
+three deliberate breaking renames) and will be advanced in tandem.
+
+## Decisions (made with Ben)
+
+1. **Card = 5 tabs**: Jobs (search table) · By User (clickable usage pie) · Wait Times
+   (histogram) · Job Sizes (histogram with nodes/CPUs/GPUs/memory dimension pills) ·
+   Durations (dedicated elapsed-time histogram tab).
+2. **Plugin aggregation support lands as additional commits directly on PR #99**
+   (`jobs_histogram(dimension, …)` + by-user usage aggregation sharing
+   `_apply_jobs_search_filters`).
+3. **New `Permission.VIEW_ALL_JOB_DATA`** gates machine-wide explorer + Status tab
+   (mirrors `VIEW_ALL_FILESYSTEM_DATA`; `view_*` naming auto-joins operator ALL_VIEW bundles).
+4. **One SAM PR to staging, ordered commits**: rename absorption → service/cache →
+   card → explorer → Status tab → My Jobs.
+
+## Cross-repo coordination
+
+- PR #99's three breaking changes SAM absorbs in the same deploy:
+  1. `COLUMNS` import moves to package root (`from job_history import COLUMNS`) —
+     SAM site `src/webapp/jobs/routes.py:312`
+  2. `has_gpus` removed → `min_gpus`/`max_gpus` — `src/webapp/jobs/service.py`
+     (6 sites incl. the count-fast-path predicate); do NOT touch unrelated
+     `has_gpus` in system_status/charts/status templates
+  3. `status` → `exit_status` (kwarg + COLUMNS/row key) — `service.py:137`,
+     `routes.py:68,172`, `src/cli/accounting/commands.py:1788` (`JOB_COLUMNS`)
+- Merge order: plugin PR #99 (extended) merges first (→ staging, then #98 staging→main),
+  SAM PR after; local dev pins `HPC_USAGE_QUERIES_REF=<sha>` for containers
+  (`docker compose build webdev`) and the hash-keyed conda env.
+- Wait-time facts baked into UI copy: use `eligible_secs` (never start−submit);
+  NULL = unmeasured; Derecho waits exist only from 2025-01-07 onward → caption the
+  excluded count.
+
+## Plugin-side plan (additional commits on PR #99, `jobs_plugin_search_drilldown`)
+
+Repo: `/Users/benkirk/codes/hpc-usage-queries/devel` (branch checked out, head `a3ca191`).
+Full design details in the repo's plan doc after Commit 0. Key decisions: memory dimension
+buckets **`reqmem` (requested), raw bytes**; hours always included (LEFT OUTER JOIN
+`job_charges`, no opt-in flag); full bucket vector returned including zeros; NULLs counted
+in-statement via a `__null__` CASE label → top-level `null_count`; by-user usage is a new
+`jobs_usage_by()` (NOT `jobs_facets(include_hours=…)` — facet self-exclusion semantics are
+wrong for a usage pie); API-only, no CLI surface for the new aggregations; dimension names
+are SAM-facing and each histogram response is self-describing (`column`, `unit`,
+`min_param`, `max_param`) so SAM never hardcodes dimension→filter maps.
+
+### Commit 0 — `[skip-ci]` amend `docs/plans/JOB_HIST_PLUGIN_ENHANCEMENTS.md`
+New §8 "Aggregation surface (added in-flight)"; supersede the "out of scope:
+include_hours facet variant" bullet; add the 4 new filters to §2; placeholder rows in the
+measured-cost table (filled by real measurements at the end).
+
+### Commit 1 — complete the range-filter set: `min/max_elapsed` + `min/max_reqmem`
+So duration and memory histogram bars can round-trip into `jobs_search` drill-down filters
+(fs_scans band-drill precedent). Table-driven rows in `_apply_jobs_search_filters`
+(no-defaults parity forces completeness); kwargs on `jobs_search`/`jobs_count`/`jobs_facets`;
+CLI flags `--min/max-elapsed-hours` (hours→secs) + `--min/max-reqmem-gb` (GB→bytes) with
+envelope `filters` entries; NULL-strict, inclusive, `is not None` guards. Tests incl.
+`max_elapsed=0` falsy-zero guard; README filter bullets.
+
+### Commit 2 — `jobs_histogram(dimension, *, <full filter set>)` + bucket tables
+- New `(label, lo, hi)` bucket tables on `QueryConfig`: `WAIT_BUCKETS` (12 log-scaled:
+  `<1m … >2d`), `DURATION_HIST_BUCKETS` (legacy 7 labels; rewrite `get_duration_buckets()`
+  to derive from it — single source of truth), `NODE_HIST_BUCKETS` (derived from
+  NODE_RANGES), `CPU_HIST_BUCKETS` (13 buckets, ×4 tail to >32768 — CORE_RANGES' >128
+  overflow would swallow multi-node jobs), `GPU_HIST_BUCKETS` (11 buckets incl. explicit
+  `"0"` — GPU_RANGES starts at 4), `REQMEM_HIST_BUCKETS` (7 GiB-boundary byte bands incl.
+  the `<1GB` band the legacy CASE mislabels)
+- `_bucket_case(field, buckets)`: NULL-first WHEN → `__null__`, then ascending `<= hi`
+  ladder (no below-range leak into overflow); `_HISTOGRAM_SPECS` dimension table
+  (`wait|nodes|cpus|gpus|memory|duration`)
+- One statement: CASE label + `COUNT(Job.id)` + `SUM(cpu_hours)` + `SUM(gpu_hours)` over
+  OUTER JOIN `job_charges`, through `_apply_jobs_search_filters`, `GROUP BY` the label;
+  Python fold zero-fills. Returns `{dimension, column, unit, min_param, max_param,
+  buckets:[{label,lo,hi,job_count,cpu_hours,gpu_hours}…], null_count, total_count}` with
+  `total_count == jobs_count(**filters)` by construction.
+- Tests: full-vector/zero-fill, per-dimension bucketing, hours sums (charge-less job → 0.0),
+  null routing, **bounds-round-trip invariant across all 6 dimensions** (forces Commit 1),
+  reqmem-not-memory, gpus-0 bucket, account-scope, one-aggregate-scan guard (no hybrid
+  subqueries), signature-parity extension, offline dialect compiles of `_bucket_case`.
+
+### Commit 3 — `jobs_usage_by(dimension, *, <full filter set>, limit=None)`
+Group the integer FK from `_FACET_SPECS` (never hybrids), OUTER JOIN charges, resolve
+names post-aggregation. No self-exclusion of any kind — every filter incl. `account`
+always applies (docstring cross-refs `_FACET_SCOPE_DIMS`). Rows sorted
+`(cpu_hours+gpu_hours)` desc; `limit` truncates post-sort; **`totals` computed before
+truncation** so SAM's pie "Other" = totals − sum(rows). Returns
+`{dimension, rows:[{value, job_count, cpu_hours, gpu_hours}…], totals:{…}}`. Tests incl.
+account-scoping security mirror, totals invariants, one-scan guard, parity.
+
+### Plugin verification
+`pytest job_history/tests/` green; timed end-to-end on local dev PG (13M-row derecho,
+one-month window) with measured figures written into the docstrings + plan-doc table;
+one PG `EXPLAIN` to confirm one-statement; SAM-venv smoke with a real projcode scope.
+
+## SAM-side plan (one PR from `job_history_expansion` → staging, 8 ordered commits)
+
+Structural template throughout: `src/webapp/disk_scans/` + its templates. Key naming
+decision: machine-wide routes use `/machine/<machine>/…` (not `resource/`) because they
+key on plugin machines (`derecho` covers Derecho + Derecho GPU). The `jobs` blueprint is
+NOT in the route-map parity snapshot — only the two new page routes
+(`status_dashboard.job_history`, `user_dashboard.my_jobs`) need `ROUTE_MAP_REGEN=1`.
+
+### Commit 1 — absorb plugin breaking renames (mechanical, UI-identical)
+- `src/webapp/jobs/routes.py`: `_load_column_specs` → `from job_history import COLUMNS`;
+  `_VERBOSE_EXTRAS` + request arg `status`→`exit_status`
+- `src/webapp/jobs/service.py`: drop `has_gpus` → `min_gpus`/`max_gpus`; `status`→`exit_status`;
+  count fast-path predicate switches to new kwargs (never silently drops)
+- `src/cli/accounting/commands.py`: `JOB_COLUMNS` + `--status`→`--exit-status`
+- `jobs_fragment.html` hidden field/badge; test mocks in `tests/unit/test_webapp_jobs.py`
+- Do NOT touch unrelated `has_gpus` in system_status/charts/status templates
+
+### Commit 2 — RBAC + config + session
+- `utils/rbac.py`: `VIEW_ALL_JOB_DATA = "view_all_job_data"` after VIEW_ALL_FILESYSTEM_DATA
+  (global view_*, auto-joins nusd/csg/ssg via ALL_VIEW; not facility-scoped)
+- `config.py`: `JOB_HISTORY_STATEMENT_TIMEOUT_MS` (default 60000)
+- `jobs/session.py`: `_attach_application_name` → `_apply_connection_settings(engine, tag, *,
+  statement_timeout_ms)` (copy disk_scans autocommit-toggle body)
+- `jobs/service.py`: `job_history_machines()` (sorted engine keys; analogue of
+  `scan_capable_resources()`)
+- Tests: `test_view_all_job_data_grants` (in nusd/csg/ssg, NOT in sureshm's WNA set),
+  statement-timeout attach, machines helper
+
+### Commit 3 — service mode families + extended filters + TTL cache
+- `service.py`: shared flat filter kwargs (`start,end,user,queue,qos,exit_status,name,
+  ignore_case,min/max_{nodes,cpus,gpus},min/max_eligible_secs`) via one `_plugin_filter_kwargs`
+  normalizer; new `search_jobs_machine`/`count_jobs_machine` (no account filter — caller must be
+  permission-gated), `search_jobs_user`/`count_jobs_user` (hard-pin `user=username`, reject
+  user kwarg), plus cached wrappers `jobs_histogram(machine, dimension, …)` and
+  `jobs_usage_by_user(machine, …)` (calls plugin `jobs_usage_by('user', …)`; pie "Other"
+  slice value = `totals` − sum of returned rows).
+  SAM-summary count fast path only when EVERY extended filter is None.
+- New `webapp/jobs/cache.py` — clone of `disk_scans/cache.py` minus scan-date signature (pure
+  TTL): bucket `historical` (`JOBS_CACHE_TTL` 6 h/256, for closed windows `end < today`) and
+  `recent` (`JOBS_RECENT_CACHE_TTL` 15 min/128, window touches today). Cache only the
+  aggregations (histogram/by-user); paged search + counts stay uncached.
+- `caching/__init__.py`: register buckets in `adapters()`/`stats()['jobs']`/`clear('jobs')`;
+  admin configuration card gets the category.
+
+### Commit 4 — chart generators + sentinel handler
+- `dashboards/charts.py`: `generate_jobs_histogram(hist, *, metric='jobs')` (single-series
+  bars, `@caching.chart_cached(name='jobs_histogram')`, `_empty_state` when all-zero) and
+  `generate_jobs_user_pie_chart(entity_data, metric='cpu_hours')` (reuses
+  `_pie_cumulative_keep` 0.90/9-cap; wedge+legend `set_url(f'#job-user-{username}')`;
+  inert Other slice)
+- `static/js/svg-chart-links.js`: `#job-user-` prefix → existing `openEntityRow` with
+  `data-job-user` rows, scoped to `.tab-pane` (same interaction as the disk pie)
+- New `tests/unit/test_webapp_jobs_charts.py`
+
+### Commit 5 — 5-tab card (project mode) wired into resource details
+- New templates: `user/partials/jobs_card.html` (mode-parameterized project|machine|user,
+  cid-namespaced, 5 tabs: Jobs · By User · Wait Times · Job Sizes · Durations; By User tab
+  hidden in user mode, "Open full view ↗"), `_jobs_macros.html`
+  (`jobs_disabled/error/empty`, `exit_status_badge` — 0=green Success, N=red Failed(N)),
+  `jobs_by_user.html` (metric pills Jobs/CPU-h/GPU-h + pie + drill-down rows
+  `tr[data-job-user=…]` expanding a user-filtered Jobs fragment), `jobs_histogram.html`
+  (one shared partial for Wait Times, Job Sizes, AND Durations; dimension pills
+  nodes/cpus/gpus/memory on Sizes only — Wait Times pins `dimension='wait'`, Durations
+  pins `dimension='duration'`; NULL-wait exclusion caption when `null_count > 0`: "N jobs
+  have no wait measurement — queued before eligible-time collection began, early 2025 on
+  Derecho")
+- `jobs/routes.py`: project fragments `by_user_fragment`/`wait_times_fragment`/
+  `job_sizes_fragment`/`durations_fragment` + `_parse_job_filters()` (whitelisted GET
+  parse, wait-hours→secs) + shared `_render_*` helpers; Jobs tab reuses existing
+  `jobs.jobs_fragment`
+- `resource_details.html`: new collapsible "Job History" card after Usage by User, gated
+  `{% if jobs_machine %}`; consolidate the duplicated inline `_resolve_jobs_machine` copy in
+  `user/blueprint.py:617-623`
+
+### Commit 6 — explorer full view + machine mode + Status tab
+- New: `user/jobs_explore_page.html` + `partials/_jobs_filters.html` (sidebar: date range,
+  `fk_search_field` user picker [not in user mode], queue, QoS select, exit code, name glob +
+  ignore-case, min/max nodes/cpus/gpus, wait-hours range, per-page; project mode gets
+  `?scope=` tree re-rooting + scope badge strip). Facet chips (`jobs_facets`) deferred to
+  follow-up (self-exclusion plan-flip 4.5× / unbounded ~200 s risk).
+- `jobs/routes.py`: `explore_page` (project) + full machine family (`/machine/<machine>/{jobs,
+  by-user,wait-times,job-sizes,durations,explore}`) gated
+  `@require_permission(VIEW_ALL_JOB_DATA)`; `<machine>` validated against
+  `job_history_machines()`, 404 otherwise
+- `jobs_fragment.html` tolerates `project=None` (machine/user modes)
+- Status tab: `status/blueprint.py` route `job_history` + `_page_context` machines;
+  `base_status.html` page_tabs entry (icon `fas fa-list-check`, visible = machines AND
+  permission); `partials/job_history.html` (nav-pill per machine, card mode='machine');
+  `utils/nav.py` `_can_view_job_history`; route-map snapshot regen
+
+### Commit 7 — My Jobs (user mode)
+- `jobs/routes.py`: user family
+  (`/user/<machine>/{jobs,wait-times,job-sizes,durations,explore}`), `@login_required`
+  only; `_user_ctx` pins `forced_user=current_user.username`, render helpers overwrite any
+  client-supplied `user` (mirror disk_scans pinned-owner)
+- `user/blueprint.py`: `my_jobs` route at `/user/jobs` (404 unless machines available) +
+  `_page_context` keys; `base_user.html` "My Jobs" page_tabs entry; `nav.py`
+  `_my_jobs_available`; new `user/my_jobs.html` + `partials/my_jobs_card.html` (machine
+  pills, card mode='user'); route-map snapshot regen
+- Tests: client-supplied `?user=` ignored in all user fragments; 404 when no machines
+
+### Commit 8 — docs
+- New `docs/plans/JOB_HISTORY_DASHBOARD.md` (context, mode/permission matrix, route table,
+  cache design, assumed plugin contract, deferred follow-ups: facet chips, By-Project
+  user-mode tab, clickable histogram bars); `src/webapp/README.md` jobs/ line update
+
+### Route table (new)
+
+| Endpoint | Rule | Gate |
+|---|---|---|
+| `jobs.by_user_fragment` / `.wait_times_fragment` / `.job_sizes_fragment` / `.durations_fragment` / `.explore_page` | `/dashboards/user/jobs/<projcode>/{by-user,wait-times,job-sizes,durations,explore}` | `@require_project_access` |
+| `jobs.*_machine_fragment` ×5 + `.explore_machine_page` | `/dashboards/user/jobs/machine/<machine>/{jobs,by-user,wait-times,job-sizes,durations,explore}` | `@require_permission(VIEW_ALL_JOB_DATA)` |
+| `jobs.*_user_fragment` ×4 + `.explore_user_page` | `/dashboards/user/jobs/user/<machine>/{jobs,wait-times,job-sizes,durations,explore}` | `@login_required`, user pinned |
+| `status_dashboard.job_history` | `/status/job-history` | `VIEW_ALL_JOB_DATA` |
+| `user_dashboard.my_jobs` | `/user/jobs` | login; 404 if unavailable |
+
+## Verification
+
+1. Rebuild against the plugin branch tip:
+   `HPC_USAGE_QUERIES_REF=<sha> docker compose build webdev` (+ hash-keyed conda env via
+   `HPC_USAGE_QUERIES_REF=<sha> source etc/config_env.sh`; `make print-env-hash` to confirm)
+2. `pytest tests/unit/test_webapp_jobs.py tests/unit/test_webapp_jobs_cache.py
+   tests/unit/test_webapp_jobs_charts.py tests/unit/test_webapp_disk_scans.py
+   tests/unit/test_rbac.py tests/unit/test_route_map_parity.py`, then full `pytest`
+   (Ben runs the suite by hand)
+3. Manual smoke on webdev (:5050): HPC resource-details → Job History card (4 tabs lazy-load,
+   pie wedge expands user row, pills re-fetch, Open Full View lands filtered); explorer
+   `?scope=` re-roots; `/status/job-history` per-machine pills + hidden for non-operators
+   (Quick Login); `/user/jobs` shows own jobs only, `?user=other` ignored; Admin →
+   Configuration shows the jobs cache buckets; `pg_stat_activity` shows tagging + timeout
+4. `grep -rn has_gpus src/ | grep -v webapp/jobs` → only the unrelated system_status/charts/
+   status-template sites remain

--- a/docs/plans/JOB_HISTORY_DRILLDOWN.md
+++ b/docs/plans/JOB_HISTORY_DRILLDOWN.md
@@ -28,6 +28,45 @@ three deliberate breaking renames) and will be advanced in tandem.
    (mirrors `VIEW_ALL_FILESYSTEM_DATA`; `view_*` naming auto-joins operator ALL_VIEW bundles).
 4. **One SAM PR to staging, ordered commits**: rename absorption → service/cache →
    card → explorer → Status tab → My Jobs.
+5. **Two-session execution with a hard pause after PR #99 is updated** — context gets
+   cleared and the SAM-side session restarts with Playwright available for browser smoke
+   testing. The restart handoff is a committed doc in the SAM repo (house convention).
+6. **Claude runs the test suites directly this time** (both repos) — pytest execution is
+   explicitly authorized for this work.
+
+## Execution phasing — two sessions, hard pause between
+
+### Session 1 (this session): plugin side + handoff
+1. In `/Users/benkirk/codes/hpc-usage-queries/devel` (branch `jobs_plugin_search_drilldown`
+   already checked out): implement plugin Commits 0–3 below; run
+   `pytest job_history/tests/` after each commit; run the timed end-to-end measurements
+   against local dev PG and write the figures into docstrings + plan doc.
+2. Push the branch (updates PR #99). Do NOT merge — Ben reviews.
+3. In SAM: write and commit `docs/plans/JOB_HISTORY_DASHBOARD.md` on `job_history_expansion`
+   as the restart/handoff doc. It must be self-sufficient for a fresh session: the full
+   SAM commit series (§SAM-side plan below), the **as-landed** plugin contract (actual
+   signatures + return shapes + the pinned branch-tip sha), the route/template/cache/chart
+   inventories, RBAC matrix, test inventory, Playwright smoke checklist, and "how to
+   resume" preamble (branch names, rebuild commands, `make print-env-hash`).
+4. Update the session memory (project memory pointing at the handoff doc + in-flight
+   state), report the PR #99 tip sha to Ben, and STOP.
+
+### Between sessions (Ben)
+- Review/approve the updated PR #99 (merge can wait — local dev pins the sha).
+- Rebuild local containers + env against the tip:
+  `HPC_USAGE_QUERIES_REF=<sha> docker compose build webdev` and
+  `HPC_USAGE_QUERIES_REF=<sha> source etc/config_env.sh`.
+- Restart Claude with cleared context + Playwright; point it at
+  `docs/plans/JOB_HISTORY_DASHBOARD.md`.
+
+### Session 2 (fresh context + Playwright): SAM side
+- Execute SAM Commits 1–8 from the handoff doc; run pytest directly after each commit
+  (`tests/unit/test_webapp_jobs*.py` etc., full `pytest` before the PR).
+- Browser verification via Playwright against webdev (:5050) using Quick Login personas:
+  the manual smoke list in §Verification becomes a scripted walk (card tabs lazy-load,
+  pie wedge → row expand, pills re-fetch, explorer deep links, RBAC visibility for
+  operator vs plain user, My Jobs `?user=` pinning).
+- Open the SAM PR to staging; plugin PR #99 merges first, SAM PR after.
 
 ## Cross-repo coordination
 
@@ -208,9 +247,10 @@ NOT in the route-map parity snapshot — only the two new page routes
 - Tests: client-supplied `?user=` ignored in all user fragments; 404 when no machines
 
 ### Commit 8 — docs
-- New `docs/plans/JOB_HISTORY_DASHBOARD.md` (context, mode/permission matrix, route table,
-  cache design, assumed plugin contract, deferred follow-ups: facet chips, By-Project
-  user-mode tab, clickable histogram bars); `src/webapp/README.md` jobs/ line update
+- `docs/plans/JOB_HISTORY_DASHBOARD.md` (created in Session 1 as the handoff doc): update
+  to as-built status — final route table, any contract drift, deferred follow-ups (facet
+  chips, By-Project user-mode tab, clickable histogram bars); `src/webapp/README.md`
+  jobs/ line update
 
 ### Route table (new)
 
@@ -229,9 +269,9 @@ NOT in the route-map parity snapshot — only the two new page routes
    `HPC_USAGE_QUERIES_REF=<sha> source etc/config_env.sh`; `make print-env-hash` to confirm)
 2. `pytest tests/unit/test_webapp_jobs.py tests/unit/test_webapp_jobs_cache.py
    tests/unit/test_webapp_jobs_charts.py tests/unit/test_webapp_disk_scans.py
-   tests/unit/test_rbac.py tests/unit/test_route_map_parity.py`, then full `pytest`
-   (Ben runs the suite by hand)
-3. Manual smoke on webdev (:5050): HPC resource-details → Job History card (4 tabs lazy-load,
+   tests/unit/test_rbac.py tests/unit/test_route_map_parity.py`, then full `pytest` —
+   run by Claude directly (authorized for this work; mysql-test container on :3307)
+3. Playwright smoke on webdev (:5050): HPC resource-details → Job History card (5 tabs lazy-load,
    pie wedge expands user row, pills re-fetch, Open Full View lands filtered); explorer
    `?scope=` re-roots; `/status/job-history` per-machine pills + hidden for non-operators
    (Quick Login); `/user/jobs` shows own jobs only, `?user=other` ignored; Admin →

--- a/docs/plans/JOB_HISTORY_DRILLDOWN.md
+++ b/docs/plans/JOB_HISTORY_DRILLDOWN.md
@@ -1,5 +1,10 @@
 # Job History Dashboard — bring job history to fs_scans feature parity
 
+> **Execution note (2026-07-26):** Session 1 (plugin side) is complete — PR #99
+> tip is `24a35ed`. The live session-2 brief, including the **as-landed** plugin
+> contract and measured costs, is [`JOB_HISTORY_DASHBOARD.md`](JOB_HISTORY_DASHBOARD.md);
+> execute from there. This file is the approved plan of record.
+
 ## Context
 
 SAM's disk-scans (fs_scans plugin) feature set — tabbed resource-details card, standalone

--- a/src/cli/accounting/commands.py
+++ b/src/cli/accounting/commands.py
@@ -1785,7 +1785,7 @@ DEFAULT_RECENT_JOBS = 50
 # plus the four the GPU/CPU classifier needs (cpu/gpu hours + charges). We
 # deliberately never request memory columns — we track but don't bill memory.
 JOB_COLUMNS = (
-    'job_id', 'account', 'user', 'queue', 'qos', 'qos_factor', 'status',
+    'job_id', 'account', 'user', 'queue', 'qos', 'qos_factor', 'exit_status',
     'submit', 'start', 'end', 'elapsed', 'walltime',
     'numnodes', 'numcpus', 'numgpus', 'cputype', 'gputype',
     'cpu_hours', 'gpu_hours', 'cpu_charges', 'gpu_charges',

--- a/src/cli/accounting/display.py
+++ b/src/cli/accounting/display.py
@@ -280,7 +280,7 @@ def display_jobs_table(ctx: Context, rows: list, start_date, end_date, *,
             ("QoS",      "left",  "white", lambda r: r.get('qos') or ''),
             ("Factor",   "right", "dim",   lambda r: _fmt_factor(r.get('qos_factor'))),
             ("Queue",    "left",  "white", lambda r: r.get('queue') or ''),
-            ("Status",   "left",  "dim",   lambda r: str(r.get('status') or '')),
+            ("Exit",     "left",  "dim",   lambda r: str(r.get('exit_status') or '')),
         ]
 
     table = Table(

--- a/src/cli/cmds/admin.py
+++ b/src/cli/cmds/admin.py
@@ -516,7 +516,7 @@ def accounting(ctx: Context, comp, disk, archive, reconcile_quotas, resource,
 @cli.command()
 @click.option('--refresh', is_flag=True,
               help='Invalidate the running webapp\'s caches')
-@click.option('--category', type=click.Choice(['flask', 'chart', 'usage', 'scans']),
+@click.option('--category', type=click.Choice(['flask', 'chart', 'usage', 'scans', 'jobs']),
               default=None,
               help='Scope the refresh to one cache category (default: all)')
 @click.option('--base', 'base_url', type=str, default=None,

--- a/src/webapp/README.md
+++ b/src/webapp/README.md
@@ -92,7 +92,9 @@ src/webapp/
 │   ├── charts.py               # Matplotlib SVG chart generators
 │   └── project_members.py      # Project-member management
 ├── disk_scans/                 # Filesystem-scan views (hpc-usage-queries plugin)
-├── jobs/                       # Job-history views (hpc-usage-queries plugin)
+├── jobs/                       # Job-history views (hpc-usage-queries plugin):
+│                               #   5-tab card (project/machine/user modes),
+│                               #   explorer, TTL cache (routes/service/cache)
 ├── limiter/                    # Rate-limiting facade (mirrors caching/)
 ├── utils/                      # rbac, htmx helpers, nav registry, csp, …
 ├── static/                     # Vendored Bootstrap 5 / htmx / FontAwesome + app JS/CSS

--- a/src/webapp/api/v1/admin.py
+++ b/src/webapp/api/v1/admin.py
@@ -33,7 +33,7 @@ bp = Blueprint('api_admin', __name__)
 register_error_handlers(bp)
 
 # Categories understood by caching.clear(); None (omitted) clears all.
-_VALID_CATEGORIES = {'flask', 'chart', 'usage', 'scans'}
+_VALID_CATEGORIES = {'flask', 'chart', 'usage', 'scans', 'jobs'}
 
 
 @bp.route('/cache/refresh', methods=['POST'])

--- a/src/webapp/caching/__init__.py
+++ b/src/webapp/caching/__init__.py
@@ -119,8 +119,8 @@ class Caching:
 
         Order: flask first, then chart caches in registration order, then
         the usage cache (if enabled), then the two fs-scans buckets (default,
-        filtered). Stable across processes since registration order is
-        deterministic.
+        filtered), then the two jobs buckets (historical, recent). Stable
+        across processes since registration order is deterministic.
         """
         out: List[CacheBase] = [self._flask_adapter, *self._chart_caches]
         try:
@@ -140,6 +140,17 @@ class Caching:
                     out.append(scans)
         except Exception:
             pass
+        try:
+            from webapp.jobs.cache import (
+                _BUCKETS as _JOBS_BUCKETS,
+                get_cache_adapter as get_jobs_adapter,
+            )
+            for bucket in _JOBS_BUCKETS:
+                jobs = get_jobs_adapter(bucket)
+                if jobs:
+                    out.append(jobs)
+        except Exception:
+            pass
         return out
 
     def stats(self) -> dict:
@@ -147,6 +158,7 @@ class Caching:
         from flask import current_app
         from sam.queries.usage_cache import usage_cache_info
         from webapp.disk_scans.cache import fs_scans_cache_info
+        from webapp.jobs.cache import jobs_cache_info
 
         return {
             'backend':         current_app.config.get('CACHE_TYPE'),
@@ -155,6 +167,7 @@ class Caching:
             'chart':           [c.info() for c in self._chart_caches],
             'usage':           usage_cache_info(),
             'scans':           fs_scans_cache_info(),
+            'jobs':            jobs_cache_info(),
         }
 
     def clear(self, category: Optional[str] = None) -> dict:
@@ -170,6 +183,9 @@ class Caching:
         if category in (None, 'scans'):
             from webapp.disk_scans.cache import purge_fs_scans_cache
             result['scans'] = purge_fs_scans_cache()
+        if category in (None, 'jobs'):
+            from webapp.jobs.cache import purge_jobs_cache
+            result['jobs'] = purge_jobs_cache()
         return result
 
 

--- a/src/webapp/config.py
+++ b/src/webapp/config.py
@@ -145,6 +145,17 @@ class SAMWebappConfig(SAMConfig):
         'pool_recycle':   int(os.getenv('JOB_HISTORY_POOL_RECYCLE',  600)),
     }
 
+    # Server-side Postgres statement_timeout (ms) applied to every
+    # job-history connection. Mirrors FS_SCAN_STATEMENT_TIMEOUT_MS: a
+    # runaway machine-wide aggregation can otherwise hold a PG connection
+    # (and a gthread thread) until the gunicorn worker timeout kills it;
+    # this caps the query server-side so it fails cleanly first. Measured
+    # warm month-window aggregations are ~0.6 s; an unbounded window is
+    # ~200 s — cap comfortably below gunicorn `timeout` (120 s). 0 disables.
+    JOB_HISTORY_STATEMENT_TIMEOUT_MS = int(
+        os.getenv('JOB_HISTORY_STATEMENT_TIMEOUT_MS', '60000')
+    )
+
     # fs-scans plugin (filesystem-scan analytics over the CNPG backend).
     # Master switch only — the plugin reads its own connection settings
     # (FS_SCAN_DB_BACKEND, FS_SCAN_PG_*) from the environment. Collections

--- a/src/webapp/dashboards/admin/configuration_routes.py
+++ b/src/webapp/dashboards/admin/configuration_routes.py
@@ -28,7 +28,7 @@ from .blueprint import bp
 
 # Categories accepted by caching.clear(); mirrors the JSON API's set
 # (webapp.api.v1.admin). None (omitted) clears everything.
-_VALID_CACHE_CATEGORIES = {'flask', 'chart', 'usage', 'scans'}
+_VALID_CACHE_CATEGORIES = {'flask', 'chart', 'usage', 'scans', 'jobs'}
 
 
 @bp.route('/htmx/configuration', methods=['GET'])

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -1162,6 +1162,174 @@ def generate_disk_entity_pie_chart(entity_data: List[Dict], kind: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Job-history charts (jobs card: Wait Times / Job Sizes / Durations + By User)
+#
+# Inputs are the hpc-usage-queries plugin envelopes verbatim (see
+# webapp.jobs.service.jobs_histogram / jobs_usage_by_user) — the histogram
+# envelope is self-describing (dimension, unit, full zero-filled bucket
+# vector, null_count), so these renderers never hardcode bucket tables.
+# ---------------------------------------------------------------------------
+
+# UI metric name → plugin bucket/row key. 'jobs' is the count metric; the
+# hours metrics come from the LEFT OUTER JOIN against job_charges upstream.
+_JOBS_METRIC_KEYS = {
+    'jobs':      'job_count',
+    'cpu_hours': 'cpu_hours',
+    'gpu_hours': 'gpu_hours',
+}
+_JOBS_METRIC_LABELS = {
+    'jobs':      'Jobs',
+    'cpu_hours': 'CPU-hours',
+    'gpu_hours': 'GPU-hours',
+}
+
+
+def _jobs_histogram_cache_key(hist, *, metric='jobs'):
+    """Hash exactly what the SVG depends on: the bucket labels, the chosen
+    metric's values, the dimension, and null_count (not the full envelope —
+    e.g. min_param/max_param don't affect the rendering)."""
+    key = _JOBS_METRIC_KEYS.get(metric, 'job_count')
+    buckets = (hist or {}).get('buckets') or []
+    payload = [(b.get('label'), float(b.get(key) or 0)) for b in buckets]
+    return _content_hash([
+        payload, str((hist or {}).get('dimension', '')),
+        int((hist or {}).get('null_count') or 0), str(metric),
+    ])
+
+
+@caching.chart_cached(name='jobs_histogram', maxsize=128,
+                      key_fn=_jobs_histogram_cache_key)
+def generate_jobs_histogram(hist, *, metric='jobs') -> str:
+    """Single-series bar chart over a jobs_histogram envelope.
+
+    Shared by the Wait Times, Job Sizes, and Durations tabs — the envelope's
+    bucket vector is already complete and ordered (zeros included), so the
+    x-axis is stable across filter changes.
+
+    Args:
+        hist: plugin envelope — ``{'dimension', 'buckets':
+            [{'label','lo','hi','job_count','cpu_hours','gpu_hours'}, …],
+            'null_count', 'total_count', …}``.
+        metric: ``'jobs'`` (bucket job counts), ``'cpu_hours'`` or
+            ``'gpu_hours'`` (charged hours per bucket).
+
+    Returns a "no jobs" placeholder div when every bucket is zero.
+    """
+    buckets = (hist or {}).get('buckets') or []
+    if not buckets:
+        return _empty_state('No jobs in this range')
+
+    key = _JOBS_METRIC_KEYS.get(metric, 'job_count')
+    labels = [b.get('label', '') for b in buckets]
+    vals = [float(b.get(key) or 0) for b in buckets]
+    if not any(vals):
+        return _empty_state('No jobs in this range')
+
+    fig, ax = plt.subplots(figsize=(14, 5))
+    ax.bar(range(len(labels)), vals,
+           color=UNITY_PALETTE_10[0],
+           edgecolor=UNITY_NCAR_NAVY, linewidth=0.5)
+    ax.set_xticks(range(len(labels)))
+    ax.set_xticklabels(labels, rotation=30, ha='right')
+    ax.set_ylabel(_JOBS_METRIC_LABELS.get(metric, 'Jobs'))
+    ax.yaxis.set_major_formatter(fmt.mpl_number_formatter())
+    ax.grid(True, axis='y', alpha=0.3)
+
+    return _fig_to_svg(fig)
+
+
+def _jobs_user_pie_cache_key(entity_data, metric='cpu_hours'):
+    key = _JOBS_METRIC_KEYS.get(metric, 'cpu_hours')
+    rows = (entity_data or {}).get('rows') or []
+    totals = (entity_data or {}).get('totals') or {}
+    payload = [(r.get('value'), float(r.get(key) or 0)) for r in rows]
+    return _content_hash([payload, float(totals.get(key) or 0), str(metric)])
+
+
+@caching.chart_cached(name='jobs_user_pie_chart', maxsize=64,
+                      key_fn=_jobs_user_pie_cache_key)
+def generate_jobs_user_pie_chart(entity_data, metric='cpu_hours') -> str:
+    """Pie of per-user usage from a jobs_usage_by('user') envelope.
+
+    Args:
+        entity_data: plugin envelope — ``{'rows': [{'value': username,
+            'job_count', 'cpu_hours', 'gpu_hours'}, …], 'totals': {…}}``.
+            ``totals`` is computed upstream BEFORE any limit truncation.
+        metric: ``'jobs'``, ``'cpu_hours'`` (default) or ``'gpu_hours'``.
+
+    The largest users up to a ~90% cumulative share (9 max) get named
+    slices; everything else — both beyond-cap rows AND the upstream
+    limit's remainder — folds into one inert "Other" slice sized
+    ``totals − Σ kept``, so the pie always sums to the true total.
+    Kept wedges + legend entries carry ``#job-user-<username>``
+    sentinels routed by svg-chart-links.js to the matching
+    ``data-job-user`` table row.
+    """
+    rows = (entity_data or {}).get('rows') or []
+    totals = (entity_data or {}).get('totals') or {}
+    key = _JOBS_METRIC_KEYS.get(metric, 'cpu_hours')
+
+    total = float(totals.get(key) or 0)
+    if not rows or total <= 0:
+        return _empty_state('No usage data available')
+
+    # Upstream sorts by combined hours; re-sort by the *chosen* metric so
+    # e.g. the Jobs view leads with the most job-count-heavy users.
+    data = sorted(rows, key=lambda r: float(r.get(key) or 0), reverse=True)
+    values_desc = [float(r.get(key) or 0) for r in data]
+    keep = _pie_cumulative_keep(values_desc)
+
+    names = [r.get('value') for r in data[:keep]]
+    labels = [n if n is not None else '(unknown)' for n in names]
+    values = list(values_desc[:keep])
+    colors = list(UNITY_PALETTE_10[:keep])
+
+    remainder = total - sum(values)
+    if remainder > 1e-9:
+        names.append(None)                     # inert slice — no set_url
+        labels.append('Other')
+        values.append(remainder)
+        colors.append(UNITY_NCAR_GRAY_LIGHT)
+
+    legend_labels = [f'{n} ({fmt.number(v)})' for n, v in zip(labels, values)]
+
+    fig, ax = plt.subplots(figsize=(7, 4))
+    wedges, _texts, autotexts = ax.pie(
+        values,
+        labels=None,
+        autopct=lambda p: fmt.pct(p, decimals=1) if p >= 5 else '',
+        startangle=_PIE_START_ANGLE,
+        counterclock=False,
+        colors=colors,
+        pctdistance=0.85,
+    )
+    for at, wedge_color in zip(autotexts, colors):
+        at.set_color(_autopct_color_for(wedge_color))
+        at.set_fontweight('bold')
+        at.set_fontsize(8)
+
+    legend = ax.legend(wedges, legend_labels, loc='center left',
+                       bbox_to_anchor=(1.0, 0.5), fontsize=9)
+
+    # Clickable wedges + legend entries → expand the matching table row.
+    # Skip "Other" and unnamed rows (name is None). svg-chart-links.js
+    # intercepts these, scoped to the originating tab pane.
+    leg_patches = legend.get_patches()
+    leg_texts = legend.get_texts()
+    for i, uname in enumerate(names):
+        if uname is None:
+            continue
+        url = f'#job-user-{uname}'
+        wedges[i].set_url(url)
+        if i < len(leg_patches):
+            leg_patches[i].set_url(url)
+        if i < len(leg_texts):
+            leg_texts[i].set_url(url)
+
+    return _fig_to_svg(fig)
+
+
+# ---------------------------------------------------------------------------
 # 6. Allocation pace chart (allocations dashboard)
 #
 # Stacked-area chart where each allocation is one band with a step at

--- a/src/webapp/dashboards/status/blueprint.py
+++ b/src/webapp/dashboards/status/blueprint.py
@@ -20,6 +20,7 @@ from ..charts import (
 
 from system_status import queries as status_queries
 from webapp.disk_scans import service as disk_scans_service
+from webapp.jobs import service as jobs_service
 
 bp = Blueprint('status_dashboard', __name__, url_prefix='/status')
 logger = logging.getLogger(__name__)
@@ -80,6 +81,10 @@ def _page_context(session):
         # in-template on VIEW_ALL_FILESYSTEM_DATA. has_permission/Permission are
         # template globals (rbac_context_processor).
         fs_scan_resources=disk_scans_service.scan_capable_resources(),
+        # Plugin machines for the gated "Job History" tab — same pattern:
+        # empty (→ tab hidden) when the hpc-usage-queries plugin is off;
+        # visibility additionally gated in-template on VIEW_ALL_JOB_DATA.
+        job_history_machines=jobs_service.job_history_machines(),
     )
 
 
@@ -207,6 +212,22 @@ def filesystem_scans():
     """Filesystem scan summaries page (staff only)."""
     return render_template(
         'dashboards/status/filesystem_scans_page.html',
+        **_page_context(db.session),
+    )
+
+
+@bp.route('/job-history')
+@login_required
+@require_permission(Permission.VIEW_ALL_JOB_DATA)
+def job_history():
+    """Machine-wide job-history page (staff only).
+
+    One subtab per plugin machine, each hosting the jobs card in machine
+    mode — the card's fragment routes are themselves VIEW_ALL_JOB_DATA-
+    gated, so this page gate is the first line, not the only one.
+    """
+    return render_template(
+        'dashboards/status/job_history_page.html',
         **_page_context(db.session),
     )
 

--- a/src/webapp/dashboards/status/blueprint.py
+++ b/src/webapp/dashboards/status/blueprint.py
@@ -225,9 +225,16 @@ def job_history():
     One subtab per plugin machine, each hosting the jobs card in machine
     mode — the card's fragment routes are themselves VIEW_ALL_JOB_DATA-
     gated, so this page gate is the first line, not the only one.
+
+    ``jobs_window_start`` bounds every card tab to the last 90 days by
+    default: an unbounded machine-wide aggregation measures ~200 s
+    against the plugin PG vs ~0.6 s per month-window. The explorer's
+    date fields let an operator widen deliberately.
     """
+    from datetime import date as _date
     return render_template(
         'dashboards/status/job_history_page.html',
+        jobs_window_start=(_date.today() - timedelta(days=90)).isoformat(),
         **_page_context(db.session),
     )
 

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -613,14 +613,8 @@ def resource_details(project):
 
     # Per-job drill-down (hpc-usage-queries) is keyed on the physical
     # machine, not the SAM resource_name — Derecho GPU jobs still live in
-    # the "derecho" DB. None disables the "Show jobs" affordance.
-    rn = (resource_name or '').lower()
-    if 'derecho' in rn:
-        jobs_machine = 'derecho'
-    elif 'casper' in rn:
-        jobs_machine = 'casper'
-    else:
-        jobs_machine = None
+    # the "derecho" DB. None disables the jobs card + "Show jobs" affordance.
+    jobs_machine = _resolve_jobs_machine(resource_name)
 
     return render_template(
         'dashboards/user/resource_details.html',

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -63,6 +63,7 @@ from ..charts import (
 )
 from webapp.disk_scans import is_enabled as is_fs_scans_enabled
 from webapp.disk_scans import service as disk_scans_service
+from webapp.jobs import service as jobs_service
 
 
 bp = Blueprint('user_dashboard', __name__, url_prefix='/user')
@@ -98,11 +99,17 @@ def _page_context():
         getattr(user_to_display, 'unix_uid', None) is not None
         and fs_scan_resources
     )
+    # My Jobs mirrors My Data: available to every authenticated user (the
+    # job routes pin user=<session user> server-side), hidden only when
+    # the hpc-usage-queries plugin is off / no machine engine is warmed.
+    job_history_machines = jobs_service.job_history_machines()
     return dict(
         user=user_to_display,
         impersonator_id=session.get('impersonator_id'),
         my_data_available=my_data_available,
         fs_scan_resources=fs_scan_resources,
+        my_jobs_available=bool(job_history_machines),
+        job_history_machines=job_history_machines,
     )
 
 
@@ -160,6 +167,16 @@ def my_data():
     if not ctx['my_data_available']:
         abort(404)
     return render_template('dashboards/user/my_data.html', **ctx)
+
+
+@bp.route('/jobs')
+@login_required
+def my_jobs():
+    """My Jobs page — per-user job-history cards (one pill per machine)."""
+    ctx = _page_context()
+    if not ctx['my_jobs_available']:
+        abort(404)
+    return render_template('dashboards/user/my_jobs.html', **ctx)
 
 
 # ---------------------------------------------------------------------------

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -172,11 +172,21 @@ def my_data():
 @bp.route('/jobs')
 @login_required
 def my_jobs():
-    """My Jobs page — per-user job-history cards (one pill per machine)."""
+    """My Jobs page — per-user job-history cards (one pill per machine).
+
+    ``jobs_window_start`` bounds every card tab to the last 90 days by
+    default — unbounded plugin aggregations are the expensive path; the
+    explorer's date fields widen deliberately.
+    """
     ctx = _page_context()
     if not ctx['my_jobs_available']:
         abort(404)
-    return render_template('dashboards/user/my_jobs.html', **ctx)
+    from datetime import date as _date
+    return render_template(
+        'dashboards/user/my_jobs.html',
+        jobs_window_start=(_date.today() - timedelta(days=90)).isoformat(),
+        **ctx,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/webapp/jobs/cache.py
+++ b/src/webapp/jobs/cache.py
@@ -119,8 +119,15 @@ def get_cache_adapter(bucket: str = 'historical') -> Optional[CacheBase]:
             try:
                 client = make_redis_client(redis_url)
                 if client is not None:
+                    # prefix=<name>: — RedisTTLAdapter namespaces keys (and
+                    # clear()/info() scans) by prefix, NOT by name. The two
+                    # jobs buckets can legitimately hold the same key with
+                    # different TTL policies, so each needs its own keyspace
+                    # or the recent bucket's 15-min entries would satisfy
+                    # historical lookups (and vice versa) on shared Redis.
                     adapter = RedisTTLAdapter(
                         name=name, client=client, ttl=ttl, maxsize=size,
+                        prefix=f'{name}:',
                     )
                     _adapters[bucket] = adapter
                     return adapter

--- a/src/webapp/jobs/cache.py
+++ b/src/webapp/jobs/cache.py
@@ -1,0 +1,222 @@
+"""TTL cache for the job-history aggregation queries.
+
+Unlike fs-scans (weekly refreshes → content-addressed scan-date keys),
+job data appends continuously — there is no freshness signature to key
+on, so this is a plain TTL cache. Two buckets share the mechanism,
+picked by whether the requested window can still change:
+
+  * ``historical`` (``jobs``) — the window's ``end`` date is strictly
+    before today, so its aggregation is immutable (late ingest aside).
+    Long TTL, larger LRU.
+  * ``recent`` (``jobs_recent``) — the window touches today (or has no
+    end bound), so new jobs keep landing in it. Short TTL keeps the
+    staleness window at ~15 minutes.
+
+Only the aggregations (histograms, usage-by rollups) go through here —
+they cost ~0.5-0.6 s warm per month-window against the plugin PG and
+back every card tab. Paged search + counts stay uncached: they're
+cheaper, highly parameterized, and users expect row-level freshness.
+
+Backend mirrors ``disk_scans/cache.py`` / ``sam.queries.usage_cache``:
+Redis-backed adapter shared across gunicorn workers when
+``CACHE_REDIS_URL`` is set, per-worker in-process TTL cache otherwise.
+Registered with the ``webapp.caching`` facade (category ``jobs``) so it
+appears in Admin → Configuration and clears via the same surfaces.
+
+Config (Flask app.config or env; 0 disables the corresponding bucket):
+  JOBS_CACHE_TTL          — historical TTL seconds (default 21600 = 6 h)
+  JOBS_CACHE_SIZE         — historical max LRU entries (default 256)
+  JOBS_RECENT_CACHE_TTL   — recent TTL seconds (default 900 = 15 min)
+  JOBS_RECENT_CACHE_SIZE  — recent max LRU entries (default 128)
+
+Key shape (hashable tuple):
+  (query_type, machine, sorted(normalized opts))
+``opts`` carries every parameter that shapes the result — the flat
+filter set plus dimension/limit — normalized so dates and lists hash
+stably.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from datetime import date
+from typing import Any, Callable, Dict, List, Optional
+
+from sam.caching import CacheBase, RedisTTLAdapter, TTLCacheAdapter, make_redis_client
+from sam.caching.ttl import disabled_info
+
+logger = logging.getLogger(__name__)
+
+
+def _get_config(key: str, default: int) -> int:
+    """Read config from Flask app context if available, else env, else default."""
+    try:
+        from flask import current_app
+        return int(current_app.config.get(key, default))
+    except RuntimeError:
+        return int(os.environ.get(key, default))
+
+
+def _norm(value: Any):
+    """Make list/date values hashable + stable for use as a key component."""
+    if isinstance(value, (list, tuple, set)):
+        return tuple(sorted(str(v) for v in value))
+    if hasattr(value, 'isoformat'):
+        return value.isoformat()
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Lazy-initialised adapters (Redis shared / in-process fallback), one per bucket
+# ---------------------------------------------------------------------------
+
+# Bucket specs: name shown in the Admin card + the (config_key, default) pairs
+# for TTL and size. Both buckets use the same backend, differing only here.
+_BUCKETS: Dict[str, Dict[str, Any]] = {
+    'historical': {
+        'name': 'jobs',
+        'ttl':  ('JOBS_CACHE_TTL', 21600),   # 6 hours
+        'size': ('JOBS_CACHE_SIZE', 256),
+    },
+    'recent': {
+        'name': 'jobs_recent',
+        'ttl':  ('JOBS_RECENT_CACHE_TTL', 900),   # 15 minutes
+        'size': ('JOBS_RECENT_CACHE_SIZE', 128),
+    },
+}
+
+# bucket -> adapter once initialised; a stored ``None`` means "initialised but
+# disabled by config" (so we don't re-probe on every call).
+_adapters: Dict[str, Optional[CacheBase]] = {}
+_init_lock = threading.RLock()
+
+
+def get_cache_adapter(bucket: str = 'historical') -> Optional[CacheBase]:
+    """Return the shared CacheBase adapter for *bucket*, init on first call.
+
+    Returns ``None`` when that bucket is disabled by config (TTL or SIZE == 0).
+    Backend mirrors ``disk_scans/cache.py``: ``RedisTTLAdapter`` when
+    ``CACHE_REDIS_URL`` is reachable (all workers share one cache), else a
+    per-worker ``TTLCacheAdapter``.
+    """
+    spec = _BUCKETS[bucket]
+
+    with _init_lock:
+        if bucket in _adapters:
+            return _adapters[bucket]
+
+        ttl  = _get_config(*spec['ttl'])
+        size = _get_config(*spec['size'])
+        if ttl <= 0 or size <= 0:
+            _adapters[bucket] = None
+            return None
+
+        name = spec['name']
+        redis_url = os.environ.get('CACHE_REDIS_URL')
+        if redis_url:
+            try:
+                client = make_redis_client(redis_url)
+                if client is not None:
+                    adapter = RedisTTLAdapter(
+                        name=name, client=client, ttl=ttl, maxsize=size,
+                    )
+                    _adapters[bucket] = adapter
+                    return adapter
+            except Exception as exc:
+                logger.warning(
+                    "jobs cache: CACHE_REDIS_URL=%s set but unreachable (%s); "
+                    "falling back to per-worker TTLCacheAdapter.",
+                    redis_url, exc,
+                )
+
+        adapter = TTLCacheAdapter(name=name, maxsize=size, ttl=ttl)
+        _adapters[bucket] = adapter
+        return adapter
+
+
+def bucket_for_window(end: Optional[date]) -> str:
+    """Pick the cache bucket for a query window ending at *end*.
+
+    ``historical`` only when the window is provably closed: an explicit
+    ``end`` strictly before today. An open end (None) or a window that
+    touches today keeps collecting jobs → ``recent``.
+    """
+    if end is not None and end < date.today():
+        return 'historical'
+    return 'recent'
+
+
+def cached_jobs_aggregation(
+    query_type: str,
+    machine: str,
+    opts: Dict[str, Any],
+    compute: Callable[[], Any],
+    bucket: str,
+) -> Any:
+    """Return a cached aggregation result or compute + store it.
+
+    *compute* must produce the FINAL caller-facing result (the plugin's
+    self-describing envelope), so a cache hit reproduces it exactly
+    without re-querying. *opts* must carry every parameter that shapes
+    the result — the caller passes the exact plugin kwargs plus any
+    SAM-side knobs (dimension, limit).
+    """
+    adapter = get_cache_adapter(bucket)
+    if adapter is None:
+        return compute()
+
+    key = (
+        query_type,
+        machine,
+        tuple(sorted((k, _norm(v)) for k, v in opts.items())),
+    )
+
+    with adapter.lock:
+        if key in adapter:
+            return adapter[key]
+        adapter.pop(key, None)
+
+    result = compute()
+
+    with adapter.lock:
+        try:
+            adapter[key] = result
+        except ValueError:
+            # Cache full and no expired entries to evict — skip the store.
+            pass
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Admin / facade hooks
+# ---------------------------------------------------------------------------
+
+def purge_jobs_cache() -> int:
+    """Clear every jobs-cache bucket. Returns the total entries cleared."""
+    total = 0
+    for bucket in _BUCKETS:
+        adapter = get_cache_adapter(bucket)
+        if adapter is not None:
+            total += adapter.clear()
+    return total
+
+
+def jobs_cache_info() -> List[Dict]:
+    """One uniform CacheBase ``info()`` dict per bucket, for the Admin card.
+
+    Returns a list (historical bucket first) so the Configuration card can
+    loop and surface each bucket's TTL — making the 15-min recent TTL
+    visible alongside the 6-hour historical one.
+    """
+    infos: List[Dict] = []
+    for bucket, spec in _BUCKETS.items():
+        adapter = get_cache_adapter(bucket)
+        if adapter is None:
+            ttl  = _get_config(*spec['ttl'])
+            size = _get_config(*spec['size'])
+            infos.append(disabled_info(spec['name'], maxsize=size, ttl=ttl))
+        else:
+            infos.append(adapter.info())
+    return infos

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -740,9 +740,18 @@ def _panel_filters(machine: str) -> dict:
     """Raw (display-unit) filter values for the explorer's sidebar panel."""
     username, user_id, user_label = _resolve_user_filter()
     per_page = _parse_pagination()['per_page']
+    start = (request.args.get('start') or '').strip()
+    end = (request.args.get('end') or '').strip()
+    if not start and not end:
+        # Unbounded windows are the expensive path (~200 s machine-wide
+        # vs ~0.6 s per month) — default the explorer to the last 90
+        # days. The field is visible in the panel; clearing it opts into
+        # the full history explicitly.
+        from datetime import timedelta
+        start = (date.today() - timedelta(days=90)).isoformat()
     return {
-        'start': (request.args.get('start') or '').strip(),
-        'end':   (request.args.get('end') or '').strip(),
+        'start': start,
+        'end':   end,
         'user': username or '',
         'user_id': user_id or '',
         'user_label': user_label,

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -44,13 +44,17 @@ from typing import Optional
 from flask import Blueprint, abort, render_template, request, url_for
 from flask_login import login_required
 
+from sam.core.users import User
+from sam.projects.projects import Project
 from webapp.api.access_control import require_project_access
 from webapp.dashboards.charts import (
     generate_jobs_histogram,
     generate_jobs_user_pie_chart,
 )
+from webapp.extensions import db
 from webapp.jobs import service
 from webapp.jobs.session import is_enabled
+from webapp.utils.rbac import Permission, require_permission
 
 bp = Blueprint('jobs', __name__)
 
@@ -154,37 +158,73 @@ def _visible_cols(default_cols, rows):
     ]
 
 
-@bp.route('/<projcode>')
-@login_required
-@require_project_access
-def jobs_fragment(project):
-    """HTMX fragment: per-job table for *project* on the requested machine."""
-    if not is_enabled():
-        # Render the partial in disabled mode rather than 404 — the
-        # resource-details page may include the hx-get unconditionally
-        # and we want a graceful "feature not available" cell.
-        return render_template(
-            'dashboards/user/partials/jobs_fragment.html',
-            project=project, machine=None, rows=[],
-            filters={}, page={'n': 1, 'per_page': _DEFAULT_PER_PAGE},
-            sort={'sort_by': None, 'sort_dir': 'desc'},
-            total=None, visible_cols=[], verbose_extras=[],
-            column_specs={},
-            enabled=False, error=None,
-        )
+def _scope_project(project) -> Project:
+    """Resolve the ``?scope=`` child project, or fall back to *project*.
 
-    machine = (request.args.get('machine') or '').strip().lower()
-    if machine not in _VALID_MACHINES:
-        abort(400, f'machine must be one of {sorted(_VALID_MACHINES)}')
+    Mirrors ``disk_scans/routes.py:_scope_project`` — an out-of-tree or
+    unknown scope silently falls back to the root project so a fragment
+    can never escape the project the decorator authorized.
+    """
+    scope = (request.args.get('scope') or '').strip()
+    if not scope or scope == project.projcode:
+        return project
+    candidate = Project.get_by_projcode(db.session, scope)
+    if candidate is None or candidate.tree_root != project.tree_root:
+        return project
+    return candidate
 
+
+def _resolve_user_filter() -> tuple:
+    """(username, user_id, label) from ``?user=`` or the fk-picker's ``?user_id=``.
+
+    The explorer's user picker stores a SAM user_id; the per-job data is
+    keyed by PBS username, so resolve here. A raw ``?user=`` (drill-downs,
+    deep links) wins over the picker.
+    """
+    raw = (request.args.get('user') or '').strip()
+    if raw:
+        return raw, None, raw
+    uid_raw = (request.args.get('user_id') or '').strip()
+    if uid_raw.isdigit():
+        u = db.session.get(User, int(uid_raw))
+        if u is not None:
+            return u.username, int(uid_raw), u.username
+    return None, None, ''
+
+
+def _jobs_table_response(*, mode, machine, fragment_url,
+                         project=None, pinned_user=None):
+    """Shared body of the per-job table fragment across the three modes.
+
+    ``mode`` selects the service family (and with it the scoping rule):
+    'project' pins the account filter to *project*'s tree, 'user' hard-pins
+    ``pinned_user`` (any client-supplied user is ignored), 'machine' is
+    unscoped — its routes are VIEW_ALL_JOB_DATA-gated.
+    """
     filters = {
         'start':  _parse_date(request.args.get('start')),
         'end':    _parse_date(request.args.get('end')),
-        'user':   (request.args.get('user') or '').strip() or None,
         'queue':  (request.args.get('queue') or '').strip() or None,
         'qos':    (request.args.get('qos') or '').strip() or None,
         'exit_status': (request.args.get('exit_status') or '').strip() or None,
+        'name':  (request.args.get('name') or '').strip() or None,
     }
+    if filters['name'] is not None:
+        filters['ignore_case'] = request.args.get('ignore_case') in ('1', 'true', 'on')
+    for key in ('min_nodes', 'max_nodes', 'min_cpus', 'max_cpus',
+                'min_gpus', 'max_gpus'):
+        v = _parse_int_arg(key)
+        if v is not None:
+            filters[key] = v
+    min_wait = _parse_float_arg('min_wait_hours')
+    max_wait = _parse_float_arg('max_wait_hours')
+    if min_wait is not None:
+        filters['min_eligible_secs'] = int(min_wait * _SECS_PER_HOUR)
+    if max_wait is not None:
+        filters['max_eligible_secs'] = int(max_wait * _SECS_PER_HOUR)
+    if pinned_user is None:
+        filters['user'], _uid, _ulabel = _resolve_user_filter()
+
     page = _parse_pagination()
     sort = _parse_sort()
     offset = (page['n'] - 1) * page['per_page']
@@ -193,29 +233,19 @@ def jobs_fragment(project):
     # renders without a second fetch. Plugin still validates each key.
     requested_cols = tuple(_DEFAULT_COLS) + tuple(_VERBOSE_EXTRAS)
 
-    # Expand the project tree so a parent's drill-down rows surface jobs
-    # charged to child projcodes. Mirrors the Historical Usage rollup in
-    # webapp/dashboards/user/blueprint.py — `get_descendants(include_self=True)`
-    # returns just [project] for non-tree projects, so single-project
-    # callers get the same effective filter as before.
-    account_projcodes = [
-        p.projcode for p in project.get_descendants(include_self=True)
-    ]
-
     # QoS options for the filter dropdown — sourced from the plugin's
     # job_qos lookup table so a future seed addition flows through
     # without a SAM-side change. Fetched BEFORE search/count so the
-    # same list can also be threaded into service.search_jobs /
-    # count_jobs as ``valid_qos_names``: this lets the legacy queue
-    # normalizer promote a 'cpu-special' drill-down's suffix to a real
-    # QoS filter (was previously discarded). Degrades to [] if the
-    # plugin call fails or the table is empty.
+    # same list can also be threaded into the service as
+    # ``valid_qos_names``: this lets the legacy queue normalizer promote
+    # a 'cpu-special' drill-down's suffix to a real QoS filter. Degrades
+    # to [] if the plugin call fails or the table is empty.
     try:
         qos_options = service.list_qos_names(machine)
     except Exception:
         from flask import current_app
         current_app.logger.exception(
-            'jobs_fragment: list_qos_names failed for machine=%s', machine,
+            'jobs table: list_qos_names failed for machine=%s', machine,
         )
         qos_options = []
 
@@ -223,29 +253,51 @@ def jobs_fragment(project):
     rows = []
     total: Optional[int] = None
     try:
-        rows = service.search_jobs(
-            machine, project=project,
+        common = dict(
             limit=page['per_page'], offset=offset,
             sort_by=sort['sort_by'], sort_dir=sort['sort_dir'],
             columns=requested_cols,
-            account_projcodes=account_projcodes,
             valid_qos_names=qos_options,
-            **filters,
         )
-        total = service.count_jobs(
-            machine, project=project,
-            account_projcodes=account_projcodes,
-            valid_qos_names=qos_options,
-            **filters,
-        )
+        if mode == 'project':
+            # Expand the (possibly ?scope=-re-rooted) project tree so a
+            # parent's rows surface jobs charged to child projcodes —
+            # mirrors the Historical Usage rollup.
+            account_projcodes = [
+                p.projcode
+                for p in _scope_project(project).get_descendants(include_self=True)
+            ]
+            rows = service.search_jobs(
+                machine, project=project,
+                account_projcodes=account_projcodes, **common, **filters,
+            )
+            total = service.count_jobs(
+                machine, project=project,
+                account_projcodes=account_projcodes,
+                valid_qos_names=qos_options, **filters,
+            )
+        elif mode == 'user':
+            rows = service.search_jobs_user(
+                machine, pinned_user, **common, **filters,
+            )
+            total = service.count_jobs_user(
+                machine, pinned_user, valid_qos_names=qos_options, **filters,
+            )
+        else:
+            rows = service.search_jobs_machine(
+                machine, **common, **filters,
+            )
+            total = service.count_jobs_machine(
+                machine, valid_qos_names=qos_options, **filters,
+            )
     except Exception as exc:
         # Catch-all so a transient plugin/DB issue degrades to a banner
         # rather than a 500 on the surrounding page. App logger captures
         # the full traceback for diagnosis.
         from flask import current_app
         current_app.logger.exception(
-            'jobs_fragment: search/count failed for project=%s machine=%s',
-            project.projcode, machine,
+            'jobs table: search/count failed for mode=%s machine=%s',
+            mode, machine,
         )
         error = str(exc)
 
@@ -285,17 +337,19 @@ def jobs_fragment(project):
             }
 
     column_specs = _load_column_specs()
-    fragment_url = url_for('jobs.jobs_fragment', projcode=project.projcode)
 
     # The caller passes the id of the container that owns this fragment so
     # sort / pagination clicks can swap that same container's innerHTML.
     # Falls back to a generic id when called without one (legacy paths).
+    scope_key = (project.projcode if project is not None
+                 else (pinned_user or 'all'))
     target_id = (request.args.get('target_id') or '').strip() \
-        or f'jobs-{project.projcode}-{machine}'
+        or f'jobs-{scope_key}-{machine}'
 
     return render_template(
         'dashboards/user/partials/jobs_fragment.html',
         project=project,
+        username=pinned_user,
         machine=machine,
         rows=rows,
         filters=filters,
@@ -310,8 +364,42 @@ def jobs_fragment(project):
         qos_badge=qos_badge,
         fragment_url=fragment_url,
         target_id=target_id,
+        roundtrip_params=_roundtrip_params(machine, target_id),
         enabled=True,
         error=error,
+    )
+
+
+def _disabled_jobs_table(project=None, username=None):
+    """The per-job table partial in disabled mode — never a 404, so a host
+    page can hx-get it unconditionally."""
+    return render_template(
+        'dashboards/user/partials/jobs_fragment.html',
+        project=project, username=username, machine=None, rows=[],
+        filters={}, page={'n': 1, 'per_page': _DEFAULT_PER_PAGE},
+        sort={'sort_by': None, 'sort_dir': 'desc'},
+        total=None, visible_cols=[], verbose_extras=[],
+        column_specs={}, roundtrip_params={},
+        enabled=False, error=None,
+    )
+
+
+@bp.route('/<projcode>')
+@login_required
+@require_project_access
+def jobs_fragment(project):
+    """HTMX fragment: per-job table for *project* on the requested machine."""
+    if not is_enabled():
+        return _disabled_jobs_table(project=project)
+
+    machine = (request.args.get('machine') or '').strip().lower()
+    if machine not in _VALID_MACHINES:
+        abort(400, f'machine must be one of {sorted(_VALID_MACHINES)}')
+
+    return _jobs_table_response(
+        mode='project', machine=machine,
+        fragment_url=url_for('jobs.jobs_fragment', projcode=project.projcode),
+        project=project,
     )
 
 
@@ -347,10 +435,11 @@ _BY_USER_LIMIT = 25
 # Filter query params round-tripped through pill/toggle re-fetches, and —
 # where the per-job fragment understands them — carried into row drill-downs.
 _ROUNDTRIP_KEYS = (
-    'start', 'end', 'user', 'queue', 'qos', 'exit_status',
+    'start', 'end', 'user', 'user_id', 'queue', 'qos', 'exit_status',
     'name', 'ignore_case',
     'min_nodes', 'max_nodes', 'min_cpus', 'max_cpus',
     'min_gpus', 'max_gpus', 'min_wait_hours', 'max_wait_hours',
+    'scope',
 )
 
 _SECS_PER_HOUR = 3600
@@ -386,7 +475,7 @@ def _parse_job_filters() -> dict:
     f: dict = {
         'start': _parse_date(request.args.get('start')),
         'end':   _parse_date(request.args.get('end')),
-        'user':  (request.args.get('user') or '').strip() or None,
+        'user':  _resolve_user_filter()[0],
         'queue': (request.args.get('queue') or '').strip() or None,
         'qos':   (request.args.get('qos') or '').strip() or None,
         'exit_status': (request.args.get('exit_status') or '').strip() or None,
@@ -432,8 +521,15 @@ def _parse_metric(default: str) -> str:
 
 
 def _tree_projcodes(project) -> list:
-    """Parent + descendants — same tree expansion as jobs_fragment."""
-    return [p.projcode for p in project.get_descendants(include_self=True)]
+    """(Scoped) parent + descendants — same tree expansion as jobs_fragment.
+
+    Honors ``?scope=`` re-rooting so every card tab and the explorer agree
+    on which slice of the tree they aggregate.
+    """
+    return [
+        p.projcode
+        for p in _scope_project(project).get_descendants(include_self=True)
+    ]
 
 
 def _render_by_user(*, mode, machine, fragment_url, jobs_fragment_url,
@@ -606,3 +702,241 @@ def durations_fragment(project):
     return _project_histogram(project, dimension='duration',
                               dimension_toggle=False,
                               endpoint='jobs.durations_fragment')
+
+
+# ---------------------------------------------------------------------------
+# Explorer full view (project mode) + machine-wide family (operator surfaces)
+# ---------------------------------------------------------------------------
+
+# Row-count choices offered by the explorer's per-page selector.
+_PER_PAGE_OPTIONS = (25, 50, 100, 200)
+
+
+def _machine_or_404(machine: str) -> str:
+    """Validate a path ``<machine>`` against the warmed engines → 404 unknown.
+
+    Dynamic (not the static _VALID_MACHINES): the machine-wide routes only
+    make sense for machines the plugin actually serves right now.
+    """
+    m = (machine or '').strip().lower()
+    if m not in service.job_history_machines():
+        abort(404)
+    return m
+
+
+def _qos_options_safe(machine: str) -> list:
+    """QoS names for the explorer's select; [] on any plugin hiccup."""
+    try:
+        return service.list_qos_names(machine)
+    except Exception:
+        from flask import current_app
+        current_app.logger.exception(
+            'jobs explorer: list_qos_names failed for machine=%s', machine,
+        )
+        return []
+
+
+def _panel_filters(machine: str) -> dict:
+    """Raw (display-unit) filter values for the explorer's sidebar panel."""
+    username, user_id, user_label = _resolve_user_filter()
+    per_page = _parse_pagination()['per_page']
+    return {
+        'start': (request.args.get('start') or '').strip(),
+        'end':   (request.args.get('end') or '').strip(),
+        'user': username or '',
+        'user_id': user_id or '',
+        'user_label': user_label,
+        'queue': (request.args.get('queue') or '').strip(),
+        'qos':   (request.args.get('qos') or '').strip(),
+        'exit_status': (request.args.get('exit_status') or '').strip(),
+        'name':  (request.args.get('name') or '').strip(),
+        'ignore_case': request.args.get('ignore_case') in ('1', 'true', 'on'),
+        'min_nodes': _parse_int_arg('min_nodes'),
+        'max_nodes': _parse_int_arg('max_nodes'),
+        'min_cpus':  _parse_int_arg('min_cpus'),
+        'max_cpus':  _parse_int_arg('max_cpus'),
+        'min_gpus':  _parse_int_arg('min_gpus'),
+        'max_gpus':  _parse_int_arg('max_gpus'),
+        'min_wait_hours': _parse_float_arg('min_wait_hours'),
+        'max_wait_hours': _parse_float_arg('max_wait_hours'),
+        'per_page': per_page,
+        'qos_options': _qos_options_safe(machine),
+    }
+
+
+def _initial_jobs_url(fragment_url: str, machine: str, target_id: str,
+                      panel: dict, scope: Optional[str] = None) -> str:
+    """Fragment URL pre-loaded by the explorer page (carries current filters).
+
+    The page's table container ``hx-get``s this on load so a deep-link /
+    reload lands on the same filtered view the panel shows; subsequent panel
+    submits re-fetch via the form's own fields.
+    """
+    from urllib.parse import urlencode
+    params = {'machine': machine, 'target_id': target_id,
+              'per_page': panel['per_page']}
+    if scope:
+        params['scope'] = scope
+    for key in ('start', 'end', 'queue', 'qos', 'exit_status', 'name'):
+        if panel[key]:
+            params[key] = panel[key]
+    if panel['user']:
+        params['user'] = panel['user']
+    if panel['ignore_case']:
+        params['ignore_case'] = '1'
+    for key in ('min_nodes', 'max_nodes', 'min_cpus', 'max_cpus',
+                'min_gpus', 'max_gpus', 'min_wait_hours', 'max_wait_hours'):
+        if panel[key] is not None:
+            params[key] = panel[key]
+    return f'{fragment_url}?{urlencode(params)}'
+
+
+def _user_search_url() -> str:
+    """The fk-picker search endpoint for the user filter (context='fk')."""
+    return url_for('admin_dashboard.htmx_search_users', context='fk')
+
+
+@bp.route('/<projcode>/explore')
+@login_required
+@require_project_access
+def explore_page(project):
+    """Standalone full-page jobs explorer for *project* (project mode).
+
+    Renders the filter panel + a table container that lazy-loads
+    ``jobs_fragment`` with the panel's params. ``?scope=<child>`` re-roots
+    to a subtree (same-tree validated); the reusable fragment is shared
+    verbatim with the machine/user modes.
+    """
+    if not is_enabled():
+        return render_template(
+            'dashboards/user/jobs_explore_page.html',
+            mode='project', enabled=False, project=project,
+            scoped_project=project, machine=None,
+        )
+    machine = _get_machine_or_400()
+    scoped = _scope_project(project)
+    target_id = 'jobs-explore'
+    fragment_url = url_for('jobs.jobs_fragment', projcode=project.projcode)
+    panel = _panel_filters(machine)
+    scope = scoped.projcode if scoped.projcode != project.projcode else None
+    return render_template(
+        'dashboards/user/jobs_explore_page.html',
+        mode='project', enabled=True,
+        project=project, scoped_project=scoped, machine=machine,
+        scope=scope,
+        fragment_url=fragment_url,
+        initial_url=_initial_jobs_url(fragment_url, machine, target_id,
+                                      panel, scope=scope),
+        filters=panel, user_search_url=_user_search_url(),
+        per_page_options=_PER_PAGE_OPTIONS, target_id=target_id,
+    )
+
+
+@bp.route('/machine/<machine>')
+@login_required
+@require_permission(Permission.VIEW_ALL_JOB_DATA)
+def jobs_machine_fragment(machine):
+    """HTMX fragment: per-job table across an ENTIRE machine (operator)."""
+    if not is_enabled():
+        return _disabled_jobs_table()
+    machine = _machine_or_404(machine)
+    return _jobs_table_response(
+        mode='machine', machine=machine,
+        fragment_url=url_for('jobs.jobs_machine_fragment', machine=machine),
+    )
+
+
+@bp.route('/machine/<machine>/by-user')
+@login_required
+@require_permission(Permission.VIEW_ALL_JOB_DATA)
+def by_user_machine_fragment(machine):
+    """HTMX fragment: machine-wide per-user usage pie + rows (operator)."""
+    if not is_enabled():
+        return _render_by_user(mode='machine', machine=None,
+                               fragment_url=None, jobs_fragment_url=None,
+                               target_id='')
+    machine = _machine_or_404(machine)
+    target_id = (request.args.get('target_id') or '').strip() \
+        or f'jobs-byuser-machine-{machine}'
+    return _render_by_user(
+        mode='machine', machine=machine,
+        fragment_url=url_for('jobs.by_user_machine_fragment', machine=machine),
+        jobs_fragment_url=url_for('jobs.jobs_machine_fragment', machine=machine),
+        target_id=target_id,
+    )
+
+
+def _machine_histogram(machine, *, dimension, dimension_toggle, endpoint):
+    """Common body of the three machine-mode histogram routes."""
+    if not is_enabled():
+        return _render_histogram(mode='machine', machine=None,
+                                 dimension=dimension,
+                                 dimension_toggle=dimension_toggle,
+                                 fragment_url=None, target_id='')
+    machine = _machine_or_404(machine)
+    target_id = (request.args.get('target_id') or '').strip() \
+        or f'jobs-{dimension}-machine-{machine}'
+    return _render_histogram(
+        mode='machine', machine=machine,
+        dimension=dimension, dimension_toggle=dimension_toggle,
+        fragment_url=url_for(endpoint, machine=machine),
+        target_id=target_id,
+    )
+
+
+@bp.route('/machine/<machine>/wait-times')
+@login_required
+@require_permission(Permission.VIEW_ALL_JOB_DATA)
+def wait_times_machine_fragment(machine):
+    return _machine_histogram(machine, dimension='wait',
+                              dimension_toggle=False,
+                              endpoint='jobs.wait_times_machine_fragment')
+
+
+@bp.route('/machine/<machine>/job-sizes')
+@login_required
+@require_permission(Permission.VIEW_ALL_JOB_DATA)
+def job_sizes_machine_fragment(machine):
+    dimension = (request.args.get('dimension') or '').strip()
+    if dimension not in _SIZE_DIMENSIONS:
+        dimension = _SIZE_DIMENSIONS[0]
+    return _machine_histogram(machine, dimension=dimension,
+                              dimension_toggle=True,
+                              endpoint='jobs.job_sizes_machine_fragment')
+
+
+@bp.route('/machine/<machine>/durations')
+@login_required
+@require_permission(Permission.VIEW_ALL_JOB_DATA)
+def durations_machine_fragment(machine):
+    return _machine_histogram(machine, dimension='duration',
+                              dimension_toggle=False,
+                              endpoint='jobs.durations_machine_fragment')
+
+
+@bp.route('/machine/<machine>/explore')
+@login_required
+@require_permission(Permission.VIEW_ALL_JOB_DATA)
+def explore_machine_page(machine):
+    """Standalone full-page jobs explorer across an ENTIRE machine.
+
+    Machine mode — unscoped, elevated. Same page template as project mode,
+    parameterized by ``mode='machine'`` + the machine fragment URL.
+    """
+    if not is_enabled():
+        return render_template(
+            'dashboards/user/jobs_explore_page.html',
+            mode='machine', enabled=False, machine=machine,
+        )
+    machine = _machine_or_404(machine)
+    target_id = 'jobs-explore'
+    fragment_url = url_for('jobs.jobs_machine_fragment', machine=machine)
+    panel = _panel_filters(machine)
+    return render_template(
+        'dashboards/user/jobs_explore_page.html',
+        mode='machine', enabled=True, machine=machine,
+        fragment_url=fragment_url,
+        initial_url=_initial_jobs_url(fragment_url, machine, target_id, panel),
+        filters=panel, user_search_url=_user_search_url(),
+        per_page_options=_PER_PAGE_OPTIONS, target_id=target_id,
+    )

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -940,3 +940,104 @@ def explore_machine_page(machine):
         filters=panel, user_search_url=_user_search_url(),
         per_page_options=_PER_PAGE_OPTIONS, target_id=target_id,
     )
+
+
+# ---------------------------------------------------------------------------
+# User family ("My Jobs") — hard-pinned to the logged-in user
+# ---------------------------------------------------------------------------
+#
+# @login_required ONLY — no permission gate. Safe because every route pins
+# user=current_user.username server-side (the service families raise on a
+# caller-supplied user), so a client-appended ?user=<other> changes nothing.
+# Mirror of the disk_scans pinned-owner rule.
+
+@bp.route('/user/<machine>')
+@login_required
+def jobs_user_fragment(machine):
+    """HTMX fragment: the logged-in user's per-job table on *machine*."""
+    from flask_login import current_user
+    if not is_enabled():
+        return _disabled_jobs_table(username=current_user.username)
+    machine = _machine_or_404(machine)
+    return _jobs_table_response(
+        mode='user', machine=machine,
+        fragment_url=url_for('jobs.jobs_user_fragment', machine=machine),
+        pinned_user=current_user.username,
+    )
+
+
+def _user_histogram(machine, *, dimension, dimension_toggle, endpoint):
+    """Common body of the three user-mode histogram routes."""
+    from flask_login import current_user
+    if not is_enabled():
+        return _render_histogram(mode='user', machine=None,
+                                 dimension=dimension,
+                                 dimension_toggle=dimension_toggle,
+                                 fragment_url=None, target_id='')
+    machine = _machine_or_404(machine)
+    target_id = (request.args.get('target_id') or '').strip() \
+        or f'jobs-{dimension}-user-{machine}'
+    return _render_histogram(
+        mode='user', machine=machine,
+        dimension=dimension, dimension_toggle=dimension_toggle,
+        fragment_url=url_for(endpoint, machine=machine),
+        target_id=target_id,
+        username=current_user.username,
+    )
+
+
+@bp.route('/user/<machine>/wait-times')
+@login_required
+def wait_times_user_fragment(machine):
+    return _user_histogram(machine, dimension='wait',
+                           dimension_toggle=False,
+                           endpoint='jobs.wait_times_user_fragment')
+
+
+@bp.route('/user/<machine>/job-sizes')
+@login_required
+def job_sizes_user_fragment(machine):
+    dimension = (request.args.get('dimension') or '').strip()
+    if dimension not in _SIZE_DIMENSIONS:
+        dimension = _SIZE_DIMENSIONS[0]
+    return _user_histogram(machine, dimension=dimension,
+                           dimension_toggle=True,
+                           endpoint='jobs.job_sizes_user_fragment')
+
+
+@bp.route('/user/<machine>/durations')
+@login_required
+def durations_user_fragment(machine):
+    return _user_histogram(machine, dimension='duration',
+                           dimension_toggle=False,
+                           endpoint='jobs.durations_user_fragment')
+
+
+@bp.route('/user/<machine>/explore')
+@login_required
+def explore_user_page(machine):
+    """Standalone jobs explorer pinned to the logged-in user ("My Jobs").
+
+    Same page template, ``mode='user'``: the filter panel omits the user
+    picker, and the fragment routes re-pin the username server-side on
+    every fetch — a hand-edited ?user= in the URL changes nothing.
+    """
+    from flask_login import current_user
+    if not is_enabled():
+        return render_template(
+            'dashboards/user/jobs_explore_page.html',
+            mode='user', enabled=False, machine=machine,
+        )
+    machine = _machine_or_404(machine)
+    target_id = 'jobs-explore'
+    fragment_url = url_for('jobs.jobs_user_fragment', machine=machine)
+    panel = _panel_filters(machine)
+    return render_template(
+        'dashboards/user/jobs_explore_page.html',
+        mode='user', enabled=True, machine=machine,
+        username=current_user.username,
+        fragment_url=fragment_url,
+        initial_url=_initial_jobs_url(fragment_url, machine, target_id, panel),
+        filters=panel, user_search_url=_user_search_url(),
+        per_page_options=_PER_PAGE_OPTIONS, target_id=target_id,
+    )

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -10,7 +10,8 @@ Query params (all optional unless noted):
   qos                  — limit to a single QoS / priority class
                          (e.g. 'premium', 'regular', 'economy',
                          'uncharged', 'special')
-  status               — limit to a single PBS exit status (e.g. 'F')
+  exit_status          — limit to a single PBS exit code as text
+                         (e.g. '0' = success, '1', '271')
   page                 — int ≥ 1; default 1
   per_page             — int in [10, 200]; default 50
   sort_by              — one of {'start', 'elapsed', 'qos',
@@ -65,7 +66,7 @@ _SORT_WHITELIST = set(_DEFAULT_COLS)
 # column (now in the main table) so the multiplier sits next to status
 # at the top of the drawer rather than buried beside memory_charges.
 _VERBOSE_EXTRAS = (
-    'status', 'qos_factor',
+    'exit_status', 'qos_factor',
     'queue', 'user',
     'submit', 'end', 'walltime',
     'mpiprocs', 'ompthreads',
@@ -169,7 +170,7 @@ def jobs_fragment(project):
         'user':   (request.args.get('user') or '').strip() or None,
         'queue':  (request.args.get('queue') or '').strip() or None,
         'qos':    (request.args.get('qos') or '').strip() or None,
-        'status': (request.args.get('status') or '').strip() or None,
+        'exit_status': (request.args.get('exit_status') or '').strip() or None,
     }
     page = _parse_pagination()
     sort = _parse_sort()
@@ -309,7 +310,7 @@ def _load_column_specs():
     falls back to the raw column key as the header.
     """
     try:
-        from job_history.cli.search.columns import COLUMNS
+        from job_history import COLUMNS
         return COLUMNS
     except Exception:
         return {}

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -1,6 +1,15 @@
-"""HTMX fragment route for per-job rows on a project's resource-usage page.
+"""HTMX fragment routes for the Job History card (per-job rows + aggregations).
 
-Endpoint: ``GET /dashboards/user/jobs/<projcode>``
+Project-mode endpoints (url_prefix ``/dashboards/user/jobs``):
+
+  GET /<projcode>             — per-job table (the Jobs tab; original route)
+  GET /<projcode>/by-user     — per-user usage pie + drillable rows
+  GET /<projcode>/wait-times  — wait-time histogram (dimension pinned 'wait')
+  GET /<projcode>/job-sizes   — resource-needs histogram (?dimension=
+                                nodes|cpus|gpus|memory)
+  GET /<projcode>/durations   — elapsed-time histogram (pinned 'duration')
+
+Jobs-tab query params: ``GET /dashboards/user/jobs/<projcode>``
 
 Query params (all optional unless noted):
   machine   (required) — 'derecho' or 'casper'
@@ -36,6 +45,10 @@ from flask import Blueprint, abort, render_template, request, url_for
 from flask_login import login_required
 
 from webapp.api.access_control import require_project_access
+from webapp.dashboards.charts import (
+    generate_jobs_histogram,
+    generate_jobs_user_pie_chart,
+)
 from webapp.jobs import service
 from webapp.jobs.session import is_enabled
 
@@ -314,3 +327,282 @@ def _load_column_specs():
         return COLUMNS
     except Exception:
         return {}
+
+
+# ---------------------------------------------------------------------------
+# Aggregation fragments (By User / Wait Times / Job Sizes / Durations)
+# ---------------------------------------------------------------------------
+
+# Chart metric pills shared by the aggregation tabs.
+_METRICS = ('jobs', 'cpu_hours', 'gpu_hours')
+_DEFAULT_METRIC_HIST = 'jobs'
+_DEFAULT_METRIC_PIE = 'cpu_hours'
+
+# Job Sizes tab dimension pills; Wait Times / Durations pin their dimension.
+_SIZE_DIMENSIONS = ('nodes', 'cpus', 'gpus', 'memory')
+
+# Rows shown in the By User table (the pie itself keeps at most 9 + Other).
+_BY_USER_LIMIT = 25
+
+# Filter query params round-tripped through pill/toggle re-fetches, and —
+# where the per-job fragment understands them — carried into row drill-downs.
+_ROUNDTRIP_KEYS = (
+    'start', 'end', 'user', 'queue', 'qos', 'exit_status',
+    'name', 'ignore_case',
+    'min_nodes', 'max_nodes', 'min_cpus', 'max_cpus',
+    'min_gpus', 'max_gpus', 'min_wait_hours', 'max_wait_hours',
+)
+
+_SECS_PER_HOUR = 3600
+
+
+def _parse_int_arg(name: str) -> Optional[int]:
+    raw = (request.args.get(name) or '').strip()
+    if not raw:
+        return None
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return None
+
+
+def _parse_float_arg(name: str) -> Optional[float]:
+    raw = (request.args.get(name) or '').strip()
+    if not raw:
+        return None
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return None
+
+
+def _parse_job_filters() -> dict:
+    """Whitelisted GET parse → service filter kwargs (plugin-native units).
+
+    Human-facing units convert at this boundary and nowhere else:
+    ``min/max_wait_hours`` (hours) → ``min/max_eligible_secs`` (seconds).
+    Unknown params are ignored; malformed numbers degrade to "no filter".
+    """
+    f: dict = {
+        'start': _parse_date(request.args.get('start')),
+        'end':   _parse_date(request.args.get('end')),
+        'user':  (request.args.get('user') or '').strip() or None,
+        'queue': (request.args.get('queue') or '').strip() or None,
+        'qos':   (request.args.get('qos') or '').strip() or None,
+        'exit_status': (request.args.get('exit_status') or '').strip() or None,
+        'name':  (request.args.get('name') or '').strip() or None,
+    }
+    if f['name'] is not None:
+        f['ignore_case'] = request.args.get('ignore_case') in ('1', 'true', 'on')
+    for key in ('min_nodes', 'max_nodes', 'min_cpus', 'max_cpus',
+                'min_gpus', 'max_gpus'):
+        v = _parse_int_arg(key)
+        if v is not None:
+            f[key] = v
+    min_wait = _parse_float_arg('min_wait_hours')
+    max_wait = _parse_float_arg('max_wait_hours')
+    if min_wait is not None:
+        f['min_eligible_secs'] = int(min_wait * _SECS_PER_HOUR)
+    if max_wait is not None:
+        f['max_eligible_secs'] = int(max_wait * _SECS_PER_HOUR)
+    return f
+
+
+def _roundtrip_params(machine: str, target_id: str) -> dict:
+    """Raw (display-unit) query params to carry through re-fetches."""
+    params = {
+        k: request.args.get(k) for k in _ROUNDTRIP_KEYS
+        if (request.args.get(k) or '').strip()
+    }
+    params['machine'] = machine
+    params['target_id'] = target_id
+    return params
+
+
+def _get_machine_or_400() -> str:
+    machine = (request.args.get('machine') or '').strip().lower()
+    if machine not in _VALID_MACHINES:
+        abort(400, f'machine must be one of {sorted(_VALID_MACHINES)}')
+    return machine
+
+
+def _parse_metric(default: str) -> str:
+    metric = (request.args.get('metric') or '').strip()
+    return metric if metric in _METRICS else default
+
+
+def _tree_projcodes(project) -> list:
+    """Parent + descendants — same tree expansion as jobs_fragment."""
+    return [p.projcode for p in project.get_descendants(include_self=True)]
+
+
+def _render_by_user(*, mode, machine, fragment_url, jobs_fragment_url,
+                    target_id, account_projcodes=None):
+    """Shared renderer for the By User tab (project + machine modes)."""
+    template = 'dashboards/user/partials/jobs_by_user.html'
+    if not is_enabled():
+        return render_template(template, enabled=False, error=None,
+                               mode=mode, machine=None, target_id=target_id)
+
+    filters = _parse_job_filters()
+    metric = _parse_metric(_DEFAULT_METRIC_PIE)
+
+    usage = None
+    error = None
+    try:
+        usage = service.jobs_usage_by_user(
+            machine, limit=_BY_USER_LIMIT,
+            account_projcodes=account_projcodes, **filters,
+        )
+    except Exception as exc:
+        from flask import current_app
+        current_app.logger.exception(
+            'jobs by-user fragment failed: mode=%s machine=%s', mode, machine,
+        )
+        error = str(exc)
+
+    pie_svg = None
+    other = None
+    if usage:
+        pie_svg = generate_jobs_user_pie_chart(usage, metric=metric)
+        totals = usage.get('totals') or {}
+        rows = usage.get('rows') or []
+        # The upstream limit's remainder: totals are pre-truncation, so any
+        # positive difference is real usage by users beyond the row cap.
+        rem = {
+            k: (totals.get(k) or 0) - sum((r.get(k) or 0) for r in rows)
+            for k in ('job_count', 'cpu_hours', 'gpu_hours')
+        }
+        if any(v > 1e-9 for v in rem.values()):
+            other = rem
+
+    return render_template(
+        template,
+        enabled=True, error=error,
+        mode=mode, machine=machine,
+        usage=usage, other=other,
+        metric=metric, pie_svg=pie_svg,
+        fragment_url=fragment_url,
+        jobs_fragment_url=jobs_fragment_url,
+        target_id=target_id,
+        params=_roundtrip_params(machine, target_id),
+    )
+
+
+def _render_histogram(*, mode, machine, dimension, dimension_toggle,
+                      fragment_url, target_id,
+                      account_projcodes=None, username=None):
+    """Shared renderer for the Wait Times / Job Sizes / Durations tabs."""
+    template = 'dashboards/user/partials/jobs_histogram.html'
+    if not is_enabled():
+        return render_template(template, enabled=False, error=None,
+                               mode=mode, machine=None, target_id=target_id,
+                               dimension=dimension,
+                               dimension_toggle=dimension_toggle)
+
+    filters = _parse_job_filters()
+    metric = _parse_metric(_DEFAULT_METRIC_HIST)
+
+    hist = None
+    error = None
+    try:
+        hist = service.jobs_histogram(
+            machine, dimension,
+            account_projcodes=account_projcodes, username=username,
+            **filters,
+        )
+    except Exception as exc:
+        from flask import current_app
+        current_app.logger.exception(
+            'jobs histogram fragment failed: mode=%s machine=%s dimension=%s',
+            mode, machine, dimension,
+        )
+        error = str(exc)
+
+    chart_svg = generate_jobs_histogram(hist, metric=metric) if hist else None
+
+    return render_template(
+        template,
+        enabled=True, error=error,
+        mode=mode, machine=machine,
+        hist=hist, chart_svg=chart_svg,
+        metric=metric,
+        dimension=dimension, dimension_toggle=dimension_toggle,
+        size_dimensions=_SIZE_DIMENSIONS,
+        fragment_url=fragment_url,
+        target_id=target_id,
+        params=_roundtrip_params(machine, target_id),
+    )
+
+
+@bp.route('/<projcode>/by-user')
+@login_required
+@require_project_access
+def by_user_fragment(project):
+    """HTMX fragment: per-user usage pie + drillable rows for *project*."""
+    if not is_enabled():
+        return _render_by_user(mode='project', machine=None,
+                               fragment_url=None, jobs_fragment_url=None,
+                               target_id='')
+    machine = _get_machine_or_400()
+    target_id = (request.args.get('target_id') or '').strip() \
+        or f'jobs-byuser-{project.projcode}-{machine}'
+    return _render_by_user(
+        mode='project', machine=machine,
+        fragment_url=url_for('jobs.by_user_fragment', projcode=project.projcode),
+        jobs_fragment_url=url_for('jobs.jobs_fragment', projcode=project.projcode),
+        target_id=target_id,
+        account_projcodes=_tree_projcodes(project),
+    )
+
+
+def _project_histogram(project, *, dimension, dimension_toggle, endpoint):
+    """Common body of the three project-mode histogram routes."""
+    if not is_enabled():
+        return _render_histogram(mode='project', machine=None,
+                                 dimension=dimension,
+                                 dimension_toggle=dimension_toggle,
+                                 fragment_url=None, target_id='')
+    machine = _get_machine_or_400()
+    target_id = (request.args.get('target_id') or '').strip() \
+        or f'jobs-{dimension}-{project.projcode}-{machine}'
+    return _render_histogram(
+        mode='project', machine=machine,
+        dimension=dimension, dimension_toggle=dimension_toggle,
+        fragment_url=url_for(endpoint, projcode=project.projcode),
+        target_id=target_id,
+        account_projcodes=_tree_projcodes(project),
+    )
+
+
+@bp.route('/<projcode>/wait-times')
+@login_required
+@require_project_access
+def wait_times_fragment(project):
+    """HTMX fragment: queue-wait histogram (dimension pinned to 'wait')."""
+    return _project_histogram(project, dimension='wait',
+                              dimension_toggle=False,
+                              endpoint='jobs.wait_times_fragment')
+
+
+@bp.route('/<projcode>/job-sizes')
+@login_required
+@require_project_access
+def job_sizes_fragment(project):
+    """HTMX fragment: resource-needs histogram with dimension pills."""
+    dimension = (request.args.get('dimension') or '').strip()
+    if dimension not in _SIZE_DIMENSIONS:
+        dimension = _SIZE_DIMENSIONS[0]
+    return _project_histogram(project, dimension=dimension,
+                              dimension_toggle=True,
+                              endpoint='jobs.job_sizes_fragment')
+
+
+@bp.route('/<projcode>/durations')
+@login_required
+@require_project_access
+def durations_fragment(project):
+    """HTMX fragment: elapsed-time histogram (pinned to 'duration')."""
+    return _project_histogram(project, dimension='duration',
+                              dimension_toggle=False,
+                              endpoint='jobs.durations_fragment')

--- a/src/webapp/jobs/service.py
+++ b/src/webapp/jobs/service.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, Dict, List, Optional, Sequence
 
+from webapp.jobs import cache as jobs_cache
 from webapp.jobs.session import (
     get_engines,
     get_module,
@@ -78,18 +79,63 @@ def _resolve_queue_and_qos(
     return base, qos
 
 
-def search_jobs(
-    machine: str,
+def _plugin_filter_kwargs(
     *,
-    project,
     start: Optional[date] = None,
     end: Optional[date] = None,
     user: Optional[str] = None,
     queue: Optional[str] = None,
     qos: Optional[str] = None,
     exit_status: Optional[str] = None,
+    name=None,
+    ignore_case: bool = False,
+    min_eligible_secs: Optional[int] = None,
+    max_eligible_secs: Optional[int] = None,
+    min_nodes: Optional[int] = None,
+    max_nodes: Optional[int] = None,
+    min_cpus: Optional[int] = None,
+    max_cpus: Optional[int] = None,
     min_gpus: Optional[int] = None,
     max_gpus: Optional[int] = None,
+    min_elapsed: Optional[int] = None,
+    max_elapsed: Optional[int] = None,
+    min_reqmem: Optional[int] = None,
+    max_reqmem: Optional[int] = None,
+    valid_qos_names: Sequence[str] = (),
+) -> Dict[str, Any]:
+    """Normalize the flat SAM-side filter set into plugin kwargs.
+
+    The single seam every query mode routes through: mirrors the
+    plugin's keyword surface 1:1 (minus ``account``, which each mode
+    pins itself), runs the legacy queue→QoS resolver, and — being
+    keyword-only — rejects unknown filter names with a TypeError instead
+    of silently dropping them. Range bounds are plugin-native units
+    (seconds / bytes / counts), inclusive, NULL-strict.
+    """
+    queue_norm, qos_norm = _resolve_queue_and_qos(queue, qos, valid_qos_names)
+    return {
+        'start': start,
+        'end':   end,
+        'user':  user,
+        'queue': queue_norm,
+        'qos':   qos_norm,
+        'exit_status': exit_status,
+        'name':  name,
+        'ignore_case': bool(ignore_case),
+        'min_eligible_secs': min_eligible_secs,
+        'max_eligible_secs': max_eligible_secs,
+        'min_nodes': min_nodes, 'max_nodes': max_nodes,
+        'min_cpus':  min_cpus,  'max_cpus':  max_cpus,
+        'min_gpus':  min_gpus,  'max_gpus':  max_gpus,
+        'min_elapsed': min_elapsed, 'max_elapsed': max_elapsed,
+        'min_reqmem':  min_reqmem,  'max_reqmem':  max_reqmem,
+    }
+
+
+def search_jobs(
+    machine: str,
+    *,
+    project,
     columns: Optional[Sequence[str]] = None,
     limit: Optional[int] = None,
     offset: int = 0,
@@ -97,6 +143,7 @@ def search_jobs(
     sort_dir: str = 'desc',
     account_projcodes: Optional[Sequence[str]] = None,
     valid_qos_names: Sequence[str] = (),
+    **filters,
 ) -> List[Dict[str, Any]]:
     """Return per-job rows for *project* on *machine*.
 
@@ -111,15 +158,6 @@ def search_jobs(
         machine: Machine name (e.g. 'derecho', 'casper').
         project: SAM Project — supplies the default ``account`` filter
             via ``project.projcode``.
-        start, end: Date range filter on ``Job.end``.
-        user, queue, qos, exit_status: Optional plain-text filters.
-            ``qos`` matches the canonical name in the plugin's
-            ``job_qos`` lookup (e.g. ``'premium'``, ``'regular'``);
-            ``exit_status`` is the PBS exit code as text (``'0'`` =
-            success).
-        min_gpus, max_gpus: Inclusive bounds on ``Job.numgpus``
-            (``min_gpus=1`` → GPU jobs only; ``max_gpus=0`` →
-            CPU-only jobs).
         columns: Optional column projection. Default is the plugin's
             ``DEFAULT_COLUMNS`` set.
         limit: Optional server-side LIMIT.
@@ -129,6 +167,10 @@ def search_jobs(
             filtering. When provided, takes precedence over
             ``project.projcode`` — the upstream plugin applies
             ``Job.account IN (...)``.
+        **filters: The flat filter set — see
+            :func:`_plugin_filter_kwargs` (start/end, user, queue, qos,
+            exit_status, name + ignore_case, and the inclusive min/max
+            bounds). Unknown names raise TypeError.
 
     Returns:
         ``list[dict]`` ordered by *sort_by* (default ``Job.end DESC``);
@@ -144,25 +186,16 @@ def search_jobs(
     mod = get_module()
     JobQueries = mod.JobQueries
 
-    # TODO(legacy-queue-names): see _resolve_queue_and_qos. Promotes
-    # 'cpu-special' → queue='cpu', qos='special' when caller left qos
-    # unset and the suffix matches a known QoS name.
-    queue_norm, qos_norm = _resolve_queue_and_qos(queue, qos, valid_qos_names)
-
-    kwargs: Dict[str, Any] = {
-        'start':   start,
-        'end':     end,
+    # TODO(legacy-queue-names): the normalizer runs _resolve_queue_and_qos,
+    # promoting 'cpu-special' → queue='cpu', qos='special' when the caller
+    # left qos unset and the suffix matches a known QoS name.
+    kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
+    kwargs.update({
         'account': list(account_projcodes) if account_projcodes is not None else project.projcode,
-        'user':    user,
-        'queue':   queue_norm,
-        'qos':     qos_norm,
-        'exit_status': exit_status,
         'columns': columns,
         'limit':   limit,
         'offset':  offset,
-        'min_gpus': min_gpus,
-        'max_gpus': max_gpus,
-    }
+    })
     if sort_by is not None:
         kwargs['sort_by']  = sort_by
         kwargs['sort_dir'] = sort_dir
@@ -175,16 +208,9 @@ def count_jobs(
     machine: str,
     *,
     project,
-    start: Optional[date] = None,
-    end: Optional[date] = None,
-    user: Optional[str] = None,
-    queue: Optional[str] = None,
-    qos: Optional[str] = None,
-    exit_status: Optional[str] = None,
-    min_gpus: Optional[int] = None,
-    max_gpus: Optional[int] = None,
     account_projcodes: Optional[Sequence[str]] = None,
     valid_qos_names: Sequence[str] = (),
+    **filters,
 ) -> int:
     """Return the total number of jobs matching the search filters.
 
@@ -198,10 +224,11 @@ def count_jobs(
     by default (small pre-aggregated table; sub-millisecond response
     against the production schema). Falls back to the plugin's
     ``JobQueries.jobs_count`` — a ``COUNT(*)`` over the raw ``job``
-    table — only when a filter outside the summary key set is in play
-    (``exit_status``, ``min_gpus``/``max_gpus``). The two counts can disagree under
-    ingester drift; SAM is treated as the source of truth for the
-    displayed totalizer since it's the project's accounting authority.
+    table — whenever ANY filter outside the summary key set is in play
+    (qos, exit_status, name, or any min/max bound). The two counts can
+    disagree under ingester drift; SAM is treated as the source of
+    truth for the displayed totalizer since it's the project's
+    accounting authority.
 
     Returns:
         ``int`` total.
@@ -213,38 +240,37 @@ def count_jobs(
                  else [project.projcode])
 
     # Fast path: SAM's daily summary covers every filter the drill-down
-    # uses. Avoids a 1-second-plus COUNT(*) over the plugin's job table.
-    # `qos` is NOT in CompChargeSummary's key set today, so a QoS filter
-    # falls back to the plugin path alongside exit_status / GPU bounds.
-    if exit_status is None and min_gpus is None and max_gpus is None and qos is None:
+    # uses — but ONLY those. `qos` is NOT in CompChargeSummary's key set
+    # today, so a QoS filter falls back to the plugin path alongside
+    # exit_status / name / every range bound. Gate on the raw filter
+    # names (not the normalized kwargs) so a falsy-but-real bound like
+    # ``max_gpus=0`` still forces the plugin path. ``ignore_case`` is a
+    # modifier on ``name`` (a bool, often explicitly False), not a
+    # filter — without a name it changes nothing, so it never gates.
+    _summary_keys = {'start', 'end', 'user', 'queue', 'ignore_case'}
+    extended = {k: v for k, v in filters.items() if k not in _summary_keys}
+    if all(v is None for v in extended.values()):
         return _count_via_sam_summary(
             machine,
             projcodes=projcodes,
-            start=start, end=end,
-            user=user, queue=queue,
+            start=filters.get('start'), end=filters.get('end'),
+            user=filters.get('user'), queue=filters.get('queue'),
         )
 
     # Plugin fallback for filter shapes outside the summary's key set.
-    # TODO(legacy-queue-names): see _resolve_queue_and_qos. The fast
-    # path above kept the raw composite queue (the summary stores it
-    # that way); the plugin path needs the split + QoS inference.
-    queue_norm, qos_norm = _resolve_queue_and_qos(queue, qos, valid_qos_names)
+    # TODO(legacy-queue-names): the normalizer runs _resolve_queue_and_qos.
+    # The fast path above kept the raw composite queue (the summary
+    # stores it that way); the plugin path needs the split + QoS
+    # inference.
+    kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
+    kwargs['account'] = (projcodes if account_projcodes is not None
+                         else project.projcode)
 
     mod = get_module()
     JobQueries = mod.JobQueries
 
     with job_history_session(machine) as session:
-        return JobQueries(session, machine=machine).jobs_count(
-            start=start,
-            end=end,
-            account=projcodes if account_projcodes is not None else project.projcode,
-            user=user,
-            queue=queue_norm,
-            qos=qos_norm,
-            exit_status=exit_status,
-            min_gpus=min_gpus,
-            max_gpus=max_gpus,
-        )
+        return JobQueries(session, machine=machine).jobs_count(**kwargs)
 
 
 def _count_via_sam_summary(
@@ -286,6 +312,210 @@ def _count_via_sam_summary(
     if queue:
         q = q.filter(CompChargeSummary.queue == queue)
     return int(q.scalar() or 0)
+
+
+def search_jobs_machine(
+    machine: str,
+    *,
+    columns: Optional[Sequence[str]] = None,
+    limit: Optional[int] = None,
+    offset: int = 0,
+    sort_by: Optional[str] = None,
+    sort_dir: str = 'desc',
+    valid_qos_names: Sequence[str] = (),
+    **filters,
+) -> List[Dict[str, Any]]:
+    """Machine-wide per-job rows — NO account scoping.
+
+    SECURITY: this deliberately issues an unscoped query (every user's
+    jobs, cross-project). The caller MUST sit behind
+    ``@require_permission(Permission.VIEW_ALL_JOB_DATA)`` — there is no
+    fallback pinning here, unlike :func:`search_jobs` (project) and
+    :func:`search_jobs_user` (session user).
+    """
+    mod = get_module()
+    JobQueries = mod.JobQueries
+
+    kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
+    kwargs.update({'columns': columns, 'limit': limit, 'offset': offset})
+    if sort_by is not None:
+        kwargs['sort_by']  = sort_by
+        kwargs['sort_dir'] = sort_dir
+
+    with job_history_session(machine) as session:
+        return JobQueries(session, machine=machine).jobs_search(**kwargs)
+
+
+def count_jobs_machine(
+    machine: str,
+    *,
+    valid_qos_names: Sequence[str] = (),
+    **filters,
+) -> int:
+    """Machine-wide job count — NO account scoping (see search_jobs_machine).
+
+    Always the plugin's ``jobs_count``: the SAM-summary fast path is a
+    per-project accounting table, and machine-wide requests are already
+    permission-gated, low-volume operator surfaces.
+    """
+    mod = get_module()
+    JobQueries = mod.JobQueries
+
+    kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
+
+    with job_history_session(machine) as session:
+        return JobQueries(session, machine=machine).jobs_count(**kwargs)
+
+
+def search_jobs_user(
+    machine: str,
+    username: str,
+    *,
+    columns: Optional[Sequence[str]] = None,
+    limit: Optional[int] = None,
+    offset: int = 0,
+    sort_by: Optional[str] = None,
+    sort_dir: str = 'desc',
+    valid_qos_names: Sequence[str] = (),
+    **filters,
+) -> List[Dict[str, Any]]:
+    """Per-job rows hard-pinned to *username* ("My Jobs" mode).
+
+    The pin is server-side and non-negotiable: an empty username raises,
+    and a ``user`` key in *filters* raises rather than being silently
+    overwritten — the route must never forward a client-supplied user
+    into this mode (mirror of disk_scans' pinned-owner rule).
+    """
+    if not username:
+        raise ValueError('search_jobs_user requires a username (user pin).')
+    if 'user' in filters:
+        raise ValueError(
+            "search_jobs_user pins user server-side; "
+            "remove the 'user' filter from the call."
+        )
+
+    mod = get_module()
+    JobQueries = mod.JobQueries
+
+    kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
+    kwargs.update({
+        'user':    username,
+        'columns': columns,
+        'limit':   limit,
+        'offset':  offset,
+    })
+    if sort_by is not None:
+        kwargs['sort_by']  = sort_by
+        kwargs['sort_dir'] = sort_dir
+
+    with job_history_session(machine) as session:
+        return JobQueries(session, machine=machine).jobs_search(**kwargs)
+
+
+def count_jobs_user(
+    machine: str,
+    username: str,
+    *,
+    valid_qos_names: Sequence[str] = (),
+    **filters,
+) -> int:
+    """Job count hard-pinned to *username* (see search_jobs_user)."""
+    if not username:
+        raise ValueError('count_jobs_user requires a username (user pin).')
+    if 'user' in filters:
+        raise ValueError(
+            "count_jobs_user pins user server-side; "
+            "remove the 'user' filter from the call."
+        )
+
+    mod = get_module()
+    JobQueries = mod.JobQueries
+
+    kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
+    kwargs['user'] = username
+
+    with job_history_session(machine) as session:
+        return JobQueries(session, machine=machine).jobs_count(**kwargs)
+
+
+def jobs_histogram(
+    machine: str,
+    dimension: str,
+    *,
+    account_projcodes: Optional[Sequence[str]] = None,
+    username: Optional[str] = None,
+    valid_qos_names: Sequence[str] = (),
+    **filters,
+) -> Dict[str, Any]:
+    """Cached bucket histogram for *dimension* (plugin envelope, verbatim).
+
+    Scope is the caller's job: ``account_projcodes`` pins a project
+    tree (project mode), ``username`` hard-pins user mode (overwriting
+    any client-supplied ``user`` filter — the pin always wins), both
+    ``None`` is machine-wide (caller must be VIEW_ALL_JOB_DATA-gated).
+
+    Results go through the jobs TTL cache: closed windows (``end`` before
+    today) land in the long-lived ``historical`` bucket, open ones in
+    ``recent``. The envelope is self-describing (``min_param`` /
+    ``max_param``) — use those for bar drill-downs, never a hardcoded
+    dimension→kwarg map.
+    """
+    kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
+    if username is not None:
+        kwargs['user'] = username
+    if account_projcodes is not None:
+        kwargs['account'] = list(account_projcodes)
+
+    def _compute():
+        mod = get_module()
+        JobQueries = mod.JobQueries
+        with job_history_session(machine) as session:
+            return JobQueries(session, machine=machine).jobs_histogram(
+                dimension, **kwargs,
+            )
+
+    opts = dict(kwargs)
+    opts['dimension'] = dimension
+    return jobs_cache.cached_jobs_aggregation(
+        'histogram', machine, opts, _compute,
+        bucket=jobs_cache.bucket_for_window(kwargs.get('end')),
+    )
+
+
+def jobs_usage_by_user(
+    machine: str,
+    *,
+    limit: Optional[int] = 50,
+    account_projcodes: Optional[Sequence[str]] = None,
+    valid_qos_names: Sequence[str] = (),
+    **filters,
+) -> Dict[str, Any]:
+    """Cached per-user usage rollup (plugin ``jobs_usage_by('user')``).
+
+    Backs the By User pie: rows are hours-desc, ``totals`` is computed
+    upstream BEFORE the limit truncation, so the pie's "Other" slice is
+    ``totals − Σ rows``. No self-exclusion of any filter — ``account``
+    scoping always applies (it's the security boundary). Same scope and
+    caching rules as :func:`jobs_histogram`.
+    """
+    kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
+    if account_projcodes is not None:
+        kwargs['account'] = list(account_projcodes)
+
+    def _compute():
+        mod = get_module()
+        JobQueries = mod.JobQueries
+        with job_history_session(machine) as session:
+            return JobQueries(session, machine=machine).jobs_usage_by(
+                'user', limit=limit, **kwargs,
+            )
+
+    opts = dict(kwargs)
+    opts['limit'] = limit
+    return jobs_cache.cached_jobs_aggregation(
+        'usage_by_user', machine, opts, _compute,
+        bucket=jobs_cache.bucket_for_window(kwargs.get('end')),
+    )
 
 
 def list_qos_names(machine: str) -> List[str]:

--- a/src/webapp/jobs/service.py
+++ b/src/webapp/jobs/service.py
@@ -69,8 +69,9 @@ def search_jobs(
     user: Optional[str] = None,
     queue: Optional[str] = None,
     qos: Optional[str] = None,
-    status: Optional[str] = None,
-    has_gpus: Optional[bool] = None,
+    exit_status: Optional[str] = None,
+    min_gpus: Optional[int] = None,
+    max_gpus: Optional[int] = None,
     columns: Optional[Sequence[str]] = None,
     limit: Optional[int] = None,
     offset: int = 0,
@@ -93,11 +94,14 @@ def search_jobs(
         project: SAM Project — supplies the default ``account`` filter
             via ``project.projcode``.
         start, end: Date range filter on ``Job.end``.
-        user, queue, qos, status: Optional plain-text filters.
+        user, queue, qos, exit_status: Optional plain-text filters.
             ``qos`` matches the canonical name in the plugin's
-            ``job_qos`` lookup (e.g. ``'premium'``, ``'regular'``).
-        has_gpus: ``None`` ignore; ``True`` → GPU jobs only; ``False`` →
-            CPU-only jobs.
+            ``job_qos`` lookup (e.g. ``'premium'``, ``'regular'``);
+            ``exit_status`` is the PBS exit code as text (``'0'`` =
+            success).
+        min_gpus, max_gpus: Inclusive bounds on ``Job.numgpus``
+            (``min_gpus=1`` → GPU jobs only; ``max_gpus=0`` →
+            CPU-only jobs).
         columns: Optional column projection. Default is the plugin's
             ``DEFAULT_COLUMNS`` set.
         limit: Optional server-side LIMIT.
@@ -134,11 +138,12 @@ def search_jobs(
         'user':    user,
         'queue':   queue_norm,
         'qos':     qos_norm,
-        'status':  status,
+        'exit_status': exit_status,
         'columns': columns,
         'limit':   limit,
         'offset':  offset,
-        'has_gpus': has_gpus,
+        'min_gpus': min_gpus,
+        'max_gpus': max_gpus,
     }
     if sort_by is not None:
         kwargs['sort_by']  = sort_by
@@ -157,8 +162,9 @@ def count_jobs(
     user: Optional[str] = None,
     queue: Optional[str] = None,
     qos: Optional[str] = None,
-    status: Optional[str] = None,
-    has_gpus: Optional[bool] = None,
+    exit_status: Optional[str] = None,
+    min_gpus: Optional[int] = None,
+    max_gpus: Optional[int] = None,
     account_projcodes: Optional[Sequence[str]] = None,
     valid_qos_names: Sequence[str] = (),
 ) -> int:
@@ -175,7 +181,7 @@ def count_jobs(
     against the production schema). Falls back to the plugin's
     ``JobQueries.jobs_count`` — a ``COUNT(*)`` over the raw ``job``
     table — only when a filter outside the summary key set is in play
-    (``status``, ``has_gpus``). The two counts can disagree under
+    (``exit_status``, ``min_gpus``/``max_gpus``). The two counts can disagree under
     ingester drift; SAM is treated as the source of truth for the
     displayed totalizer since it's the project's accounting authority.
 
@@ -191,8 +197,8 @@ def count_jobs(
     # Fast path: SAM's daily summary covers every filter the drill-down
     # uses. Avoids a 1-second-plus COUNT(*) over the plugin's job table.
     # `qos` is NOT in CompChargeSummary's key set today, so a QoS filter
-    # falls back to the plugin path alongside status / has_gpus.
-    if status is None and has_gpus is None and qos is None:
+    # falls back to the plugin path alongside exit_status / GPU bounds.
+    if exit_status is None and min_gpus is None and max_gpus is None and qos is None:
         return _count_via_sam_summary(
             machine,
             projcodes=projcodes,
@@ -217,8 +223,9 @@ def count_jobs(
             user=user,
             queue=queue_norm,
             qos=qos_norm,
-            status=status,
-            has_gpus=has_gpus,
+            exit_status=exit_status,
+            min_gpus=min_gpus,
+            max_gpus=max_gpus,
         )
 
 

--- a/src/webapp/jobs/service.py
+++ b/src/webapp/jobs/service.py
@@ -15,7 +15,25 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, Dict, List, Optional, Sequence
 
-from webapp.jobs.session import get_module, job_history_session
+from webapp.jobs.session import (
+    get_engines,
+    get_module,
+    is_enabled,
+    job_history_session,
+)
+
+
+def job_history_machines() -> List[str]:
+    """Machines with a warmed job-history engine, sorted.
+
+    Analogue of ``disk_scans.service.scan_capable_resources()`` — the
+    single source for "which machines can the jobs UI offer?". Returns
+    ``[]`` when the plugin is disabled, so nav items / tabs / route
+    validation all degrade together.
+    """
+    if not is_enabled():
+        return []
+    return sorted(get_engines().keys())
 
 
 def _resolve_queue_and_qos(

--- a/src/webapp/jobs/session.py
+++ b/src/webapp/jobs/session.py
@@ -57,6 +57,9 @@ def init_job_history(app: Flask) -> None:
     """
     machines = app.config.get('JOB_HISTORY_MACHINES', ['derecho', 'casper'])
     pool_kwargs = app.config.get('JOB_HISTORY_POOL_KWARGS', {}) or {}
+    statement_timeout_ms = int(
+        app.config.get('JOB_HISTORY_STATEMENT_TIMEOUT_MS', 0) or 0
+    )
 
     state: Dict[str, Any] = {
         'module':  None,
@@ -101,7 +104,11 @@ def init_job_history(app: Flask) -> None:
             engine = mod.get_engine(machine, pool_kwargs=pool_kwargs)
             state['engines'][machine] = engine
             if engine.url.drivername.startswith('postgresql'):
-                _attach_application_name(engine, f'sam-webapp:{pod_id}:job_history:{machine}')
+                _apply_connection_settings(
+                    engine,
+                    f'sam-webapp:{pod_id}:job_history:{machine}',
+                    statement_timeout_ms=statement_timeout_ms,
+                )
             logger.info(
                 'hpc-usage-queries engine ready: machine=%s url=%s',
                 machine,
@@ -116,28 +123,41 @@ def init_job_history(app: Flask) -> None:
     state['enabled'] = bool(state['engines'])
 
 
-def _attach_application_name(engine, app_name: str) -> None:
-    """Run ``SET application_name`` on every new DBAPI connection for this engine.
+def _apply_connection_settings(
+    engine, app_name: str, *, statement_timeout_ms: int = 0
+) -> None:
+    """Apply per-connection postgres settings on every new DBAPI connection.
+
+    Sets ``application_name`` (for ``pg_stat_activity`` attribution) and,
+    when ``statement_timeout_ms`` > 0, a server-side ``statement_timeout``
+    so a runaway job-history query fails cleanly instead of holding a PG
+    connection (and a gthread thread) until the gunicorn worker timeout.
 
     The ``connect`` event fires once per fresh postgres connection (not on
     pool checkout), so this is the cheap, correct hook to tag connections
     when the engine's ``connect_args`` are owned by the plugin and can't
-    be amended in-place.
+    be amended in-place. Mirrors ``webapp/disk_scans/session.py``.
 
-    Toggles autocommit around the ``SET`` because postgres documents
+    Toggles autocommit around the ``SET``s because postgres documents
     that ``application_name`` changes made via ``SET`` "will not appear
     in pg_stat_activity until after a commit or rollback" — and
     psycopg2's default is ``autocommit=False``, so a bare ``SET``
     inside the implicit transaction would never become visible.
     """
     @event.listens_for(engine, 'connect')
-    def _set_app_name(dbapi_conn, _conn_record):
+    def _on_connect(dbapi_conn, _conn_record):
         saved = dbapi_conn.autocommit
         dbapi_conn.autocommit = True
         try:
             cur = dbapi_conn.cursor()
             try:
                 cur.execute("SET application_name = %s", (app_name,))
+                if statement_timeout_ms and statement_timeout_ms > 0:
+                    # statement_timeout accepts an integer number of ms.
+                    cur.execute(
+                        "SET statement_timeout = %s",
+                        (str(int(statement_timeout_ms)),),
+                    )
             finally:
                 cur.close()
         finally:

--- a/src/webapp/static/js/svg-chart-links.js
+++ b/src/webapp/static/js/svg-chart-links.js
@@ -51,6 +51,10 @@
     // Stacked-by-user Usage Trend chart (compute resource-details): a legend
     // username click expands that user's row in the Usage by User card.
     var USAGE_USER_PREFIX = '#usage-user-';
+    // Job-history By User pie: a wedge/legend click expands the matching
+    // user's row, found by data-job-user (see jobs_by_user.html). Same
+    // interaction as the disk-scans entity pie.
+    var JOB_USER_PREFIX = '#job-user-';
 
     // Distribution histogram (Access-history / File-size tabs) → expand the
     // matching bucket's per-user detail row. The bucket <tr> carries
@@ -196,6 +200,15 @@
             if (gid === '') return;
             e.preventDefault();
             openEntityRow('data-group-gid', gid, a.closest('.tab-pane'));
+            return;
+        }
+
+        // Jobs pie wedge/legend → expand the user's jobs row (scoped pane)
+        if (href.indexOf(JOB_USER_PREFIX) === 0) {
+            var juser = href.slice(JOB_USER_PREFIX.length);
+            if (juser === '') return;
+            e.preventDefault();
+            openEntityRow('data-job-user', juser, a.closest('.tab-pane'));
             return;
         }
 

--- a/src/webapp/templates/dashboards/admin/fragments/caching_card_body.html
+++ b/src/webapp/templates/dashboards/admin/fragments/caching_card_body.html
@@ -56,6 +56,24 @@
 {% endfor %}
 {% endif %}
 
+{% if cache_state.jobs %}
+<hr class="my-3">
+<div class="text-muted small mb-2"><strong>Job-history cache</strong></div>
+{# Two buckets: closed windows (end < today) are immutable → long TTL;
+   windows touching today keep collecting jobs → short TTL. Looping
+   surfaces each bucket's TTL so the 15-min recent TTL is visible next
+   to the 6-hour historical one. #}
+{% for _b in cache_state.jobs %}
+  <div class="text-muted small mb-1">
+    {{ 'Recent (open windows)' if _b.name == 'jobs_recent'
+       else 'Historical (closed windows)' }}
+    <code class="ms-1">{{ _b.name }}</code>
+  </div>
+  {{ cache_row(_b) }}
+  {% if not loop.last %}<div class="mb-2"></div>{% endif %}
+{% endfor %}
+{% endif %}
+
 {% if cache_state.flask %}
 <hr class="my-3">
 <div class="text-muted small mb-2"><strong>Flask-Cache (HTTP-level)</strong></div>

--- a/src/webapp/templates/dashboards/admin/fragments/configuration_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/configuration_card.html
@@ -238,7 +238,8 @@
                                         ('flask', 'Flask (HTTP)'),
                                         ('chart', 'Chart SVG'),
                                         ('usage', 'Allocation usage'),
-                                        ('scans', 'Filesystem scans')] %}
+                                        ('scans', 'Filesystem scans'),
+                                        ('jobs', 'Job history')] %}
                                 <li>
                                     <button type="button" class="dropdown-item"
                                             hx-post="{{ _clear_url }}?category={{ cat }}"

--- a/src/webapp/templates/dashboards/status/base_status.html
+++ b/src/webapp/templates/dashboards/status/base_status.html
@@ -119,6 +119,9 @@
     {'endpoint': 'status_dashboard.filesystem_scans', 'label': 'Filesystem Scans',
      'icon': 'fas fa-magnifying-glass-chart',
      'visible': true if (fs_scan_resources and has_permission(Permission.VIEW_ALL_FILESYSTEM_DATA)) else false},
+    {'endpoint': 'status_dashboard.job_history', 'label': 'Job History',
+     'icon': 'fas fa-list-check',
+     'visible': true if (job_history_machines and has_permission(Permission.VIEW_ALL_JOB_DATA)) else false},
 ], class='mb-4') }}
 
 {% block status_content %}{% endblock %}

--- a/src/webapp/templates/dashboards/status/job_history_page.html
+++ b/src/webapp/templates/dashboards/status/job_history_page.html
@@ -1,0 +1,13 @@
+{% extends 'dashboards/status/base_status.html' %}
+
+{% block title %}Job History - SAM{% endblock %}
+
+{% block status_content %}
+{% if job_history_machines %}
+    {% include 'dashboards/status/partials/job_history.html' %}
+{% else %}
+<div class="alert alert-info">
+    <i class="fas fa-info-circle"></i> No job-history data is currently available.
+</div>
+{% endif %}
+{% endblock %}

--- a/src/webapp/templates/dashboards/status/partials/job_history.html
+++ b/src/webapp/templates/dashboards/status/partials/job_history.html
@@ -38,6 +38,7 @@
                 cid='jobs-m' ~ loop.index,
                 tablist_id='jobHistCardTabs' ~ loop.index,
                 machine=m,
+                start=jobs_window_start,
                 load_trigger=_trigger %}
             {% include 'dashboards/user/partials/jobs_card.html' %}
         {% endwith %}

--- a/src/webapp/templates/dashboards/status/partials/job_history.html
+++ b/src/webapp/templates/dashboards/status/partials/job_history.html
@@ -1,0 +1,46 @@
+{# ── Job History tab body (Status dashboard) ────────────────────────────
+   One subtab per plugin machine (job_history_machines, from
+   webapp.jobs.service.job_history_machines()). Each subtab hosts the SAME
+   jobs card the project resource-details page shows, but in machine mode —
+   unscoped over the whole machine (VIEW_ALL_JOB_DATA-gated routes).
+
+   Lazy-load: this partial renders only on its own /status/job-history
+   page, where the first subtab's pane is visible immediately — so its
+   card's first inner tab fires on `load`. Other subtabs load when their
+   own subtab nav-link is shown. Bind to the shown event, not click
+   (feedback_persisted_collapse_htmx). Closed subtabs cost nothing.
+
+   This partial is only included when job_history_machines is non-empty
+   AND the viewer holds VIEW_ALL_JOB_DATA (gated at the route + tab), so
+   it never needs its own empty/disabled state.
+#}
+<ul class="nav nav-pills mb-3" id="jobHistSubtabs" role="tablist">
+    {% for m in job_history_machines %}
+    <li class="nav-item" role="presentation">
+        <a class="nav-link {% if loop.first %}active{% endif %}"
+           id="job-hist-subtab-{{ loop.index }}"
+           data-bs-toggle="tab" href="#job-hist-pane-{{ loop.index }}" role="tab">
+            <i class="fas fa-server me-1"></i> {{ m | capitalize }}
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+<div class="tab-content" id="jobHistSubtabContent">
+    {% for m in job_history_machines %}
+    <div class="tab-pane fade {% if loop.first %}show active{% endif %}"
+         id="job-hist-pane-{{ loop.index }}" role="tabpanel">
+        {% if loop.first %}
+            {% set _trigger = 'load once' %}
+        {% else %}
+            {% set _trigger = 'shown.bs.tab once from:#job-hist-subtab-' ~ loop.index %}
+        {% endif %}
+        {% with mode='machine',
+                cid='jobs-m' ~ loop.index,
+                tablist_id='jobHistCardTabs' ~ loop.index,
+                machine=m,
+                load_trigger=_trigger %}
+            {% include 'dashboards/user/partials/jobs_card.html' %}
+        {% endwith %}
+    </div>
+    {% endfor %}
+</div>

--- a/src/webapp/templates/dashboards/user/base_user.html
+++ b/src/webapp/templates/dashboards/user/base_user.html
@@ -20,6 +20,8 @@
     {'endpoint': 'user_dashboard.info',     'label': 'User Information', 'icon': 'fas fa-user-circle'},
     {'endpoint': 'user_dashboard.my_data',  'label': 'My Data', 'icon': 'fas fa-hard-drive',
      'visible': my_data_available},
+    {'endpoint': 'user_dashboard.my_jobs',  'label': 'My Jobs', 'icon': 'fas fa-list-check',
+     'visible': my_jobs_available},
 ]) }}
 
 {% block user_content %}{% endblock %}

--- a/src/webapp/templates/dashboards/user/jobs_explore_page.html
+++ b/src/webapp/templates/dashboards/user/jobs_explore_page.html
@@ -1,0 +1,78 @@
+{% extends 'dashboards/base.html' %}
+{% from 'dashboards/user/partials/_jobs_filters.html' import jobs_filters %}
+{% from 'dashboards/user/partials/_jobs_macros.html' import jobs_disabled, mode_badge %}
+{#
+  Standalone jobs-explorer page — all three modes, parameterized by *mode*
+  ('project'|'machine'|'user') and *fragment_url* (which per-job fragment
+  to lazy-load). Renders a filter panel above a table container; the
+  container hx-get's *initial_url* (fragment_url pre-loaded with the
+  current filters) on load, and the filter panel / in-table sort +
+  pagination re-fetch into the same container thereafter.
+
+  Context (set in webapp/jobs/routes.py explore_page /
+  explore_machine_page / explore_user_page): mode, enabled, machine,
+  fragment_url, initial_url, filters, user_search_url, per_page_options,
+  target_id, plus mode-specific scope (project, scoped_project, scope /
+  username).
+#}
+
+{% block title %}Job explorer — SAM{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+
+  <div class="d-flex align-items-center flex-wrap gap-2 mb-2">
+    <h3 class="mb-0">
+      <i class="fas fa-list-check me-2"></i>
+      {% if mode == 'machine' %}
+        {{ machine | capitalize }}
+        <small class="text-muted fw-normal">— all jobs</small>
+      {% elif mode == 'user' %}
+        My Jobs
+        <small class="text-muted fw-normal">— your jobs on {{ machine | capitalize }}</small>
+      {% else %}
+        {{ scoped_project.projcode if scoped_project else project.projcode }}
+        <small class="text-muted fw-normal">jobs on {{ machine | capitalize if machine }}</small>
+      {% endif %}
+    </h3>
+    {% if mode == 'machine' %}
+      <span class="badge bg-warning-subtle text-dark border">
+        <i class="fas fa-shield-halved me-1"></i> Machine-wide (operator view)
+      </span>
+    {% elif mode == 'project' and scope %}
+      <span class="badge bg-secondary-subtle text-dark border"
+            title="Re-rooted to a subtree of {{ project.projcode }}">
+        <i class="fas fa-diagram-project me-1"></i> scope: {{ scope }}
+      </span>
+    {% endif %}
+  </div>
+
+  {% if not enabled %}
+    {{ jobs_disabled() }}
+  {% else %}
+
+  {# Unity NCAR navy panel — same .filter-sidebar tokens as the allocations
+     and disk-scans filters, so this explorer matches the rest of the
+     dashboard. #}
+  <div class="filter-sidebar mb-3">
+    {{ jobs_filters('jobs-filters-panel-' ~ target_id, fragment_url, target_id,
+                    filters, user_search_url, machine, scope,
+                    per_page_options, mode=mode) }}
+  </div>
+
+  <div class="card">
+    <div class="card-body p-2">
+      <div id="{{ target_id }}"
+           hx-get="{{ initial_url }}"
+           hx-trigger="load"
+           hx-swap="innerHTML">
+        <p class="text-muted small mb-0 p-2">
+          <i class="fas fa-spinner fa-spin me-1"></i> Loading jobs…
+        </p>
+      </div>
+    </div>
+  </div>
+
+  {% endif %}
+</div>
+{% endblock %}

--- a/src/webapp/templates/dashboards/user/my_jobs.html
+++ b/src/webapp/templates/dashboards/user/my_jobs.html
@@ -1,0 +1,7 @@
+{% extends 'dashboards/user/base_user.html' %}
+
+{% block title %}My Jobs - SAM{% endblock %}
+
+{% block user_content %}
+{% include 'dashboards/user/partials/my_jobs_card.html' %}
+{% endblock %}

--- a/src/webapp/templates/dashboards/user/partials/_jobs_filters.html
+++ b/src/webapp/templates/dashboards/user/partials/_jobs_filters.html
@@ -1,0 +1,158 @@
+{% from 'dashboards/fragments/form_fields.html' import fk_search_field %}
+{#
+  Reusable jobs-explorer filter panel in the Unity .filter-sidebar house
+  style (navy panel + gold title + white controls + "Clear filters"),
+  matching _disk_scans_dir_filters.html. The caller wraps this macro in a
+  <div class="filter-sidebar">. Rendered above the table container on the
+  standalone explorer page; on submit it hx-get's *fragment_url* (the
+  mode's per-job fragment) into #target_id with all of its fields.
+
+  Args:
+    form_id         unique id for this form instance
+    fragment_url    the per-job fragment to fetch (project/machine/user mode)
+    target_id       container the fragment swaps into
+    filters         the parsed _panel_filters() dict (current raw values)
+    user_search_url fk-picker search endpoint (admin_dashboard.htmx_search_users, fk)
+    machine         plugin machine key, echoed back on submit
+    scope           project-mode subtree re-root, echoed back on submit
+    per_page_options  row-count choices for the rows selector
+    mode            'project' | 'machine' | 'user'
+
+  The user picker stores a SAM user_id under ``user_id``; the route
+  resolves it to the PBS username the job data is keyed on (see
+  _resolve_user_filter). User mode pins the username server-side, so the
+  picker is omitted — it must not be possible to re-filter the explorer
+  to another user there.
+#}
+{% macro jobs_filters(form_id, fragment_url, target_id, filters,
+                      user_search_url, machine, scope, per_page_options,
+                      mode='project') %}
+<form id="{{ form_id }}"
+      hx-get="{{ fragment_url }}"
+      hx-target="#{{ target_id }}"
+      hx-swap="innerHTML"
+      hx-trigger="submit">
+  <div class="filter-sidebar-header">
+    <h2 class="filter-sidebar-title">
+      <button class="filter-sidebar-toggle" type="button"
+              data-bs-toggle="collapse" data-bs-target="#{{ form_id }}-fields"
+              aria-expanded="true" aria-controls="{{ form_id }}-fields">
+        Filters <i class="fas fa-chevron-down filter-sidebar-chevron ms-1"></i>
+      </button>
+    </h2>
+    {# CSP-clean reset: form-reset-submit (static/js/actions.js) resets the
+       form and re-triggers its htmx submit. fk-picker.js also clears its
+       badge on the native reset event, so the user picker clears too. #}
+    <a class="filter-sidebar-clear" style="cursor: pointer;"
+       data-action="form-reset-submit" data-form-id="{{ form_id }}">Clear filters</a>
+  </div>
+
+  {# Collapsed by default on phones (dashboard-init.js strips .show below md).
+     data-no-persist: the responsive default owns the initial state. #}
+  <div id="{{ form_id }}-fields" class="collapse show filter-fields-collapse" data-no-persist>
+
+  {# Scope context — submitted alongside the visible filter controls. #}
+  <input type="hidden" name="machine" value="{{ machine }}">
+  {% if scope %}<input type="hidden" name="scope" value="{{ scope }}">{% endif %}
+  <input type="hidden" name="target_id" value="{{ target_id }}">
+
+  <div class="d-flex flex-wrap align-items-end gap-3">
+    <div>
+      <label class="form-label"><strong>Jobs ending after</strong></label>
+      <input type="date" class="form-control"
+             name="start" value="{{ filters.start }}"
+             style="width:160px;">
+    </div>
+    <div>
+      <label class="form-label"><strong>Jobs ending before</strong></label>
+      <input type="date" class="form-control"
+             name="end" value="{{ filters.end }}"
+             style="width:160px;">
+    </div>
+
+    {% if mode != 'user' %}
+    <div style="min-width:240px;">
+      {{ fk_search_field('user_id', 'User', user_search_url,
+                         placeholder='Search users…',
+                         optional_text='',
+                         selected_id=filters.user_id or '',
+                         selected_label=filters.user_label or '',
+                         label_class='form-label') }}
+    </div>
+    {% endif %}
+
+    <div>
+      <label class="form-label"><strong>Queue</strong></label>
+      <input type="text" class="form-control" name="queue"
+             value="{{ filters.queue }}" placeholder="e.g. main"
+             style="width:130px;">
+    </div>
+
+    <div>
+      <label class="form-label"><strong>QoS</strong></label>
+      <select class="form-select" name="qos" style="width:140px;">
+        <option value="">All QoS</option>
+        {% for q in filters.qos_options %}
+          <option value="{{ q }}" {% if filters.qos == q %}selected{% endif %}>{{ q }}</option>
+        {% endfor %}
+      </select>
+    </div>
+
+    <div>
+      <label class="form-label"><strong>Exit code</strong></label>
+      <input type="text" class="form-control" name="exit_status"
+             value="{{ filters.exit_status }}" placeholder="0 = success"
+             title="PBS exit code as text — 0 is success"
+             style="width:120px;">
+    </div>
+
+    <div>
+      <label class="form-label"><strong>Job name</strong></label>
+      <input type="text" class="form-control" name="name"
+             value="{{ filters.name }}" placeholder="glob, e.g. wrf*"
+             style="width:160px;">
+    </div>
+
+    <div class="form-check form-switch align-self-center mb-2">
+      <input class="form-check-input" type="checkbox" role="switch"
+             id="{{ form_id }}-icase" name="ignore_case" value="1"
+             {% if filters.ignore_case %}checked{% endif %}>
+      <label class="form-check-label" for="{{ form_id }}-icase">Ignore case</label>
+    </div>
+  </div>
+
+  <div class="d-flex flex-wrap align-items-end gap-3 mt-2">
+    {% for lo_name, hi_name, label, width in [
+        ('min_nodes', 'max_nodes', 'Nodes', '90px'),
+        ('min_cpus',  'max_cpus',  'CPUs',  '90px'),
+        ('min_gpus',  'max_gpus',  'GPUs',  '90px'),
+        ('min_wait_hours', 'max_wait_hours', 'Wait (hours)', '110px')] %}
+    <div>
+      <label class="form-label"><strong>{{ label }}</strong></label>
+      <div class="d-flex gap-1">
+        <input type="number" class="form-control" name="{{ lo_name }}"
+               value="{{ filters[lo_name] if filters[lo_name] is not none }}"
+               placeholder="min" min="0" style="width:{{ width }};">
+        <input type="number" class="form-control" name="{{ hi_name }}"
+               value="{{ filters[hi_name] if filters[hi_name] is not none }}"
+               placeholder="max" min="0" style="width:{{ width }};">
+      </div>
+    </div>
+    {% endfor %}
+
+    <div>
+      <label class="form-label"><strong>Rows</strong></label>
+      <select class="form-select" name="per_page" style="width:100px;">
+        {% for n in per_page_options %}
+          <option value="{{ n }}" {% if filters.per_page == n %}selected{% endif %}>{{ n }}</option>
+        {% endfor %}
+      </select>
+    </div>
+
+    <button type="submit" class="btn btn-outline-white mb-2">
+      <i class="fas fa-filter me-1"></i> Apply
+    </button>
+  </div>
+  </div>
+</form>
+{% endmacro %}

--- a/src/webapp/templates/dashboards/user/partials/_jobs_macros.html
+++ b/src/webapp/templates/dashboards/user/partials/_jobs_macros.html
@@ -1,0 +1,70 @@
+{#
+  Shared banners + badges for the Job History fragments. Mirrors the
+  disabled / error / empty shape of _disk_scans_macros.html so the jobs
+  tabs degrade identically to the filesystem-scan ones.
+#}
+
+{# Plugin not loaded / no warmed engine — graceful "unavailable" notice
+   (the card may hx-get fragments unconditionally), never a 404. #}
+{% macro jobs_disabled() %}
+  <div class="alert alert-secondary py-2 mb-0" role="status">
+    <small>
+      Per-job data is unavailable: the
+      <code>hpc-usage-queries</code> plugin is not loaded.
+      <a href="/dashboards/admin/configuration"
+         target="_blank" rel="noopener">
+        Check the Database card on the Admin → Configuration page
+      </a>
+      for plugin/DB health.
+    </small>
+  </div>
+{% endmacro %}
+
+{# A jobs query raised (transient plugin/DB issue) — warn inline. #}
+{% macro jobs_error(error) %}
+  <div class="alert alert-warning py-2 mb-0" role="alert">
+    <small>Could not load job-history data: {{ error }}</small>
+  </div>
+{% endmacro %}
+
+{# Query succeeded but matched nothing. #}
+{% macro jobs_empty(message) %}
+  <p class="text-muted small mb-0">{{ message }}</p>
+{% endmacro %}
+
+{# Scope badge for the explorer header: which slice of the machine's jobs
+   this view can see. #}
+{% macro mode_badge(mode, machine, projcode=None, username=None) %}
+  <span class="badge bg-light text-dark border me-1">
+    <i class="fas fa-server me-1"></i>{{ machine }}
+  </span>
+  {% if mode == 'project' and projcode %}
+    <span class="badge bg-light text-dark border me-1">
+      <i class="fas fa-diagram-project me-1"></i>{{ projcode }}
+    </span>
+  {% elif mode == 'user' and username %}
+    <span class="badge bg-light text-dark border me-1">
+      <i class="fas fa-user me-1"></i>{{ username }}
+    </span>
+  {% elif mode == 'machine' %}
+    <span class="badge bg-warning-subtle text-dark border me-1"
+          title="Machine-wide view: every user's jobs, cross-project">
+      <i class="fas fa-globe me-1"></i>all jobs
+    </span>
+  {% endif %}
+{% endmacro %}
+
+{# PBS exit code badge: '0' → success, anything else → failure with the
+   raw code. None/empty → unmeasured em-dash. The raw code stays in
+   title= either way for copy/paste. #}
+{% macro exit_status_badge(val) %}
+  {%- if val is none or val == '' -%}
+    <span class="text-muted">—</span>
+  {%- elif val | string == '0' -%}
+    <span class="badge bg-success-subtle text-success border"
+          title="exit status 0">Success</span>
+  {%- else -%}
+    <span class="badge bg-danger-subtle text-danger border"
+          title="exit status {{ val }}">Failed ({{ val }})</span>
+  {%- endif -%}
+{% endmacro %}

--- a/src/webapp/templates/dashboards/user/partials/jobs_by_user.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_by_user.html
@@ -1,0 +1,138 @@
+{% from 'dashboards/user/partials/_jobs_macros.html'
+   import jobs_disabled, jobs_error, jobs_empty %}
+{#
+  By User fragment — per-user usage pie + drillable rows. Embedded via
+  hx-get from the Job History card (project + machine modes; hidden in
+  user mode). Context (set in webapp/jobs/routes.py::_render_by_user):
+    enabled, error, mode ('project'|'machine'), machine,
+    usage   — plugin jobs_usage_by('user') envelope {rows, totals}
+    other   — {'job_count','cpu_hours','gpu_hours'} remainder beyond the
+              row cap (totals are pre-truncation), or None
+    metric  — 'jobs' | 'cpu_hours' | 'gpu_hours' (drives the pie)
+    pie_svg — chart SVG (clickable #job-user-<username> sentinels)
+    fragment_url      — this fragment (metric pill re-fetch)
+    jobs_fragment_url — the mode's per-job fragment (row drill target)
+    target_id, params — container id + hidden round-trip params
+#}
+
+{% if not enabled %}
+  {{ jobs_disabled() }}
+{% elif error %}
+  {{ jobs_error(error) }}
+{% else %}
+  <form id="jobs-byuser-params-{{ target_id }}" class="d-none">
+    {% for k, v in params.items() %}
+    <input type="hidden" name="{{ k }}" value="{{ v }}">
+    {% endfor %}
+  </form>
+
+  {% set rows = (usage.rows if usage else []) or [] %}
+  {% set totals = (usage.totals if usage else {}) or {} %}
+
+  <div class="d-flex align-items-center flex-wrap gap-2 mb-2">
+    {# Metric pills — re-fetch this same pane with ?metric=. #}
+    <div class="btn-group btn-group-sm me-1" role="group" aria-label="Pie metric">
+      {% for m, label in [('jobs', 'Jobs'),
+                          ('cpu_hours', 'CPU-hours'),
+                          ('gpu_hours', 'GPU-hours')] %}
+      <button type="button"
+              class="btn btn-outline-secondary {% if metric == m %}active{% endif %}"
+              hx-get="{{ fragment_url }}?metric={{ m }}"
+              hx-target="#{{ target_id }}"
+              hx-include="#jobs-byuser-params-{{ target_id }}"
+              hx-swap="innerHTML">
+        {{ label }}
+      </button>
+      {% endfor %}
+    </div>
+    <span class="ms-auto text-muted small">
+      {{ totals.get('job_count', 0) | fmt_number }} jobs ·
+      {{ totals.get('cpu_hours', 0) | fmt_number }} CPU-h ·
+      {{ totals.get('gpu_hours', 0) | fmt_number }} GPU-h
+    </span>
+  </div>
+
+  {% if not rows %}
+    {{ jobs_empty('No jobs match the current filters.') }}
+  {% else %}
+    {# Usage pie (top ~90% + one "Other"). Wedges and legend entries are
+       clickable (set_url sentinels → svg-chart-links.js) and expand the
+       matching user's row below. #}
+    {% if pie_svg %}
+    <div class="d-flex justify-content-center mb-3 jobs-user-pie">
+      {{ pie_svg | safe }}
+    </div>
+    {% endif %}
+
+    {# MULTI-TBODY (tbody.sortable-group): each user's row and its lazy
+       drill-down detail row reorder together under client sort. #}
+    <div class="table-responsive">
+      <table class="table table-sm table-hover align-middle mb-0">
+        <thead class="table-light">
+          <tr>
+            <th class="sortable-header" data-sort="text">User</th>
+            <th class="sortable-header text-end" data-sort="numeric">Jobs</th>
+            <th class="sortable-header text-end sort-desc" data-sort="numeric">CPU-hours</th>
+            <th class="sortable-header text-end" data-sort="numeric">GPU-hours</th>
+          </tr>
+        </thead>
+        {% for r in rows %}
+          {% set uname = r.value %}
+          {% set _rid = target_id ~ '-u' ~ loop.index %}
+          <tbody class="sortable-group">
+            {# data-job-user + data-bs-target let a pie-wedge click open this
+               row's collapse (svg-chart-links.js), same as the chevron. #}
+            <tr {% if uname %}data-job-user="{{ uname }}"{% endif %}
+                data-bs-target="#{{ _rid }}-row">
+              <td data-sort-value="{{ uname or '~' }}">
+                {% if uname %}
+                <button class="btn btn-sm btn-link text-decoration-none p-0 me-1"
+                        type="button" data-bs-toggle="collapse"
+                        data-bs-target="#{{ _rid }}-row"
+                        aria-expanded="false" aria-controls="{{ _rid }}-row">
+                  <i class="fas fa-chevron-right collapse-icon small"></i>
+                </button>
+                <code>{{ uname }}</code>
+                {% else %}
+                <span class="text-muted" title="jobs with no recorded user">(unknown)</span>
+                {% endif %}
+              </td>
+              <td class="text-end" data-sort-value="{{ r.job_count }}">{{ r.job_count | fmt_number }}</td>
+              <td class="text-end" data-sort-value="{{ r.cpu_hours }}">{{ r.cpu_hours | fmt_number }}</td>
+              <td class="text-end" data-sort-value="{{ r.gpu_hours }}">{{ r.gpu_hours | fmt_number }}</td>
+            </tr>
+            {% if uname %}
+            <tr class="collapse" id="{{ _rid }}-row">
+              <td colspan="4" class="p-0 border-0">
+                {# Lazy-load this user's jobs on first expand. Bind to
+                   shown.bs.collapse (not click) so it fires under
+                   nav-view-persistence restore too. Carries the pane's
+                   date window + shared filters into the drill. #}
+                <div class="p-2 bg-light" id="{{ _rid }}-content"
+                     hx-get="{{ jobs_fragment_url }}?machine={{ machine }}&user={{ uname }}{% if params.start %}&start={{ params.start }}{% endif %}{% if params.end %}&end={{ params.end }}{% endif %}{% if params.queue %}&queue={{ params.queue }}{% endif %}{% if params.qos %}&qos={{ params.qos }}{% endif %}{% if params.exit_status %}&exit_status={{ params.exit_status }}{% endif %}&target_id={{ _rid }}-content"
+                     hx-trigger="shown.bs.collapse from:closest tr.collapse once"
+                     hx-swap="innerHTML">
+                  <p class="text-muted small mb-0">
+                    <i class="fas fa-spinner fa-spin me-1"></i>
+                    Loading {{ uname }}'s jobs…
+                  </p>
+                </div>
+              </td>
+            </tr>
+            {% endif %}
+          </tbody>
+        {% endfor %}
+        {% if other %}
+        <tbody>
+          <tr class="text-muted">
+            <td>Other <span class="small">(beyond top {{ rows | length }})</span></td>
+            <td class="text-end">{{ other.job_count | fmt_number }}</td>
+            <td class="text-end">{{ other.cpu_hours | fmt_number }}</td>
+            <td class="text-end">{{ other.gpu_hours | fmt_number }}</td>
+          </tr>
+        </tbody>
+        {% endif %}
+      </table>
+    </div>
+  {% endif %}
+{% endif %}

--- a/src/webapp/templates/dashboards/user/partials/jobs_card.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_card.html
@@ -24,6 +24,11 @@
    VIEW_ALL_JOB_DATA); in user mode the username is pinned server-side and
    the By User tab is omitted (it would be a pie of one).
 #}
+{# Optional params default to none so url_for drops them (an undefined
+   name would reach url_for as Jinja Undefined and break URL building). #}
+{% set start = start | default(none) %}
+{% set end = end | default(none) %}
+{% set scope = scope | default(none) %}
 {% if mode == 'machine' %}
     {% set _jobs_url  = url_for('jobs.jobs_machine_fragment',       machine=machine, start=start, end=end, target_id=cid ~ '-jobs') %}
     {% set _user_url  = url_for('jobs.by_user_machine_fragment',    machine=machine, start=start, end=end, target_id=cid ~ '-byuser') %}
@@ -44,8 +49,7 @@
     {% set _wait_url  = url_for('jobs.wait_times_fragment', projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-wait') %}
     {% set _sizes_url = url_for('jobs.job_sizes_fragment',  projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-sizes') %}
     {% set _dur_url   = url_for('jobs.durations_fragment',  projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-durations') %}
-    {# explore_page lands with the explorer commit — until then no button #}
-    {% set _full_url  = none %}
+    {% set _full_url  = url_for('jobs.explore_page',        projcode=projcode, machine=machine, start=start, end=end, scope=scope) %}
 {% endif %}
 <ul class="nav nav-tabs mb-0" id="{{ tablist_id }}" role="tablist">
     <li class="nav-item" role="presentation">

--- a/src/webapp/templates/dashboards/user/partials/jobs_card.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_card.html
@@ -1,0 +1,157 @@
+{# ── Job History card (shared, mode-parameterized) ──────────────────────
+   The Jobs / By User / Wait Times / Job Sizes / Durations tab strip, each
+   lazy-loading its jobs.* fragment via hx-get. Shared by the compute
+   resource-details page (mode='project'), the Status dashboard's Job
+   History subtabs (mode='machine'), and the My Jobs page (mode='user').
+
+   Params:
+     mode        'project' | 'machine' | 'user'
+     cid         element-id prefix; namespaces every id so multiple cards on
+                 one page (Status subtabs, My Jobs machine pills) don't collide.
+     tablist_id  id for the <ul class="nav-tabs"> (drives nav-view-persistence's
+                 tab:<id> key; keep stable per card).
+     machine     plugin machine key ('derecho' | 'casper')
+     load_trigger  hx-trigger for the first (Jobs) tab — the only bit of
+                   lazy-load wiring that differs by host: project mode fires
+                   on card-open (collapse) + tab show; machine/user modes fire
+                   when their pane is shown. See feedback_persisted_collapse_htmx.
+     projcode, scope  project mode only.
+     start, end   optional YYYY-MM-DD window carried into every tab (project
+                  mode passes the page's date range so aggregations stay
+                  bounded; url_for drops None values).
+
+   In machine mode there is no account scoping (routes are gated behind
+   VIEW_ALL_JOB_DATA); in user mode the username is pinned server-side and
+   the By User tab is omitted (it would be a pie of one).
+#}
+{% if mode == 'machine' %}
+    {% set _jobs_url  = url_for('jobs.jobs_machine_fragment',       machine=machine, start=start, end=end, target_id=cid ~ '-jobs') %}
+    {% set _user_url  = url_for('jobs.by_user_machine_fragment',    machine=machine, start=start, end=end, target_id=cid ~ '-byuser') %}
+    {% set _wait_url  = url_for('jobs.wait_times_machine_fragment', machine=machine, start=start, end=end, target_id=cid ~ '-wait') %}
+    {% set _sizes_url = url_for('jobs.job_sizes_machine_fragment',  machine=machine, start=start, end=end, target_id=cid ~ '-sizes') %}
+    {% set _dur_url   = url_for('jobs.durations_machine_fragment',  machine=machine, start=start, end=end, target_id=cid ~ '-durations') %}
+    {% set _full_url  = url_for('jobs.explore_machine_page',        machine=machine, start=start, end=end) %}
+{% elif mode == 'user' %}
+    {% set _jobs_url  = url_for('jobs.jobs_user_fragment',       machine=machine, start=start, end=end, target_id=cid ~ '-jobs') %}
+    {% set _wait_url  = url_for('jobs.wait_times_user_fragment', machine=machine, start=start, end=end, target_id=cid ~ '-wait') %}
+    {% set _sizes_url = url_for('jobs.job_sizes_user_fragment',  machine=machine, start=start, end=end, target_id=cid ~ '-sizes') %}
+    {% set _dur_url   = url_for('jobs.durations_user_fragment',  machine=machine, start=start, end=end, target_id=cid ~ '-durations') %}
+    {% set _full_url  = url_for('jobs.explore_user_page',        machine=machine, start=start, end=end) %}
+    {# no _user_url — the By User tab is hidden in user mode #}
+{% else %}
+    {% set _jobs_url  = url_for('jobs.jobs_fragment',       projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-jobs') %}
+    {% set _user_url  = url_for('jobs.by_user_fragment',    projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-byuser') %}
+    {% set _wait_url  = url_for('jobs.wait_times_fragment', projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-wait') %}
+    {% set _sizes_url = url_for('jobs.job_sizes_fragment',  projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-sizes') %}
+    {% set _dur_url   = url_for('jobs.durations_fragment',  projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-durations') %}
+    {# explore_page lands with the explorer commit — until then no button #}
+    {% set _full_url  = none %}
+{% endif %}
+<ul class="nav nav-tabs mb-0" id="{{ tablist_id }}" role="tablist">
+    <li class="nav-item" role="presentation">
+        <button class="nav-link active" id="{{ cid }}-jobs-tab"
+                data-bs-toggle="tab" data-bs-target="#tab-{{ cid }}-jobs"
+                type="button" role="tab"
+                hx-get="{{ _jobs_url }}"
+                hx-target="#{{ cid }}-jobs"
+                hx-swap="innerHTML"
+                hx-trigger="{{ load_trigger }}">
+            <i class="fas fa-list me-1"></i> Jobs
+        </button>
+    </li>
+    {% if mode != 'user' %}
+    <li class="nav-item" role="presentation">
+        <button class="nav-link" id="{{ cid }}-byuser-tab"
+                data-bs-toggle="tab" data-bs-target="#tab-{{ cid }}-byuser"
+                type="button" role="tab"
+                hx-get="{{ _user_url }}"
+                hx-target="#{{ cid }}-byuser"
+                hx-swap="innerHTML"
+                hx-trigger="shown.bs.tab once">
+            <i class="fas fa-users me-1"></i> By User
+        </button>
+    </li>
+    {% endif %}
+    <li class="nav-item" role="presentation">
+        <button class="nav-link" id="{{ cid }}-wait-tab"
+                data-bs-toggle="tab" data-bs-target="#tab-{{ cid }}-wait"
+                type="button" role="tab"
+                hx-get="{{ _wait_url }}"
+                hx-target="#{{ cid }}-wait"
+                hx-swap="innerHTML"
+                hx-trigger="shown.bs.tab once">
+            <i class="fas fa-hourglass-half me-1"></i> Wait Times
+        </button>
+    </li>
+    <li class="nav-item" role="presentation">
+        <button class="nav-link" id="{{ cid }}-sizes-tab"
+                data-bs-toggle="tab" data-bs-target="#tab-{{ cid }}-sizes"
+                type="button" role="tab"
+                hx-get="{{ _sizes_url }}"
+                hx-target="#{{ cid }}-sizes"
+                hx-swap="innerHTML"
+                hx-trigger="shown.bs.tab once">
+            <i class="fas fa-layer-group me-1"></i> Job Sizes
+        </button>
+    </li>
+    <li class="nav-item" role="presentation">
+        <button class="nav-link" id="{{ cid }}-durations-tab"
+                data-bs-toggle="tab" data-bs-target="#tab-{{ cid }}-durations"
+                type="button" role="tab"
+                hx-get="{{ _dur_url }}"
+                hx-target="#{{ cid }}-durations"
+                hx-swap="innerHTML"
+                hx-trigger="shown.bs.tab once">
+            <i class="fas fa-stopwatch me-1"></i> Durations
+        </button>
+    </li>
+</ul>
+<div class="tab-content border border-top-0 rounded-bottom p-3"
+     id="{{ tablist_id }}Content">
+    <div class="tab-pane fade show active" id="tab-{{ cid }}-jobs" role="tabpanel">
+        {% if _full_url %}
+        <div class="d-flex justify-content-end mb-2">
+            <a class="btn btn-sm btn-outline-primary"
+               href="{{ _full_url }}"
+               target="_blank" rel="noopener">
+                Open full view <i class="fas fa-up-right-from-square ms-1"></i>
+            </a>
+        </div>
+        {% endif %}
+        <div id="{{ cid }}-jobs">
+            <p class="text-muted small mb-0">
+                <i class="fas fa-spinner fa-spin me-1"></i> Loading jobs…
+            </p>
+        </div>
+    </div>
+    {% if mode != 'user' %}
+    <div class="tab-pane fade" id="tab-{{ cid }}-byuser" role="tabpanel">
+        <div id="{{ cid }}-byuser">
+            <p class="text-muted small mb-0">
+                <i class="fas fa-spinner fa-spin me-1"></i> Loading…
+            </p>
+        </div>
+    </div>
+    {% endif %}
+    <div class="tab-pane fade" id="tab-{{ cid }}-wait" role="tabpanel">
+        <div id="{{ cid }}-wait">
+            <p class="text-muted small mb-0">
+                <i class="fas fa-spinner fa-spin me-1"></i> Loading wait times…
+            </p>
+        </div>
+    </div>
+    <div class="tab-pane fade" id="tab-{{ cid }}-sizes" role="tabpanel">
+        <div id="{{ cid }}-sizes">
+            <p class="text-muted small mb-0">
+                <i class="fas fa-spinner fa-spin me-1"></i> Loading job sizes…
+            </p>
+        </div>
+    </div>
+    <div class="tab-pane fade" id="tab-{{ cid }}-durations" role="tabpanel">
+        <div id="{{ cid }}-durations">
+            <p class="text-muted small mb-0">
+                <i class="fas fa-spinner fa-spin me-1"></i> Loading durations…
+            </p>
+        </div>
+    </div>
+</div>

--- a/src/webapp/templates/dashboards/user/partials/jobs_fragment.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_fragment.html
@@ -116,7 +116,7 @@
        serialized into every hx-include without risking a duplicate
        `qos=` query param. #}
     {% if filters.qos and not qos_options %}<input type="hidden" name="qos" value="{{ filters.qos }}">{% endif %}
-    {% if filters.status %}<input type="hidden" name="status" value="{{ filters.status }}">{% endif %}
+    {% if filters.exit_status %}<input type="hidden" name="exit_status" value="{{ filters.exit_status }}">{% endif %}
   </form>
 
   <div class="d-flex align-items-center mb-2">

--- a/src/webapp/templates/dashboards/user/partials/jobs_fragment.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_fragment.html
@@ -101,26 +101,30 @@
 {% else %}
 
   {# Hidden filter form — pagination/sort hx-includes pick up its values
-     so users keep their filters as they page or re-sort. `target_id` is
-     round-tripped here so the next request's response targets the same
-     container this fragment was originally swapped into. #}
+     so users keep their filters as they page or re-sort (including the
+     explorer's extended set: name glob, min/max bounds, wait-hours,
+     scope). `target_id` is round-tripped here so the next request's
+     response targets the same container this fragment was originally
+     swapped into. NB: qos is skipped whenever the visible <select> below
+     renders — it's bound to this form via HTML5 form="…" so its current
+     value is serialized into every hx-include without risking a
+     duplicate `qos=` query param. #}
   <form id="jobs-filters-{{ target_id }}" class="d-none">
-    <input type="hidden" name="machine" value="{{ machine }}">
-    <input type="hidden" name="target_id" value="{{ target_id }}">
-    {% if filters.start %}<input type="hidden" name="start" value="{{ filters.start }}">{% endif %}
-    {% if filters.end %}<input type="hidden" name="end" value="{{ filters.end }}">{% endif %}
-    {% if filters.user %}<input type="hidden" name="user" value="{{ filters.user }}">{% endif %}
-    {% if filters.queue %}<input type="hidden" name="queue" value="{{ filters.queue }}">{% endif %}
-    {# NB: qos is NOT in the hidden form — the visible <select> below is
-       bound to this form via HTML5 form="…" so its current value is
-       serialized into every hx-include without risking a duplicate
-       `qos=` query param. #}
-    {% if filters.qos and not qos_options %}<input type="hidden" name="qos" value="{{ filters.qos }}">{% endif %}
-    {% if filters.exit_status %}<input type="hidden" name="exit_status" value="{{ filters.exit_status }}">{% endif %}
+    {% for k, v in roundtrip_params.items() %}
+      {% if k != 'qos' or not qos_options %}
+    <input type="hidden" name="{{ k }}" value="{{ v }}">
+      {% endif %}
+    {% endfor %}
   </form>
 
   <div class="d-flex align-items-center mb-2">
+    {% if project %}
     <strong class="me-2">{{ project.projcode }}</strong>
+    {% elif username %}
+    <strong class="me-2"><code>{{ username }}</code></strong>
+    {% else %}
+    <strong class="me-2 text-muted" title="Machine-wide view: every user's jobs">all jobs</strong>
+    {% endif %}
     <span class="text-muted small me-3">{{ machine }}</span>
     {% if filters.start or filters.end %}
       <span class="text-muted small me-3">

--- a/src/webapp/templates/dashboards/user/partials/jobs_histogram.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_histogram.html
@@ -1,0 +1,118 @@
+{% from 'dashboards/user/partials/_jobs_macros.html'
+   import jobs_disabled, jobs_error, jobs_empty %}
+{#
+  Histogram fragment — shared by the Wait Times, Job Sizes, and Durations
+  tabs (identical envelope shape; only the dimension differs). Embedded
+  via hx-get from the Job History card. Context (set in
+  webapp/jobs/routes.py::_render_histogram):
+    enabled, error, mode, machine,
+    hist       — plugin jobs_histogram envelope (self-describing: buckets
+                 with label/lo/hi + per-bucket job_count/cpu_hours/
+                 gpu_hours, null_count, total_count, unit)
+    chart_svg  — rendered SVG (or an empty-state div)
+    metric     — 'jobs' | 'cpu_hours' | 'gpu_hours'
+    dimension  — 'wait' | 'nodes' | 'cpus' | 'gpus' | 'memory' | 'duration'
+    dimension_toggle — True only on the Job Sizes tab
+    size_dimensions  — the dimension pill order
+    fragment_url, target_id, params — re-fetch plumbing
+#}
+
+{% if not enabled %}
+  {{ jobs_disabled() }}
+{% elif error %}
+  {{ jobs_error(error) }}
+{% elif not hist %}
+  {{ jobs_empty('No job data for this scope.') }}
+{% else %}
+  <form id="jobs-hist-params-{{ target_id }}" class="d-none">
+    {% for k, v in params.items() %}
+    <input type="hidden" name="{{ k }}" value="{{ v }}">
+    {% endfor %}
+  </form>
+
+  <div class="d-flex align-items-center flex-wrap gap-2 mb-2">
+    {% if dimension_toggle %}
+      {# Dimension pills — nodes / CPUs / GPUs / memory re-fetch this pane
+         with ?dimension= (memory = REQUESTED memory, Job.reqmem). #}
+      <div class="btn-group btn-group-sm me-1" role="group" aria-label="Size dimension">
+        {% for d, label in [('nodes', 'Nodes'), ('cpus', 'CPUs'),
+                            ('gpus', 'GPUs'), ('memory', 'Memory')] %}
+        <button type="button"
+                class="btn btn-outline-secondary {% if dimension == d %}active{% endif %}"
+                hx-get="{{ fragment_url }}?dimension={{ d }}&metric={{ metric }}"
+                hx-target="#{{ target_id }}"
+                hx-include="#jobs-hist-params-{{ target_id }}"
+                hx-swap="innerHTML">
+          {{ label }}
+        </button>
+        {% endfor %}
+      </div>
+    {% endif %}
+    {# Metric pills — count vs charged hours per bucket. #}
+    <div class="btn-group btn-group-sm me-1" role="group" aria-label="Bar metric">
+      {% for m, label in [('jobs', 'Jobs'),
+                          ('cpu_hours', 'CPU-hours'),
+                          ('gpu_hours', 'GPU-hours')] %}
+      <button type="button"
+              class="btn btn-outline-secondary {% if metric == m %}active{% endif %}"
+              hx-get="{{ fragment_url }}?metric={{ m }}{% if dimension_toggle %}&dimension={{ dimension }}{% endif %}"
+              hx-target="#{{ target_id }}"
+              hx-include="#jobs-hist-params-{{ target_id }}"
+              hx-swap="innerHTML">
+        {{ label }}
+      </button>
+      {% endfor %}
+    </div>
+    <span class="ms-auto text-muted small">
+      {{ hist.total_count | fmt_number }} job{{ '' if hist.total_count == 1 else 's' }}
+    </span>
+  </div>
+
+  {% if chart_svg %}
+  <div class="d-flex justify-content-center mb-2 jobs-histogram-chart">
+    {{ chart_svg | safe }}
+  </div>
+  {% endif %}
+
+  {% if hist.null_count and hist.null_count > 0 %}
+    <p class="text-muted small mb-2">
+      <i class="fas fa-circle-info me-1"></i>
+      {% if dimension == 'wait' %}
+        {{ hist.null_count | fmt_number }} job{{ '' if hist.null_count == 1 else 's' }}
+        in this range have no wait measurement (queued before eligible-time
+        collection began, early 2025 on Derecho) and are excluded.
+      {% else %}
+        {{ hist.null_count | fmt_number }} job{{ '' if hist.null_count == 1 else 's' }}
+        in this range have no recorded value for this dimension and are excluded.
+      {% endif %}
+    </p>
+  {% endif %}
+
+  {# Bucket table under the SVG — the same full, zero-filled vector the
+     chart renders, so counts are copy/paste-able. #}
+  <details class="mt-1">
+    <summary class="small text-muted">Bucket counts</summary>
+    <div class="table-responsive mt-2">
+      <table class="table table-sm table-hover align-middle mb-0">
+        <thead class="table-light">
+          <tr>
+            <th>Range</th>
+            <th class="text-end">Jobs</th>
+            <th class="text-end">CPU-hours</th>
+            <th class="text-end">GPU-hours</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for b in hist.buckets %}
+          <tr {% if not b.job_count %}class="text-muted"{% endif %}>
+            <td><code>{{ b.label }}</code></td>
+            <td class="text-end">{{ b.job_count | fmt_number }}</td>
+            <td class="text-end">{{ b.cpu_hours | fmt_number }}</td>
+            <td class="text-end">{{ b.gpu_hours | fmt_number }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </details>
+{% endif %}

--- a/src/webapp/templates/dashboards/user/partials/my_jobs_card.html
+++ b/src/webapp/templates/dashboards/user/partials/my_jobs_card.html
@@ -1,0 +1,49 @@
+{# ── "My Jobs" tab body (User dashboard) ────────────────────────────────
+   One subtab per plugin machine (job_history_machines, from
+   webapp.jobs.service.job_history_machines()). Each subtab hosts the SAME
+   jobs card the project resource-details page shows, but in user mode —
+   machine-rooted and filtered to the jobs the logged-in user RAN. The
+   username is pinned server-side (see jobs/routes.py user family), so
+   these routes are @login_required only (no VIEW_ALL_JOB_DATA).
+
+   The "By User" tab is hidden in user mode (single user).
+
+   Lazy-load: /user/jobs is a routable page, so the first subtab is
+   visible on page load and its card loads immediately (trigger 'load').
+   Other subtabs load when their own subtab nav-link is shown — bind to
+   the shown event, not click (feedback_persisted_collapse_htmx).
+
+   This partial is only included when job_history_machines is non-empty
+   (the my_jobs route 404s otherwise), so it never needs its own
+   empty/disabled state.
+#}
+<ul class="nav nav-pills mb-3" id="myJobsSubtabs" role="tablist">
+    {% for m in job_history_machines %}
+    <li class="nav-item" role="presentation">
+        <a class="nav-link {% if loop.first %}active{% endif %}"
+           id="my-jobs-subtab-{{ loop.index }}"
+           data-bs-toggle="tab" href="#my-jobs-pane-{{ loop.index }}" role="tab">
+            <i class="fas fa-server me-1"></i> {{ m | capitalize }}
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+<div class="tab-content" id="myJobsSubtabContent">
+    {% for m in job_history_machines %}
+    <div class="tab-pane fade {% if loop.first %}show active{% endif %}"
+         id="my-jobs-pane-{{ loop.index }}" role="tabpanel">
+        {% if loop.first %}
+            {% set _trigger = 'load once' %}
+        {% else %}
+            {% set _trigger = 'shown.bs.tab once from:#my-jobs-subtab-' ~ loop.index %}
+        {% endif %}
+        {% with mode='user',
+                cid='my-jobs-m' ~ loop.index,
+                tablist_id='myJobsCardTabs' ~ loop.index,
+                machine=m,
+                load_trigger=_trigger %}
+            {% include 'dashboards/user/partials/jobs_card.html' %}
+        {% endwith %}
+    </div>
+    {% endfor %}
+</div>

--- a/src/webapp/templates/dashboards/user/partials/my_jobs_card.html
+++ b/src/webapp/templates/dashboards/user/partials/my_jobs_card.html
@@ -41,6 +41,7 @@
                 cid='my-jobs-m' ~ loop.index,
                 tablist_id='myJobsCardTabs' ~ loop.index,
                 machine=m,
+                start=jobs_window_start,
                 load_trigger=_trigger %}
             {% include 'dashboards/user/partials/jobs_card.html' %}
         {% endwith %}

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -510,6 +510,37 @@
 </div>
 {% endif %}
 
+<!-- Job History Card — per-job drill + aggregation tabs from the
+     hpc-usage-queries plugin. Only for resources that map onto a plugin
+     machine (Derecho/Derecho GPU → derecho, Casper → casper). Collapsed
+     by default: the tabs' queries are the most expensive on this page,
+     so nothing fires until the user opens the card (the first tab's
+     hx-trigger binds to shown.bs.collapse — see
+     feedback_persisted_collapse_htmx). -->
+{% if jobs_machine %}
+<div class="card mb-4">
+    <div class="card-header cursor-pointer" data-bs-toggle="collapse" data-bs-target="#collapseJobsHist" aria-expanded="false">
+        <h5 class="mb-0">
+            <i class="fas fa-list-check"></i> Job History
+            {% if has_children and scope != projcode %}
+            <small class="text-muted fw-normal ms-2">{{ scope }}</small>
+            {% endif %}
+            <i class="fas fa-chevron-down float-end transition-smooth"></i>
+        </h5>
+    </div>
+    <div id="collapseJobsHist" class="collapse">
+        <div class="card-body">
+            {% with mode='project', cid='jobs-hist', tablist_id='jobsCardTabs',
+                    machine=jobs_machine, projcode=projcode, scope=scope,
+                    start=start_date, end=end_date,
+                    load_trigger='shown.bs.tab once, shown.bs.collapse once from:#collapseJobsHist' %}
+                {% include 'dashboards/user/partials/jobs_card.html' %}
+            {% endwith %}
+        </div>
+    </div>
+</div>
+{% endif %}
+
 <!-- Allocation Management Modals -->
 {% include 'dashboards/user/fragments/allocation_modals.html' %}
 

--- a/src/webapp/utils/nav.py
+++ b/src/webapp/utils/nav.py
@@ -84,6 +84,16 @@ def _my_data_available():
     return bool(disk_scans_service.scan_capable_resources())
 
 
+def _my_jobs_available():
+    # Mirrors user_dashboard._page_context(): any authenticated user (the
+    # job routes pin the username server-side); hidden only when no
+    # job-history machine engine is warmed.
+    if not current_user.is_authenticated:
+        return False
+    from webapp.jobs import service as jobs_service
+    return bool(jobs_service.job_history_machines())
+
+
 # ── The registry ──────────────────────────────────────────────────────────
 #
 # Section keys: 'blueprint' drives section-level active state; 'endpoint' is
@@ -106,6 +116,8 @@ NAV_SECTIONS = (
              'icon': 'fas fa-user-circle'},
             {'endpoint': 'user_dashboard.my_data', 'label': 'My Data',
              'icon': 'fas fa-hard-drive', 'visible': _my_data_available},
+            {'endpoint': 'user_dashboard.my_jobs', 'label': 'My Jobs',
+             'icon': 'fas fa-list-check', 'visible': _my_jobs_available},
         ),
     },
     {

--- a/src/webapp/utils/nav.py
+++ b/src/webapp/utils/nav.py
@@ -60,6 +60,18 @@ def _can_view_fs_scans():
     return bool(disk_scans_service.scan_capable_resources())
 
 
+def _can_view_job_history():
+    # Same gate as the status tab strip: permission AND at least one warmed
+    # job-history engine. job_history_machines() is an in-memory extension
+    # lookup — cheap per request. When the plugin is off, no job-history
+    # link appears anywhere on the page.
+    if not (current_user.is_authenticated
+            and has_permission(current_user, Permission.VIEW_ALL_JOB_DATA)):
+        return False
+    from webapp.jobs import service as jobs_service
+    return bool(jobs_service.job_history_machines())
+
+
 def _my_data_available():
     # Mirrors user_dashboard._page_context(): needs a filesystem identity and
     # at least one warmed scan collection. scan_capable_resources() is a
@@ -112,6 +124,8 @@ NAV_SECTIONS = (
              'icon': 'fas fa-calendar-alt'},
             {'endpoint': 'status_dashboard.filesystem_scans', 'label': 'Filesystem Scans',
              'icon': 'fas fa-magnifying-glass-chart', 'visible': _can_view_fs_scans},
+            {'endpoint': 'status_dashboard.job_history', 'label': 'Job History',
+             'icon': 'fas fa-list-check', 'visible': _can_view_job_history},
         ),
     },
     {

--- a/src/webapp/utils/rbac.py
+++ b/src/webapp/utils/rbac.py
@@ -109,6 +109,19 @@ class Permission(Enum):
     # facility-scoped.
     VIEW_ALL_FILESYSTEM_DATA = "view_all_filesystem_data"
 
+    # Job history (elevated)
+    # Browse per-job data across an entire machine, UNSCOPED — every user's
+    # jobs, queues, and charges, cross-project and cross-user (the machine-wide
+    # jobs explorer + the Status page "Job History" tab). The project-scoped
+    # jobs card needs no permission (project access already gates it) and the
+    # "My Jobs" view pins to the session user; this gates only the machine-wide
+    # surfaces. Named ``view_*`` so it is auto-granted to the operator bundles
+    # via ``ALL_VIEW`` (today exactly nusd/csg/ssg) and NOT to the
+    # facility-scoped tier, which enumerates its VIEW_* grants explicitly.
+    # Plugin machines (derecho/casper) don't map onto UNIV/WNA/NCAR
+    # facilities, so this is intentionally global, not facility-scoped.
+    VIEW_ALL_JOB_DATA = "view_all_job_data"
+
     # System administration
     ACCESS_ADMIN_DASHBOARD = "access_admin_dashboard"  # Land on /admin/ and see the navbar tab
     MANAGE_ROLES = "manage_roles"

--- a/tests/api/test_admin_cache.py
+++ b/tests/api/test_admin_cache.py
@@ -36,9 +36,11 @@ class TestAdminCacheRefreshBehavior:
 
     def test_clear_all_covers_every_category(self, auth_client):
         data = auth_client.post('/api/v1/admin/cache/refresh').get_json()
-        assert set(data['cleared'].keys()) == {'flask', 'chart', 'usage', 'scans'}
+        assert set(data['cleared'].keys()) == {'flask', 'chart', 'usage',
+                                               'scans', 'jobs'}
 
-    @pytest.mark.parametrize('category', ['flask', 'chart', 'usage', 'scans'])
+    @pytest.mark.parametrize('category',
+                             ['flask', 'chart', 'usage', 'scans', 'jobs'])
     def test_single_category_scopes_the_clear(self, auth_client, category):
         data = auth_client.post(
             f'/api/v1/admin/cache/refresh?category={category}'

--- a/tests/unit/snapshots/dashboard_route_map.json
+++ b/tests/unit/snapshots/dashboard_route_map.json
@@ -1631,6 +1631,13 @@
     ]
   ],
   [
+    "user_dashboard.my_jobs",
+    "/user/jobs",
+    [
+      "GET"
+    ]
+  ],
+  [
     "user_dashboard.project_details_modal",
     "/user/project-details-modal/<projcode>",
     [

--- a/tests/unit/snapshots/dashboard_route_map.json
+++ b/tests/unit/snapshots/dashboard_route_map.json
@@ -1477,6 +1477,13 @@
     ]
   ],
   [
+    "status_dashboard.job_history",
+    "/status/job-history",
+    [
+      "GET"
+    ]
+  ],
+  [
     "status_dashboard.jupyterhub",
     "/status/jupyterhub",
     [

--- a/tests/unit/test_sam_search_jobs_cli.py
+++ b/tests/unit/test_sam_search_jobs_cli.py
@@ -35,7 +35,7 @@ def _job(**over):
     """Build a per-job dict shaped like JobQueries.jobs_search() output."""
     row = dict(
         job_id='1234567.desched1', account='SCSG0001', user='benkirk',
-        queue='main', qos='regular', qos_factor=1.0, status='F',
+        queue='main', qos='regular', qos_factor=1.0, exit_status='0',
         submit='2026-05-01T10:00:00', start='2026-05-01T10:05:00',
         end='2026-05-01T12:05:00', elapsed=7200, walltime=7200,
         numnodes=4, numcpus=512, numgpus=0, cputype='milan', gputype=None,

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -1720,3 +1720,224 @@ def test_histogram_fragment_metric_pill_roundtrip(
     import re
     assert re.search(r'active[^>]*>\s*CPU-hours', body) or \
         re.search(r'CPU-hours', body)
+
+
+# ---------------------------------------------------------------------------
+# Commit 6: machine-wide family (operator) + explorer pages + Status tab
+# ---------------------------------------------------------------------------
+
+_MACHINE_FRAGMENTS = ['', '/by-user', '/wait-times', '/job-sizes', '/durations']
+
+
+@pytest.mark.parametrize('suffix', _MACHINE_FRAGMENTS + ['/explore'])
+def test_machine_routes_403_without_permission(non_admin_client, suffix):
+    resp = non_admin_client.get(f'/dashboards/user/jobs/machine/derecho{suffix}')
+    assert resp.status_code == 403
+
+
+@pytest.mark.parametrize('suffix', _MACHINE_FRAGMENTS + ['/explore'])
+def test_machine_routes_disabled_banner_with_permission(auth_client, suffix):
+    """benkirk holds VIEW_ALL_JOB_DATA → 200 (plugin off → banner)."""
+    resp = auth_client.get(f'/dashboards/user/jobs/machine/derecho{suffix}')
+    assert resp.status_code == 200
+    assert 'Per-job data is unavailable' in resp.get_data(as_text=True)
+
+
+@pytest.mark.parametrize('suffix', _MACHINE_FRAGMENTS + ['/explore'])
+def test_machine_routes_404_unknown_machine(app, auth_client, monkeypatch, suffix):
+    """With the plugin up for derecho only, /machine/gust → 404."""
+    _install_mock_plugin(app, monkeypatch, machines=('derecho',))
+    resp = auth_client.get(f'/dashboards/user/jobs/machine/gust{suffix}')
+    assert resp.status_code == 404
+
+
+def test_machine_jobs_fragment_unscoped(app, auth_client, monkeypatch):
+    """The machine table issues no account filter and renders rows."""
+    captured = _install_mock_plugin(app, monkeypatch,
+                                    jobs_search_return=[_make_row()],
+                                    jobs_count_return=1)
+    resp = auth_client.get('/dashboards/user/jobs/machine/derecho')
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert '500.desched1' in body
+    kw = captured['last_jobs_search_kwargs']
+    assert 'account' not in kw
+    ckw = captured['last_jobs_count_kwargs']
+    assert 'account' not in ckw
+
+
+def test_machine_by_user_fragment_unscoped(app, auth_client, monkeypatch):
+    captured = _install_mock_plugin(app, monkeypatch,
+                                    jobs_usage_by_return=_sample_usage())
+    resp = auth_client.get('/dashboards/user/jobs/machine/derecho/by-user')
+    assert resp.status_code == 200
+    assert 'data-job-user="alice"' in resp.get_data(as_text=True)
+    _dim, kwargs = captured['last_jobs_usage_by']
+    assert 'account' not in kwargs
+
+
+def test_machine_histogram_fragment_unscoped(app, auth_client, monkeypatch):
+    captured = _install_mock_plugin(app, monkeypatch,
+                                    jobs_histogram_return=_sample_hist())
+    resp = auth_client.get('/dashboards/user/jobs/machine/derecho/wait-times')
+    assert resp.status_code == 200
+    _dim, kwargs = captured['last_jobs_histogram']
+    assert 'account' not in kwargs
+
+
+def test_explore_machine_page_renders_filter_panel(app, auth_client, monkeypatch):
+    _install_mock_plugin(app, monkeypatch)
+    resp = auth_client.get('/dashboards/user/jobs/machine/derecho/explore')
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'filter-sidebar' in body
+    assert 'Machine-wide (operator view)' in body
+    # Panel fields present.
+    assert 'name="min_nodes"' in body
+    assert 'name="exit_status"' in body
+
+
+def test_explore_page_project_mode(app, auth_client, active_project, monkeypatch):
+    _install_mock_plugin(app, monkeypatch)
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/explore?machine=derecho'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'filter-sidebar' in body
+    assert active_project.projcode in body
+    # Machine-wide badge must NOT show in project mode.
+    assert 'Machine-wide (operator view)' not in body
+
+
+def test_explore_page_carries_filters_into_initial_url(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Deep-link with filters → the lazy-load URL reproduces them."""
+    _install_mock_plugin(app, monkeypatch)
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/explore'
+        '?machine=derecho&queue=main&min_nodes=4&min_wait_hours=1.5'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'queue=main' in body
+    assert 'min_nodes=4' in body
+    assert 'min_wait_hours=1.5' in body
+
+
+def test_explore_page_scope_rerooting_badge(
+    app, auth_client, active_project, monkeypatch,
+):
+    """A valid child scope shows the scope badge; out-of-tree falls back."""
+    import types as _types
+    from sam import Project
+
+    child = _types.SimpleNamespace(projcode='CHILD0001')
+    real_get = Project.get_by_projcode
+
+    def _fake_get(session, projcode):
+        if projcode == 'CHILD0001':
+            fake = MagicMock()
+            fake.projcode = 'CHILD0001'
+            fake.tree_root = active_project.tree_root
+            fake.get_descendants = lambda include_self=True: [child]
+            return fake
+        return real_get(session, projcode)
+
+    monkeypatch.setattr(Project, 'get_by_projcode', staticmethod(_fake_get))
+    _install_mock_plugin(app, monkeypatch)
+
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/explore'
+        '?machine=derecho&scope=CHILD0001'
+    )
+    assert resp.status_code == 200
+    assert 'scope: CHILD0001' in resp.get_data(as_text=True)
+
+
+def test_fragment_scope_rerooting_narrows_account(
+    app, auth_client, active_project, monkeypatch,
+):
+    """?scope=<child> narrows the account filter to the child's subtree."""
+    import types as _types
+    from sam import Project
+
+    child_desc = [_types.SimpleNamespace(projcode='CHILD0001'),
+                  _types.SimpleNamespace(projcode='CHILD0001_a')]
+    real_get = Project.get_by_projcode
+
+    def _fake_get(session, projcode):
+        if projcode == 'CHILD0001':
+            fake = MagicMock()
+            fake.projcode = 'CHILD0001'
+            fake.tree_root = active_project.tree_root
+            fake.get_descendants = lambda include_self=True: child_desc
+            return fake
+        return real_get(session, projcode)
+
+    monkeypatch.setattr(Project, 'get_by_projcode', staticmethod(_fake_get))
+    captured = _install_mock_plugin(app, monkeypatch,
+                                    jobs_histogram_return=_sample_hist())
+
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times'
+        '?machine=derecho&scope=CHILD0001'
+    )
+    _dim, kwargs = captured['last_jobs_histogram']
+    assert kwargs['account'] == ['CHILD0001', 'CHILD0001_a']
+
+
+# ---------------------------------------------------------------------------
+# Status dashboard: Job History tab
+# ---------------------------------------------------------------------------
+
+def test_status_job_history_403_without_permission(non_admin_client):
+    resp = non_admin_client.get('/status/job-history')
+    assert resp.status_code == 403
+
+
+def test_status_job_history_empty_state_when_disabled(auth_client):
+    """Plugin off → no machines → the info alert (never a broken card)."""
+    resp = auth_client.get('/status/job-history')
+    assert resp.status_code == 200
+    assert 'No job-history data is currently available' in resp.get_data(as_text=True)
+
+
+def test_status_job_history_machine_pills_when_enabled(
+    app, auth_client, monkeypatch,
+):
+    _install_mock_plugin(app, monkeypatch, machines=('derecho', 'casper'))
+    resp = auth_client.get('/status/job-history')
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'job-hist-subtab-1' in body
+    assert 'Derecho' in body
+    assert 'Casper' in body
+    # Machine-mode card fragments wired per pill.
+    assert '/dashboards/user/jobs/machine/casper' in body
+
+
+def test_status_tab_hidden_without_machines(auth_client):
+    """Plugin off → the Job History tab is absent from the status pages."""
+    resp = auth_client.get('/status/derecho')
+    assert resp.status_code == 200
+    assert '/status/job-history' not in resp.get_data(as_text=True)
+
+
+def test_status_tab_visible_for_operator_with_machines(
+    app, auth_client, monkeypatch,
+):
+    _install_mock_plugin(app, monkeypatch, machines=('derecho',))
+    resp = auth_client.get('/status/derecho')
+    assert resp.status_code == 200
+    assert '/status/job-history' in resp.get_data(as_text=True)
+
+
+def test_status_tab_hidden_for_plain_user_with_machines(
+    app, non_admin_client, monkeypatch,
+):
+    """Even with machines up, no VIEW_ALL_JOB_DATA → no tab, anywhere."""
+    _install_mock_plugin(app, monkeypatch, machines=('derecho',))
+    resp = non_admin_client.get('/status/derecho')
+    assert resp.status_code == 200
+    assert '/status/job-history' not in resp.get_data(as_text=True)

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -145,6 +145,45 @@ def test_init_job_history_engine_failure_skips_machine(monkeypatch):
 
 _DEFAULT_QOS_NAMES = ['economy', 'premium', 'regular', 'special', 'uncharged']
 
+# Pinned copy of the plugin's COLUMNS headers (hpc-usage-queries PR #99
+# contract, `from job_history import COLUMNS`). _install_mock_plugin patches
+# routes._load_column_specs to return THIS, so header-label assertions test
+# SAM's rendering against a fixed contract instead of whichever plugin
+# version happens to be installed — CI builds the plugin from main until
+# PR #99 merges, and the local hash-keyed conda-env flips refs, so the real
+# import may legitimately be missing or stale during the transition.
+_FAKE_COLUMN_SPECS = {
+    'job_id': {'header': 'Job ID'},
+    'name': {'header': 'Name'},
+    'qos': {'header': 'QoS'},
+    'start': {'header': 'Start'},
+    'elapsed': {'header': 'Elapsed'},
+    'numnodes': {'header': 'Nodes'},
+    'numcpus': {'header': 'CPUs'},
+    'numgpus': {'header': 'GPUs'},
+    'cpu_charges': {'header': 'CPU chg'},
+    'gpu_charges': {'header': 'GPU chg'},
+    'exit_status': {'header': 'Exit'},
+    'qos_factor': {'header': 'Factor'},
+    'queue': {'header': 'Queue'},
+    'user': {'header': 'User'},
+    'submit': {'header': 'Submit'},
+    'end': {'header': 'End'},
+    'walltime': {'header': 'Walltime'},
+    'mpiprocs': {'header': 'Ranks per Node'},
+    'ompthreads': {'header': 'OMP Threads'},
+    'reqmem': {'header': 'ReqMem'},
+    'memory': {'header': 'Mem'},
+    'vmemory': {'header': 'VMem'},
+    'cputype': {'header': 'CPU type'},
+    'gputype': {'header': 'GPU type'},
+    'resources': {'header': 'Resources'},
+    'cpu_hours': {'header': 'CPU-h'},
+    'gpu_hours': {'header': 'GPU-h'},
+    'memory_hours': {'header': 'Mem-h'},
+    'memory_charges': {'header': 'Mem chg'},
+}
+
 
 def _install_mock_plugin(app, monkeypatch, *, jobs_search_return=None,
                         jobs_count_return=None, qos_names=None,
@@ -207,6 +246,13 @@ def _install_mock_plugin(app, monkeypatch, *, jobs_search_return=None,
         'enabled': True,
     }
     monkeypatch.setitem(app.extensions, 'hpc_usage_queries', new_state)
+
+    # Column headers come from the pinned stub, never the installed plugin
+    # (see _FAKE_COLUMN_SPECS) — completes the isolation the fake module
+    # starts: these tests must pass with no plugin installed at all.
+    from webapp.jobs import routes as jobs_routes
+    monkeypatch.setattr(jobs_routes, '_load_column_specs',
+                        lambda: _FAKE_COLUMN_SPECS)
     return captured
 
 

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -271,7 +271,7 @@ def test_count_jobs_sam_summary_keeps_legacy_queue_name(
     _install_mock_plugin(app, monkeypatch)
 
     with app.app_context():
-        # No status / has_gpus → goes through the SAM summary fast path.
+        # No exit_status / GPU bounds → goes through the SAM summary fast path.
         total = service.count_jobs(
             'derecho', project=active_project, queue='cpu-special',
         )
@@ -284,8 +284,9 @@ def test_count_jobs_plugin_fallback_normalizes_legacy_queue_name(
     app, active_project, monkeypatch,
 ):
     """When the request adds a filter outside the summary key set
-    (``status``, ``has_gpus``), count_jobs hits the plugin — which DOES
-    need the normalized queue. Mirrors the search_jobs test."""
+    (``exit_status``, ``min_gpus``/``max_gpus``), count_jobs hits the
+    plugin — which DOES need the normalized queue. Mirrors the
+    search_jobs test."""
     from webapp.jobs import service
 
     captured = _install_mock_plugin(app, monkeypatch, jobs_count_return=7)
@@ -294,7 +295,7 @@ def test_count_jobs_plugin_fallback_normalizes_legacy_queue_name(
         service.count_jobs(
             'derecho', project=active_project,
             queue='cpu-economy',
-            status='F',  # forces plugin path
+            exit_status='1',  # forces plugin path
         )
 
     ckw = captured['last_jobs_count_kwargs']
@@ -404,8 +405,8 @@ def test_count_jobs_sam_summary_ignores_inferred_qos(
 def test_count_jobs_plugin_fallback_promotes_legacy_queue_suffix_to_qos(
     app, active_project, monkeypatch,
 ):
-    """When count_jobs takes the plugin path (e.g. because status is
-    set), it also runs the queue/qos resolver so 'cpu-special' →
+    """When count_jobs takes the plugin path (e.g. because exit_status
+    is set), it also runs the queue/qos resolver so 'cpu-special' →
     queue='cpu', qos='special' on the plugin call."""
     from webapp.jobs import service
 
@@ -415,7 +416,7 @@ def test_count_jobs_plugin_fallback_promotes_legacy_queue_suffix_to_qos(
         service.count_jobs(
             'derecho', project=active_project,
             queue='cpu-special',
-            status='F',  # forces plugin path
+            exit_status='1',  # forces plugin path
             valid_qos_names=['premium', 'regular', 'special'],
         )
 
@@ -536,7 +537,7 @@ def _make_row(**overrides):
     to a sensible non-empty value so suppression / drawer tests can opt
     fields back to 0/None without redefining the full superset."""
     base = {
-        'job_id': '500.desched1', 'name': 'demo', 'status': 'F',
+        'job_id': '500.desched1', 'name': 'demo', 'exit_status': '1',
         'user': 'alice', 'account': 'SCSG0001', 'queue': 'main',
         'start': '2026-05-01 10:00:00',
         'end':   '2026-05-01 11:00:00',
@@ -561,8 +562,8 @@ def test_jobs_fragment_pagination_forwards_offset(
     """?page=3&per_page=25 ⇒ service receives offset=50, limit=25.
 
     The count call goes to SAM's CompChargeSummary now, not the plugin —
-    a separate test (``…_status_filter_uses_plugin_count``) covers the
-    plugin-fallback shape.
+    a separate test (``…_exit_status_filter_uses_plugin_count``) covers
+    the plugin-fallback shape.
     """
     captured = _install_mock_plugin(app, monkeypatch,
                                     jobs_search_return=[_make_row()])
@@ -576,18 +577,18 @@ def test_jobs_fragment_pagination_forwards_offset(
     assert kw['offset'] == 50    # (3 - 1) * 25
 
 
-def test_jobs_fragment_status_filter_uses_plugin_count(
+def test_jobs_fragment_exit_status_filter_uses_plugin_count(
     app, auth_client, active_project, monkeypatch,
 ):
     """When the request adds a filter outside CompChargeSummary's key set
-    (``status``, ``has_gpus``), count_jobs delegates to the plugin's
-    ``jobs_count`` rather than SAM's summary."""
+    (``exit_status``, ``min_gpus``/``max_gpus``), count_jobs delegates to
+    the plugin's ``jobs_count`` rather than SAM's summary."""
     captured = _install_mock_plugin(app, monkeypatch,
                                     jobs_search_return=[_make_row()],
                                     jobs_count_return=42)
     resp = auth_client.get(
         f'/dashboards/user/jobs/{active_project.projcode}'
-        '?machine=derecho&status=F'
+        '?machine=derecho&exit_status=1'
     )
     assert resp.status_code == 200
     ckw = captured['last_jobs_count_kwargs']
@@ -598,7 +599,7 @@ def test_jobs_fragment_status_filter_uses_plugin_count(
     # whether the snapshot picked a leaf or a tree-parent fixture.
     assert isinstance(ckw['account'], list)
     assert active_project.projcode in ckw['account']
-    assert ckw['status']  == 'F'
+    assert ckw['exit_status'] == '1'
 
 
 def test_jobs_fragment_passes_tree_projcodes(
@@ -799,31 +800,31 @@ def test_jobs_fragment_qos_dropdown_pre_selects_active_filter(
         'QoS dropdown should pre-select the active ?qos= value'
 
 
-def test_jobs_fragment_qos_factor_drawer_after_status(
+def test_jobs_fragment_qos_factor_drawer_after_exit_status(
     app, auth_client, active_project, monkeypatch,
 ):
-    """`qos_factor` is rendered in the drawer immediately after `status`
-    (the re-ordered _VERBOSE_EXTRAS) so the multiplier sits next to the
-    QoS column above the fold of the drawer."""
+    """`qos_factor` is rendered in the drawer immediately after
+    `exit_status` (the re-ordered _VERBOSE_EXTRAS) so the multiplier sits
+    next to the QoS column above the fold of the drawer."""
     _install_mock_plugin(
         app, monkeypatch,
         jobs_search_return=[_make_row(qos='premium', qos_factor=1.5,
-                                      status='F')],
+                                      exit_status='1')],
     )
     resp = auth_client.get(
         f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
     )
     body = resp.get_data(as_text=True)
-    # Plugin's COLUMNS dict labels: status="Status", qos_factor="Factor".
+    # Plugin's COLUMNS dict labels: exit_status="Exit", qos_factor="Factor".
     # The <dt> wraps the label with whitespace, so match the bare text;
     # neither label appears elsewhere in the jobs fragment, so the first
     # occurrence is the drawer header.
-    status_idx = body.find('Status')
+    exit_idx = body.find('Exit')
     factor_idx = body.find('Factor')
-    assert status_idx >= 0, 'Status label missing from drawer'
+    assert exit_idx >= 0, 'Exit label (exit_status) missing from drawer'
     assert factor_idx >= 0, 'Factor label (qos_factor) missing from drawer'
-    assert factor_idx > status_idx, \
-        f'expected Status before Factor (qos_factor); got {status_idx=} {factor_idx=}'
+    assert factor_idx > exit_idx, \
+        f'expected Exit (exit_status) before Factor (qos_factor); got {exit_idx=} {factor_idx=}'
 
 
 def test_jobs_fragment_qos_options_populated_from_plugin(

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -1186,3 +1186,121 @@ def test_gather_runtime_state_surfaces_db_linked_api_keys(app, monkeypatch):
     with app.app_context():
         state = gather_runtime_state(app, db)
     assert state['auth']['api_keys_db_enabled'] is False
+
+
+# ---------------------------------------------------------------------------
+# Commit 2: RBAC grant + connection settings + machines helper
+# ---------------------------------------------------------------------------
+
+def test_view_all_job_data_grants():
+    """Auto-granted to operator bundles via ALL_VIEW; NOT to facility tier."""
+    from webapp.utils.rbac import (
+        GROUP_PERMISSIONS, USER_FACILITY_PERMISSIONS, Permission,
+    )
+    p = Permission.VIEW_ALL_JOB_DATA
+    for bundle in ('nusd', 'csg', 'ssg'):
+        assert p in GROUP_PERMISSIONS[bundle], bundle
+    assert p not in USER_FACILITY_PERMISSIONS['sureshm']['WNA']
+
+
+def test_apply_connection_settings_sets_name_and_timeout(monkeypatch):
+    """The connect listener issues SET application_name + statement_timeout.
+
+    ``event.listens_for`` needs a real Engine, so capture the registered
+    listener via a fake decorator and drive it with a stub DBAPI
+    connection — asserting on the exact SQL the listener issues.
+    """
+    from webapp.jobs import session as jobs_session
+
+    registered = {}
+
+    def _fake_listens_for(target, name):
+        def _decorator(fn):
+            registered['fn'] = fn
+            return fn
+        return _decorator
+
+    monkeypatch.setattr(jobs_session.event, 'listens_for', _fake_listens_for)
+
+    jobs_session._apply_connection_settings(
+        MagicMock(name='engine'), 'sam-webapp:pod:job_history:derecho',
+        statement_timeout_ms=60000,
+    )
+
+    executed = []
+
+    class _Cursor:
+        def execute(self, sql, params=None):
+            executed.append((sql, params))
+        def close(self):
+            pass
+
+    dbapi_conn = MagicMock()
+    dbapi_conn.autocommit = False
+    dbapi_conn.cursor = lambda: _Cursor()
+
+    registered['fn'](dbapi_conn, None)
+
+    assert executed[0] == (
+        "SET application_name = %s",
+        ('sam-webapp:pod:job_history:derecho',),
+    )
+    assert executed[1] == ("SET statement_timeout = %s", ('60000',))
+    # autocommit restored after the SETs.
+    assert dbapi_conn.autocommit is False
+
+
+def test_apply_connection_settings_zero_timeout_skips_set(monkeypatch):
+    """statement_timeout_ms=0 (disabled) issues only the app-name SET."""
+    from webapp.jobs import session as jobs_session
+
+    registered = {}
+
+    def _fake_listens_for(target, name):
+        def _decorator(fn):
+            registered['fn'] = fn
+            return fn
+        return _decorator
+
+    monkeypatch.setattr(jobs_session.event, 'listens_for', _fake_listens_for)
+
+    jobs_session._apply_connection_settings(
+        MagicMock(name='engine'), 'tag', statement_timeout_ms=0,
+    )
+
+    executed = []
+
+    class _Cursor:
+        def execute(self, sql, params=None):
+            executed.append(sql)
+        def close(self):
+            pass
+
+    dbapi_conn = MagicMock()
+    dbapi_conn.autocommit = False
+    dbapi_conn.cursor = lambda: _Cursor()
+
+    registered['fn'](dbapi_conn, None)
+
+    assert executed == ["SET application_name = %s"]
+
+
+def test_job_history_machines_sorted_when_enabled(app, monkeypatch):
+    """Sorted engine keys when the plugin is up; [] when disabled."""
+    from webapp.jobs import service
+
+    monkeypatch.setitem(app.extensions, 'hpc_usage_queries', {
+        'module':  types.SimpleNamespace(JobQueries=object),
+        'engines': {'derecho': MagicMock(), 'casper': MagicMock()},
+        'enabled': True,
+    })
+    with app.app_context():
+        assert service.job_history_machines() == ['casper', 'derecho']
+
+
+def test_job_history_machines_empty_when_disabled(app):
+    """TestingConfig keeps the plugin off → no machines offered."""
+    from webapp.jobs import service
+
+    with app.app_context():
+        assert service.job_history_machines() == []

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -31,6 +31,22 @@ import pytest
 from flask import Flask
 
 
+@pytest.fixture(autouse=True)
+def _disable_jobs_cache():
+    """Disable the aggregation TTL cache for these tests by default.
+
+    The route tests exercise the service path directly with per-test mock
+    returns; a live cache would leak one test's envelope into the next
+    (same key: filters all None). Explicit cache behavior is covered by
+    test_webapp_jobs_cache.py. Reset on teardown so other modules aren't
+    affected by the process-wide adapter singleton.
+    """
+    from webapp.jobs import cache as _c
+    _c._adapters = {b: None for b in _c._BUCKETS}
+    yield
+    _c._adapters = {}   # clear → buckets re-init on next use
+
+
 # ---------------------------------------------------------------------------
 # init_job_history — startup hook
 # ---------------------------------------------------------------------------
@@ -132,7 +148,9 @@ _DEFAULT_QOS_NAMES = ['economy', 'premium', 'regular', 'special', 'uncharged']
 
 def _install_mock_plugin(app, monkeypatch, *, jobs_search_return=None,
                         jobs_count_return=None, qos_names=None,
-                        machines=('derecho',)):
+                        machines=('derecho',),
+                        jobs_histogram_return=None,
+                        jobs_usage_by_return=None):
     """Wire a mock job_history module onto app.extensions and return the
     captured JobQueries kwargs so tests can assert on the call.
 
@@ -143,6 +161,8 @@ def _install_mock_plugin(app, monkeypatch, *, jobs_search_return=None,
     captured = {
         'last_jobs_search_kwargs': None,
         'last_jobs_count_kwargs':  None,
+        'last_jobs_histogram':     None,   # (dimension, kwargs)
+        'last_jobs_usage_by':      None,   # (dimension, kwargs)
     }
     qos_list = (list(qos_names) if qos_names is not None
                 else list(_DEFAULT_QOS_NAMES))
@@ -158,6 +178,20 @@ def _install_mock_plugin(app, monkeypatch, *, jobs_search_return=None,
             captured['last_jobs_count_kwargs'] = kwargs
             return jobs_count_return if jobs_count_return is not None \
                 else len(jobs_search_return or [])
+        def jobs_histogram(self, dimension, **kwargs):
+            captured['last_jobs_histogram'] = (dimension, kwargs)
+            if jobs_histogram_return is not None:
+                return dict(jobs_histogram_return, dimension=dimension)
+            return {'dimension': dimension, 'column': 'x', 'unit': 'u',
+                    'min_param': 'min_x', 'max_param': 'max_x',
+                    'buckets': [], 'null_count': 0, 'total_count': 0}
+        def jobs_usage_by(self, dimension, **kwargs):
+            captured['last_jobs_usage_by'] = (dimension, kwargs)
+            if jobs_usage_by_return is not None:
+                return jobs_usage_by_return
+            return {'dimension': dimension, 'rows': [],
+                    'totals': {'job_count': 0, 'cpu_hours': 0.0,
+                               'gpu_hours': 0.0}}
         def list_qos_names(self, **kwargs):
             return list(qos_list)
 
@@ -1456,3 +1490,233 @@ def test_search_jobs_rejects_unknown_filter(app, active_project, monkeypatch):
             service.search_jobs(
                 'derecho', project=active_project, min_gups=1,  # typo
             )
+
+
+# ---------------------------------------------------------------------------
+# Commit 5: aggregation fragments (By User / Wait Times / Job Sizes / Durations)
+# ---------------------------------------------------------------------------
+
+def _sample_hist(dimension='wait', null_count=0):
+    return {
+        'dimension': dimension, 'column': 'eligible_secs', 'unit': 'seconds',
+        'min_param': 'min_eligible_secs', 'max_param': 'max_eligible_secs',
+        'buckets': [
+            {'label': '<1m', 'lo': 0, 'hi': 59,
+             'job_count': 10, 'cpu_hours': 100.0, 'gpu_hours': 0.0},
+            {'label': '1-5m', 'lo': 60, 'hi': 299,
+             'job_count': 4, 'cpu_hours': 40.0, 'gpu_hours': 1.0},
+        ],
+        'null_count': null_count,
+        'total_count': 14 + null_count,
+    }
+
+
+def _sample_usage(totals=None):
+    return {
+        'dimension': 'user',
+        'rows': [
+            {'value': 'alice', 'job_count': 30, 'cpu_hours': 300.0, 'gpu_hours': 0.0},
+            {'value': 'bob',   'job_count': 12, 'cpu_hours': 120.0, 'gpu_hours': 2.0},
+        ],
+        'totals': totals or {'job_count': 42, 'cpu_hours': 420.0, 'gpu_hours': 2.0},
+    }
+
+
+def test_by_user_fragment_renders_rows_and_pie(
+    app, auth_client, active_project, monkeypatch,
+):
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_usage_by_return=_sample_usage(),
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/by-user?machine=derecho'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'data-job-user="alice"' in body
+    assert 'data-job-user="bob"' in body
+    assert '<svg' in body                       # pie rendered
+    assert '#job-user-alice' in body            # clickable wedge sentinel
+    # No remainder beyond the row cap → no Other row.
+    assert 'beyond top' not in body
+    # Plugin was asked for the user dimension, scoped to the project tree.
+    dim, kwargs = captured['last_jobs_usage_by']
+    assert dim == 'user'
+    assert active_project.projcode in kwargs['account']
+
+
+def test_by_user_fragment_other_row_from_pretruncation_totals(
+    app, auth_client, active_project, monkeypatch,
+):
+    """totals bigger than the visible rows → an inert Other summary row."""
+    usage = _sample_usage(totals={'job_count': 100, 'cpu_hours': 900.0,
+                                  'gpu_hours': 5.0})
+    _install_mock_plugin(app, monkeypatch, jobs_usage_by_return=usage)
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/by-user?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'beyond top' in body
+
+
+def test_by_user_fragment_disabled_banner(auth_client, active_project):
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/by-user?machine=derecho'
+    )
+    assert resp.status_code == 200
+    assert 'Per-job data is unavailable' in resp.get_data(as_text=True)
+
+
+def test_by_user_fragment_400_on_invalid_machine(
+    app, auth_client, active_project, monkeypatch,
+):
+    _install_mock_plugin(app, monkeypatch)
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/by-user?machine=gust'
+    )
+    assert resp.status_code == 400
+
+
+def test_by_user_fragment_404_on_unknown_projcode(auth_client):
+    resp = auth_client.get('/dashboards/user/jobs/NOPE9999/by-user?machine=derecho')
+    assert resp.status_code == 404
+
+
+def test_wait_times_fragment_caption_on_null_count(
+    app, auth_client, active_project, monkeypatch,
+):
+    """null_count > 0 on the wait dimension → the eligible-time caption."""
+    _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist(null_count=7),
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times?machine=derecho'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'no wait measurement' in body
+    assert 'early 2025 on Derecho' in body
+
+
+def test_wait_times_fragment_no_caption_when_all_measured(
+    app, auth_client, active_project, monkeypatch,
+):
+    _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist(null_count=0),
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times?machine=derecho'
+    )
+    assert 'no wait measurement' not in resp.get_data(as_text=True)
+
+
+def test_wait_times_fragment_pins_wait_dimension(
+    app, auth_client, active_project, monkeypatch,
+):
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist(),
+    )
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times'
+        '?machine=derecho&dimension=gpus'   # client cannot override the pin
+    )
+    dim, _kwargs = captured['last_jobs_histogram']
+    assert dim == 'wait'
+
+
+def test_job_sizes_fragment_dimension_pills_and_default(
+    app, auth_client, active_project, monkeypatch,
+):
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist(dimension='nodes'),
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/job-sizes?machine=derecho'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # Dimension pills present (only on the Sizes tab).
+    assert 'dimension=cpus' in body
+    assert 'dimension=memory' in body
+    # Default dimension is nodes.
+    dim, _kwargs = captured['last_jobs_histogram']
+    assert dim == 'nodes'
+
+
+def test_job_sizes_fragment_invalid_dimension_falls_back(
+    app, auth_client, active_project, monkeypatch,
+):
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist(dimension='nodes'),
+    )
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/job-sizes'
+        '?machine=derecho&dimension=bogus'
+    )
+    dim, _kwargs = captured['last_jobs_histogram']
+    assert dim == 'nodes'
+
+
+def test_job_sizes_fragment_memory_dimension_forwarded(
+    app, auth_client, active_project, monkeypatch,
+):
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist(dimension='memory'),
+    )
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/job-sizes'
+        '?machine=derecho&dimension=memory'
+    )
+    dim, _kwargs = captured['last_jobs_histogram']
+    assert dim == 'memory'
+
+
+def test_durations_fragment_pins_duration_dimension(
+    app, auth_client, active_project, monkeypatch,
+):
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist(dimension='duration'),
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/durations?machine=derecho'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    dim, _kwargs = captured['last_jobs_histogram']
+    assert dim == 'duration'
+    # No dimension pills outside the Sizes tab.
+    assert 'dimension=cpus' not in body
+
+
+def test_histogram_fragment_converts_wait_hours_to_secs(
+    app, auth_client, active_project, monkeypatch,
+):
+    """min/max_wait_hours (human units) convert to eligible_secs at the
+    route boundary — the service/plugin only ever see seconds."""
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist(),
+    )
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times'
+        '?machine=derecho&min_wait_hours=2&max_wait_hours=4.5'
+    )
+    _dim, kwargs = captured['last_jobs_histogram']
+    assert kwargs['min_eligible_secs'] == 7200
+    assert kwargs['max_eligible_secs'] == 16200
+
+
+def test_histogram_fragment_metric_pill_roundtrip(
+    app, auth_client, active_project, monkeypatch,
+):
+    _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist(),
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times'
+        '?machine=derecho&metric=cpu_hours'
+    )
+    body = resp.get_data(as_text=True)
+    # The cpu_hours pill is the active one.
+    import re
+    assert re.search(r'active[^>]*>\s*CPU-hours', body) or \
+        re.search(r'CPU-hours', body)

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -1941,3 +1941,106 @@ def test_status_tab_hidden_for_plain_user_with_machines(
     resp = non_admin_client.get('/status/derecho')
     assert resp.status_code == 200
     assert '/status/job-history' not in resp.get_data(as_text=True)
+
+
+# ---------------------------------------------------------------------------
+# Commit 7: user family ("My Jobs") — server-side pinning + page/tab
+# ---------------------------------------------------------------------------
+
+_USER_FRAGMENTS = ['', '/wait-times', '/job-sizes', '/durations']
+
+
+@pytest.mark.parametrize('suffix', _USER_FRAGMENTS + ['/explore'])
+def test_user_routes_disabled_banner(auth_client, suffix):
+    """Plugin off → 200 with the unavailable banner (login only, no perm)."""
+    resp = auth_client.get(f'/dashboards/user/jobs/user/derecho{suffix}')
+    assert resp.status_code == 200
+    assert 'Per-job data is unavailable' in resp.get_data(as_text=True)
+
+
+@pytest.mark.parametrize('suffix', _USER_FRAGMENTS + ['/explore'])
+def test_user_routes_404_unknown_machine(app, auth_client, monkeypatch, suffix):
+    _install_mock_plugin(app, monkeypatch, machines=('derecho',))
+    resp = auth_client.get(f'/dashboards/user/jobs/user/gust{suffix}')
+    assert resp.status_code == 404
+
+
+def test_user_jobs_fragment_pins_session_user(app, auth_client, monkeypatch):
+    """The table is pinned to the logged-in user (benkirk for auth_client)."""
+    captured = _install_mock_plugin(app, monkeypatch,
+                                    jobs_search_return=[_make_row()],
+                                    jobs_count_return=1)
+    resp = auth_client.get('/dashboards/user/jobs/user/derecho')
+    assert resp.status_code == 200
+    kw = captured['last_jobs_search_kwargs']
+    assert kw['user'] == 'benkirk'
+    ckw = captured['last_jobs_count_kwargs']
+    assert ckw['user'] == 'benkirk'
+
+
+def test_user_jobs_fragment_ignores_client_user_param(
+    app, auth_client, monkeypatch,
+):
+    """?user=<other> must change nothing — the pin always wins."""
+    captured = _install_mock_plugin(app, monkeypatch,
+                                    jobs_search_return=[_make_row()],
+                                    jobs_count_return=1)
+    resp = auth_client.get('/dashboards/user/jobs/user/derecho?user=mallory')
+    assert resp.status_code == 200
+    assert captured['last_jobs_search_kwargs']['user'] == 'benkirk'
+    assert captured['last_jobs_count_kwargs']['user'] == 'benkirk'
+
+
+@pytest.mark.parametrize('suffix', ['/wait-times', '/job-sizes', '/durations'])
+def test_user_histogram_fragments_ignore_client_user_param(
+    app, auth_client, monkeypatch, suffix,
+):
+    captured = _install_mock_plugin(app, monkeypatch,
+                                    jobs_histogram_return=_sample_hist())
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/user/derecho{suffix}?user=mallory'
+    )
+    assert resp.status_code == 200
+    _dim, kwargs = captured['last_jobs_histogram']
+    assert kwargs['user'] == 'benkirk'
+
+
+def test_user_explore_page_omits_user_picker(app, auth_client, monkeypatch):
+    _install_mock_plugin(app, monkeypatch)
+    resp = auth_client.get('/dashboards/user/jobs/user/derecho/explore')
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'My Jobs' in body
+    # No user picker in user mode — the pin is not negotiable.
+    assert 'name="user_id"' not in body
+    # Other filter fields still present.
+    assert 'name="queue"' in body
+
+
+def test_my_jobs_page_404_without_machines(auth_client):
+    """Plugin off → no machines → the page 404s (tab is hidden too)."""
+    resp = auth_client.get('/user/jobs')
+    assert resp.status_code == 404
+
+
+def test_my_jobs_page_renders_machine_pills(app, auth_client, monkeypatch):
+    _install_mock_plugin(app, monkeypatch, machines=('derecho', 'casper'))
+    resp = auth_client.get('/user/jobs')
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'my-jobs-subtab-1' in body
+    assert 'Derecho' in body and 'Casper' in body
+    # User-mode card fragments wired per pill.
+    assert '/dashboards/user/jobs/user/casper' in body
+    # By User tab suppressed in user mode.
+    assert 'By User' not in body
+
+
+def test_my_jobs_tab_visibility_follows_machines(app, auth_client, monkeypatch):
+    # Hidden when plugin off…
+    resp = auth_client.get('/user/accounts')
+    assert '/user/jobs' not in resp.get_data(as_text=True)
+    # …visible when machines are up.
+    _install_mock_plugin(app, monkeypatch, machines=('derecho',))
+    resp = auth_client.get('/user/accounts')
+    assert '/user/jobs' in resp.get_data(as_text=True)

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -1304,3 +1304,155 @@ def test_job_history_machines_empty_when_disabled(app):
 
     with app.app_context():
         assert service.job_history_machines() == []
+
+
+# ---------------------------------------------------------------------------
+# Commit 3: mode families + extended-filter count gating
+# ---------------------------------------------------------------------------
+
+def test_search_jobs_machine_forwards_no_account(app, monkeypatch):
+    """Machine mode issues an UNSCOPED query — no account key at all."""
+    from webapp.jobs import service
+
+    captured = _install_mock_plugin(app, monkeypatch)
+
+    with app.app_context():
+        service.search_jobs_machine('derecho', user='alice', limit=10)
+
+    kw = captured['last_jobs_search_kwargs']
+    assert 'account' not in kw
+    assert kw['user'] == 'alice'
+    assert kw['limit'] == 10
+
+
+def test_count_jobs_machine_uses_plugin_count(app, monkeypatch):
+    """Machine mode never touches the SAM per-project summary."""
+    from webapp.jobs import service
+
+    captured = _install_mock_plugin(app, monkeypatch, jobs_count_return=9)
+
+    with app.app_context():
+        total = service.count_jobs_machine('derecho', queue='main')
+
+    assert total == 9
+    ckw = captured['last_jobs_count_kwargs']
+    assert ckw is not None
+    assert 'account' not in ckw
+
+
+def test_search_jobs_user_pins_username(app, monkeypatch):
+    from webapp.jobs import service
+
+    captured = _install_mock_plugin(app, monkeypatch)
+
+    with app.app_context():
+        service.search_jobs_user('derecho', 'benkirk', queue='main')
+
+    kw = captured['last_jobs_search_kwargs']
+    assert kw['user'] == 'benkirk'
+
+
+def test_search_jobs_user_rejects_user_filter(app, monkeypatch):
+    """A client-supplied user filter must raise, not be silently dropped."""
+    from webapp.jobs import service
+
+    _install_mock_plugin(app, monkeypatch)
+
+    with app.app_context():
+        with pytest.raises(ValueError, match='pins user'):
+            service.search_jobs_user('derecho', 'benkirk', user='mallory')
+
+
+def test_search_jobs_user_requires_username(app, monkeypatch):
+    from webapp.jobs import service
+
+    _install_mock_plugin(app, monkeypatch)
+
+    with app.app_context():
+        with pytest.raises(ValueError, match='username'):
+            service.search_jobs_user('derecho', '')
+
+
+def test_count_jobs_user_pins_username(app, monkeypatch):
+    from webapp.jobs import service
+
+    captured = _install_mock_plugin(app, monkeypatch, jobs_count_return=4)
+
+    with app.app_context():
+        total = service.count_jobs_user('derecho', 'benkirk')
+
+    assert total == 4
+    assert captured['last_jobs_count_kwargs']['user'] == 'benkirk'
+
+
+def test_count_jobs_zero_bound_forces_plugin_path(app, active_project, monkeypatch):
+    """max_gpus=0 is a REAL filter (CPU-only) — the falsy value must not
+    slip through the fast-path gate onto the SAM summary."""
+    from webapp.jobs import service
+
+    captured = _install_mock_plugin(app, monkeypatch, jobs_count_return=2)
+
+    with app.app_context():
+        total = service.count_jobs(
+            'derecho', project=active_project, max_gpus=0,
+        )
+
+    assert total == 2
+    ckw = captured['last_jobs_count_kwargs']
+    assert ckw is not None
+    assert ckw['max_gpus'] == 0
+
+
+def test_count_jobs_ignore_case_alone_keeps_fast_path(
+    app, active_project, monkeypatch,
+):
+    """ignore_case without a name filter changes nothing — stay on the
+    SAM-summary fast path."""
+    from webapp.jobs import service
+
+    monkeypatch.setattr(
+        service, '_count_via_sam_summary',
+        lambda machine, **kw: 13,
+    )
+    captured = _install_mock_plugin(app, monkeypatch)
+
+    with app.app_context():
+        total = service.count_jobs(
+            'derecho', project=active_project, ignore_case=False,
+        )
+
+    assert total == 13
+    assert captured['last_jobs_count_kwargs'] is None
+
+
+def test_count_jobs_name_filter_forces_plugin_path(
+    app, active_project, monkeypatch,
+):
+    from webapp.jobs import service
+
+    captured = _install_mock_plugin(app, monkeypatch, jobs_count_return=5)
+
+    with app.app_context():
+        service.count_jobs(
+            'derecho', project=active_project,
+            name='wrf*', ignore_case=True,
+        )
+
+    ckw = captured['last_jobs_count_kwargs']
+    assert ckw is not None
+    assert ckw['name'] == 'wrf*'
+    assert ckw['ignore_case'] is True
+
+
+def test_search_jobs_rejects_unknown_filter(app, active_project, monkeypatch):
+    """_plugin_filter_kwargs is keyword-only: a typo'd filter raises
+    TypeError instead of silently vanishing."""
+    from webapp.jobs import service
+
+    _install_mock_plugin(app, monkeypatch)
+
+    with app.app_context():
+        with pytest.raises(TypeError):
+            service.search_jobs(
+                'derecho', project=active_project, min_gups=1,  # typo
+            )

--- a/tests/unit/test_webapp_jobs_cache.py
+++ b/tests/unit/test_webapp_jobs_cache.py
@@ -17,12 +17,19 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _reset_jobs_cache():
+def _reset_jobs_cache(monkeypatch):
     """Start each test with the cache disabled; reset the singleton after.
 
     A stored ``None`` per bucket means "initialised but disabled"; the
     cache-behavior tests below re-enable by clearing ``_adapters``.
+
+    CACHE_REDIS_URL is dropped so re-init always builds the in-process
+    TTLCacheAdapter: the bucket-policy logic under test is backend-
+    independent, and a real Redis (CI runs with one) is shared across
+    xdist workers — concurrent cache tests would corrupt each other's
+    hit counts and purge totals.
     """
+    monkeypatch.delenv('CACHE_REDIS_URL', raising=False)
     from webapp.jobs import cache as _c
     _c._adapters = {b: None for b in _c._BUCKETS}
     yield

--- a/tests/unit/test_webapp_jobs_cache.py
+++ b/tests/unit/test_webapp_jobs_cache.py
@@ -1,0 +1,292 @@
+"""Tests for the job-history TTL cache (webapp/jobs/cache.py) and the
+cached aggregation wrappers in webapp/jobs/service.py.
+
+The cache is a process-wide singleton (module-level ``_adapters``), so
+every test starts from the autouse fixture's disabled state and the
+cache-behavior cases re-enable explicitly — mirroring
+``test_webapp_disk_scans.py``.
+"""
+
+from __future__ import annotations
+
+import types
+from datetime import date, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_jobs_cache():
+    """Start each test with the cache disabled; reset the singleton after.
+
+    A stored ``None`` per bucket means "initialised but disabled"; the
+    cache-behavior tests below re-enable by clearing ``_adapters``.
+    """
+    from webapp.jobs import cache as _c
+    _c._adapters = {b: None for b in _c._BUCKETS}
+    yield
+    _c._adapters = {}   # clear → buckets re-init on next use
+
+
+# ---------------------------------------------------------------------------
+# bucket_for_window
+# ---------------------------------------------------------------------------
+
+def test_bucket_for_window_closed_is_historical():
+    from webapp.jobs.cache import bucket_for_window
+    assert bucket_for_window(date.today() - timedelta(days=1)) == 'historical'
+
+
+def test_bucket_for_window_today_is_recent():
+    """A window ending today is still collecting jobs → recent bucket."""
+    from webapp.jobs.cache import bucket_for_window
+    assert bucket_for_window(date.today()) == 'recent'
+
+
+def test_bucket_for_window_open_end_is_recent():
+    from webapp.jobs.cache import bucket_for_window
+    assert bucket_for_window(None) == 'recent'
+
+
+# ---------------------------------------------------------------------------
+# cached_jobs_aggregation — hit / miss / key discrimination
+# ---------------------------------------------------------------------------
+
+def _counting_compute(results=None):
+    calls = {'n': 0}
+
+    def compute():
+        calls['n'] += 1
+        return results if results is not None else {'n': calls['n']}
+    return calls, compute
+
+
+def test_cached_aggregation_hit_and_miss():
+    from webapp.jobs import cache as c
+    c._adapters.clear()  # re-enable (autouse fixture disabled all buckets)
+
+    calls, compute = _counting_compute({'buckets': []})
+    opts = {'dimension': 'wait', 'start': date(2026, 6, 1), 'end': date(2026, 6, 30)}
+
+    r1 = c.cached_jobs_aggregation('histogram', 'derecho', opts, compute, 'historical')
+    r2 = c.cached_jobs_aggregation('histogram', 'derecho', opts, compute, 'historical')
+    assert calls['n'] == 1          # second call was a hit
+    assert r1 == r2 == {'buckets': []}
+
+    # Different machine → different key.
+    c.cached_jobs_aggregation('histogram', 'casper', opts, compute, 'historical')
+    assert calls['n'] == 2
+
+    # Different opts (dimension) → different key.
+    opts2 = dict(opts, dimension='nodes')
+    c.cached_jobs_aggregation('histogram', 'derecho', opts2, compute, 'historical')
+    assert calls['n'] == 3
+
+    # Different query_type → different key.
+    c.cached_jobs_aggregation('usage_by_user', 'derecho', opts, compute, 'historical')
+    assert calls['n'] == 4
+
+
+def test_cached_aggregation_normalizes_dates_and_lists():
+    """date objects and account lists hash stably — equal values hit."""
+    from webapp.jobs import cache as c
+    c._adapters.clear()
+
+    calls, compute = _counting_compute()
+    opts_a = {'end': date(2026, 6, 30), 'account': ['B', 'A']}
+    opts_b = {'end': date(2026, 6, 30), 'account': ['A', 'B']}  # order-insensitive
+
+    c.cached_jobs_aggregation('histogram', 'derecho', opts_a, compute, 'historical')
+    c.cached_jobs_aggregation('histogram', 'derecho', opts_b, compute, 'historical')
+    assert calls['n'] == 1
+
+
+def test_cached_aggregation_buckets_are_independent():
+    """Same key in different buckets → separate entries (recent vs historical)."""
+    from webapp.jobs import cache as c
+    c._adapters.clear()
+
+    calls, compute = _counting_compute()
+    opts = {'dimension': 'wait'}
+    c.cached_jobs_aggregation('histogram', 'derecho', opts, compute, 'historical')
+    c.cached_jobs_aggregation('histogram', 'derecho', opts, compute, 'recent')
+    assert calls['n'] == 2
+
+
+def test_cached_aggregation_disabled_bucket_computes_every_time():
+    """Autouse fixture leaves every bucket disabled → no caching at all."""
+    from webapp.jobs import cache as c
+
+    calls, compute = _counting_compute()
+    opts = {'dimension': 'wait'}
+    c.cached_jobs_aggregation('histogram', 'derecho', opts, compute, 'recent')
+    c.cached_jobs_aggregation('histogram', 'derecho', opts, compute, 'recent')
+    assert calls['n'] == 2
+
+
+# ---------------------------------------------------------------------------
+# purge + info
+# ---------------------------------------------------------------------------
+
+def test_purge_jobs_cache_clears_all_buckets():
+    from webapp.jobs import cache as c
+    c._adapters.clear()
+
+    calls, compute = _counting_compute()
+    c.cached_jobs_aggregation('histogram', 'derecho', {'d': 1}, compute, 'historical')
+    c.cached_jobs_aggregation('histogram', 'derecho', {'d': 2}, compute, 'recent')
+
+    assert c.purge_jobs_cache() == 2
+
+    # Entries gone → both recompute.
+    c.cached_jobs_aggregation('histogram', 'derecho', {'d': 1}, compute, 'historical')
+    c.cached_jobs_aggregation('histogram', 'derecho', {'d': 2}, compute, 'recent')
+    assert calls['n'] == 4
+
+
+def test_jobs_cache_info_shape_enabled():
+    from webapp.jobs import cache as c
+    c._adapters.clear()
+
+    infos = c.jobs_cache_info()
+    assert [i['name'] for i in infos] == ['jobs', 'jobs_recent']
+
+
+def test_jobs_cache_info_shape_disabled():
+    """With buckets disabled, info still reports both (disabled_info shape)."""
+    from webapp.jobs import cache as c
+
+    infos = c.jobs_cache_info()
+    assert [i['name'] for i in infos] == ['jobs', 'jobs_recent']
+
+
+def test_caching_facade_reports_and_clears_jobs_category(app):
+    """The webapp caching facade includes the jobs buckets in stats()/clear()."""
+    from webapp.jobs import cache as c
+    from webapp.caching import caching
+
+    c._adapters.clear()
+    calls, compute = _counting_compute()
+    c.cached_jobs_aggregation('histogram', 'derecho', {'d': 1}, compute, 'historical')
+
+    with app.app_context():
+        stats = caching.stats()
+    assert [i['name'] for i in stats['jobs']] == ['jobs', 'jobs_recent']
+
+    cleared = caching.clear('jobs')
+    assert cleared == {'jobs': 1}
+
+
+# ---------------------------------------------------------------------------
+# service.jobs_histogram / jobs_usage_by_user — cached wrappers
+# ---------------------------------------------------------------------------
+
+def _install_agg_plugin(app, monkeypatch):
+    """Mock plugin capturing jobs_histogram / jobs_usage_by calls."""
+    captured = {'histogram': [], 'usage_by': []}
+
+    class FakeJobQueries:
+        def __init__(self, session, machine='derecho'):
+            self.machine = machine
+
+        def jobs_histogram(self, dimension, **kwargs):
+            captured['histogram'].append((dimension, kwargs))
+            return {'dimension': dimension, 'buckets': [], 'null_count': 0,
+                    'total_count': 0}
+
+        def jobs_usage_by(self, dimension, **kwargs):
+            captured['usage_by'].append((dimension, kwargs))
+            return {'dimension': dimension, 'rows': [],
+                    'totals': {'job_count': 0, 'cpu_hours': 0.0, 'gpu_hours': 0.0}}
+
+    fake_mod = types.SimpleNamespace(
+        get_engine=lambda machine, pool_kwargs=None: MagicMock(),
+        get_session=lambda machine, engine=None: MagicMock(name='jh_session'),
+        JobQueries=FakeJobQueries,
+    )
+    monkeypatch.setitem(app.extensions, 'hpc_usage_queries', {
+        'module': fake_mod,
+        'engines': {'derecho': MagicMock(), 'casper': MagicMock()},
+        'enabled': True,
+    })
+    return captured
+
+
+def test_service_jobs_histogram_caches_closed_window(app, monkeypatch):
+    """Two identical closed-window calls → one plugin query."""
+    from webapp.jobs import cache as c, service
+    c._adapters.clear()
+
+    captured = _install_agg_plugin(app, monkeypatch)
+    win = {'start': date(2026, 6, 1), 'end': date(2026, 6, 30)}
+
+    with app.app_context():
+        service.jobs_histogram('derecho', 'wait', account_projcodes=['SCSG0001'], **win)
+        service.jobs_histogram('derecho', 'wait', account_projcodes=['SCSG0001'], **win)
+
+    assert len(captured['histogram']) == 1
+    dimension, kwargs = captured['histogram'][0]
+    assert dimension == 'wait'
+    assert kwargs['account'] == ['SCSG0001']
+
+
+def test_service_jobs_histogram_username_pin_overwrites_user_filter(app, monkeypatch):
+    """user-mode pin always wins over a client-supplied user filter."""
+    from webapp.jobs import service
+
+    captured = _install_agg_plugin(app, monkeypatch)
+
+    with app.app_context():
+        service.jobs_histogram('derecho', 'duration',
+                               username='benkirk', user='mallory')
+
+    _, kwargs = captured['histogram'][0]
+    assert kwargs['user'] == 'benkirk'
+
+
+def test_service_jobs_histogram_machine_wide_has_no_account(app, monkeypatch):
+    """No account_projcodes → no account key (machine-wide, caller gated)."""
+    from webapp.jobs import service
+
+    captured = _install_agg_plugin(app, monkeypatch)
+
+    with app.app_context():
+        service.jobs_histogram('derecho', 'nodes')
+
+    _, kwargs = captured['histogram'][0]
+    assert 'account' not in kwargs
+
+
+def test_service_jobs_usage_by_user_forwards_limit_and_account(app, monkeypatch):
+    from webapp.jobs import service
+
+    captured = _install_agg_plugin(app, monkeypatch)
+
+    with app.app_context():
+        out = service.jobs_usage_by_user(
+            'derecho', limit=7, account_projcodes=['SCSG0001', 'SCSG0002'],
+        )
+
+    dimension, kwargs = captured['usage_by'][0]
+    assert dimension == 'user'
+    assert kwargs['limit'] == 7
+    assert kwargs['account'] == ['SCSG0001', 'SCSG0002']
+    assert 'rows' in out and 'totals' in out
+
+
+def test_service_jobs_usage_by_user_caches(app, monkeypatch):
+    from webapp.jobs import cache as c, service
+    c._adapters.clear()
+
+    captured = _install_agg_plugin(app, monkeypatch)
+    win = {'start': date(2026, 6, 1), 'end': date(2026, 6, 30)}
+
+    with app.app_context():
+        service.jobs_usage_by_user('derecho', account_projcodes=['SCSG0001'], **win)
+        service.jobs_usage_by_user('derecho', account_projcodes=['SCSG0001'], **win)
+        # A different limit is a different result → recompute.
+        service.jobs_usage_by_user('derecho', limit=3,
+                                   account_projcodes=['SCSG0001'], **win)
+
+    assert len(captured['usage_by']) == 2

--- a/tests/unit/test_webapp_jobs_charts.py
+++ b/tests/unit/test_webapp_jobs_charts.py
@@ -1,0 +1,174 @@
+"""Unit tests for the job-history chart generators (webapp/dashboards/charts.py).
+
+``generate_jobs_histogram`` renders the plugin's self-describing histogram
+envelope; ``generate_jobs_user_pie_chart`` renders the jobs_usage_by('user')
+envelope with clickable ``#job-user-<username>`` sentinels routed by
+svg-chart-links.js. matplotlib's SVG backend rasterizes most text to paths,
+so assertions favor behavior (placeholders, sentinels, distinct output per
+metric) over label grepping.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from webapp.dashboards.charts import (
+    generate_jobs_histogram,
+    generate_jobs_user_pie_chart,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _hist(counts=(10, 5, 0), cpu_hours=(100.0, 50.0, 0.0),
+          gpu_hours=(0.0, 2.0, 0.0), dimension='wait', null_count=0):
+    labels = ['<1m', '1-5m', '5-15m'][:len(counts)]
+    los = [0, 60, 300]
+    his = [59, 299, 899]
+    return {
+        'dimension': dimension, 'column': 'eligible_secs', 'unit': 'seconds',
+        'min_param': 'min_eligible_secs', 'max_param': 'max_eligible_secs',
+        'buckets': [
+            {'label': lbl, 'lo': lo, 'hi': hi,
+             'job_count': c, 'cpu_hours': ch, 'gpu_hours': gh}
+            for lbl, lo, hi, c, ch, gh
+            in zip(labels, los, his, counts, cpu_hours, gpu_hours)
+        ],
+        'null_count': null_count,
+        'total_count': sum(counts) + null_count,
+    }
+
+
+def _usage(rows=None, totals=None):
+    if rows is None:
+        rows = [
+            {'value': 'alice', 'job_count': 50, 'cpu_hours': 500.0, 'gpu_hours': 0.0},
+            {'value': 'bob',   'job_count': 10, 'cpu_hours': 100.0, 'gpu_hours': 5.0},
+        ]
+    if totals is None:
+        totals = {'job_count': 60, 'cpu_hours': 600.0, 'gpu_hours': 5.0}
+    return {'dimension': 'user', 'rows': rows, 'totals': totals}
+
+
+# ---------------------------------------------------------------------------
+# generate_jobs_histogram
+# ---------------------------------------------------------------------------
+
+def test_histogram_renders_svg_for_all_metrics():
+    for metric in ('jobs', 'cpu_hours', 'gpu_hours'):
+        out = generate_jobs_histogram(_hist(), metric=metric)
+        assert '<svg' in out
+
+
+def test_histogram_metrics_render_differently():
+    """Same envelope, different metric → different SVG (and distinct cache
+    keys, so variants never collide in the LRU)."""
+    svg_jobs = generate_jobs_histogram(_hist(), metric='jobs')
+    svg_cpu  = generate_jobs_histogram(_hist(), metric='cpu_hours')
+    assert svg_jobs != svg_cpu
+
+
+def test_histogram_empty_envelope_returns_placeholder():
+    assert 'No jobs in this range' in generate_jobs_histogram({'buckets': []})
+    assert 'No jobs in this range' in generate_jobs_histogram({})
+    assert 'No jobs in this range' in generate_jobs_histogram(None)
+
+
+def test_histogram_all_zero_returns_placeholder():
+    out = generate_jobs_histogram(_hist(counts=(0, 0, 0),
+                                        cpu_hours=(0, 0, 0),
+                                        gpu_hours=(0, 0, 0)))
+    assert '<svg' not in out
+    assert 'No jobs in this range' in out
+
+
+def test_histogram_zero_metric_nonzero_other_metric():
+    """A CPU-only window has zero gpu_hours everywhere → GPU view shows the
+    placeholder while the jobs view still renders."""
+    h = _hist(counts=(5, 3, 1), cpu_hours=(50.0, 30.0, 10.0),
+              gpu_hours=(0.0, 0.0, 0.0))
+    assert 'No jobs in this range' in generate_jobs_histogram(h, metric='gpu_hours')
+    assert '<svg' in generate_jobs_histogram(h, metric='jobs')
+
+
+def test_histogram_dimension_in_cache_key():
+    """Identical bucket values under different dimensions must not share a
+    cache entry (labels differ in practice, but the key must not rely on it)."""
+    from webapp.dashboards.charts import _jobs_histogram_cache_key
+    a = _jobs_histogram_cache_key(_hist(dimension='wait'))
+    b = _jobs_histogram_cache_key(_hist(dimension='duration'))
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# generate_jobs_user_pie_chart
+# ---------------------------------------------------------------------------
+
+def test_pie_wedges_clickable():
+    svg = generate_jobs_user_pie_chart(_usage())
+    assert '<svg' in svg
+    assert '#job-user-alice' in svg
+    assert '#job-user-bob' in svg
+
+
+def test_pie_other_slice_from_pretruncation_totals():
+    """rows sum to 600 but totals say 800 — the upstream limit dropped rows,
+    and the difference must surface as an inert Other slice (no sentinel)."""
+    usage = _usage(totals={'job_count': 100, 'cpu_hours': 800.0, 'gpu_hours': 5.0})
+    svg = generate_jobs_user_pie_chart(usage)
+    assert 'Other' in svg
+    assert '#job-user-Other' not in svg
+    assert '#job-user-None' not in svg
+
+
+def test_pie_no_other_when_rows_cover_totals():
+    svg = generate_jobs_user_pie_chart(_usage())
+    assert 'Other' not in svg
+
+
+def test_pie_long_tail_lumped_at_hard_cap():
+    rows = [{'value': f'u{i}', 'job_count': 1,
+             'cpu_hours': float(100 - i), 'gpu_hours': 0.0}
+            for i in range(15)]
+    total = sum(r['cpu_hours'] for r in rows)
+    usage = _usage(rows=rows, totals={'job_count': 15, 'cpu_hours': total,
+                                      'gpu_hours': 0.0})
+    svg = generate_jobs_user_pie_chart(usage)
+    assert '#job-user-u0' in svg            # biggest user kept + clickable
+    assert '#job-user-u14' not in svg       # tail folded into Other
+    assert 'Other' in svg
+
+
+def test_pie_metric_selects_and_resorts():
+    """metric='jobs' re-sorts by job_count — bob leads despite fewer hours."""
+    rows = [
+        {'value': 'alice', 'job_count': 5,   'cpu_hours': 500.0, 'gpu_hours': 0.0},
+        {'value': 'bob',   'job_count': 200, 'cpu_hours': 10.0,  'gpu_hours': 0.0},
+    ]
+    usage = _usage(rows=rows, totals={'job_count': 205, 'cpu_hours': 510.0,
+                                      'gpu_hours': 0.0})
+    svg_hours = generate_jobs_user_pie_chart(usage, metric='cpu_hours')
+    svg_jobs  = generate_jobs_user_pie_chart(usage, metric='jobs')
+    assert svg_hours != svg_jobs
+    assert '#job-user-bob' in svg_jobs
+
+
+def test_pie_empty_and_zero_total_return_placeholder():
+    assert 'No usage data' in generate_jobs_user_pie_chart(
+        {'rows': [], 'totals': {}})
+    assert 'No usage data' in generate_jobs_user_pie_chart(
+        _usage(totals={'job_count': 0, 'cpu_hours': 0.0, 'gpu_hours': 0.0}))
+    assert 'No usage data' in generate_jobs_user_pie_chart(None)
+
+
+def test_pie_unknown_user_row_is_inert():
+    """A NULL username row renders (as '(unknown)') but gets no sentinel."""
+    rows = [
+        {'value': 'alice', 'job_count': 5, 'cpu_hours': 50.0, 'gpu_hours': 0.0},
+        {'value': None,    'job_count': 2, 'cpu_hours': 20.0, 'gpu_hours': 0.0},
+    ]
+    usage = _usage(rows=rows, totals={'job_count': 7, 'cpu_hours': 70.0,
+                                      'gpu_hours': 0.0})
+    svg = generate_jobs_user_pie_chart(usage)
+    assert '#job-user-alice' in svg
+    assert '#job-user-None' not in svg


### PR DESCRIPTION
## Summary

Brings job history to fs_scans feature parity, backed by hpc-usage-queries
PR benkirk/hpc-usage-queries#99 (`jobs_histogram` / `jobs_usage_by` +
elapsed/reqmem filters; pinned tip `24a35ed`):

- **5-tab Job History card** on compute resource-details (project mode,
  collapsed by default, bounded to the page's date window): Jobs ·
  By User (clickable usage pie → row drill) · Wait Times · Job Sizes
  (nodes/CPUs/GPUs/memory pills) · Durations. Metric pills
  (Jobs/CPU-h/GPU-h) on every aggregation tab.
- **"Open Full View" explorer** — standalone page with the house
  filter-sidebar (dates, user picker, queue, QoS, exit code, name glob,
  nodes/CPUs/GPUs/wait-hour ranges); project mode supports `?scope=`
  subtree re-rooting; deep links reproduce filter state; defaults to a
  90-day window (unbounded is the ~200 s path).
- **Status page "Job History" tab** — machine-wide cards (derecho /
  casper), gated by the new global `Permission.VIEW_ALL_JOB_DATA`
  (auto-joins operator bundles via ALL_VIEW; NOT facility-scoped).
- **"My Jobs"** on the User Dashboard — same card pinned server-side to
  the session user (`?user=` is ignored by construction; By User tab
  suppressed).
- **Aggregation TTL cache** (`webapp/jobs/cache.py`): `historical`
  6 h / 256 for closed windows, `recent` 15 min / 128; registered as
  caching category `jobs` (admin card, API, `sam-admin cache`).
- Server-side PG `statement_timeout` (60 s default) + `pg_stat_activity`
  tagging on every job-history connection.
- Absorbs PR #99's three breaking renames (`COLUMNS` at package root,
  `has_gpus` → `min/max_gpus`, `status` → `exit_status`).

**Merge order:** plugin PR benkirk/hpc-usage-queries#99 merges first;
this PR deploys against it (local dev pins `HPC_USAGE_QUERIES_REF`).

Deferred follow-ups are recorded in `docs/plans/JOB_HISTORY_DASHBOARD.md`
(facet chips, clickable histogram bars, By-Project user-mode tab,
elapsed/reqmem explorer inputs).

### Test Results
- Full suite: **3220 passed**, 30 skipped, 1 xfailed (84 s)
- New: `test_webapp_jobs_cache.py`, `test_webapp_jobs_charts.py`;
  `test_webapp_jobs.py` grown to 100+ cases (RBAC grants, mode
  scoping/pinning, fast-path gating, fragments, Status/My Jobs pages)
- Route-map parity snapshot regenerated (`status_dashboard.job_history`,
  `user_dashboard.my_jobs`)
- Playwright smoke on webdev :5050 against live plugin DBs: card
  tabs/pills/pie-drill, wait-caption behavior (380K excluded on a 2024
  Derecho window; none on Casper), explorer deep links, RBAC negatives
  (plain user + WNA-scoped admin 403 / tabs hidden), My Jobs pinning,
  admin cache card, connection tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)