### PR TITLE
jobs: round-2 follow-ups — memory dims, bar drills, facet chips, By Project, elapsed/reqmem inputs

### DIFF
--- a/docs/plans/JOB_HISTORY_DASHBOARD.md
+++ b/docs/plans/JOB_HISTORY_DASHBOARD.md
@@ -1,7 +1,8 @@
 # Job History Dashboard — SAM-side implementation (Session 2 handoff)
 
 **Status (2026-07-27): IMPLEMENTED.** Plugin side landed on PR #99 (tip
-`24a35ed`); SAM Commits 1–7 are on `job_history_expansion` as planned, with
+`24a35ed`; round-2 memory dims moved it to `e07238f` — see
+`JOB_HISTORY_FOLLOWUPS.md`); SAM Commits 1–7 are on `job_history_expansion` as planned, with
 the deltas recorded in *As-built notes* below. The approved plan of record
 (full rationale, plugin-side commit details) is
 [`JOB_HISTORY_DRILLDOWN.md`](JOB_HISTORY_DRILLDOWN.md); where the two differ,
@@ -37,11 +38,12 @@ THIS doc reflects what actually landed.
 
 1. Branch: `job_history_expansion` (this repo). Plugin repo:
    `~/codes/hpc-usage-queries/devel`, branch `jobs_plugin_search_drilldown`
-   = PR #99, **tip `24a35edffd4f1cea633ccebee7c9fdd5308ec1a3`**.
+   = PR #99, **tip `e07238f5f77317ad36d67f111b92e934eae07528`** (round-2
+   memory dims; round-1 contract below was verified at `24a35ed`).
 2. Rebuild against the pinned sha (both, before any webapp/pytest work):
    ```bash
-   HPC_USAGE_QUERIES_REF=24a35edffd4f1cea633ccebee7c9fdd5308ec1a3 docker compose build webdev
-   HPC_USAGE_QUERIES_REF=24a35edffd4f1cea633ccebee7c9fdd5308ec1a3 source etc/config_env.sh
+   HPC_USAGE_QUERIES_REF=e07238f5f77317ad36d67f111b92e934eae07528 docker compose build webdev
+   HPC_USAGE_QUERIES_REF=e07238f5f77317ad36d67f111b92e934eae07528 source etc/config_env.sh
    make print-env-hash   # confirm the hash-keyed conda-env rebuilt
    ```
 3. Webapp: `docker compose up webdev --watch` → http://localhost:5050 (stub

--- a/docs/plans/JOB_HISTORY_DASHBOARD.md
+++ b/docs/plans/JOB_HISTORY_DASHBOARD.md
@@ -322,24 +322,28 @@ Personas via Quick Login: `benkirk` (full operator), a plain project user,
 6. `docker compose exec` psql: `pg_stat_activity` shows
    `sam-webapp:…:job_history:<machine>` tagging and `statement_timeout`.
 
-## Deferred follow-ups (confirmed deferred as of 2026-07-27)
+## Deferred follow-ups (updated 2026-07-27, post round 2)
 
-- `jobs_facets` filter chips in the explorer (cost: self-exclusion plan
-  flips measured 4.5×; needs a default window policy first).
-- By-Project tab in user mode (needs nothing new server-side —
-  `jobs_usage_by('account', user=<me>)` — UI decision only).
-- Clickable histogram bars (drill via `min_param`/`max_param` envelope,
-  mirroring the disk band-drill; the envelope's self-describing
-  min/max_param fields are already threaded through to the template
-  context, so this is chart + JS work only).
-- `memory_used` histogram dimension upstream if ever asked (one spec row).
-- Explorer inputs for elapsed/reqmem bounds (`min/max_elapsed`,
-  `min/max_reqmem` are already accepted by the service normalizer; only
-  panel fields + roundtrip keys are missing).
+**Items 1–5 SHIPPED in round 2** — branch `job_history_followups`, plan +
+as-built notes in `JOB_HISTORY_FOLLOWUPS.md`:
+
+- ~~`jobs_facets` filter chips in the explorer~~ → S4 (OOB chip strip,
+  90-day-window costs acceptable per the measured policy).
+- ~~By-Project tab in user mode~~ → S5 (`jobs_usage_by_project`,
+  `account` narrowing in user mode only).
+- ~~Clickable histogram bars~~ → S3 (`#jh-bar-<i>` sentinels → inline
+  bucket-row drill via the envelope's `min_param`/`max_param`).
+- ~~`memory_used` histogram dimension~~ → plugin `e07238f` added
+  `memory_used` AND `memory_wasted` (+ four range filters); SAM S1
+  surfaces both as Job Sizes pills.
+- ~~Explorer inputs for elapsed/reqmem bounds~~ → S2.
+
+**Still open** (its own PR, AFTER round 2 merges — Ben's sequencing):
+
 - **Pre-existing, discovered via CI**: `RedisTTLAdapter` namespaces keys
   and `clear()`/`info()` scans by `prefix` only, and the usage cache AND
   both fs_scans buckets all sit on the default `'usage:'` prefix — so on
   Redis, `clear('usage')` / `clear('scans')` wipe each other's entries
-  and their `info()` counts merge. The jobs buckets now pass distinct
+  and their `info()` counts merge. The jobs buckets pass distinct
   `prefix=<name>:` values; migrating fs_scans/usage the same way is a
   separate PR (existing 'usage:' keys orphan until TTL at cutover).

--- a/docs/plans/JOB_HISTORY_DASHBOARD.md
+++ b/docs/plans/JOB_HISTORY_DASHBOARD.md
@@ -1,8 +1,11 @@
 # Job History Dashboard — SAM-side implementation (Session 2 handoff)
 
-**Status (2026-07-27): IMPLEMENTED.** Plugin side landed on PR #99 (tip
-`24a35ed`; round-2 memory dims moved it to `e07238f` — see
-`JOB_HISTORY_FOLLOWUPS.md`); SAM Commits 1–7 are on `job_history_expansion` as planned, with
+**Status (2026-07-27): IMPLEMENTED; plugin MERGED upstream.** Plugin side
+landed on PR #99 (round-1 `24a35ed`; round-2 memory dims `e07238f`; review
+fix `dcb177f` closing the cpus/nodes bucket tables at the domain floor — see
+`JOB_HISTORY_FOLLOWUPS.md`) and merged through hpc-usage-queries `main`
+2026-07-27, so default builds now include it (no `HPC_USAGE_QUERIES_REF`
+pin needed); SAM Commits 1–7 are on `job_history_expansion` as planned, with
 the deltas recorded in *As-built notes* below. The approved plan of record
 (full rationale, plugin-side commit details) is
 [`JOB_HISTORY_DRILLDOWN.md`](JOB_HISTORY_DRILLDOWN.md); where the two differ,
@@ -37,13 +40,13 @@ THIS doc reflects what actually landed.
 ## How to resume
 
 1. Branch: `job_history_expansion` (this repo). Plugin repo:
-   `~/codes/hpc-usage-queries/devel`, branch `jobs_plugin_search_drilldown`
-   = PR #99, **tip `e07238f5f77317ad36d67f111b92e934eae07528`** (round-2
-   memory dims; round-1 contract below was verified at `24a35ed`).
-2. Rebuild against the pinned sha (both, before any webapp/pytest work):
+   `~/codes/hpc-usage-queries/devel` — PR #99 (final tip `dcb177f`) is
+   **merged to `main`**, so default builds include it (the round-1 contract
+   below was verified at `24a35ed`; `e07238f` added the memory dims).
+2. Rebuild normally (no ref pin — plugin@main has everything):
    ```bash
-   HPC_USAGE_QUERIES_REF=e07238f5f77317ad36d67f111b92e934eae07528 docker compose build webdev
-   HPC_USAGE_QUERIES_REF=e07238f5f77317ad36d67f111b92e934eae07528 source etc/config_env.sh
+   docker compose build webdev
+   source etc/config_env.sh
    make print-env-hash   # confirm the hash-keyed conda-env rebuilt
    ```
 3. Webapp: `docker compose up webdev --watch` → http://localhost:5050 (stub
@@ -51,7 +54,9 @@ THIS doc reflects what actually landed.
    `export SAM_TEST_DB_URL='mysql+pymysql://root:root@127.0.0.1:3307/sam'`.
    **Running pytest directly is authorized for this track** (both repos).
 4. Merge order at the end: plugin PR #99 → staging (then #98 staging→main);
-   SAM PR (this branch → staging) only after.
+   SAM PR (this branch → staging) only after. **DONE 2026-07-27**: plugin
+   merged through main; SAM PR #381 squash-merged to staging; PR #382
+   (round 2) rebased onto staging behind it.
 
 ## As-landed plugin contract (verified, tip 24a35ed)
 

--- a/docs/plans/JOB_HISTORY_FOLLOWUPS.md
+++ b/docs/plans/JOB_HISTORY_FOLLOWUPS.md
@@ -1,0 +1,203 @@
+# Job History follow-ups — round 2 (memory dims, bar drill, facet chips, By-Project, elapsed/reqmem inputs)
+
+## Context
+
+Round 1 is complete: SAM **PR #381** (`job_history_expansion` → staging) is open with CI
+green; plugin **PR #99** (`jobs_plugin_search_drilldown`, tip `24a35ed`) awaits Ben's
+review. Merge order stays plugin → SAM. This round executes deferred items 1–5 from
+`docs/plans/JOB_HISTORY_DASHBOARD.md` as: **additional commits on PR #99** (memory
+dimensions) + **ONE stacked SAM PR** on top of #381. Item 6 (RedisTTLAdapter shared
+`'usage:'` prefix for fs_scans/usage caches) is deliberately excluded — its own PR later.
+
+**Window-policy decision (measured 2026-07-27, warm cache, webdev PG):**
+
+| Window | Rows (der/cas) | count | histogram |
+|---|---|---|---|
+| 30 d | 0.36M / 0.56M | 0.17–0.22 s | 1.7–2.8 s |
+| 365 d | 4.7M / 10.9M | 7.9–13.6 s | 4.4–8.2 s |
+| unbounded | 13M / 21M | 1.7–2.3 s | 5.5–9.1 s |
+
+Cost driver is rows-touched × cache temperature (btree(`end`) range scan + per-row
+job_charges join), NOT boundedness — unbounded count beats the year count because the
+planner flips to a seq/index-only scan. The historical "~200 s" was cold page cache.
+**Policy: keep the 90-day defaults everywhere, no hard cap; the 60 s statement timeout +
+jobs TTL cache guard the tail.** Cold whole-history first attempts may hit the timeout;
+each attempt warms PG buffers so retries converge (raise JOB_HISTORY_STATEMENT_TIMEOUT_MS
+if this bites in practice). Facet chips therefore compute within the current window.
+
+**Decisions (Ben, 2026-07-27):**
+1. memory_used + memory_wasted → **Job Sizes pills on BOTH machines** (coverage is ~99.3%
+   on both, last 90 d); Derecho gets a caption noting whole-node reqmem inflates "wasted"
+   (median 176 GiB vs Casper's meaningful 19 GiB).
+2. Bar drill = **inline bucket-row expansion** (mirror the disk band-drill / openBucketRow
+   pattern), not a jump to the explorer.
+3. Facet chips **with live counts** (self-exclusion on; jobs_facets ≈150 ms/month-window).
+4. memory_wasted = `reqmem − memory` (bytes); 0.3–0.4% of jobs have used > requested →
+   explicit **"over request" band** (hi = −1) leads the bucket table.
+
+## How to resume (post-compact)
+
+- SAM: branch **`job_history_followups`** off `job_history_expansion`. Commit THIS plan as
+  `docs/plans/JOB_HISTORY_FOLLOWUPS.md` first (house convention).
+- Plugin: `~/codes/hpc-usage-queries/devel`, branch `jobs_plugin_search_drilldown` (PR #99).
+  Plugin tests: `./conda-env/bin/python -m pytest job_history/tests/` (peer repo).
+- After pushing plugin commits, re-pin BOTH builds to the new tip:
+  `HPC_USAGE_QUERIES_REF=<sha> docker compose build webdev` and
+  `HPC_USAGE_QUERIES_REF=<sha> source etc/config_env.sh` (Claude runs these; pause for Ben
+  only on failure). Record the new sha in PR #99 comment + the SAM plan doc.
+- SAM tests: mysql-test on :3307, `export SAM_TEST_DB_URL='mysql+pymysql://root:root@127.0.0.1:3307/sam'`;
+  pytest directly authorized in both repos. Before pushing, run the CI-emulation sweep:
+  full `pytest` with `CACHE_REDIS_URL='redis://127.0.0.1:6379/0'` AND, if feasible, under a
+  main-ref conda env — **SAM tests must stay hermetic to plugin version**
+  (`_FAKE_COLUMN_SPECS` / `_install_mock_plugin` patterns; CI builds plugin@main until #99
+  merges).
+- Playwright smoke on webdev :5050 (Quick Login: benkirk operator, bdobbins plain,
+  sureshm WNA-scoped). Live data: SCSG0001 × Derecho; queues are cpu/gpu/cpudev (NOT main).
+
+## Plugin side — commits on PR #99
+
+### Commit P1 — memory_used + memory_wasted histogram dimensions + filters
+Files: `job_history/queries/jobs.py`, `job_history/cli/cmds/jobhist.py`,
+`job_history/cli/search/commands.py`, `job_history/tests/test_jobs_search.py`,
+`test_cli_search.py`, README/plan-doc.
+
+- **Filters** (bounds-round-trip invariant forces these): `min/max_memory_used`
+  (`Job.memory`, bytes) and `min/max_memory_wasted` (`Job.reqmem - Job.memory` expression,
+  bytes; NULL-strict — NULL when either column NULL; negatives legal) as new rows in
+  `_apply_jobs_search_filters`'s range-bounds table + kwargs/docstrings on `jobs_search` /
+  `jobs_count` / `jobs_facets` / `jobs_histogram` / `jobs_usage_by`
+  (TestFilterSignatureParity enforces completeness).
+- **Buckets** on `QueryConfig`: `MEMUSED_HIST_BUCKETS` (reuse the REQMEM GiB band
+  boundaries `<1GB…>1000GB`); `MEMWASTED_HIST_BUCKETS` = `('over request', None, -1)` then
+  the same ascending GiB bands (`_bucket_case`'s NULL-first + ascending `<= hi` ladder
+  handles the negative band naturally).
+- **`_HISTOGRAM_SPECS`** += `'memory_used'` → (Job.memory, …, 'bytes',
+  'min_memory_used', 'max_memory_used') and `'memory_wasted'` → (reqmem−memory
+  expression, …). `_bucket_case` takes SQLAlchemy expressions as-is.
+- **CLI flags** (consistency with 06a8657): `--min/max-memory-used-gb`,
+  `--min/max-memory-wasted-gb` (GB→bytes via `_BYTES_PER_GB`; wasted accepts negatives)
+  + envelope `filters` keys.
+- **Tests**: over-request routing into the negative band, either-NULL → null_count,
+  zero-fill vector, existing bounds-round-trip invariant loop picks the new specs up
+  automatically (verify), one-aggregate-scan guard, CLI conversions, parity-set updates.
+- Push; do NOT merge — Ben reviews. New tip sha replaces `24a35ed` in all pins.
+
+## SAM side — stacked PR (`job_history_followups`, base `job_history_expansion`)
+
+Retarget the PR base to `staging` after #381 merges (stacked-PR reopen recipe if the
+parent merge closes it).
+
+### Commit S0 — commit this plan as `docs/plans/JOB_HISTORY_FOLLOWUPS.md` `[skip ci]`
+
+### Commit S1 — native-unit filter passthrough + memory dimension pills
+- `jobs/routes.py`: `_parse_job_filters` (and `_jobs_table_response`'s inline parse —
+  consider unifying them here) accept the **plugin-native** bound params the bar drill
+  emits verbatim from the envelope: `min/max_eligible_secs`, `min/max_elapsed`,
+  `min/max_reqmem`, `min/max_memory_used`, `min/max_memory_wasted` (ints; wasted may be
+  negative — don't clamp to ≥0 for that pair). `_ROUNDTRIP_KEYS` += the native names.
+  Human-unit inputs (wait-hours etc.) keep converting at the boundary as today.
+- `_SIZE_DIMENSIONS` → `('nodes','cpus','gpus','memory','memory_used','memory_wasted')`;
+  pill labels in `jobs_histogram.html`: Nodes / CPUs / GPUs / Req mem / Used mem / Wasted.
+- Derecho caption in `jobs_histogram.html`: when `machine == 'derecho'` and
+  `dimension == 'memory_wasted'` → note that whole-node scheduling assigns ~235 GB/node
+  regardless of request, inflating "wasted" (Casper's shared nodes are the meaningful case).
+- Update the pinned sha note in `docs/plans/JOB_HISTORY_DASHBOARD.md`.
+  `_FAKE_COLUMN_SPECS` needs no change (COLUMNS untouched upstream).
+
+### Commit S2 — explorer elapsed/reqmem inputs (item 5)
+- `partials/_jobs_filters.html`: two more min/max pairs — "Elapsed (hours)" (float,
+  ×3600 → `min/max_elapsed`) and "Req memory (GB)" (float, ×1024³ → `min/max_reqmem`;
+  GB label matches the bucket labels, GiB internally). Add `min/max_elapsed_hours`,
+  `min/max_reqmem_gb` to `_parse_job_filters` (human units), `_panel_filters`,
+  `_initial_jobs_url`, `_ROUNDTRIP_KEYS`.
+
+### Commit S3 — clickable histogram bars → inline bucket drill (item 3)
+- `charts.py generate_jobs_histogram`: bars with `job_count > 0` get
+  `set_url(f'#jh-bar-{i}')` (index-keyed; cache key already hashes the count vector).
+- `jobs_histogram.html`: Bucket-counts rows become expandable — `tr[data-jh-bucket="i"]`
+  + `data-bs-target` collapse row lazy-loading the **mode's jobs fragment** with
+  `{min_param: lo, max_param: hi}` from the envelope (omit min when `lo` is None/negative
+  band's open end, omit max when `hi` is None) + the pane's roundtrip params + machine +
+  target_id; bind `shown.bs.collapse … once`.
+- `svg-chart-links.js`: `#jh-bar-` prefix → open the matching `data-jh-bucket` row scoped
+  to `.tab-pane` (parameterize `openBucketRow`'s attr or add a sibling fn), forcing the
+  enclosing `<details>` open first before scrolling.
+- Works uniformly across Wait Times / Job Sizes (all 6 dims) / Durations because S1's
+  native passthrough accepts every envelope's `min_param`/`max_param`.
+
+### Commit S4 — facet chips in the explorer (item 1)
+- `jobs/service.py`: cached `jobs_facets(machine, *, facets=('queue','qos','exit_status'),
+  account_projcodes=None, username=None, **filters)` wrapper (plugin `jobs_facets`,
+  self_exclude default True) through `jobs_cache.cached_jobs_aggregation('facets', …)`
+  with `bucket_for_window`.
+- Explorer routes (`explore_page` / `explore_machine_page` / `explore_user_page`): fetch
+  facets for the current window+filters (scope-pinned per mode); degrade to no chips on
+  any error.
+- `jobs_explore_page.html` (or a small `_jobs_facet_chips.html` partial): chip strip
+  above the table — value + count per dim; click sets the matching panel form field and
+  re-submits. CSP-clean: a `data-action="set-filter-submit"` handler in
+  `static/js/actions.js` (writes the value into the named input of the panel form, then
+  `requestSubmit()`); active chip renders highlighted + acts as clear.
+- Cap values per dim (limit≈8) with the existing plugin `limit` param.
+
+### Commit S5 — By-Project tab in user mode (item 2)
+- `jobs/service.py`: `jobs_usage_by_project(machine, *, username, limit=25, **filters)` →
+  plugin `jobs_usage_by('account', user=username, …)`, cached
+  (`'usage_by_account'` query type). Username pin mandatory (mirror
+  `jobs_usage_by_user`'s pin-overwrites rule).
+- `search_jobs_user` / `count_jobs_user` accept an optional `account` narrowing filter
+  (safe: the user pin still applies; this narrows one's OWN jobs). `_jobs_table_response`
+  user branch parses a whitelisted `account` arg (project/machine modes unchanged —
+  project mode's account remains server-derived only).
+- `charts.py`: generalize the pie —
+  `generate_jobs_usage_pie_chart(entity_data, metric, *, sentinel_prefix, unknown_label)`
+  with the existing user pie delegating to it; **sentinel_prefix must join the cache
+  key**. `#job-proj-<projcode>` sentinels.
+- New route `/user/<machine>/by-project` (`@login_required`, pinned) + tab in
+  `jobs_card.html` (user mode only, where By User is hidden); `jobs_by_project.html`
+  clone of `jobs_by_user.html` with `tr[data-job-project=…]` rows drilling into the
+  user-mode jobs fragment with `&account=<projcode>`; svg-chart-links.js `#job-proj-` →
+  `openEntityRow('data-job-project', …)`.
+- No route-map regen needed (jobs bp is not pinned; no new page routes) — verify parity
+  test stays green.
+
+### Commit S6 — docs + follow-ups ledger
+- `JOB_HISTORY_DASHBOARD.md`: flip items 1–5 to done, keep item 6 (Redis prefix
+  migration) as the open follow-up; `JOB_HISTORY_FOLLOWUPS.md` as-built notes;
+  `src/webapp/README.md` touch-up if warranted.
+
+## Test inventory
+
+- **Plugin**: histogram fixture rows for memory (incl. used>requested and either-NULL);
+  negative-band routing; round-trip invariant auto-covers new dims; CLI conversion tests;
+  parity sets. Suite was 546 — expect ~560+.
+- **SAM** (`test_webapp_jobs.py` + charts/cache files, all hermetic via mock plugin +
+  `_FAKE_COLUMN_SPECS`): native param passthrough (incl. negative wasted bounds);
+  6 sizes pills + Derecho wasted caption; bucket rows carry correct min/max drill params
+  (None-end omission both directions); chips render with counts / click wiring / degrade
+  on facets error; `jobs_usage_by_project` pin + `account` narrowing in user mode
+  (`?user=` still ignored); explorer elapsed/reqmem inputs round-trip; pie generalization
+  sentinel prefixes (incl. distinct cache keys); cache query types 'facets' /
+  'usage_by_account'.
+- Full `pytest` in both repos; SAM CI-emulation run with `CACHE_REDIS_URL` set before push.
+
+## Verification
+
+1. Plugin: suite green; quick timed check of both new dimensions on dev PG (month window).
+2. Rebuild webdev + conda env at the new pin; verify `jobs_histogram('memory_wasted', …)`
+   from the container.
+3. SAM suites per commit; full sweep + CI emulation before push.
+4. Playwright smoke (webdev :5050): 6 sizes pills switch (Derecho shows wasted caption;
+   Casper doesn't); bar click on Wait Times / Sizes / Durations opens the matching bucket
+   row with a correctly filtered jobs table (spot-check a count matches the bucket);
+   explorer chips show counts, click filters, active chip clears; elapsed/reqmem panel
+   fields round-trip through a deep link; My Jobs → By Project pie + wedge → row drill →
+   account-narrowed own-jobs table; `?user=` override still ignored; quick RBAC spot-check
+   (bdobbins: no machine surfaces).
+5. Open the stacked PR (`--base job_history_expansion`); note in the body: retarget to
+   staging after #381 merges; plugin PR #99 (new tip) merges before either.
+
+## Out of scope (this round)
+- Item 6: migrating fs_scans/usage caches off the shared `'usage:'` Redis prefix —
+  separate PR after this lands (cutover orphans existing keys until TTL).
+- `jobs_facets` name-glob facets, memory charging, By-Project outside user mode.

--- a/docs/plans/JOB_HISTORY_FOLLOWUPS.md
+++ b/docs/plans/JOB_HISTORY_FOLLOWUPS.md
@@ -1,5 +1,31 @@
 # Job History follow-ups — round 2 (memory dims, bar drill, facet chips, By-Project, elapsed/reqmem inputs)
 
+**Status (2026-07-27): IMPLEMENTED** — plugin P1 pushed as `e07238f`
+(PR #99), SAM S0–S6 on `job_history_followups`. Full suite 3,257 green
+(+ CI emulation with `CACHE_REDIS_URL`); plugin suite 565. Playwright
+smoke + stacked PR are the remaining steps. As-built deltas from the
+plan below:
+
+- **S1**: the per-job table's inline filter parse was UNIFIED onto
+  `_parse_job_filters(include_user=…)` (the plan's "consider unifying"
+  taken); native bounds parse after human-unit forms, so native wins on
+  a double-spelled bound.
+- **S3**: drill URLs are computed server-side in `_bucket_drill_url` as
+  a parallel `bucket_drills` list (the envelope is a shared cache entry
+  and must not be mutated); a same-named pane bound is dropped in favor
+  of the clicked band's. The chart cache key gained the job_count-
+  positivity vector (clickability follows job_count even on an hours
+  metric).
+- **S4**: the chip strip is rendered by the jobs fragment as an
+  `hx-swap-oob` block (gated by `?chips=1`, sent only by the explorer)
+  rather than by the explorer routes — a statically rendered strip
+  would go stale after the first table refetch. `chips` rides
+  `_ROUNDTRIP_KEYS`, the panel form, and `_initial_jobs_url`.
+- **S5**: `jobs_usage_by_project` raises on empty username or a `user`
+  filter (the strict user-family rule, not pin-overwrites); user-mode
+  `account` narrowing surfaces as a "project:" header badge injected
+  post-service.
+
 ## Context
 
 Round 1 is complete: SAM **PR #381** (`job_history_expansion` → staging) is open with CI

--- a/docs/plans/JOB_HISTORY_FOLLOWUPS.md
+++ b/docs/plans/JOB_HISTORY_FOLLOWUPS.md
@@ -1,9 +1,13 @@
 # Job History follow-ups — round 2 (memory dims, bar drill, facet chips, By-Project, elapsed/reqmem inputs)
 
-**Status (2026-07-27): IMPLEMENTED** — plugin P1 pushed as `e07238f`
-(PR #99), SAM S0–S6 on `job_history_followups`. Full suite 3,257 green
-(+ CI emulation with `CACHE_REDIS_URL`); plugin suite 565. Playwright
-smoke + stacked PR are the remaining steps. As-built deltas from the
+**Status (2026-07-27): IMPLEMENTED & MERGED upstream** — plugin P1 pushed
+as `e07238f` (PR #99); review fix `dcb177f` closed the cpus/nodes bucket
+tables at the domain floor (leading `("0", 0, 0)` bands — sub-floor rows
+were mis-filed into the "1" band, breaking the bar↔drill round-trip);
+PR #99 then merged through hpc-usage-queries `main`. SAM S0–S6 on
+`job_history_followups` (PR #382, rebased onto staging after #381
+merged). Full suite 3,257 green (+ CI emulation with `CACHE_REDIS_URL`);
+plugin suite 565→568. Playwright smoke passed. As-built deltas from the
 plan below:
 
 - **S1**: the per-job table's inline filter parse was UNIFIED onto

--- a/docs/plans/JOB_HISTORY_FOLLOWUPS.md
+++ b/docs/plans/JOB_HISTORY_FOLLOWUPS.md
@@ -81,6 +81,9 @@ Files: `job_history/queries/jobs.py`, `job_history/cli/cmds/jobhist.py`,
   zero-fill vector, existing bounds-round-trip invariant loop picks the new specs up
   automatically (verify), one-aggregate-scan guard, CLI conversions, parity-set updates.
 - Push; do NOT merge — Ben reviews. New tip sha replaces `24a35ed` in all pins.
+  **DONE 2026-07-27: tip is `e07238f5f77317ad36d67f111b92e934eae07528`**
+  (suite 546 → 565; dev-PG verified: over-request band == count(max=-1),
+  887 derecho / 2,566 casper).
 
 ## SAM side — stacked PR (`job_history_followups`, base `job_history_expansion`)
 

--- a/src/webapp/README.md
+++ b/src/webapp/README.md
@@ -94,7 +94,8 @@ src/webapp/
 ├── disk_scans/                 # Filesystem-scan views (hpc-usage-queries plugin)
 ├── jobs/                       # Job-history views (hpc-usage-queries plugin):
 │                               #   5-tab card (project/machine/user modes),
-│                               #   explorer, TTL cache (routes/service/cache)
+│                               #   explorer + facet chips, bar→bucket drills,
+│                               #   TTL cache (routes/service/cache)
 ├── limiter/                    # Rate-limiting facade (mirrors caching/)
 ├── utils/                      # rbac, htmx helpers, nav registry, csp, …
 ├── static/                     # Vendored Bootstrap 5 / htmx / FontAwesome + app JS/CSS

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -1187,12 +1187,16 @@ _JOBS_METRIC_LABELS = {
 def _jobs_histogram_cache_key(hist, *, metric='jobs'):
     """Hash exactly what the SVG depends on: the bucket labels, the chosen
     metric's values, the dimension, and null_count (not the full envelope —
-    e.g. min_param/max_param don't affect the rendering)."""
+    e.g. min_param/max_param don't affect the rendering). The job_count
+    positivity vector joins the key because it decides which bars carry
+    #jh-bar-<i> drill URLs — an hours-metric SVG with matching hours but a
+    different populated-band set must not be reused."""
     key = _JOBS_METRIC_KEYS.get(metric, 'job_count')
     buckets = (hist or {}).get('buckets') or []
     payload = [(b.get('label'), float(b.get(key) or 0)) for b in buckets]
+    clickable = [int(bool(b.get('job_count'))) for b in buckets]
     return _content_hash([
-        payload, str((hist or {}).get('dimension', '')),
+        payload, clickable, str((hist or {}).get('dimension', '')),
         int((hist or {}).get('null_count') or 0), str(metric),
     ])
 
@@ -1226,9 +1230,16 @@ def generate_jobs_histogram(hist, *, metric='jobs') -> str:
         return _empty_state('No jobs in this range')
 
     fig, ax = plt.subplots(figsize=(14, 5))
-    ax.bar(range(len(labels)), vals,
-           color=UNITY_PALETTE_10[0],
-           edgecolor=UNITY_NCAR_NAVY, linewidth=0.5)
+    bars = ax.bar(range(len(labels)), vals,
+                  color=UNITY_PALETTE_10[0],
+                  edgecolor=UNITY_NCAR_NAVY, linewidth=0.5)
+    # Populated bands are clickable: #jh-bar-<index> sentinels route
+    # through svg-chart-links.js to the matching data-jh-bucket row in
+    # the Bucket-counts table, which lazy-loads that band's jobs.
+    # Index-keyed (not label) so the JS never parses band labels.
+    for i, (rect, b) in enumerate(zip(bars, buckets)):
+        if b.get('job_count'):
+            rect.set_url(f'#jh-bar-{i}')
     ax.set_xticks(range(len(labels)))
     ax.set_xticklabels(labels, rotation=30, ha='right')
     ax.set_ylabel(_JOBS_METRIC_LABELS.get(metric, 'Jobs'))

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -1249,32 +1249,45 @@ def generate_jobs_histogram(hist, *, metric='jobs') -> str:
     return _fig_to_svg(fig)
 
 
-def _jobs_user_pie_cache_key(entity_data, metric='cpu_hours'):
+def _jobs_usage_pie_cache_key(entity_data, metric='cpu_hours', *,
+                              sentinel_prefix='job-user',
+                              unknown_label='(unknown)'):
+    """sentinel_prefix joins the key: identical usage vectors rendered for
+    different entity kinds carry different drill anchors."""
     key = _JOBS_METRIC_KEYS.get(metric, 'cpu_hours')
     rows = (entity_data or {}).get('rows') or []
     totals = (entity_data or {}).get('totals') or {}
     payload = [(r.get('value'), float(r.get(key) or 0)) for r in rows]
-    return _content_hash([payload, float(totals.get(key) or 0), str(metric)])
+    return _content_hash([payload, float(totals.get(key) or 0), str(metric),
+                          str(sentinel_prefix), str(unknown_label)])
 
 
-@caching.chart_cached(name='jobs_user_pie_chart', maxsize=64,
-                      key_fn=_jobs_user_pie_cache_key)
-def generate_jobs_user_pie_chart(entity_data, metric='cpu_hours') -> str:
-    """Pie of per-user usage from a jobs_usage_by('user') envelope.
+@caching.chart_cached(name='jobs_usage_pie_chart', maxsize=64,
+                      key_fn=_jobs_usage_pie_cache_key)
+def generate_jobs_usage_pie_chart(entity_data, metric='cpu_hours', *,
+                                  sentinel_prefix='job-user',
+                                  unknown_label='(unknown)') -> str:
+    """Pie of per-entity usage from a jobs_usage_by(dimension) envelope.
+
+    Entity-kind-agnostic: the By User tab renders it with
+    ``sentinel_prefix='job-user'`` (via the delegating
+    :func:`generate_jobs_user_pie_chart`), the My Jobs By Project tab
+    with ``'job-proj'``.
 
     Args:
-        entity_data: plugin envelope — ``{'rows': [{'value': username,
+        entity_data: plugin envelope — ``{'rows': [{'value': name,
             'job_count', 'cpu_hours', 'gpu_hours'}, …], 'totals': {…}}``.
             ``totals`` is computed upstream BEFORE any limit truncation.
         metric: ``'jobs'``, ``'cpu_hours'`` (default) or ``'gpu_hours'``.
+        sentinel_prefix: drill-anchor prefix — kept wedges + legend
+            entries carry ``#<sentinel_prefix>-<value>`` sentinels routed
+            by svg-chart-links.js to the matching table row.
+        unknown_label: legend label for a NULL entity value (inert slice).
 
-    The largest users up to a ~90% cumulative share (9 max) get named
+    The largest entities up to a ~90% cumulative share (9 max) get named
     slices; everything else — both beyond-cap rows AND the upstream
     limit's remainder — folds into one inert "Other" slice sized
     ``totals − Σ kept``, so the pie always sums to the true total.
-    Kept wedges + legend entries carry ``#job-user-<username>``
-    sentinels routed by svg-chart-links.js to the matching
-    ``data-job-user`` table row.
     """
     rows = (entity_data or {}).get('rows') or []
     totals = (entity_data or {}).get('totals') or {}
@@ -1291,7 +1304,7 @@ def generate_jobs_user_pie_chart(entity_data, metric='cpu_hours') -> str:
     keep = _pie_cumulative_keep(values_desc)
 
     names = [r.get('value') for r in data[:keep]]
-    labels = [n if n is not None else '(unknown)' for n in names]
+    labels = [n if n is not None else unknown_label for n in names]
     values = list(values_desc[:keep])
     colors = list(UNITY_PALETTE_10[:keep])
 
@@ -1327,10 +1340,10 @@ def generate_jobs_user_pie_chart(entity_data, metric='cpu_hours') -> str:
     # intercepts these, scoped to the originating tab pane.
     leg_patches = legend.get_patches()
     leg_texts = legend.get_texts()
-    for i, uname in enumerate(names):
-        if uname is None:
+    for i, name in enumerate(names):
+        if name is None:
             continue
-        url = f'#job-user-{uname}'
+        url = f'#{sentinel_prefix}-{name}'
         wedges[i].set_url(url)
         if i < len(leg_patches):
             leg_patches[i].set_url(url)
@@ -1338,6 +1351,13 @@ def generate_jobs_user_pie_chart(entity_data, metric='cpu_hours') -> str:
             leg_texts[i].set_url(url)
 
     return _fig_to_svg(fig)
+
+
+def generate_jobs_user_pie_chart(entity_data, metric='cpu_hours') -> str:
+    """By User pie — delegates to the entity-agnostic renderer with the
+    ``#job-user-<username>`` sentinel family."""
+    return generate_jobs_usage_pie_chart(entity_data, metric,
+                                         sentinel_prefix='job-user')
 
 
 # ---------------------------------------------------------------------------

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -233,6 +233,7 @@ def _jobs_table_response(*, mode, machine, fragment_url,
     error = None
     rows = []
     total: Optional[int] = None
+    account_projcodes = None
     try:
         common = dict(
             limit=page['per_page'], offset=offset,
@@ -319,6 +320,28 @@ def _jobs_table_response(*, mode, machine, fragment_url,
 
     column_specs = _load_column_specs()
 
+    # Explorer chip strip (?chips=1): facet counts for the same filter set
+    # this table shows, rendered as an hx-swap-oob block so chips and
+    # table always refresh together (panel submit, chip click, sort,
+    # pagination). Card/drill embeds never send chips=1. Degrades to no
+    # chips on any facet failure — the table is the primary content.
+    facet_chips = None
+    if request.args.get('chips') == '1' and error is None:
+        try:
+            facet_chips = service.jobs_facets(
+                machine,
+                account_projcodes=account_projcodes,
+                username=pinned_user,
+                valid_qos_names=qos_options,
+                **filters,
+            )
+        except Exception:
+            from flask import current_app
+            current_app.logger.exception(
+                'jobs table: facets failed for mode=%s machine=%s',
+                mode, machine,
+            )
+
     # The caller passes the id of the container that owns this fragment so
     # sort / pagination clicks can swap that same container's innerHTML.
     # Falls back to a generic id when called without one (legacy paths).
@@ -346,6 +369,7 @@ def _jobs_table_response(*, mode, machine, fragment_url,
         fragment_url=fragment_url,
         target_id=target_id,
         roundtrip_params=_roundtrip_params(machine, target_id),
+        facet_chips=facet_chips,
         enabled=True,
         error=error,
     )
@@ -360,7 +384,7 @@ def _disabled_jobs_table(project=None, username=None):
         filters={}, page={'n': 1, 'per_page': _DEFAULT_PER_PAGE},
         sort={'sort_by': None, 'sort_dir': 'desc'},
         total=None, visible_cols=[], verbose_extras=[],
-        column_specs={}, roundtrip_params={},
+        column_specs={}, roundtrip_params={}, facet_chips=None,
         enabled=False, error=None,
     )
 
@@ -430,7 +454,7 @@ _ROUNDTRIP_KEYS = (
     'min_elapsed', 'max_elapsed', 'min_reqmem', 'max_reqmem',
     'min_memory_used', 'max_memory_used',
     'min_memory_wasted', 'max_memory_wasted',
-    'scope',
+    'scope', 'chips',
 )
 
 _SECS_PER_HOUR = 3600
@@ -867,7 +891,7 @@ def _initial_jobs_url(fragment_url: str, machine: str, target_id: str,
     """
     from urllib.parse import urlencode
     params = {'machine': machine, 'target_id': target_id,
-              'per_page': panel['per_page']}
+              'per_page': panel['per_page'], 'chips': '1'}
     if scope:
         params['scope'] = scope
     for key in ('start', 'end', 'queue', 'qos', 'exit_status', 'name'):

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -423,6 +423,8 @@ _ROUNDTRIP_KEYS = (
     'name', 'ignore_case',
     'min_nodes', 'max_nodes', 'min_cpus', 'max_cpus',
     'min_gpus', 'max_gpus', 'min_wait_hours', 'max_wait_hours',
+    'min_elapsed_hours', 'max_elapsed_hours',
+    'min_reqmem_gb', 'max_reqmem_gb',
     # Plugin-native bounds (bar-drill deep links / envelope replays).
     'min_eligible_secs', 'max_eligible_secs',
     'min_elapsed', 'max_elapsed', 'min_reqmem', 'max_reqmem',
@@ -432,6 +434,10 @@ _ROUNDTRIP_KEYS = (
 )
 
 _SECS_PER_HOUR = 3600
+
+# 1 GB = 1024^3 bytes — the plugin's GB↔bytes convention (its CLI's
+# _BYTES_PER_GB); the "GB" panel labels match its bucket-label vocabulary.
+_BYTES_PER_GB = 1024 ** 3
 
 
 def _parse_int_arg(name: str) -> Optional[int]:
@@ -469,7 +475,8 @@ def _parse_job_filters(include_user: bool = True) -> dict:
     """Whitelisted GET parse → service filter kwargs (plugin-native units).
 
     Human-facing units convert at this boundary and nowhere else:
-    ``min/max_wait_hours`` (hours) → ``min/max_eligible_secs`` (seconds).
+    ``min/max_wait_hours`` and ``min/max_elapsed_hours`` (hours →
+    seconds), ``min/max_reqmem_gb`` (GB → bytes, 1024³).
     Unknown params are ignored; malformed numbers degrade to "no filter".
 
     Plugin-native bound params (the names a histogram envelope's
@@ -506,6 +513,14 @@ def _parse_job_filters(include_user: bool = True) -> dict:
         f['min_eligible_secs'] = int(min_wait * _SECS_PER_HOUR)
     if max_wait is not None:
         f['max_eligible_secs'] = int(max_wait * _SECS_PER_HOUR)
+    for arg, target, factor in (
+            ('min_elapsed_hours', 'min_elapsed', _SECS_PER_HOUR),
+            ('max_elapsed_hours', 'max_elapsed', _SECS_PER_HOUR),
+            ('min_reqmem_gb',     'min_reqmem',  _BYTES_PER_GB),
+            ('max_reqmem_gb',     'max_reqmem',  _BYTES_PER_GB)):
+        v = _parse_float_arg(arg)
+        if v is not None:
+            f[target] = int(v * factor)
     for key in ('min_eligible_secs', 'max_eligible_secs',
                 'min_elapsed', 'max_elapsed',
                 'min_reqmem', 'max_reqmem',
@@ -791,6 +806,10 @@ def _panel_filters(machine: str) -> dict:
         'max_gpus':  _parse_int_arg('max_gpus'),
         'min_wait_hours': _parse_float_arg('min_wait_hours'),
         'max_wait_hours': _parse_float_arg('max_wait_hours'),
+        'min_elapsed_hours': _parse_float_arg('min_elapsed_hours'),
+        'max_elapsed_hours': _parse_float_arg('max_elapsed_hours'),
+        'min_reqmem_gb': _parse_float_arg('min_reqmem_gb'),
+        'max_reqmem_gb': _parse_float_arg('max_reqmem_gb'),
         'per_page': per_page,
         'qos_options': _qos_options_safe(machine),
     }
@@ -817,7 +836,9 @@ def _initial_jobs_url(fragment_url: str, machine: str, target_id: str,
     if panel['ignore_case']:
         params['ignore_case'] = '1'
     for key in ('min_nodes', 'max_nodes', 'min_cpus', 'max_cpus',
-                'min_gpus', 'max_gpus', 'min_wait_hours', 'max_wait_hours'):
+                'min_gpus', 'max_gpus', 'min_wait_hours', 'max_wait_hours',
+                'min_elapsed_hours', 'max_elapsed_hours',
+                'min_reqmem_gb', 'max_reqmem_gb'):
         if panel[key] is not None:
             params[key] = panel[key]
     return f'{fragment_url}?{urlencode(params)}'

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -49,6 +49,7 @@ from sam.projects.projects import Project
 from webapp.api.access_control import require_project_access
 from webapp.dashboards.charts import (
     generate_jobs_histogram,
+    generate_jobs_usage_pie_chart,
     generate_jobs_user_pie_chart,
 )
 from webapp.extensions import db
@@ -234,6 +235,7 @@ def _jobs_table_response(*, mode, machine, fragment_url,
     rows = []
     total: Optional[int] = None
     account_projcodes = None
+    user_account = None
     try:
         common = dict(
             limit=page['per_page'], offset=offset,
@@ -259,11 +261,17 @@ def _jobs_table_response(*, mode, machine, fragment_url,
                 valid_qos_names=qos_options, **filters,
             )
         elif mode == 'user':
+            # `account` narrows one's OWN jobs to a single projcode (the
+            # By Project drill) — safe from the client in this mode only
+            # because the username pin still applies. Project mode keeps
+            # its account list server-derived.
+            user_account = (request.args.get('account') or '').strip() or None
             rows = service.search_jobs_user(
-                machine, pinned_user, **common, **filters,
+                machine, pinned_user, account=user_account, **common, **filters,
             )
             total = service.count_jobs_user(
-                machine, pinned_user, valid_qos_names=qos_options, **filters,
+                machine, pinned_user, account=user_account,
+                valid_qos_names=qos_options, **filters,
             )
         else:
             rows = service.search_jobs_machine(
@@ -330,7 +338,8 @@ def _jobs_table_response(*, mode, machine, fragment_url,
         try:
             facet_chips = service.jobs_facets(
                 machine,
-                account_projcodes=account_projcodes,
+                account_projcodes=(
+                    [user_account] if user_account else account_projcodes),
                 username=pinned_user,
                 valid_qos_names=qos_options,
                 **filters,
@@ -341,6 +350,8 @@ def _jobs_table_response(*, mode, machine, fragment_url,
                 'jobs table: facets failed for mode=%s machine=%s',
                 mode, machine,
             )
+    if user_account:
+        filters['account'] = user_account   # header badge (post-service)
 
     # The caller passes the id of the container that owns this fragment so
     # sort / pagination clicks can swap that same container's innerHTML.
@@ -454,7 +465,7 @@ _ROUNDTRIP_KEYS = (
     'min_elapsed', 'max_elapsed', 'min_reqmem', 'max_reqmem',
     'min_memory_used', 'max_memory_used',
     'min_memory_wasted', 'max_memory_wasted',
-    'scope', 'chips',
+    'scope', 'chips', 'account',
 )
 
 _SECS_PER_HOUR = 3600
@@ -594,6 +605,18 @@ def _tree_projcodes(project) -> list:
     ]
 
 
+def _usage_other(usage) -> Optional[dict]:
+    """The upstream limit's remainder: totals are pre-truncation, so any
+    positive difference is real usage by entities beyond the row cap."""
+    totals = usage.get('totals') or {}
+    rows = usage.get('rows') or []
+    rem = {
+        k: (totals.get(k) or 0) - sum((r.get(k) or 0) for r in rows)
+        for k in ('job_count', 'cpu_hours', 'gpu_hours')
+    }
+    return rem if any(v > 1e-9 for v in rem.values()) else None
+
+
 def _render_by_user(*, mode, machine, fragment_url, jobs_fragment_url,
                     target_id, account_projcodes=None):
     """Shared renderer for the By User tab (project + machine modes)."""
@@ -619,25 +642,55 @@ def _render_by_user(*, mode, machine, fragment_url, jobs_fragment_url,
         )
         error = str(exc)
 
-    pie_svg = None
-    other = None
-    if usage:
-        pie_svg = generate_jobs_user_pie_chart(usage, metric=metric)
-        totals = usage.get('totals') or {}
-        rows = usage.get('rows') or []
-        # The upstream limit's remainder: totals are pre-truncation, so any
-        # positive difference is real usage by users beyond the row cap.
-        rem = {
-            k: (totals.get(k) or 0) - sum((r.get(k) or 0) for r in rows)
-            for k in ('job_count', 'cpu_hours', 'gpu_hours')
-        }
-        if any(v > 1e-9 for v in rem.values()):
-            other = rem
+    pie_svg = generate_jobs_user_pie_chart(usage, metric=metric) \
+        if usage else None
+    other = _usage_other(usage) if usage else None
 
     return render_template(
         template,
         enabled=True, error=error,
         mode=mode, machine=machine,
+        usage=usage, other=other,
+        metric=metric, pie_svg=pie_svg,
+        fragment_url=fragment_url,
+        jobs_fragment_url=jobs_fragment_url,
+        target_id=target_id,
+        params=_roundtrip_params(machine, target_id),
+    )
+
+
+def _render_by_project(*, machine, fragment_url, jobs_fragment_url,
+                       target_id, username=None):
+    """Renderer for the My Jobs "By Project" tab (user mode only)."""
+    template = 'dashboards/user/partials/jobs_by_project.html'
+    if not is_enabled():
+        return render_template(template, enabled=False, error=None,
+                               mode='user', machine=None, target_id=target_id)
+
+    filters = _parse_job_filters(include_user=False)
+    metric = _parse_metric(_DEFAULT_METRIC_PIE)
+
+    usage = None
+    error = None
+    try:
+        usage = service.jobs_usage_by_project(
+            machine, username=username, limit=_BY_USER_LIMIT, **filters,
+        )
+    except Exception as exc:
+        from flask import current_app
+        current_app.logger.exception(
+            'jobs by-project fragment failed: machine=%s', machine,
+        )
+        error = str(exc)
+
+    pie_svg = generate_jobs_usage_pie_chart(
+        usage, metric=metric, sentinel_prefix='job-proj') if usage else None
+    other = _usage_other(usage) if usage else None
+
+    return render_template(
+        template,
+        enabled=True, error=error,
+        mode='user', machine=machine,
         usage=usage, other=other,
         metric=metric, pie_svg=pie_svg,
         fragment_url=fragment_url,
@@ -1084,6 +1137,32 @@ def jobs_user_fragment(machine):
         mode='user', machine=machine,
         fragment_url=url_for('jobs.jobs_user_fragment', machine=machine),
         pinned_user=current_user.username,
+    )
+
+
+@bp.route('/user/<machine>/by-project')
+@login_required
+def by_project_user_fragment(machine):
+    """HTMX fragment: the logged-in user's per-project usage pie + rows.
+
+    The user-mode counterpart of By User (which is hidden there — a pie
+    of one): which projects MY jobs charged. Username pinned server-side
+    like every /user/ route; rows drill into the user-mode jobs fragment
+    narrowed by ``account=<projcode>``.
+    """
+    from flask_login import current_user
+    if not is_enabled():
+        return _render_by_project(machine=None, fragment_url=None,
+                                  jobs_fragment_url=None, target_id='')
+    machine = _machine_or_404(machine)
+    target_id = (request.args.get('target_id') or '').strip() \
+        or f'jobs-byproj-user-{machine}'
+    return _render_by_project(
+        machine=machine,
+        fragment_url=url_for('jobs.by_project_user_fragment', machine=machine),
+        jobs_fragment_url=url_for('jobs.jobs_user_fragment', machine=machine),
+        target_id=target_id,
+        username=current_user.username,
     )
 
 

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -201,29 +201,10 @@ def _jobs_table_response(*, mode, machine, fragment_url,
     ``pinned_user`` (any client-supplied user is ignored), 'machine' is
     unscoped — its routes are VIEW_ALL_JOB_DATA-gated.
     """
-    filters = {
-        'start':  _parse_date(request.args.get('start')),
-        'end':    _parse_date(request.args.get('end')),
-        'queue':  (request.args.get('queue') or '').strip() or None,
-        'qos':    (request.args.get('qos') or '').strip() or None,
-        'exit_status': (request.args.get('exit_status') or '').strip() or None,
-        'name':  (request.args.get('name') or '').strip() or None,
-    }
-    if filters['name'] is not None:
-        filters['ignore_case'] = request.args.get('ignore_case') in ('1', 'true', 'on')
-    for key in ('min_nodes', 'max_nodes', 'min_cpus', 'max_cpus',
-                'min_gpus', 'max_gpus'):
-        v = _parse_int_arg(key)
-        if v is not None:
-            filters[key] = v
-    min_wait = _parse_float_arg('min_wait_hours')
-    max_wait = _parse_float_arg('max_wait_hours')
-    if min_wait is not None:
-        filters['min_eligible_secs'] = int(min_wait * _SECS_PER_HOUR)
-    if max_wait is not None:
-        filters['max_eligible_secs'] = int(max_wait * _SECS_PER_HOUR)
-    if pinned_user is None:
-        filters['user'], _uid, _ulabel = _resolve_user_filter()
+    # Same parse as the aggregation fragments — one boundary, one unit
+    # convention. User mode drops the user key entirely (the service
+    # families raise if it sneaks in beside the server-side pin).
+    filters = _parse_job_filters(include_user=(pinned_user is None))
 
     page = _parse_pagination()
     sort = _parse_sort()
@@ -427,7 +408,10 @@ _DEFAULT_METRIC_HIST = 'jobs'
 _DEFAULT_METRIC_PIE = 'cpu_hours'
 
 # Job Sizes tab dimension pills; Wait Times / Durations pin their dimension.
-_SIZE_DIMENSIONS = ('nodes', 'cpus', 'gpus', 'memory')
+# memory = REQUESTED (reqmem); memory_used = consumed (Job.memory);
+# memory_wasted = requested − used (negative ⇒ used more than requested).
+_SIZE_DIMENSIONS = ('nodes', 'cpus', 'gpus',
+                    'memory', 'memory_used', 'memory_wasted')
 
 # Rows shown in the By User table (the pie itself keeps at most 9 + Other).
 _BY_USER_LIMIT = 25
@@ -439,6 +423,11 @@ _ROUNDTRIP_KEYS = (
     'name', 'ignore_case',
     'min_nodes', 'max_nodes', 'min_cpus', 'max_cpus',
     'min_gpus', 'max_gpus', 'min_wait_hours', 'max_wait_hours',
+    # Plugin-native bounds (bar-drill deep links / envelope replays).
+    'min_eligible_secs', 'max_eligible_secs',
+    'min_elapsed', 'max_elapsed', 'min_reqmem', 'max_reqmem',
+    'min_memory_used', 'max_memory_used',
+    'min_memory_wasted', 'max_memory_wasted',
     'scope',
 )
 
@@ -465,22 +454,45 @@ def _parse_float_arg(name: str) -> Optional[float]:
         return None
 
 
-def _parse_job_filters() -> dict:
+def _parse_signed_int_arg(name: str) -> Optional[int]:
+    """Like ``_parse_int_arg`` but negatives are legal (memory_wasted)."""
+    raw = (request.args.get(name) or '').strip()
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _parse_job_filters(include_user: bool = True) -> dict:
     """Whitelisted GET parse → service filter kwargs (plugin-native units).
 
     Human-facing units convert at this boundary and nowhere else:
     ``min/max_wait_hours`` (hours) → ``min/max_eligible_secs`` (seconds).
     Unknown params are ignored; malformed numbers degrade to "no filter".
+
+    Plugin-native bound params (the names a histogram envelope's
+    ``min_param``/``max_param`` announce) pass through verbatim — the bar
+    drill replays a clicked band without re-deriving display units. They
+    parse AFTER the human-unit forms, so if both spell the same bound the
+    native one wins. The ``memory_wasted`` pair is signed: negative bounds
+    select over-request jobs and must not be clamped.
+
+    ``include_user=False`` omits the ``user`` key entirely — the user-mode
+    service family raises if a user filter arrives beside its server-side
+    pin.
     """
     f: dict = {
         'start': _parse_date(request.args.get('start')),
         'end':   _parse_date(request.args.get('end')),
-        'user':  _resolve_user_filter()[0],
         'queue': (request.args.get('queue') or '').strip() or None,
         'qos':   (request.args.get('qos') or '').strip() or None,
         'exit_status': (request.args.get('exit_status') or '').strip() or None,
         'name':  (request.args.get('name') or '').strip() or None,
     }
+    if include_user:
+        f['user'] = _resolve_user_filter()[0]
     if f['name'] is not None:
         f['ignore_case'] = request.args.get('ignore_case') in ('1', 'true', 'on')
     for key in ('min_nodes', 'max_nodes', 'min_cpus', 'max_cpus',
@@ -494,6 +506,17 @@ def _parse_job_filters() -> dict:
         f['min_eligible_secs'] = int(min_wait * _SECS_PER_HOUR)
     if max_wait is not None:
         f['max_eligible_secs'] = int(max_wait * _SECS_PER_HOUR)
+    for key in ('min_eligible_secs', 'max_eligible_secs',
+                'min_elapsed', 'max_elapsed',
+                'min_reqmem', 'max_reqmem',
+                'min_memory_used', 'max_memory_used'):
+        v = _parse_int_arg(key)
+        if v is not None:
+            f[key] = v
+    for key in ('min_memory_wasted', 'max_memory_wasted'):
+        v = _parse_signed_int_arg(key)
+        if v is not None:
+            f[key] = v
     return f
 
 

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -623,8 +623,35 @@ def _render_by_user(*, mode, machine, fragment_url, jobs_fragment_url,
     )
 
 
+def _bucket_drill_url(jobs_fragment_url: str, hist: dict, bucket: dict,
+                      roundtrip: dict) -> Optional[str]:
+    """Per-band URL for the mode's jobs fragment, or None for empty bands.
+
+    Replays the envelope's self-describing bounds verbatim
+    (``{min_param: lo, max_param: hi}``, omitting a ``None`` end — the
+    open side of an unbounded band, including the wasted dimension's
+    negative 'over request' band) plus the pane's round-trip filters.
+    A pane param spelling the same native bound as the band is dropped —
+    the clicked band's meaning wins. The template appends its own
+    ``target_id``.
+    """
+    if not bucket.get('job_count'):
+        return None
+    from urllib.parse import urlencode
+    params = {}
+    if bucket.get('lo') is not None:
+        params[hist['min_param']] = bucket['lo']
+    if bucket.get('hi') is not None:
+        params[hist['max_param']] = bucket['hi']
+    for k, v in roundtrip.items():
+        if k != 'target_id' and k not in params:
+            params[k] = v
+    return f'{jobs_fragment_url}?{urlencode(params)}'
+
+
 def _render_histogram(*, mode, machine, dimension, dimension_toggle,
                       fragment_url, target_id,
+                      jobs_fragment_url=None,
                       account_projcodes=None, username=None):
     """Shared renderer for the Wait Times / Job Sizes / Durations tabs."""
     template = 'dashboards/user/partials/jobs_histogram.html'
@@ -654,6 +681,18 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
         error = str(exc)
 
     chart_svg = generate_jobs_histogram(hist, metric=metric) if hist else None
+    params = _roundtrip_params(machine, target_id)
+
+    # One drill URL per band (None for empty bands) — computed here, not
+    # in the template, so the envelope's min_param/max_param replay stays
+    # in one place. A parallel list rather than mutating hist: the
+    # envelope is a shared cache entry.
+    bucket_drills = None
+    if hist and jobs_fragment_url:
+        bucket_drills = [
+            _bucket_drill_url(jobs_fragment_url, hist, b, params)
+            for b in hist.get('buckets') or []
+        ]
 
     return render_template(
         template,
@@ -664,8 +703,9 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
         dimension=dimension, dimension_toggle=dimension_toggle,
         size_dimensions=_SIZE_DIMENSIONS,
         fragment_url=fragment_url,
+        bucket_drills=bucket_drills,
         target_id=target_id,
-        params=_roundtrip_params(machine, target_id),
+        params=params,
     )
 
 
@@ -704,6 +744,8 @@ def _project_histogram(project, *, dimension, dimension_toggle, endpoint):
         mode='project', machine=machine,
         dimension=dimension, dimension_toggle=dimension_toggle,
         fragment_url=url_for(endpoint, projcode=project.projcode),
+        jobs_fragment_url=url_for('jobs.jobs_fragment',
+                                  projcode=project.projcode),
         target_id=target_id,
         account_projcodes=_tree_projcodes(project),
     )
@@ -933,6 +975,8 @@ def _machine_histogram(machine, *, dimension, dimension_toggle, endpoint):
         mode='machine', machine=machine,
         dimension=dimension, dimension_toggle=dimension_toggle,
         fragment_url=url_for(endpoint, machine=machine),
+        jobs_fragment_url=url_for('jobs.jobs_machine_fragment',
+                                  machine=machine),
         target_id=target_id,
     )
 
@@ -1034,6 +1078,8 @@ def _user_histogram(machine, *, dimension, dimension_toggle, endpoint):
         mode='user', machine=machine,
         dimension=dimension, dimension_toggle=dimension_toggle,
         fragment_url=url_for(endpoint, machine=machine),
+        jobs_fragment_url=url_for('jobs.jobs_user_fragment',
+                                  machine=machine),
         target_id=target_id,
         username=current_user.username,
     )

--- a/src/webapp/jobs/service.py
+++ b/src/webapp/jobs/service.py
@@ -101,6 +101,10 @@ def _plugin_filter_kwargs(
     max_elapsed: Optional[int] = None,
     min_reqmem: Optional[int] = None,
     max_reqmem: Optional[int] = None,
+    min_memory_used: Optional[int] = None,
+    max_memory_used: Optional[int] = None,
+    min_memory_wasted: Optional[int] = None,
+    max_memory_wasted: Optional[int] = None,
     valid_qos_names: Sequence[str] = (),
 ) -> Dict[str, Any]:
     """Normalize the flat SAM-side filter set into plugin kwargs.
@@ -110,7 +114,9 @@ def _plugin_filter_kwargs(
     pins itself), runs the legacy queue→QoS resolver, and — being
     keyword-only — rejects unknown filter names with a TypeError instead
     of silently dropping them. Range bounds are plugin-native units
-    (seconds / bytes / counts), inclusive, NULL-strict.
+    (seconds / bytes / counts), inclusive, NULL-strict. The
+    ``memory_wasted`` pair (requested − used bytes) is signed: negative
+    bounds select jobs that used MORE than they requested.
     """
     queue_norm, qos_norm = _resolve_queue_and_qos(queue, qos, valid_qos_names)
     return {
@@ -129,6 +135,10 @@ def _plugin_filter_kwargs(
         'min_gpus':  min_gpus,  'max_gpus':  max_gpus,
         'min_elapsed': min_elapsed, 'max_elapsed': max_elapsed,
         'min_reqmem':  min_reqmem,  'max_reqmem':  max_reqmem,
+        'min_memory_used': min_memory_used,
+        'max_memory_used': max_memory_used,
+        'min_memory_wasted': min_memory_wasted,
+        'max_memory_wasted': max_memory_wasted,
     }
 
 

--- a/src/webapp/jobs/service.py
+++ b/src/webapp/jobs/service.py
@@ -528,6 +528,53 @@ def jobs_usage_by_user(
     )
 
 
+def jobs_facets(
+    machine: str,
+    *,
+    facets: Sequence[str] = ('queue', 'qos', 'exit_status'),
+    limit: Optional[int] = 8,
+    account_projcodes: Optional[Sequence[str]] = None,
+    username: Optional[str] = None,
+    valid_qos_names: Sequence[str] = (),
+    **filters,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Cached per-dimension value counts (plugin ``jobs_facets``).
+
+    Backs the explorer's filter chips: ``{dim: [{'value', 'count'}, …]}``
+    with live counts for the current window + filters. The plugin's
+    ``self_exclude`` default stays on — a dimension's own filter doesn't
+    constrain its own counts, so the queue chips still list every queue
+    while a queue filter is active (click-to-switch). ``limit`` caps each
+    dimension's chip count; the tail is dropped, not folded.
+
+    Same scope and caching rules as :func:`jobs_histogram` — ``username``
+    hard-pins user mode (never self-excluded: 'user' isn't a requested
+    facet dimension), ``account_projcodes`` pins a project tree, and
+    ``account`` is never self-excluded upstream by design.
+    """
+    kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
+    if username is not None:
+        kwargs['user'] = username
+    if account_projcodes is not None:
+        kwargs['account'] = list(account_projcodes)
+
+    def _compute():
+        mod = get_module()
+        JobQueries = mod.JobQueries
+        with job_history_session(machine) as session:
+            return JobQueries(session, machine=machine).jobs_facets(
+                facets=tuple(facets), limit=limit, **kwargs,
+            )
+
+    opts = dict(kwargs)
+    opts['facets'] = tuple(facets)
+    opts['limit'] = limit
+    return jobs_cache.cached_jobs_aggregation(
+        'facets', machine, opts, _compute,
+        bucket=jobs_cache.bucket_for_window(kwargs.get('end')),
+    )
+
+
 def list_qos_names(machine: str) -> List[str]:
     """Return active QoS names from the plugin's ``job_qos`` lookup table.
 

--- a/src/webapp/jobs/service.py
+++ b/src/webapp/jobs/service.py
@@ -381,6 +381,7 @@ def search_jobs_user(
     machine: str,
     username: str,
     *,
+    account: Optional[str] = None,
     columns: Optional[Sequence[str]] = None,
     limit: Optional[int] = None,
     offset: int = 0,
@@ -395,6 +396,10 @@ def search_jobs_user(
     and a ``user`` key in *filters* raises rather than being silently
     overwritten — the route must never forward a client-supplied user
     into this mode (mirror of disk_scans' pinned-owner rule).
+
+    ``account`` is a NARROWING filter, safe to accept from the client in
+    this mode only: the user pin still applies, so it restricts which of
+    one's OWN jobs show (the By Project drill), never widens access.
     """
     if not username:
         raise ValueError('search_jobs_user requires a username (user pin).')
@@ -408,6 +413,8 @@ def search_jobs_user(
     JobQueries = mod.JobQueries
 
     kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
+    if account:
+        kwargs['account'] = account
     kwargs.update({
         'user':    username,
         'columns': columns,
@@ -426,6 +433,7 @@ def count_jobs_user(
     machine: str,
     username: str,
     *,
+    account: Optional[str] = None,
     valid_qos_names: Sequence[str] = (),
     **filters,
 ) -> int:
@@ -442,6 +450,8 @@ def count_jobs_user(
     JobQueries = mod.JobQueries
 
     kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
+    if account:
+        kwargs['account'] = account
     kwargs['user'] = username
 
     with job_history_session(machine) as session:
@@ -524,6 +534,54 @@ def jobs_usage_by_user(
     opts['limit'] = limit
     return jobs_cache.cached_jobs_aggregation(
         'usage_by_user', machine, opts, _compute,
+        bucket=jobs_cache.bucket_for_window(kwargs.get('end')),
+    )
+
+
+def jobs_usage_by_project(
+    machine: str,
+    *,
+    username: str,
+    limit: Optional[int] = 25,
+    valid_qos_names: Sequence[str] = (),
+    **filters,
+) -> Dict[str, Any]:
+    """Cached per-project usage rollup for ONE user's jobs (plugin
+    ``jobs_usage_by('account', user=username)``).
+
+    Backs the My Jobs "By Project" pie: which projects the logged-in
+    user's jobs charged, hours-desc. User-mode-only by construction —
+    the username pin is mandatory and non-negotiable exactly like
+    :func:`search_jobs_user` (raises on empty username or a ``user``
+    filter), so this can never aggregate anyone else's jobs. Same
+    pre-truncation ``totals`` invariant and caching rules as
+    :func:`jobs_usage_by_user`; cached as query type
+    ``'usage_by_account'``.
+    """
+    if not username:
+        raise ValueError(
+            'jobs_usage_by_project requires a username (user pin).')
+    if 'user' in filters:
+        raise ValueError(
+            "jobs_usage_by_project pins user server-side; "
+            "remove the 'user' filter from the call."
+        )
+
+    kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
+    kwargs['user'] = username
+
+    def _compute():
+        mod = get_module()
+        JobQueries = mod.JobQueries
+        with job_history_session(machine) as session:
+            return JobQueries(session, machine=machine).jobs_usage_by(
+                'account', limit=limit, **kwargs,
+            )
+
+    opts = dict(kwargs)
+    opts['limit'] = limit
+    return jobs_cache.cached_jobs_aggregation(
+        'usage_by_account', machine, opts, _compute,
         bucket=jobs_cache.bucket_for_window(kwargs.get('end')),
     )
 

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -1262,6 +1262,15 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     color: var(--ncar-gray);
 }
 
+/* fk-pickers embedded in a horizontal align-items-end filter row (jobs +
+   disk-scans panels, which pass wrapper_class='' to drop the stacked-form
+   mb-3): the empty typeahead dropdown's mt-1 still makes the cell 4px
+   taller than its siblings, floating the picker's label above the other
+   columns' labels. !important is required to beat the utility class. */
+.filter-sidebar .align-items-end .fk-picker-results:empty {
+    margin-top: 0 !important;
+}
+
 /* On phones the horizontal filter rows wrap into a ragged multi-column mess:
    stack every field full-width instead. !important is required to beat the
    inline style="width:###px" attributes that size the fields on desktop

--- a/src/webapp/static/js/actions.js
+++ b/src/webapp/static/js/actions.js
@@ -112,6 +112,32 @@
         htmx.trigger(form, 'submit');
     });
 
+    /* Jobs-explorer facet chips: write the chip's value into the named
+     * field of the filter panel form, then re-submit it (the panel's
+     * hx-trigger="submit" refetches the table + OOB chip strip). An
+     * empty data-value clears the filter — the active chip doubles as
+     * its own clear button. A <select> target (the QoS dropdown) gets
+     * the option appended if the catalog doesn't already list it, so a
+     * facet value can never silently fail to apply. */
+    window.registerAction('set-filter-submit', function (el) {
+        var form = document.getElementById(el.dataset.formId);
+        if (!form) { return; }
+        var field = form.elements[el.dataset.field];
+        if (!field) { return; }
+        var value = el.dataset.value || '';
+        if (field.tagName === 'SELECT' && value &&
+                !Array.prototype.some.call(field.options, function (o) {
+                    return o.value === value;
+                })) {
+            var opt = document.createElement('option');
+            opt.value = value;
+            opt.textContent = value;
+            field.appendChild(opt);
+        }
+        field.value = value;
+        htmx.trigger(form, 'submit');
+    });
+
     /* Confirm-gated plain-form submit (samConfirm is an async Bootstrap
      * modal — always preventDefault, re-submit from onConfirm). Used via
      * <form data-action-submit="confirm-submit" data-confirm-message=...>. */

--- a/src/webapp/static/js/svg-chart-links.js
+++ b/src/webapp/static/js/svg-chart-links.js
@@ -23,6 +23,9 @@
  *   - Legend href starts with #usage-user-<username> (stacked-by-user
  *     Usage Trend chart on the compute resource-details page) → expand
  *     that user's row in the Usage by User card below.
+ *   - Bar href starts with #jh-bar-<index> (job-history histograms) →
+ *     open the Bucket-counts <details> and expand that band's row,
+ *     which lazy-loads the band's per-job table.
  *
  * Safe on pages where the target containers aren't included — each
  * branch checks for its targets and silently no-ops.
@@ -55,6 +58,12 @@
     // user's row, found by data-job-user (see jobs_by_user.html). Same
     // interaction as the disk-scans entity pie.
     var JOB_USER_PREFIX = '#job-user-';
+    // Job-history histogram (Wait Times / Job Sizes / Durations): a bar
+    // click expands the matching band's row in the Bucket-counts table
+    // (data-jh-bucket, see jobs_histogram.html), which lazy-loads that
+    // band's per-job fragment. The table sits inside a <details> that
+    // must be opened first or the row would expand invisibly.
+    var BAR_JH_PREFIX = '#jh-bar-';
 
     // Distribution histogram (Access-history / File-size tabs) → expand the
     // matching bucket's per-user detail row. The bucket <tr> carries
@@ -80,6 +89,26 @@
     // collapse target in data-bs-target (same attribute the chevron toggles),
     // keyed by attr (data-owner-uid / data-group-gid). Scoped to the clicked
     // chart's tab pane so other panes' identical sentinels never cross-fire.
+    // Jobs-histogram bar → expand the band's bucket row. Same shape as
+    // openBucketRow but keyed on data-jh-bucket, and the row lives inside
+    // a collapsed-by-default <details> that must be opened before the
+    // Bootstrap collapse (and the scroll) can be seen.
+    function openJobsBucketRow(index, scopeEl) {
+        var root = scopeEl || document;
+        var row = root.querySelector('tr[data-jh-bucket="' + index + '"]');
+        if (!row || !window.bootstrap) return;
+        var details = row.closest('details');
+        if (details) details.open = true;
+        var targetSel = row.getAttribute('data-bs-target');
+        if (!targetSel) return;
+        var el = document.querySelector(targetSel);
+        if (!el) return;
+        bootstrap.Collapse.getOrCreateInstance(el, {toggle: false}).show();
+        setTimeout(function () {
+            row.scrollIntoView({behavior: 'smooth', block: 'center'});
+        }, 60);
+    }
+
     function openEntityRow(attr, id, scopeEl) {
         var root = scopeEl || document;
         var row = root.querySelector('tr[' + attr + '="' + id + '"]');
@@ -200,6 +229,15 @@
             if (gid === '') return;
             e.preventDefault();
             openEntityRow('data-group-gid', gid, a.closest('.tab-pane'));
+            return;
+        }
+
+        // Jobs-histogram bar → expand the band's bucket row (scoped pane)
+        if (href.indexOf(BAR_JH_PREFIX) === 0) {
+            var jhIdx = href.slice(BAR_JH_PREFIX.length);
+            if (jhIdx === '') return;
+            e.preventDefault();
+            openJobsBucketRow(jhIdx, a.closest('.tab-pane'));
             return;
         }
 

--- a/src/webapp/static/js/svg-chart-links.js
+++ b/src/webapp/static/js/svg-chart-links.js
@@ -58,6 +58,9 @@
     // user's row, found by data-job-user (see jobs_by_user.html). Same
     // interaction as the disk-scans entity pie.
     var JOB_USER_PREFIX = '#job-user-';
+    // Job-history By Project pie (My Jobs): same interaction, keyed by
+    // data-job-project (see jobs_by_project.html).
+    var JOB_PROJ_PREFIX = '#job-proj-';
     // Job-history histogram (Wait Times / Job Sizes / Durations): a bar
     // click expands the matching band's row in the Bucket-counts table
     // (data-jh-bucket, see jobs_histogram.html), which lazy-loads that
@@ -247,6 +250,15 @@
             if (juser === '') return;
             e.preventDefault();
             openEntityRow('data-job-user', juser, a.closest('.tab-pane'));
+            return;
+        }
+
+        // Jobs pie wedge/legend → expand the project's jobs row (My Jobs)
+        if (href.indexOf(JOB_PROJ_PREFIX) === 0) {
+            var jproj = href.slice(JOB_PROJ_PREFIX.length);
+            if (jproj === '') return;
+            e.preventDefault();
+            openEntityRow('data-job-project', jproj, a.closest('.tab-pane'));
             return;
         }
 

--- a/src/webapp/templates/dashboards/fragments/form_fields.html
+++ b/src/webapp/templates/dashboards/fragments/form_fields.html
@@ -356,7 +356,8 @@
                          badge_class='bg-info py-1 px-2',
                          search_class='form-control',
                          selected_id='', selected_label='',
-                         id_prefix=None, label_class='form-label') %}
+                         id_prefix=None, label_class='form-label',
+                         wrapper_class='mb-3') %}
 {%- set _prefix = id_prefix or ('fk_' ~ name) -%}
 {%- set _id_input = _prefix ~ '_id' -%}
 {%- set _badge_id = _prefix ~ '_badge' -%}
@@ -366,7 +367,11 @@
 {%- set _form_id = form.get(name) if form else selected_id -%}
 {%- set _form_label = (form.get(name ~ '_display') if form else None) or selected_label -%}
 {%- set _has_value = (_form_id is not none and _form_id != '') -%}
-<div class="mb-3 fk-picker">
+{# wrapper_class='' for pickers embedded in a horizontal align-items-end
+   filter row — the stacked-form mb-3 makes the cell taller than its
+   siblings there, floating the label above the neighbouring columns'.
+   (A CSS override can't do it: Bootstrap utility margins are !important.) #}
+<div class="{{ wrapper_class }} fk-picker">
     {{ _label(name, label, required=required, optional_text=optional_text, id=_search_id, label_class=label_class) }}
 
     <div id="{{ _selected_id }}" class="fk-picker-selected mb-1"

--- a/src/webapp/templates/dashboards/user/jobs_explore_page.html
+++ b/src/webapp/templates/dashboards/user/jobs_explore_page.html
@@ -60,6 +60,11 @@
                     per_page_options, mode=mode) }}
   </div>
 
+  {# Facet chip strip — populated out-of-band by the jobs fragment
+     (hx-swap-oob on #jobs-facet-chips-…), so counts and active states
+     always match the table below. Empty until the first fragment load. #}
+  <div id="jobs-facet-chips-{{ target_id }}"></div>
+
   <div class="card">
     <div class="card-body p-2">
       <div id="{{ target_id }}"

--- a/src/webapp/templates/dashboards/user/partials/_disk_scans_dir_filters.html
+++ b/src/webapp/templates/dashboards/user/partials/_disk_scans_dir_filters.html
@@ -84,7 +84,8 @@
                          optional_text='',
                          selected_id=filters.owner_user_id or '',
                          selected_label=filters.owner_label or '',
-                         label_class='form-label') }}
+                         label_class='form-label',
+                         wrapper_class='') }}
     </div>
     {% endif %}
 

--- a/src/webapp/templates/dashboards/user/partials/_jobs_facet_chips.html
+++ b/src/webapp/templates/dashboards/user/partials/_jobs_facet_chips.html
@@ -1,0 +1,46 @@
+{#
+  Facet chip strip for the jobs explorer — live value counts per filter
+  dimension, computed by service.jobs_facets under the table's exact
+  filter set (self-exclusion on: a dimension's own chips stay complete
+  while its filter is active, so chips double as switchers).
+
+  Rendered by jobs_fragment.html inside an hx-swap-oob block so the strip
+  refreshes together with the table on every panel submit / chip click /
+  sort / page change. A chip click writes its value into the named field
+  of the filter panel form and re-submits it (data-action
+  "set-filter-submit" in static/js/actions.js — CSP-clean, no inline
+  handlers). The active chip is highlighted and clicking it clears the
+  filter (empty data-value).
+
+  Args:
+    facets   — {dim: [{'value', 'count'}, …]} from service.jobs_facets
+    filters  — the fragment's parsed filter dict (current values)
+    form_id  — the explorer filter panel form to write into + submit
+#}
+{% macro jobs_facet_chips(facets, filters, form_id) %}
+{% if facets %}
+<div class="d-flex flex-wrap align-items-center gap-1 mb-2 small">
+  {% for dim, label in [('queue', 'Queue'), ('qos', 'QoS'),
+                        ('exit_status', 'Exit')] %}
+    {% set rows = facets.get(dim) or [] %}
+    {% if rows %}
+      <span class="text-muted ms-2 me-1">{{ label }}:</span>
+      {# NULL-FK rows are counts, not filterable values — skip them. #}
+      {% for row in rows if row.value is not none %}
+        {% set active = ((filters.get(dim) or '') | string == row.value | string) %}
+        <button type="button"
+                class="btn btn-sm py-0 {{ 'btn-primary' if active else 'btn-outline-secondary' }}"
+                data-action="set-filter-submit"
+                data-form-id="{{ form_id }}"
+                data-field="{{ dim }}"
+                data-value="{{ '' if active else row.value }}"
+                title="{{ 'Clear this filter' if active else 'Filter by ' ~ label ~ ' ' ~ row.value }}">
+          {{ row.value }}
+          <span class="badge {{ 'text-bg-light' if active else 'text-bg-secondary' }} ms-1">{{ row.count | fmt_number }}</span>
+        </button>
+      {% endfor %}
+    {% endif %}
+  {% endfor %}
+</div>
+{% endif %}
+{% endmacro %}

--- a/src/webapp/templates/dashboards/user/partials/_jobs_filters.html
+++ b/src/webapp/templates/dashboards/user/partials/_jobs_filters.html
@@ -51,10 +51,13 @@
      data-no-persist: the responsive default owns the initial state. #}
   <div id="{{ form_id }}-fields" class="collapse show filter-fields-collapse" data-no-persist>
 
-  {# Scope context — submitted alongside the visible filter controls. #}
+  {# Scope context — submitted alongside the visible filter controls.
+     chips=1 asks the fragment for the OOB facet-chip strip (explorer is
+     this macro's only consumer; card embeds never send it). #}
   <input type="hidden" name="machine" value="{{ machine }}">
   {% if scope %}<input type="hidden" name="scope" value="{{ scope }}">{% endif %}
   <input type="hidden" name="target_id" value="{{ target_id }}">
+  <input type="hidden" name="chips" value="1">
 
   <div class="d-flex flex-wrap align-items-end gap-3">
     <div>

--- a/src/webapp/templates/dashboards/user/partials/_jobs_filters.html
+++ b/src/webapp/templates/dashboards/user/partials/_jobs_filters.html
@@ -80,7 +80,8 @@
                          optional_text='',
                          selected_id=filters.user_id or '',
                          selected_label=filters.user_label or '',
-                         label_class='form-label') }}
+                         label_class='form-label',
+                         wrapper_class='') }}
     </div>
     {% endif %}
 
@@ -156,7 +157,7 @@
       </select>
     </div>
 
-    <button type="submit" class="btn btn-outline-white mb-2">
+    <button type="submit" class="btn btn-outline-white ms-auto">
       <i class="fas fa-filter me-1"></i> Apply
     </button>
   </div>

--- a/src/webapp/templates/dashboards/user/partials/_jobs_filters.html
+++ b/src/webapp/templates/dashboards/user/partials/_jobs_filters.html
@@ -122,20 +122,24 @@
   </div>
 
   <div class="d-flex flex-wrap align-items-end gap-3 mt-2">
-    {% for lo_name, hi_name, label, width in [
-        ('min_nodes', 'max_nodes', 'Nodes', '90px'),
-        ('min_cpus',  'max_cpus',  'CPUs',  '90px'),
-        ('min_gpus',  'max_gpus',  'GPUs',  '90px'),
-        ('min_wait_hours', 'max_wait_hours', 'Wait (hours)', '110px')] %}
+    {# step='any' on the float pairs — the browser's default step=1 would
+       reject fractional bounds like 1.5 h at submit time. #}
+    {% for lo_name, hi_name, label, width, step in [
+        ('min_nodes', 'max_nodes', 'Nodes', '90px', '1'),
+        ('min_cpus',  'max_cpus',  'CPUs',  '90px', '1'),
+        ('min_gpus',  'max_gpus',  'GPUs',  '90px', '1'),
+        ('min_wait_hours', 'max_wait_hours', 'Wait (hours)', '110px', 'any'),
+        ('min_elapsed_hours', 'max_elapsed_hours', 'Elapsed (hours)', '110px', 'any'),
+        ('min_reqmem_gb', 'max_reqmem_gb', 'Req mem (GB)', '110px', 'any')] %}
     <div>
       <label class="form-label"><strong>{{ label }}</strong></label>
       <div class="d-flex gap-1">
         <input type="number" class="form-control" name="{{ lo_name }}"
                value="{{ filters[lo_name] if filters[lo_name] is not none }}"
-               placeholder="min" min="0" style="width:{{ width }};">
+               placeholder="min" min="0" step="{{ step }}" style="width:{{ width }};">
         <input type="number" class="form-control" name="{{ hi_name }}"
                value="{{ filters[hi_name] if filters[hi_name] is not none }}"
-               placeholder="max" min="0" style="width:{{ width }};">
+               placeholder="max" min="0" step="{{ step }}" style="width:{{ width }};">
       </div>
     </div>
     {% endfor %}

--- a/src/webapp/templates/dashboards/user/partials/jobs_by_project.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_by_project.html
@@ -1,0 +1,141 @@
+{% from 'dashboards/user/partials/_jobs_macros.html'
+   import jobs_disabled, jobs_error, jobs_empty %}
+{#
+  By Project fragment — the logged-in user's per-project usage pie +
+  drillable rows (user mode only; the mirror of jobs_by_user.html, which
+  is hidden there). Context (set in
+  webapp/jobs/routes.py::_render_by_project):
+    enabled, error, mode ('user'), machine,
+    usage   — plugin jobs_usage_by('account') envelope {rows, totals},
+              user-pinned upstream
+    other   — remainder beyond the row cap (totals are pre-truncation)
+    metric  — 'jobs' | 'cpu_hours' | 'gpu_hours' (drives the pie)
+    pie_svg — chart SVG (clickable #job-proj-<projcode> sentinels)
+    fragment_url      — this fragment (metric pill re-fetch)
+    jobs_fragment_url — the user-mode per-job fragment (row drill target,
+                        narrowed by account=<projcode>)
+    target_id, params — container id + hidden round-trip params
+#}
+
+{% if not enabled %}
+  {{ jobs_disabled() }}
+{% elif error %}
+  {{ jobs_error(error) }}
+{% else %}
+  <form id="jobs-byproj-params-{{ target_id }}" class="d-none">
+    {% for k, v in params.items() %}
+    <input type="hidden" name="{{ k }}" value="{{ v }}">
+    {% endfor %}
+  </form>
+
+  {% set rows = (usage.rows if usage else []) or [] %}
+  {% set totals = (usage.totals if usage else {}) or {} %}
+
+  <div class="d-flex align-items-center flex-wrap gap-2 mb-2">
+    {# Metric pills — re-fetch this same pane with ?metric=. #}
+    <div class="btn-group btn-group-sm me-1" role="group" aria-label="Pie metric">
+      {% for m, label in [('jobs', 'Jobs'),
+                          ('cpu_hours', 'CPU-hours'),
+                          ('gpu_hours', 'GPU-hours')] %}
+      <button type="button"
+              class="btn btn-outline-secondary {% if metric == m %}active{% endif %}"
+              hx-get="{{ fragment_url }}?metric={{ m }}"
+              hx-target="#{{ target_id }}"
+              hx-include="#jobs-byproj-params-{{ target_id }}"
+              hx-swap="innerHTML">
+        {{ label }}
+      </button>
+      {% endfor %}
+    </div>
+    <span class="ms-auto text-muted small">
+      {{ totals.get('job_count', 0) | fmt_number }} jobs ·
+      {{ totals.get('cpu_hours', 0) | fmt_number }} CPU-h ·
+      {{ totals.get('gpu_hours', 0) | fmt_number }} GPU-h
+    </span>
+  </div>
+
+  {% if not rows %}
+    {{ jobs_empty('No jobs match the current filters.') }}
+  {% else %}
+    {# Usage pie (top ~90% + one "Other"). Wedges and legend entries are
+       clickable (set_url sentinels → svg-chart-links.js) and expand the
+       matching project's row below. #}
+    {% if pie_svg %}
+    <div class="d-flex justify-content-center mb-3 jobs-user-pie">
+      {{ pie_svg | safe }}
+    </div>
+    {% endif %}
+
+    {# MULTI-TBODY (tbody.sortable-group): each project's row and its lazy
+       drill-down detail row reorder together under client sort. #}
+    <div class="table-responsive">
+      <table class="table table-sm table-hover align-middle mb-0">
+        <thead class="table-light">
+          <tr>
+            <th class="sortable-header" data-sort="text">Project</th>
+            <th class="sortable-header text-end" data-sort="numeric">Jobs</th>
+            <th class="sortable-header text-end sort-desc" data-sort="numeric">CPU-hours</th>
+            <th class="sortable-header text-end" data-sort="numeric">GPU-hours</th>
+          </tr>
+        </thead>
+        {% for r in rows %}
+          {% set projcode = r.value %}
+          {% set _rid = target_id ~ '-p' ~ loop.index %}
+          <tbody class="sortable-group">
+            {# data-job-project + data-bs-target let a pie-wedge click open
+               this row's collapse (svg-chart-links.js), same as the chevron. #}
+            <tr {% if projcode %}data-job-project="{{ projcode }}"{% endif %}
+                data-bs-target="#{{ _rid }}-row">
+              <td data-sort-value="{{ projcode or '~' }}">
+                {% if projcode %}
+                <button class="btn btn-sm btn-link text-decoration-none p-0 me-1"
+                        type="button" data-bs-toggle="collapse"
+                        data-bs-target="#{{ _rid }}-row"
+                        aria-expanded="false" aria-controls="{{ _rid }}-row">
+                  <i class="fas fa-chevron-right collapse-icon small"></i>
+                </button>
+                <code>{{ projcode }}</code>
+                {% else %}
+                <span class="text-muted" title="jobs with no recorded project">(unknown)</span>
+                {% endif %}
+              </td>
+              <td class="text-end" data-sort-value="{{ r.job_count }}">{{ r.job_count | fmt_number }}</td>
+              <td class="text-end" data-sort-value="{{ r.cpu_hours }}">{{ r.cpu_hours | fmt_number }}</td>
+              <td class="text-end" data-sort-value="{{ r.gpu_hours }}">{{ r.gpu_hours | fmt_number }}</td>
+            </tr>
+            {% if projcode %}
+            <tr class="collapse" id="{{ _rid }}-row">
+              <td colspan="4" class="p-0 border-0">
+                {# Lazy-load this project's slice of MY jobs on first
+                   expand (account narrows, the server-side user pin still
+                   applies). Bind to shown.bs.collapse so a pie-wedge open
+                   triggers it too. Carries the pane's date window +
+                   shared filters into the drill. #}
+                <div class="p-2 bg-light" id="{{ _rid }}-content"
+                     hx-get="{{ jobs_fragment_url }}?machine={{ machine }}&account={{ projcode }}{% if params.start %}&start={{ params.start }}{% endif %}{% if params.end %}&end={{ params.end }}{% endif %}{% if params.queue %}&queue={{ params.queue }}{% endif %}{% if params.qos %}&qos={{ params.qos }}{% endif %}{% if params.exit_status %}&exit_status={{ params.exit_status }}{% endif %}&target_id={{ _rid }}-content"
+                     hx-trigger="shown.bs.collapse from:closest tr.collapse once"
+                     hx-swap="innerHTML">
+                  <p class="text-muted small mb-0">
+                    <i class="fas fa-spinner fa-spin me-1"></i>
+                    Loading {{ projcode }} jobs…
+                  </p>
+                </div>
+              </td>
+            </tr>
+            {% endif %}
+          </tbody>
+        {% endfor %}
+        {% if other %}
+        <tbody>
+          <tr class="text-muted">
+            <td>Other <span class="small">(beyond top {{ rows | length }})</span></td>
+            <td class="text-end">{{ other.job_count | fmt_number }}</td>
+            <td class="text-end">{{ other.cpu_hours | fmt_number }}</td>
+            <td class="text-end">{{ other.gpu_hours | fmt_number }}</td>
+          </tr>
+        </tbody>
+        {% endif %}
+      </table>
+    </div>
+  {% endif %}
+{% endif %}

--- a/src/webapp/templates/dashboards/user/partials/jobs_card.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_card.html
@@ -38,11 +38,13 @@
     {% set _full_url  = url_for('jobs.explore_machine_page',        machine=machine, start=start, end=end) %}
 {% elif mode == 'user' %}
     {% set _jobs_url  = url_for('jobs.jobs_user_fragment',       machine=machine, start=start, end=end, target_id=cid ~ '-jobs') %}
+    {% set _proj_url  = url_for('jobs.by_project_user_fragment', machine=machine, start=start, end=end, target_id=cid ~ '-byproj') %}
     {% set _wait_url  = url_for('jobs.wait_times_user_fragment', machine=machine, start=start, end=end, target_id=cid ~ '-wait') %}
     {% set _sizes_url = url_for('jobs.job_sizes_user_fragment',  machine=machine, start=start, end=end, target_id=cid ~ '-sizes') %}
     {% set _dur_url   = url_for('jobs.durations_user_fragment',  machine=machine, start=start, end=end, target_id=cid ~ '-durations') %}
     {% set _full_url  = url_for('jobs.explore_user_page',        machine=machine, start=start, end=end) %}
-    {# no _user_url — the By User tab is hidden in user mode #}
+    {# no _user_url — the By User tab is hidden in user mode (a pie of
+       one); By Project takes its slot: which projects MY jobs charged. #}
 {% else %}
     {% set _jobs_url  = url_for('jobs.jobs_fragment',       projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-jobs') %}
     {% set _user_url  = url_for('jobs.by_user_fragment',    projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-byuser') %}
@@ -73,6 +75,18 @@
                 hx-swap="innerHTML"
                 hx-trigger="shown.bs.tab once">
             <i class="fas fa-users me-1"></i> By User
+        </button>
+    </li>
+    {% else %}
+    <li class="nav-item" role="presentation">
+        <button class="nav-link" id="{{ cid }}-byproj-tab"
+                data-bs-toggle="tab" data-bs-target="#tab-{{ cid }}-byproj"
+                type="button" role="tab"
+                hx-get="{{ _proj_url }}"
+                hx-target="#{{ cid }}-byproj"
+                hx-swap="innerHTML"
+                hx-trigger="shown.bs.tab once">
+            <i class="fas fa-diagram-project me-1"></i> By Project
         </button>
     </li>
     {% endif %}
@@ -131,6 +145,14 @@
     {% if mode != 'user' %}
     <div class="tab-pane fade" id="tab-{{ cid }}-byuser" role="tabpanel">
         <div id="{{ cid }}-byuser">
+            <p class="text-muted small mb-0">
+                <i class="fas fa-spinner fa-spin me-1"></i> Loading…
+            </p>
+        </div>
+    </div>
+    {% else %}
+    <div class="tab-pane fade" id="tab-{{ cid }}-byproj" role="tabpanel">
+        <div id="{{ cid }}-byproj">
             <p class="text-muted small mb-0">
                 <i class="fas fa-spinner fa-spin me-1"></i> Loading…
             </p>

--- a/src/webapp/templates/dashboards/user/partials/jobs_fragment.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_fragment.html
@@ -225,4 +225,17 @@
     {{ pagination(page, total, fragment_url, target_id,
                   'jobs-filters-' ~ target_id, sort) }}
   {% endif %}
+
+  {% if facet_chips %}
+    {# Out-of-band swap into the explorer's chip placeholder — keeps the
+       chip strip (counts + active states) in lockstep with this table on
+       every refetch. The panel form id follows the explorer page's
+       'jobs-filters-panel-<target_id>' convention. #}
+    {% from 'dashboards/user/partials/_jobs_facet_chips.html'
+       import jobs_facet_chips %}
+    <div id="jobs-facet-chips-{{ target_id }}" hx-swap-oob="innerHTML">
+      {{ jobs_facet_chips(facet_chips, filters,
+                          'jobs-filters-panel-' ~ target_id) }}
+    </div>
+  {% endif %}
 {% endif %}

--- a/src/webapp/templates/dashboards/user/partials/jobs_fragment.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_fragment.html
@@ -137,6 +137,10 @@
     {% if filters.queue %}
       <span class="badge bg-light text-dark me-1">queue: {{ filters.queue }}</span>
     {% endif %}
+    {% if filters.account %}
+      {# User-mode account narrowing (the By Project drill). #}
+      <span class="badge bg-light text-dark me-1">project: {{ filters.account }}</span>
+    {% endif %}
     {% if qos_options %}
       {# QoS filter — bound to the hidden filter form via form="…" so
          sort/pagination hx-includes serialize the current selection

--- a/src/webapp/templates/dashboards/user/partials/jobs_histogram.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_histogram.html
@@ -111,7 +111,12 @@
   {% endif %}
 
   {# Bucket table under the SVG — the same full, zero-filled vector the
-     chart renders, so counts are copy/paste-able. #}
+     chart renders, so counts are copy/paste-able. Populated bands are
+     expandable: the collapse row lazy-loads the mode's per-job fragment
+     filtered to that band's bounds (bucket_drills, computed in
+     _render_histogram). A bar click (#jh-bar-<i> sentinel) opens the
+     matching data-jh-bucket row via svg-chart-links.js, forcing this
+     <details> open first. #}
   <details class="mt-1">
     <summary class="small text-muted">Bucket counts</summary>
     <div class="table-responsive mt-2">
@@ -124,16 +129,49 @@
             <th class="text-end">GPU-hours</th>
           </tr>
         </thead>
-        <tbody>
-          {% for b in hist.buckets %}
-          <tr {% if not b.job_count %}class="text-muted"{% endif %}>
-            <td><code>{{ b.label }}</code></td>
-            <td class="text-end">{{ b.job_count | fmt_number }}</td>
-            <td class="text-end">{{ b.cpu_hours | fmt_number }}</td>
-            <td class="text-end">{{ b.gpu_hours | fmt_number }}</td>
-          </tr>
-          {% endfor %}
-        </tbody>
+        {% for b in hist.buckets %}
+          {% set drill_url = bucket_drills[loop.index0]
+             if bucket_drills else none %}
+          {% set _rid = target_id ~ '-b' ~ loop.index0 %}
+          <tbody>
+            <tr {% if not b.job_count %}class="text-muted"
+                {% else %}data-jh-bucket="{{ loop.index0 }}"
+                          data-bs-target="#{{ _rid }}-row"{% endif %}>
+              <td>
+                {% if drill_url %}
+                <button class="btn btn-sm btn-link text-decoration-none p-0 me-1"
+                        type="button" data-bs-toggle="collapse"
+                        data-bs-target="#{{ _rid }}-row"
+                        aria-expanded="false" aria-controls="{{ _rid }}-row">
+                  <i class="fas fa-chevron-right collapse-icon small"></i>
+                </button>
+                {% endif %}
+                <code>{{ b.label }}</code>
+              </td>
+              <td class="text-end">{{ b.job_count | fmt_number }}</td>
+              <td class="text-end">{{ b.cpu_hours | fmt_number }}</td>
+              <td class="text-end">{{ b.gpu_hours | fmt_number }}</td>
+            </tr>
+            {% if drill_url %}
+            <tr class="collapse" id="{{ _rid }}-row">
+              <td colspan="4" class="p-0 border-0">
+                {# Lazy-load this band's jobs on first expand — bind to
+                   shown.bs.collapse (not click) so a bar-click open
+                   triggers it too. #}
+                <div class="p-2 bg-light" id="{{ _rid }}-content"
+                     hx-get="{{ drill_url }}&target_id={{ _rid }}-content"
+                     hx-trigger="shown.bs.collapse from:closest tr.collapse once"
+                     hx-swap="innerHTML">
+                  <p class="text-muted small mb-0">
+                    <i class="fas fa-spinner fa-spin me-1"></i>
+                    Loading jobs in the {{ b.label }} band…
+                  </p>
+                </div>
+              </td>
+            </tr>
+            {% endif %}
+          </tbody>
+        {% endfor %}
       </table>
     </div>
   </details>

--- a/src/webapp/templates/dashboards/user/partials/jobs_histogram.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_histogram.html
@@ -11,7 +11,8 @@
                  gpu_hours, null_count, total_count, unit)
     chart_svg  — rendered SVG (or an empty-state div)
     metric     — 'jobs' | 'cpu_hours' | 'gpu_hours'
-    dimension  — 'wait' | 'nodes' | 'cpus' | 'gpus' | 'memory' | 'duration'
+    dimension  — 'wait' | 'nodes' | 'cpus' | 'gpus' | 'memory' |
+                 'memory_used' | 'memory_wasted' | 'duration'
     dimension_toggle — True only on the Job Sizes tab
     size_dimensions  — the dimension pill order
     fragment_url, target_id, params — re-fetch plumbing
@@ -32,11 +33,14 @@
 
   <div class="d-flex align-items-center flex-wrap gap-2 mb-2">
     {% if dimension_toggle %}
-      {# Dimension pills — nodes / CPUs / GPUs / memory re-fetch this pane
-         with ?dimension= (memory = REQUESTED memory, Job.reqmem). #}
+      {# Dimension pills re-fetch this pane with ?dimension=. The memory
+         trio: Req mem = requested (Job.reqmem), Used mem = consumed
+         (Job.memory), Wasted = requested − used. #}
       <div class="btn-group btn-group-sm me-1" role="group" aria-label="Size dimension">
         {% for d, label in [('nodes', 'Nodes'), ('cpus', 'CPUs'),
-                            ('gpus', 'GPUs'), ('memory', 'Memory')] %}
+                            ('gpus', 'GPUs'), ('memory', 'Req mem'),
+                            ('memory_used', 'Used mem'),
+                            ('memory_wasted', 'Wasted')] %}
         <button type="button"
                 class="btn btn-outline-secondary {% if dimension == d %}active{% endif %}"
                 hx-get="{{ fragment_url }}?dimension={{ d }}&metric={{ metric }}"
@@ -74,6 +78,17 @@
   </div>
   {% endif %}
 
+  {% if dimension == 'memory_wasted' and machine == 'derecho' %}
+    <p class="text-muted small mb-2">
+      <i class="fas fa-circle-info me-1"></i>
+      Derecho schedules whole nodes: every job is assigned all of each
+      node's memory (~235&nbsp;GB) regardless of what it requested, so
+      large "wasted" values here are an artifact of node-exclusive
+      scheduling, not over-requesting. Casper's shared nodes are where
+      this distribution is actionable.
+    </p>
+  {% endif %}
+
   {% if hist.null_count and hist.null_count > 0 %}
     <p class="text-muted small mb-2">
       <i class="fas fa-circle-info me-1"></i>
@@ -81,6 +96,13 @@
         {{ hist.null_count | fmt_number }} job{{ '' if hist.null_count == 1 else 's' }}
         in this range have no wait measurement (queued before eligible-time
         collection began, early 2025 on Derecho) and are excluded.
+      {% elif dimension == 'memory_used' %}
+        {{ hist.null_count | fmt_number }} job{{ '' if hist.null_count == 1 else 's' }}
+        in this range have no recorded memory usage and are excluded.
+      {% elif dimension == 'memory_wasted' %}
+        {{ hist.null_count | fmt_number }} job{{ '' if hist.null_count == 1 else 's' }}
+        in this range are missing the used or requested memory measurement
+        and are excluded.
       {% else %}
         {{ hist.null_count | fmt_number }} job{{ '' if hist.null_count == 1 else 's' }}
         in this range have no recorded value for this dimension and are excluded.

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -189,7 +189,9 @@ def _install_mock_plugin(app, monkeypatch, *, jobs_search_return=None,
                         jobs_count_return=None, qos_names=None,
                         machines=('derecho',),
                         jobs_histogram_return=None,
-                        jobs_usage_by_return=None):
+                        jobs_usage_by_return=None,
+                        jobs_facets_return=None,
+                        jobs_facets_raises=False):
     """Wire a mock job_history module onto app.extensions and return the
     captured JobQueries kwargs so tests can assert on the call.
 
@@ -202,6 +204,7 @@ def _install_mock_plugin(app, monkeypatch, *, jobs_search_return=None,
         'last_jobs_count_kwargs':  None,
         'last_jobs_histogram':     None,   # (dimension, kwargs)
         'last_jobs_usage_by':      None,   # (dimension, kwargs)
+        'last_jobs_facets_kwargs': None,
     }
     qos_list = (list(qos_names) if qos_names is not None
                 else list(_DEFAULT_QOS_NAMES))
@@ -231,6 +234,13 @@ def _install_mock_plugin(app, monkeypatch, *, jobs_search_return=None,
             return {'dimension': dimension, 'rows': [],
                     'totals': {'job_count': 0, 'cpu_hours': 0.0,
                                'gpu_hours': 0.0}}
+        def jobs_facets(self, **kwargs):
+            captured['last_jobs_facets_kwargs'] = kwargs
+            if jobs_facets_raises:
+                raise RuntimeError('facets exploded')
+            if jobs_facets_return is not None:
+                return jobs_facets_return
+            return {d: [] for d in kwargs.get('facets', ())}
         def list_qos_names(self, **kwargs):
             return list(qos_list)
 
@@ -2174,6 +2184,122 @@ def test_fragment_converts_elapsed_hours_and_reqmem_gb(
     assert skw['max_elapsed'] == 86400
     assert skw['min_reqmem'] == 512 * 1024 ** 2      # 0.5 GB
     assert skw['max_reqmem'] == 128 * 1024 ** 3
+
+
+_SAMPLE_FACETS = {
+    'queue': [{'value': 'cpu', 'count': 120}, {'value': 'gpu', 'count': 30},
+              {'value': None, 'count': 2}],
+    'qos': [{'value': 'regular', 'count': 100}, {'value': 'premium', 'count': 50}],
+    'exit_status': [{'value': '0', 'count': 140}, {'value': '271', 'count': 10}],
+}
+
+
+def test_explore_page_initial_url_requests_chips(
+    app, auth_client, active_project, monkeypatch,
+):
+    """The explorer's lazy-load URL asks the fragment for the OOB chip
+    strip, and the page renders the placeholder it swaps into."""
+    _install_mock_plugin(app, monkeypatch)
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/explore?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'chips=1' in body
+    assert 'id="jobs-facet-chips-jobs-explore"' in body
+    assert 'name="chips"' in body          # panel form round-trips it
+
+
+def test_fragment_chips_render_oob_with_counts(
+    app, auth_client, active_project, monkeypatch,
+):
+    """?chips=1 → the fragment appends an hx-swap-oob strip: value chips
+    with live counts, NULL-FK rows skipped, wired to the panel form."""
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_facets_return=_SAMPLE_FACETS,
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}'
+        '?machine=derecho&chips=1&queue=cpu'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'hx-swap-oob' in body
+    assert 'data-action="set-filter-submit"' in body
+    assert 'data-form-id="jobs-filters-panel-jobs-' in body
+    # Active chip (queue=cpu) highlights and clears on click.
+    import re
+    cpu_chip = re.search(
+        r'<button[^>]*data-field="queue"[^>]*data-value=""[^>]*>', body)
+    assert cpu_chip is not None and 'btn-primary' in cpu_chip.group(0)
+    # Inactive chip carries its value.
+    assert 'data-value="gpu"' in body
+    assert 'data-value="271"' in body
+    # NULL-FK queue row renders no chip (nothing to filter by).
+    assert 'data-value="None"' not in body
+    # The facets call saw the same filter set as the table.
+    fkw = captured['last_jobs_facets_kwargs']
+    assert fkw['queue'] == 'cpu'
+    assert fkw['limit'] == 8
+
+
+def test_fragment_no_chips_without_param(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Card/drill embeds never send chips=1 → no facets query, no OOB."""
+    captured = _install_mock_plugin(app, monkeypatch)
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'hx-swap-oob' not in body
+    assert captured['last_jobs_facets_kwargs'] is None
+
+
+def test_fragment_chips_degrade_on_facets_error(
+    app, auth_client, active_project, monkeypatch,
+):
+    """A facets failure must not take the table down — the fragment
+    renders normally with no chip strip."""
+    _install_mock_plugin(
+        app, monkeypatch, jobs_facets_raises=True,
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}'
+        '?machine=derecho&chips=1'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'hx-swap-oob' not in body
+    assert 'Could not load per-job data' not in body
+
+
+def test_fragment_chips_project_scope_pins_account(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Facets are scoped exactly like the table — the project tree's
+    projcodes pin the account filter."""
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_facets_return=_SAMPLE_FACETS,
+    )
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}'
+        '?machine=derecho&chips=1'
+    )
+    fkw = captured['last_jobs_facets_kwargs']
+    assert active_project.projcode in fkw['account']
+
+
+def test_user_fragment_chips_pin_username(app, auth_client, monkeypatch):
+    """User-mode chips describe the pinned user's jobs only — the session
+    username rides into the facets call, client ?user= notwithstanding."""
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_facets_return=_SAMPLE_FACETS,
+    )
+    auth_client.get(
+        '/dashboards/user/jobs/user/derecho'
+        '?machine=derecho&chips=1&user=mallory'
+    )
+    fkw = captured['last_jobs_facets_kwargs']
+    assert fkw['user'] == 'benkirk'
 
 
 def test_explore_page_scope_rerooting_badge(

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -2046,6 +2046,46 @@ def test_explore_page_carries_filters_into_initial_url(
     assert 'min_wait_hours=1.5' in body
 
 
+def test_explore_page_elapsed_reqmem_panel_roundtrip(
+    app, auth_client, active_project, monkeypatch,
+):
+    """The panel renders the elapsed/req-mem inputs, echoes deep-linked
+    values back into them, and carries them into the lazy-load URL."""
+    _install_mock_plugin(app, monkeypatch)
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/explore'
+        '?machine=derecho&min_elapsed_hours=2.5&max_reqmem_gb=128'
+    )
+    body = resp.get_data(as_text=True)
+    # Panel inputs exist (all four names) with the deep-linked values.
+    for field in ('min_elapsed_hours', 'max_elapsed_hours',
+                  'min_reqmem_gb', 'max_reqmem_gb'):
+        assert f'name="{field}"' in body
+    assert 'value="2.5"' in body
+    assert 'value="128' in body
+    # …and the initial fragment URL reproduces them.
+    assert 'min_elapsed_hours=2.5' in body
+    assert 'max_reqmem_gb=128' in body
+
+
+def test_fragment_converts_elapsed_hours_and_reqmem_gb(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Panel units convert at the route boundary: hours → seconds for
+    elapsed, GB → bytes (1024³) for requested memory."""
+    captured = _install_mock_plugin(app, monkeypatch)
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}'
+        '?machine=derecho&min_elapsed_hours=1.5&max_elapsed_hours=24'
+        '&min_reqmem_gb=0.5&max_reqmem_gb=128'
+    )
+    skw = captured['last_jobs_search_kwargs']
+    assert skw['min_elapsed'] == 5400
+    assert skw['max_elapsed'] == 86400
+    assert skw['min_reqmem'] == 512 * 1024 ** 2      # 0.5 GB
+    assert skw['max_reqmem'] == 128 * 1024 ** 3
+
+
 def test_explore_page_scope_rerooting_badge(
     app, auth_client, active_project, monkeypatch,
 ):

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -1926,6 +1926,96 @@ def test_histogram_fragment_converts_wait_hours_to_secs(
     assert kwargs['max_eligible_secs'] == 16200
 
 
+def test_histogram_bucket_rows_carry_band_drill_urls(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Populated bands render data-jh-bucket rows whose collapse content
+    lazy-loads the per-job fragment with the envelope's min/max bounds
+    plus the pane's round-trip filters."""
+    _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist(),
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times'
+        '?machine=derecho&queue=cpu'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'data-jh-bucket="0"' in body
+    assert 'data-jh-bucket="1"' in body
+    import re
+    url0 = re.search(r'id="[^"]*-b0-content"\s+hx-get="([^"]+)"', body).group(1)
+    assert f'/dashboards/user/jobs/{active_project.projcode}?' in url0
+    assert 'min_eligible_secs=0' in url0
+    assert 'max_eligible_secs=59' in url0
+    assert 'queue=cpu' in url0             # pane filters carried into the drill
+    assert 'machine=derecho' in url0
+    assert 'target_id=' in url0
+
+
+_WASTED_HIST = {
+    'dimension': 'memory_wasted', 'column': 'memory_wasted', 'unit': 'bytes',
+    'min_param': 'min_memory_wasted', 'max_param': 'max_memory_wasted',
+    'buckets': [
+        {'label': 'over request', 'lo': None, 'hi': -1,
+         'job_count': 3, 'cpu_hours': 30.0, 'gpu_hours': 0.0},
+        {'label': '<1GB', 'lo': 0, 'hi': 2 ** 30 - 1,
+         'job_count': 0, 'cpu_hours': 0.0, 'gpu_hours': 0.0},
+        {'label': '>1GB', 'lo': 2 ** 30, 'hi': None,
+         'job_count': 7, 'cpu_hours': 70.0, 'gpu_hours': 0.0},
+    ],
+    'null_count': 0, 'total_count': 10,
+}
+
+
+def test_histogram_bucket_drill_omits_open_ends(
+    app, auth_client, active_project, monkeypatch,
+):
+    """A None band end is an open side — its param is omitted from the
+    drill URL in both directions: the negative 'over request' band emits
+    only the max bound, the open top band only the min. Empty bands get
+    no drill row at all."""
+    import re
+    _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_WASTED_HIST,
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/job-sizes'
+        '?machine=derecho&dimension=memory_wasted'
+    )
+    body = resp.get_data(as_text=True)
+
+    url0 = re.search(r'id="[^"]*-b0-content"\s+hx-get="([^"]+)"', body).group(1)
+    assert 'min_memory_wasted' not in url0
+    assert 'max_memory_wasted=-1' in url0
+
+    assert 'data-jh-bucket="1"' not in body        # empty band: inert row
+    assert re.search(r'id="[^"]*-b1-content"', body) is None
+
+    url2 = re.search(r'id="[^"]*-b2-content"\s+hx-get="([^"]+)"', body).group(1)
+    assert f'min_memory_wasted={2 ** 30}' in url2
+    assert 'max_memory_wasted' not in url2
+
+
+def test_histogram_bucket_drill_band_bound_replaces_pane_param(
+    app, auth_client, active_project, monkeypatch,
+):
+    """When the pane itself is filtered on the same native bound the band
+    replays, the band's value replaces the pane's in the drill URL —
+    never both."""
+    import re
+    _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist(),
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times'
+        '?machine=derecho&min_eligible_secs=999'
+    )
+    body = resp.get_data(as_text=True)
+    url0 = re.search(r'id="[^"]*-b0-content"\s+hx-get="([^"]+)"', body).group(1)
+    assert 'min_eligible_secs=0' in url0
+    assert 'min_eligible_secs=999' not in url0
+
+
 def test_histogram_fragment_metric_pill_roundtrip(
     app, auth_client, active_project, monkeypatch,
 ):

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -2482,6 +2482,117 @@ def test_user_histogram_fragments_ignore_client_user_param(
     assert kwargs['user'] == 'benkirk'
 
 
+_PROJECT_USAGE = {
+    'dimension': 'account',
+    'rows': [
+        {'value': 'SCSG0001', 'job_count': 30, 'cpu_hours': 300.0, 'gpu_hours': 0.0},
+        {'value': 'UABC0002', 'job_count': 12, 'cpu_hours': 120.0, 'gpu_hours': 2.0},
+    ],
+    'totals': {'job_count': 42, 'cpu_hours': 420.0, 'gpu_hours': 2.0},
+}
+
+
+def test_by_project_fragment_renders_rows_and_pinned_pie(
+    app, auth_client, monkeypatch,
+):
+    """The My Jobs By Project tab: plugin grouped by 'account' with the
+    session user pinned (client ?user= ignored); rows carry
+    data-job-project and the pie #job-proj sentinels."""
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_usage_by_return=_PROJECT_USAGE,
+    )
+    resp = auth_client.get(
+        '/dashboards/user/jobs/user/derecho/by-project?user=mallory'
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    dim, kwargs = captured['last_jobs_usage_by']
+    assert dim == 'account'
+    assert kwargs['user'] == 'benkirk'
+    assert kwargs['limit'] == 25
+    assert 'data-job-project="SCSG0001"' in body
+    assert '#job-proj-SCSG0001' in body
+    # Row drill narrows the user-mode jobs fragment by account.
+    assert '/dashboards/user/jobs/user/derecho?machine=derecho&account=SCSG0001' in body
+
+
+def test_by_project_fragment_404_unknown_machine(app, auth_client, monkeypatch):
+    _install_mock_plugin(app, monkeypatch)
+    resp = auth_client.get('/dashboards/user/jobs/user/fugaku/by-project')
+    assert resp.status_code == 404
+
+
+def test_by_project_fragment_disabled_banner(auth_client):
+    resp = auth_client.get('/dashboards/user/jobs/user/derecho/by-project')
+    assert resp.status_code == 200
+    assert 'plugin is not loaded' in resp.get_data(as_text=True)
+
+
+def test_user_fragment_account_narrows_own_jobs(app, auth_client, monkeypatch):
+    """?account=<projcode> narrows the pinned user's OWN jobs — both the
+    rows and the count see it, and the user pin survives."""
+    captured = _install_mock_plugin(app, monkeypatch)
+    resp = auth_client.get(
+        '/dashboards/user/jobs/user/derecho?machine=derecho&account=SCSG0001'
+    )
+    assert resp.status_code == 200
+    skw = captured['last_jobs_search_kwargs']
+    assert skw['account'] == 'SCSG0001'
+    assert skw['user'] == 'benkirk'
+    ckw = captured['last_jobs_count_kwargs']
+    assert ckw['account'] == 'SCSG0001'
+    assert ckw['user'] == 'benkirk'
+    # The narrowing surfaces as a header badge.
+    assert 'project: SCSG0001' in resp.get_data(as_text=True)
+
+
+def test_project_fragment_ignores_client_account_param(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Project mode keeps its account list server-derived — a client
+    ?account= must not replace the tree pin."""
+    captured = _install_mock_plugin(app, monkeypatch)
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}'
+        '?machine=derecho&account=EVIL0001'
+    )
+    skw = captured['last_jobs_search_kwargs']
+    assert skw['account'] == [active_project.projcode] or \
+        active_project.projcode in skw['account']
+    assert 'EVIL0001' not in skw['account']
+
+
+def test_my_jobs_card_offers_by_project_tab(app, auth_client, monkeypatch):
+    """The user-mode card swaps By User for By Project."""
+    _install_mock_plugin(app, monkeypatch)
+    resp = auth_client.get('/user/jobs')
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'By Project' in body
+    assert 'by-project' in body
+    assert 'By User' not in body
+
+
+def test_service_jobs_usage_by_project_requires_username(app, monkeypatch):
+    from webapp.jobs import service
+
+    _install_mock_plugin(app, monkeypatch)
+    with app.app_context():
+        with pytest.raises(ValueError, match='username'):
+            service.jobs_usage_by_project('derecho', username='')
+
+
+def test_service_jobs_usage_by_project_rejects_user_filter(app, monkeypatch):
+    from webapp.jobs import service
+
+    _install_mock_plugin(app, monkeypatch)
+    with app.app_context():
+        with pytest.raises(ValueError, match='user'):
+            service.jobs_usage_by_project(
+                'derecho', username='benkirk', user='mallory',
+            )
+
+
 def test_user_explore_page_omits_user_picker(app, auth_client, monkeypatch):
     _install_mock_plugin(app, monkeypatch)
     resp = auth_client.get('/dashboards/user/jobs/user/derecho/explore')

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -1524,6 +1524,47 @@ def test_count_jobs_name_filter_forces_plugin_path(
     assert ckw['ignore_case'] is True
 
 
+def test_count_jobs_memory_bound_forces_plugin_path(
+    app, active_project, monkeypatch,
+):
+    """The new memory bounds are outside the SAM summary's key set — any
+    value (including a negative wasted bound) must take the plugin path."""
+    from webapp.jobs import service
+
+    captured = _install_mock_plugin(app, monkeypatch, jobs_count_return=3)
+
+    with app.app_context():
+        total = service.count_jobs(
+            'derecho', project=active_project, max_memory_wasted=-1,
+        )
+
+    assert total == 3
+    ckw = captured['last_jobs_count_kwargs']
+    assert ckw is not None
+    assert ckw['max_memory_wasted'] == -1
+
+
+def test_search_jobs_forwards_memory_filters(app, active_project, monkeypatch):
+    """_plugin_filter_kwargs mirrors the plugin surface 1:1 — the four new
+    memory bounds flow through search_jobs untouched."""
+    from webapp.jobs import service
+
+    captured = _install_mock_plugin(app, monkeypatch)
+
+    with app.app_context():
+        service.search_jobs(
+            'derecho', project=active_project,
+            min_memory_used=2 * 1024 ** 3, max_memory_used=64 * 1024 ** 3,
+            min_memory_wasted=-(4 * 1024 ** 3), max_memory_wasted=0,
+        )
+
+    kw = captured['last_jobs_search_kwargs']
+    assert kw['min_memory_used'] == 2 * 1024 ** 3
+    assert kw['max_memory_used'] == 64 * 1024 ** 3
+    assert kw['min_memory_wasted'] == -(4 * 1024 ** 3)
+    assert kw['max_memory_wasted'] == 0
+
+
 def test_search_jobs_rejects_unknown_filter(app, active_project, monkeypatch):
     """_plugin_filter_kwargs is keyword-only: a typo'd filter raises
     TypeError instead of silently vanishing."""
@@ -1715,6 +1756,140 @@ def test_job_sizes_fragment_memory_dimension_forwarded(
     )
     dim, _kwargs = captured['last_jobs_histogram']
     assert dim == 'memory'
+
+
+def test_job_sizes_fragment_offers_memory_trio_pills(
+    app, auth_client, active_project, monkeypatch,
+):
+    """The Sizes tab renders all six dimension pills, memory trio labeled
+    Req mem / Used mem / Wasted."""
+    _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist(dimension='nodes'),
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/job-sizes?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'dimension=memory_used' in body
+    assert 'dimension=memory_wasted' in body
+    assert 'Req mem' in body
+    assert 'Used mem' in body
+    assert 'Wasted' in body
+
+
+@pytest.mark.parametrize('dimension', ['memory_used', 'memory_wasted'])
+def test_job_sizes_fragment_memory_trio_forwarded(
+    app, auth_client, active_project, monkeypatch, dimension,
+):
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist(dimension=dimension),
+    )
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/job-sizes'
+        f'?machine=derecho&dimension={dimension}'
+    )
+    dim, _kwargs = captured['last_jobs_histogram']
+    assert dim == dimension
+
+
+def test_job_sizes_wasted_caption_derecho_only(
+    app, auth_client, active_project, monkeypatch,
+):
+    """The whole-node caveat renders on derecho's Wasted view and nowhere
+    else — not on casper (shared nodes make wasted meaningful there) and
+    not on derecho's other dimensions."""
+    _install_mock_plugin(
+        app, monkeypatch,
+        jobs_histogram_return=_sample_hist(dimension='memory_wasted'),
+        machines=('derecho', 'casper'),
+    )
+    base = f'/dashboards/user/jobs/{active_project.projcode}/job-sizes'
+
+    body = auth_client.get(
+        f'{base}?machine=derecho&dimension=memory_wasted').get_data(as_text=True)
+    assert 'node-exclusive' in body
+
+    body = auth_client.get(
+        f'{base}?machine=casper&dimension=memory_wasted').get_data(as_text=True)
+    assert 'node-exclusive' not in body
+
+    body = auth_client.get(
+        f'{base}?machine=derecho&dimension=memory').get_data(as_text=True)
+    assert 'node-exclusive' not in body
+
+
+def test_histogram_fragment_native_bounds_passthrough(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Envelope-native params (min_param/max_param names) pass through
+    verbatim — no display-unit re-derivation, no double conversion."""
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist(),
+    )
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times'
+        '?machine=derecho&min_eligible_secs=120&max_eligible_secs=900'
+        '&min_reqmem=1073741824&min_memory_used=2147483648'
+    )
+    _dim, kwargs = captured['last_jobs_histogram']
+    assert kwargs['min_eligible_secs'] == 120
+    assert kwargs['max_eligible_secs'] == 900
+    assert kwargs['min_reqmem'] == 1073741824
+    assert kwargs['min_memory_used'] == 2147483648
+
+
+def test_histogram_fragment_native_bound_wins_over_human_units(
+    app, auth_client, active_project, monkeypatch,
+):
+    """When a deep link carries both spellings of the same bound, the
+    native form (parsed last) wins."""
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist(),
+    )
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times'
+        '?machine=derecho&min_wait_hours=2&min_eligible_secs=120'
+    )
+    _dim, kwargs = captured['last_jobs_histogram']
+    assert kwargs['min_eligible_secs'] == 120
+
+
+def test_histogram_fragment_negative_wasted_bound_not_clamped(
+    app, auth_client, active_project, monkeypatch,
+):
+    """The 'over request' band replays as max_memory_wasted=-1 — the signed
+    parse must forward the negative, not clamp it to 0 or drop it."""
+    captured = _install_mock_plugin(
+        app, monkeypatch,
+        jobs_histogram_return=_sample_hist(dimension='memory_wasted'),
+    )
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/job-sizes'
+        '?machine=derecho&dimension=memory_wasted&max_memory_wasted=-1'
+    )
+    _dim, kwargs = captured['last_jobs_histogram']
+    assert kwargs['max_memory_wasted'] == -1
+
+
+def test_jobs_fragment_native_bounds_forwarded_to_search_and_count(
+    app, auth_client, active_project, monkeypatch,
+):
+    """The per-job table accepts the same native bounds (bar-drill target):
+    both jobs_search and the count see them, and the count leaves the
+    SAM-summary fast path (range bound in play)."""
+    captured = _install_mock_plugin(app, monkeypatch)
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}'
+        '?machine=derecho&min_memory_wasted=-4294967296&max_memory_wasted=-1'
+        '&min_elapsed=3600'
+    )
+    skw = captured['last_jobs_search_kwargs']
+    assert skw['min_memory_wasted'] == -4294967296
+    assert skw['max_memory_wasted'] == -1
+    assert skw['min_elapsed'] == 3600
+    ckw = captured['last_jobs_count_kwargs']
+    assert ckw is not None                      # plugin path, not SAM summary
+    assert ckw['max_memory_wasted'] == -1
 
 
 def test_durations_fragment_pins_duration_dimension(

--- a/tests/unit/test_webapp_jobs_cache.py
+++ b/tests/unit/test_webapp_jobs_cache.py
@@ -190,8 +190,8 @@ def test_caching_facade_reports_and_clears_jobs_category(app):
 # ---------------------------------------------------------------------------
 
 def _install_agg_plugin(app, monkeypatch):
-    """Mock plugin capturing jobs_histogram / jobs_usage_by calls."""
-    captured = {'histogram': [], 'usage_by': []}
+    """Mock plugin capturing jobs_histogram / jobs_usage_by / jobs_facets."""
+    captured = {'histogram': [], 'usage_by': [], 'facets': []}
 
     class FakeJobQueries:
         def __init__(self, session, machine='derecho'):
@@ -206,6 +206,10 @@ def _install_agg_plugin(app, monkeypatch):
             captured['usage_by'].append((dimension, kwargs))
             return {'dimension': dimension, 'rows': [],
                     'totals': {'job_count': 0, 'cpu_hours': 0.0, 'gpu_hours': 0.0}}
+
+        def jobs_facets(self, **kwargs):
+            captured['facets'].append(kwargs)
+            return {d: [] for d in kwargs.get('facets', ())}
 
     fake_mod = types.SimpleNamespace(
         get_engine=lambda machine, pool_kwargs=None: MagicMock(),
@@ -280,6 +284,41 @@ def test_service_jobs_usage_by_user_forwards_limit_and_account(app, monkeypatch)
     assert kwargs['limit'] == 7
     assert kwargs['account'] == ['SCSG0001', 'SCSG0002']
     assert 'rows' in out and 'totals' in out
+
+
+def test_service_jobs_facets_caches_closed_window(app, monkeypatch):
+    """Two identical closed-window facet calls → one plugin query; a
+    different facet tuple or limit is a different key."""
+    from webapp.jobs import cache as c, service
+    c._adapters.clear()
+
+    captured = _install_agg_plugin(app, monkeypatch)
+    win = {'start': date(2026, 6, 1), 'end': date(2026, 6, 30)}
+
+    with app.app_context():
+        service.jobs_facets('derecho', account_projcodes=['SCSG0001'], **win)
+        service.jobs_facets('derecho', account_projcodes=['SCSG0001'], **win)
+        service.jobs_facets('derecho', account_projcodes=['SCSG0001'],
+                            limit=3, **win)
+
+    assert len(captured['facets']) == 2
+    kwargs = captured['facets'][0]
+    assert kwargs['facets'] == ('queue', 'qos', 'exit_status')
+    assert kwargs['limit'] == 8
+    assert kwargs['account'] == ['SCSG0001']
+
+
+def test_service_jobs_facets_username_pin_overwrites_user_filter(
+    app, monkeypatch,
+):
+    from webapp.jobs import service
+
+    captured = _install_agg_plugin(app, monkeypatch)
+
+    with app.app_context():
+        service.jobs_facets('derecho', username='benkirk', user='mallory')
+
+    assert captured['facets'][0]['user'] == 'benkirk'
 
 
 def test_service_jobs_usage_by_user_caches(app, monkeypatch):

--- a/tests/unit/test_webapp_jobs_cache.py
+++ b/tests/unit/test_webapp_jobs_cache.py
@@ -336,3 +336,27 @@ def test_service_jobs_usage_by_user_caches(app, monkeypatch):
                                    account_projcodes=['SCSG0001'], **win)
 
     assert len(captured['usage_by']) == 2
+
+
+def test_service_jobs_usage_by_project_caches_under_own_query_type(
+    app, monkeypatch,
+):
+    """usage_by_account is its own cache key family — a by-project call
+    never satisfies (or is satisfied by) a by-user call with the same
+    filter set."""
+    from webapp.jobs import cache as c, service
+    c._adapters.clear()
+
+    captured = _install_agg_plugin(app, monkeypatch)
+    win = {'start': date(2026, 6, 1), 'end': date(2026, 6, 30)}
+
+    with app.app_context():
+        service.jobs_usage_by_project('derecho', username='benkirk', **win)
+        service.jobs_usage_by_project('derecho', username='benkirk', **win)
+        # Same window as a by-user call → still a fresh plugin query.
+        service.jobs_usage_by_user('derecho', user='benkirk', limit=25, **win)
+
+    assert len(captured['usage_by']) == 2
+    dim, kwargs = captured['usage_by'][0]
+    assert dim == 'account'
+    assert kwargs['user'] == 'benkirk'

--- a/tests/unit/test_webapp_jobs_charts.py
+++ b/tests/unit/test_webapp_jobs_charts.py
@@ -202,3 +202,26 @@ def test_pie_unknown_user_row_is_inert():
     svg = generate_jobs_user_pie_chart(usage)
     assert '#job-user-alice' in svg
     assert '#job-user-None' not in svg
+
+
+def test_pie_sentinel_prefix_parameterized():
+    """The generalized renderer emits the caller's sentinel family — the
+    By Project pie drills data-job-project rows, not user rows."""
+    from webapp.dashboards.charts import generate_jobs_usage_pie_chart
+    rows = [
+        {'value': 'SCSG0001', 'job_count': 5, 'cpu_hours': 50.0, 'gpu_hours': 0.0},
+    ]
+    usage = _usage(rows=rows, totals={'job_count': 5, 'cpu_hours': 50.0,
+                                      'gpu_hours': 0.0})
+    svg = generate_jobs_usage_pie_chart(usage, sentinel_prefix='job-proj')
+    assert '#job-proj-SCSG0001' in svg
+    assert '#job-user-' not in svg
+
+
+def test_pie_sentinel_prefix_in_cache_key():
+    """Identical usage vectors under different sentinel families must not
+    share a cache entry — the embedded drill anchors differ."""
+    from webapp.dashboards.charts import _jobs_usage_pie_cache_key
+    a = _jobs_usage_pie_cache_key(_usage(), sentinel_prefix='job-user')
+    b = _jobs_usage_pie_cache_key(_usage(), sentinel_prefix='job-proj')
+    assert a != b

--- a/tests/unit/test_webapp_jobs_charts.py
+++ b/tests/unit/test_webapp_jobs_charts.py
@@ -100,6 +100,36 @@ def test_histogram_dimension_in_cache_key():
     assert a != b
 
 
+def test_histogram_bars_carry_bucket_sentinels():
+    """Populated bands are wrapped in #jh-bar-<index> anchors (index-keyed,
+    matching data-jh-bucket rows); empty bands get no anchor."""
+    svg = generate_jobs_histogram(_hist(counts=(10, 5, 0)))
+    assert '#jh-bar-0' in svg
+    assert '#jh-bar-1' in svg
+    assert '#jh-bar-2' not in svg
+
+
+def test_histogram_sentinels_follow_job_count_not_metric():
+    """Clickability is decided by job_count even on an hours metric — a band
+    with jobs but zero cpu_hours must still be drillable."""
+    h = _hist(counts=(10, 5, 3), cpu_hours=(100.0, 50.0, 0.0))
+    svg = generate_jobs_histogram(h, metric='cpu_hours')
+    assert '#jh-bar-2' in svg
+
+
+def test_histogram_count_vector_in_cache_key():
+    """Two envelopes with identical hours vectors but different populated
+    band sets must not share a cache entry — the drill URLs differ."""
+    from webapp.dashboards.charts import _jobs_histogram_cache_key
+    a = _jobs_histogram_cache_key(
+        _hist(counts=(10, 5, 3), cpu_hours=(100.0, 50.0, 0.0)),
+        metric='cpu_hours')
+    b = _jobs_histogram_cache_key(
+        _hist(counts=(10, 5, 0), cpu_hours=(100.0, 50.0, 0.0)),
+        metric='cpu_hours')
+    assert a != b
+
+
 # ---------------------------------------------------------------------------
 # generate_jobs_user_pie_chart
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Round 2 of the job-history dashboard (stacked on #381; plan of record:
`docs/plans/JOB_HISTORY_FOLLOWUPS.md`). Executes deferred items 1–5 from
round 1:

- **S1 — memory dimensions + native passthrough**: the Job Sizes tab grows to
  six pills — Nodes / CPUs / GPUs / **Req mem / Used mem / Wasted** — consuming
  plugin PR benkirk/hpc-usage-queries#99 tip `e07238f` (`memory_used` +
  `memory_wasted` histogram dimensions and four signed range filters). Derecho's
  Wasted view carries a whole-node-scheduling caveat (Casper is where wasted is
  actionable). Filter parsing accepts the envelope-native bound params
  (`min/max_eligible_secs`, `_elapsed`, `_reqmem`, `_memory_used`,
  `_memory_wasted` — the wasted pair signed), and the per-job table's inline
  parse unified onto `_parse_job_filters`.
- **S2 — explorer inputs**: Elapsed (hours) and Req mem (GB) min/max pairs in
  the filter panel; hours×3600 / GB×1024³ conversion at the route boundary,
  `step="any"` so fractional bounds survive browser validation.
- **S3 — clickable histogram bars**: every populated band on every dimension in
  all three modes carries a `#jh-bar-<i>` sentinel that opens the matching
  Bucket-counts row (forcing the `<details>` open) and lazy-loads that band's
  per-job table via the envelope's self-describing `min_param`/`max_param` —
  the negative "over request" band replays as `max_memory_wasted=-1` with no
  min. Chart cache key gains the count-positivity vector.
- **S4 — facet chips**: queue / QoS / exit-code chips with live counts above
  the explorer table (plugin `jobs_facets`, cached as query type `facets`,
  self-exclusion on). Rendered by the jobs fragment as an `hx-swap-oob` block
  so counts + active states refresh in lockstep with the table; a chip click
  writes the panel field and re-submits (CSP-clean `set-filter-submit` action).
  Active chip doubles as clear.
- **S5 — By Project in user mode**: My Jobs gains the tab By User can't be
  (a pie of one) — which projects MY jobs charged
  (`jobs_usage_by_project`, cached as `usage_by_account`, username pin
  mandatory). Rows/wedges drill into the user-mode fragment narrowed by
  `account=<projcode>` — safe only there because the user pin still applies.
  The pie generalizes to `generate_jobs_usage_pie_chart(sentinel_prefix=…)`.

### Test results

- Full suite **3,257 passed** (+37), 30 skipped, 1 xfailed — green both plain
  and under CI emulation (`CACHE_REDIS_URL` set). Tests stay hermetic to the
  plugin version (mock plugin + `_FAKE_COLUMN_SPECS`).
- Plugin suite 546 → **565** on PR #99.
- Playwright smoke on webdev (plugin `e07238f`): six pills + Derecho caption;
  bar→bucket drill count matches the band exactly (1,025 = 1,025); chips show
  live counts, filter on click (queue chips stay complete via self-exclusion,
  QoS chips narrow), active chip clears; elapsed/reqmem deep-link round-trips
  (panel echo + filtered table); By Project pie wedge → 448-job
  account-narrowed drill with `project:` badge; bdobbins: machine surfaces 403,
  My Jobs 200, `?user=` override still pinned.

### Merge order

1. Plugin PR benkirk/hpc-usage-queries#99 (tip `e07238f`) — deploy pin.
2. SAM PR #381 (`job_history_expansion` → staging).
3. **This PR** — retarget base to `staging` after #381 merges (reopen with the
   recorded head if the parent merge auto-closes it).

Deferred to its own PR after this lands: fs_scans/usage Redis `'usage:'`
prefix migration (item 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)