### PR TITLE
UX round 3 + Redis cache-prefix retirement (former-projects card, jobs drill-downs, namespaced caches)

### DIFF
--- a/docs/plans/JOBS_BY_PROJECT.md
+++ b/docs/plans/JOBS_BY_PROJECT.md
@@ -1,8 +1,8 @@
 # Jobs "By Project" everywhere multi-project + entity modals + histogram User|Project pill
 
-**Status (2026-07-27): Unit P (plugin PR #101) OPEN; Unit 1 (SAM tab/drills/
-modals) IMPLEMENTED on `redis_and_ux_tweaks`; Unit 2 (histogram pill) BLOCKED
-on #101 merge + container rebuild.**
+**Status (2026-07-27): COMPLETE. Unit P = plugin PR #101 (merged; local
+containers carry it); Units 1+2 IMPLEMENTED on `redis_and_ux_tweaks`
+(PR #383). All three units Playwright-verified.**
 
 Cross-repo status doc for the round following Job History UX round 3
 (`JOB_HISTORY_UX_ROUND3.md`). Ben's asks: By Project wherever the context
@@ -44,21 +44,36 @@ Branch `jobs_histogram_owners_by` off `main` (`aed06d6`).
   scope discrimination. Route-map snapshot untouched (jobs blueprint not
   covered).
 
-## Unit 2 — SAM histogram pill (DO AFTER #101 merge + rebuild)
+## Unit 2 — SAM histogram pill (IMPLEMENTED)
 
 - `service.jobs_histogram`: `owners_by=None`, forwarded + cached **only when
   set and != 'user'** → soft degradation, no lockstep (old plugin only breaks
-  the Project pill click).
-- `_render_histogram`: `?owners_by=` param, pill offered only in
-  multi-project contexts (machine mode; project mode w/ `jobs_multi_project`).
+  the Project pill click; the User path never sends the kwarg).
+- `_render_histogram`: `?owners_by=` param honored only in multi-project
+  contexts (machine mode; project tree > 1 — same gate as the By Project
+  tab); round-tripped through the metric/dimension pills via the hidden
+  params form (added AFTER drill URLs, which don't take it).
 - `jobs_histogram.html`: User|Project pill; drives all three drill levels —
-  stacked segments, bucket owner tables (projcode + modal trigger), per-owner
-  jobs drill via `&account=` instead of `&user=`. charts.py unchanged.
-- Tests: pill gating, threading + cache key, account-mode drill URLs.
+  stacked segments, bucket owner tier (Project header, projcode modal
+  triggers, "Other projects"), per-owner jobs drill via `&account=`. The
+  owner rows' collapse toggle moved from the `<tr>` to the chevron + stat
+  `<td>`s (capture-phase rule, fragments/collapse.html) so the nested
+  entity-modal buttons work — user-mode owner cells got the user-modal
+  affordance in the same restructure. charts.py unchanged
+  (`_jobs_bucket_segments` is owner-shape-agnostic).
+- Tests: pill gating (machine / user-ignored / tree-size), soft-degradation
+  forwarding, account tier + drill + round-trip input, owner-cell modals,
+  cache-key discrimination (explicit 'user' aliases the omitted default).
 
 ## Verification
 
-Unit 1 Playwright-smoked on webdev (status → Derecho → Job History): both
-tabs; By Project 25 rows + "Other beyond top 25 by CPU-hours"; UTAM0017 modal
-pop; row drill → `project: UTAM0017` badge + that project's 5,171 jobs;
-By User fredc → User Details modal. Full pytest suite green before commit.
+Playwright-smoked on webdev (status → Derecho → Job History):
+- Unit 1: both tabs; By Project 25 rows + "Other beyond top 25 by
+  CPU-hours"; UTAM0017 modal pop; row drill → `project: UTAM0017` badge +
+  that project's 5,171 jobs; By User fredc → User Details modal.
+- Unit 2 (container at plugin #101): Wait Times Owner-dimension pill;
+  Project pill → per-project bucket tier (UCBK0034 rank 1, 9.5% of band,
+  "Other projects (beyond top 10)"); projcode click pops the project modal
+  without toggling the collapse; chevron drill → `project: UCBK0034` badge
+  + the tier row's exact 50,651 jobs.
+Full pytest suite green before each commit (3325 at unit 2).

--- a/docs/plans/JOBS_BY_PROJECT.md
+++ b/docs/plans/JOBS_BY_PROJECT.md
@@ -1,0 +1,64 @@
+# Jobs "By Project" everywhere multi-project + entity modals + histogram User|Project pill
+
+**Status (2026-07-27): Unit P (plugin PR #101) OPEN; Unit 1 (SAM tab/drills/
+modals) IMPLEMENTED on `redis_and_ux_tweaks`; Unit 2 (histogram pill) BLOCKED
+on #101 merge + container rebuild.**
+
+Cross-repo status doc for the round following Job History UX round 3
+(`JOB_HISTORY_UX_ROUND3.md`). Ben's asks: By Project wherever the context
+spans >1 project; projcode/username cells pop the entity modals ("we could
+backport this to user too"); histograms gain a User|Project owners pill in the
+same contexts.
+
+## Unit P — plugin `owners_by` (hpc-usage-queries PR #101)
+
+`jobs_histogram(..., owners_by='user'|'account')` — per-bucket `owners`
+generalized through `_FACET_SPECS` (GROUP BY `Job.account_id`, account-code
+keys). Default `'user'` byte-identical. 213 plugin tests green (8 new).
+Branch `jobs_histogram_owners_by` off `main` (`aed06d6`).
+
+## Unit 1 — SAM (works against deployed plugin, no wait)
+
+- `service.jobs_usage_by_project`: `username` now optional; `account_projcodes`
+  added (tree scoping); the pin-collision raise applies only when pinned.
+  `search_jobs_machine`/`count_jobs_machine` accept a narrowing `account=`.
+- `routes.py`: `_render_by_project` mode-parameterized; new routes
+  `/machine/<machine>/by-project` (VIEW_ALL_JOB_DATA) and
+  `/<projcode>/by-project` (require_project_access, tree-scoped).
+  `_jobs_table_response`: machine branch accepts `?account=` narrowing;
+  project branch accepts it ONLY in-tree (out-of-tree ignored — tree stays
+  the security boundary).
+- `jobs_card.html`: machine mode renders BOTH By User and By Project; project
+  mode gates By Project on `jobs_multi_project` (computed in the
+  resource-details view via `_resolve_scope_projcodes` — tab visibility and
+  row scoping always agree); user mode unchanged.
+- Entity modals: username cells (By User, gated `can_view_users` — the
+  user_card route's VIEW_USERS gate, project_members.py idiom) →
+  `#userDetailsModal`; projcode cells (By Project, `can_view_projects or
+  user mode`) → `#projectDetailsModal`. Canonical trigger pattern from
+  allocations/project_table.html. `resource_details.html` gained the two
+  missing modal shells (it extends dashboards/base.html directly).
+- Tests: `/by-project` in `_MACHINE_FRAGMENTS`; machine/project by-project
+  scoping + drills + badges; modal affordance present/absent by permission;
+  both-tabs on status card; shells + tab gate on resource-details; cache
+  scope discrimination. Route-map snapshot untouched (jobs blueprint not
+  covered).
+
+## Unit 2 — SAM histogram pill (DO AFTER #101 merge + rebuild)
+
+- `service.jobs_histogram`: `owners_by=None`, forwarded + cached **only when
+  set and != 'user'** → soft degradation, no lockstep (old plugin only breaks
+  the Project pill click).
+- `_render_histogram`: `?owners_by=` param, pill offered only in
+  multi-project contexts (machine mode; project mode w/ `jobs_multi_project`).
+- `jobs_histogram.html`: User|Project pill; drives all three drill levels —
+  stacked segments, bucket owner tables (projcode + modal trigger), per-owner
+  jobs drill via `&account=` instead of `&user=`. charts.py unchanged.
+- Tests: pill gating, threading + cache key, account-mode drill URLs.
+
+## Verification
+
+Unit 1 Playwright-smoked on webdev (status → Derecho → Job History): both
+tabs; By Project 25 rows + "Other beyond top 25 by CPU-hours"; UTAM0017 modal
+pop; row drill → `project: UTAM0017` badge + that project's 5,171 jobs;
+By User fredc → User Details modal. Full pytest suite green before commit.

--- a/docs/plans/JOB_HISTORY_DASHBOARD.md
+++ b/docs/plans/JOB_HISTORY_DASHBOARD.md
@@ -343,12 +343,10 @@ as-built notes in `JOB_HISTORY_FOLLOWUPS.md`:
   surfaces both as Job Sizes pills.
 - ~~Explorer inputs for elapsed/reqmem bounds~~ → S2.
 
-**Still open** (its own PR, AFTER round 2 merges — Ben's sequencing):
+**Still open**: none.
 
-- **Pre-existing, discovered via CI**: `RedisTTLAdapter` namespaces keys
-  and `clear()`/`info()` scans by `prefix` only, and the usage cache AND
-  both fs_scans buckets all sit on the default `'usage:'` prefix — so on
-  Redis, `clear('usage')` / `clear('scans')` wipe each other's entries
-  and their `info()` counts merge. The jobs buckets pass distinct
-  `prefix=<name>:` values; migrating fs_scans/usage the same way is a
-  separate PR (existing 'usage:' keys orphan until TTL at cutover).
+- ~~`RedisTTLAdapter` shared `'usage:'` prefix (usage cache + both fs_scans
+  buckets → `clear('usage')`/`clear('scans')` cross-wipe, blended `info()`
+  counts)~~ → SHIPPED on `redis_and_ux_tweaks`: name-derived default prefix,
+  flask-adapter `_FOREIGN_PREFIXES` skip list, FLUSHDB-at-deploy cutover.
+  See `REDIS_CACHE_PREFIXES.md`.

--- a/docs/plans/JOB_HISTORY_UX_ROUND3.md
+++ b/docs/plans/JOB_HISTORY_UX_ROUND3.md
@@ -1,0 +1,34 @@
+# Job History UX round 3 — cross-repo status & restart doc
+
+**State (2026-07-27): Phase A done (plugin PR #100 under review); Phase B implemented on `redis_and_ux_tweaks` and Playwright-verified against a locally rebuilt container. Remaining: plugin PR #100 merge to `main`, full SAM pytest run (Ben), then the SAM PR to `staging` — which must note the lockstep deploy dependency on #100.**
+
+## The four issues (Ben's review of PRs #381/#382)
+
+1. Job name column blows up table width → truncate at `max-width: 35ch` (tooltip already exists).
+2. No User column in job tables → add (sortable), smart-suppressed when the view has one user.
+3. Histograms flat vs fs_scans; bucket table single-level behind `<details>` → owner-stacked gradient bars, table always visible, two-level bin → users → user's-jobs drill.
+4. Derecho / By User / GPU-Hours shows one user → plugin ranked by combined hours before top-25 truncation.
+
+## Phase A — DONE
+
+Plugin PR: **https://github.com/benkirk/hpc-usage-queries/pull/100** (branch `jobs_plugin_enhancements`, base `main`).
+
+- `jobs_histogram(..., owners_limit=N)` → per-bucket `owners: {username: {job_count, cpu_hours, gpu_hours}}`, top-N by combined hours, appended key, totals authoritative (remainder = totals − Σ owners). Default `None` = byte-identical envelope.
+- `jobs_usage_by(..., sort_by='hours'|'cpu_hours'|'gpu_hours'|'job_count')` — ranks before `limit` truncation (fixes issue 4). Totals stay pre-truncation.
+- `jobs_search` `sort_by` on `user`/`account`/`queue`/`qos` → OUTER-join lookup + ORDER BY name column (kills the 10× correlated-subquery path); `_SORT_LOOKUP_JOINS` table.
+- 178/178 in `job_history/tests/test_jobs_search.py` (15 new). fs_scans facade failures are a pre-existing live-Postgres env issue.
+
+**Gate to Phase B: Ben merges PR #100, then rebuild picks up plugin `main`** (SAM's dependency is an unpinned git ref; webdev container + conda-env rebuild).
+
+## Phase B — SAM landing (not started)
+
+Full spec lives in the approved plan (session plan file); summary:
+
+- **B1 charts.py**: `_jobs_bucket_segments(bucket, key)` (ascending owner values + remainder-first segment); `generate_jobs_histogram` stacks with `_shade_family` per-bucket `UNITY_STACK_10` colors when owners present, byte-identical flat path when absent; sentinels `#jh-bar-<i>` on every segment iff `job_count`; cache key gains `(label, value, segments)` payload.
+- **B2 jobs_histogram.html**: drop `<details>`; bucket rows clickable; per-bucket collapse row → server-rendered owner table (ranked by active metric `_mkey`, rank/User/Jobs/CPU-h/GPU-h/% of bucket, "Other users" remainder row) → per-user collapse rows lazy-loading jobs via `user_jobs_drill(dt_id, uname, drill_url)` macro (`&user=<urlencoded>`, `hx-trigger="shown.bs.collapse from:closest tr.collapse once"`); single-owner shortcut; owners-absent fallback keeps today's markup **verbatim** (drill-URL regression tests regex it); `data-no-persist` on all histogram collapse rows (nav-view-persistence would auto-refetch).
+- **B3 svg-chart-links.js**: fold `openBucketRow` + `openJobsBucketRow` into `openEntityRow('data-ah-bucket'|'data-jh-bucket', idx, pane)`.
+- **B4 routes.py + jobs_fragment.html**: `'user'` second in `_DEFAULT_COLS`, out of `_VERBOSE_EXTRAS`; `_user_col_suppressed(pinned_user, filters, rows, total, per_page)` — pin / `user=` filter / single-page-uniform; uniform case emits `user_badge`; name td gets `text-truncate` + `style="max-width: 35ch"`.
+- **B5 service.py/routes.py**: thread `sort_by` (`_USAGE_SORT_BY` map) into `jobs_usage_by_user/_project` + cache opts; `owners_limit=_HIST_OWNERS_LIMIT` (10) into `service.jobs_histogram` + opts; by-user/by-project initial sort indicator follows metric.
+- **B6 tests**: per plan — stacked/flat chart tests, owner-table render, drill `user=` param, suppression matrix, `sort_by` threading, cache-key coverage. `test_jobs_fragment_renders_rows_when_enabled` passes via `user_badge` (update stale comment).
+
+Deploy note: SAM will always send `owners_limit` → old plugin TypeErrors. Lockstep ship (atime_recursive precedent); document in the SAM PR.

--- a/docs/plans/JOB_HISTORY_UX_ROUND3.md
+++ b/docs/plans/JOB_HISTORY_UX_ROUND3.md
@@ -1,6 +1,6 @@
 # Job History UX round 3 — cross-repo status & restart doc
 
-**State (2026-07-27): Phase A done (plugin PR #100 under review); Phase B implemented on `redis_and_ux_tweaks` and Playwright-verified against a locally rebuilt container. Remaining: plugin PR #100 merge to `main`, full SAM pytest run (Ben), then the SAM PR to `staging` — which must note the lockstep deploy dependency on #100.**
+**State (2026-07-27): Phase A done; upstream review added two follow-ups to PR #100 (`04684f8` owners_sort_by, `0ae1823` FK-based lookup filters) and SAM reacted (`62c89e2`: threads `owners_sort_by=metric` into the histogram call + cache opts). Phase B implemented on `redis_and_ux_tweaks`, Playwright-verified except the stacked-GPU ranking, which needs a container rebuild at plugin `0ae1823` (the pre-review build TypeErrors on `owners_sort_by` — degrades to the error banner). Remaining: rebuild + GPU-pill re-smoke, #100 merge to `main`, then the SAM PR to `staging` with the lockstep-deploy note (now pinned at plugin ≥ `04684f8`).**
 
 ## The four issues (Ben's review of PRs #381/#382)
 

--- a/docs/plans/REDIS_CACHE_PREFIXES.md
+++ b/docs/plans/REDIS_CACHE_PREFIXES.md
@@ -1,0 +1,81 @@
+# Redis cache prefixes — retire the shared `'usage:'` namespace
+
+**Status: IMPLEMENTED (2026-07-27), branch `redis_and_ux_tweaks`.** Item 6
+deferred from `JOB_HISTORY_DASHBOARD.md` / `JOB_HISTORY_FOLLOWUPS.md`. No
+plugin (hpc-usage-queries) changes.
+
+## The problem
+
+`RedisTTLAdapter` (`src/sam/caching/redis_ttl.py`) namespaces keys — and its
+`clear()` / `info()` SCANs — by a constructor `prefix` that defaulted to
+`_DEFAULT_PREFIX = 'usage:'`. Three of the five constructions never passed one:
+
+| Adapter (name) | Constructed in | Redis prefix (before) | TTL |
+|---|---|---|---|
+| `allocation_usage` | `sam/queries/usage_cache.py` | `usage:` (default) | 1 h |
+| `fs_scans` | `webapp/disk_scans/cache.py` | `usage:` (default) | **8 d** |
+| `fs_scans_filtered` | `webapp/disk_scans/cache.py` | `usage:` (default) | 30 min |
+| `jobs` | `webapp/jobs/cache.py` | `jobs:` (explicit, round 1) | 6 h |
+| `jobs_recent` | `webapp/jobs/cache.py` | `jobs_recent:` (explicit) | 15 min |
+
+Consequences (all live with `CACHE_REDIS_URL` set):
+
+1. **Cross-wipe**: `caching.clear('usage')` and `clear('scans')` each
+   SCAN-deleted `usage:*` — clearing cheap 1-hour usage rollups silently
+   discarded 8-day fs-scan aggregations and vice versa.
+2. **Blended stats**: `usage_cache_info()` and `fs_scans_cache_info()` both
+   counted the same `usage:*` superset.
+3. **Cross-TTL keyspace**: `fs_scans` (8 d) and `fs_scans_filtered` (30 min)
+   shared one namespace — a same-shaped key cached by one bucket would satisfy
+   lookups from the other under the wrong TTL policy.
+4. `FlaskCacheAdapter._redis_introspect()` skipped foreign keys via a
+   hardcoded `chart:`/`usage:` pair — the round-1 `jobs:`/`jobs_recent:`
+   prefixes were never added, so jobs keys miscounted into the flask card's
+   `other` group.
+5. The explicit jobs `prefix=` kwargs had no unit pin.
+
+## What shipped
+
+- **Name-derived default prefix** (`redis_ttl.py`): `prefix: Optional[str] =
+  None` → `self._prefix = prefix if prefix is not None else f'{name}:'`;
+  `_DEFAULT_PREFIX` deleted. Every construction gets a distinct namespace with
+  no call-site edits; the explicit jobs kwargs became redundant and were
+  dropped (the per-bucket-keyspace rationale moved to the adapter docstring).
+  Resulting prefixes: `allocation_usage:`, `fs_scans:`, `fs_scans_filtered:`,
+  `jobs:`, `jobs_recent:`. (Glob safety: `fs_scans:*` does not match
+  `fs_scans_filtered:…` — the colon terminates the shorter prefix.)
+- **flask_adapter skip list**: module-level `_FOREIGN_PREFIXES` (+ `_B` bytes
+  form) = `('chart:',)` + the five adapter prefixes. **No legacy `'usage:'`
+  entry** — the deploy-time FLUSHDB (below) removes the orphan window
+  entirely. `tests/unit/test_flask_cache_adapter.py` cross-checks the tuple
+  against every live non-flask adapter's `_prefix` via `caching.adapters()`
+  so a future sixth cache cannot silently regress it.
+- **Unit pins** (`tests/unit/test_redis_cache.py::TestDerivedPrefixes`):
+  per-factory prefix assertions (fakeredis) + cross-wipe regression.
+- **No category changes**: `flask|chart|usage|scans|jobs` remains the
+  `_VALID_CATEGORIES` set in `api/v1/admin.py`, the CLI, and the Admin card —
+  the categories were always right; only their keyspaces overlapped.
+- **`scripts/cirrus_redis_purge.sh`**: deploy-time cache flush for nwc1
+  (dry-run by default, `--yes` to execute FLUSHDB on DB 0; `--pattern GLOB`
+  for targeted SCAN→DEL cutovers). First Redis-mutating script in `scripts/`
+  — healthcheck and weblog-audit stay read-only by design.
+
+## Deploy
+
+Cutover = flush, not migration: after this lands, old `usage:*` entries are
+never read again. At the deploy window run
+
+    scripts/cirrus_redis_purge.sh          # dry-run: shows DBSIZE + per-prefix counts
+    scripts/cirrus_redis_purge.sh --yes    # FLUSHDB on DB 0
+
+(house pattern from the CSP rollout; the app rebuilds caches on demand by
+design). Rate-limit data lives in Redis DB 1 and is untouched. Without the
+flush, orphaned `usage:*` keys would persist up to the fs_scans 8-day TTL and
+count into the flask card's `other` group — cosmetic, but avoidable.
+
+## Out of scope
+
+- Plugin repo changes (none needed).
+- Chart cache (`chart:`) and Flask-Caching (`flask_cache_`) keyspaces —
+  already namespaced.
+- Any change to cache TTL/size config keys or categories.

--- a/scripts/cirrus_redis_purge.sh
+++ b/scripts/cirrus_redis_purge.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# cirrus_redis_purge.sh — deploy-time cache flush for the samuel Redis on nwc1.
+#
+# The FIRST mutating script in scripts/ (cirrus_healthcheck.sh and
+# cirrus_weblog_audit.sh are deliberately read-only), so it is guarded:
+# the default run is a read-only DRY-RUN that surveys the keyspace and
+# prints what WOULD be removed; nothing is deleted without --yes.
+#
+# Use case: cache-namespace cutovers and deploy-window flushes (the CSP
+# rollout set the pattern). The app rebuilds every cache on demand by
+# design, so a flush costs only warm-up time. Example: the retirement of
+# the shared 'usage:' RedisTTLAdapter prefix (docs/plans/
+# REDIS_CACHE_PREFIXES.md) orphans all pre-cutover usage:* keys — flush
+# them at deploy instead of letting them sit until TTL (up to 8 days).
+#
+# Scope: Redis DB 0 only — the app's cache keyspace. Rate-limiter data
+# lives in DB 1 and is NEVER touched by this script.
+#
+# Deletion is performed server-side via a Lua SCAN+DEL (or FLUSHDB): the
+# TTL-adapter keys are prefix + raw pickle bytes, which do not survive a
+# round-trip through `redis-cli --scan | xargs redis-cli del`.
+#
+# Usage:
+#   scripts/cirrus_redis_purge.sh [options]
+#
+# Options:
+#   --yes                 Actually delete (default is dry-run)
+#   --pattern GLOB        Targeted SCAN+DEL of matching keys instead of
+#                         FLUSHDB (e.g. --pattern 'usage:*')
+#   -n, --namespace NS    Namespace the release lives in   (default: sam-queries)
+#   -r, --release    REL  Helm release name                (default: samuel)
+#       --context    CTX  kubectl context to target        (default: current)
+#       --no-color        Disable ANSI color
+#   -v, --verbose         Extra detail
+#   -h, --help            Show this help
+
+set -euo pipefail
+
+_LIBDIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib"
+# shellcheck source=lib/cirrus_common.sh
+source "${_LIBDIR}/cirrus_common.sh"
+
+CONFIRM=0
+PATTERN=""
+
+while [[ $# -gt 0 ]]; do
+    if handle_common_arg "$@"; then shift "$_CONSUMED"; continue; fi
+    case "$1" in
+        --yes)     CONFIRM=1;    shift;;
+        --pattern) PATTERN="$2"; shift 2;;
+        *) echo "Unknown option: $1" >&2; exit 2;;
+    esac
+done
+
+setup_colors
+build_kctl
+require_cmd kubectl
+
+# Cache DB only; the rate limiter's DB 1 is out of bounds by design.
+REDIS_DB=0
+
+# Known keyspaces, for the survey display only (deletion never depends on
+# this list). Mirrors flask_adapter._FOREIGN_PREFIXES + the flask-cache and
+# legacy namespaces.
+SURVEY_PREFIXES=(
+    'flask_cache_*'
+    'chart:*'
+    'allocation_usage:*'
+    'fs_scans:*'
+    'fs_scans_filtered:*'
+    'jobs:*'
+    'jobs_recent:*'
+    'usage:*'          # legacy (pre name-derived prefixes) — orphans after cutover
+)
+
+# Server-side Lua so binary (pickle-suffixed) keys never round-trip through
+# the shell. COUNT-only and DEL variants share the SCAN loop shape.
+LUA_COUNT='local c="0" local n=0 repeat local r=redis.call("SCAN",c,"MATCH",ARGV[1],"COUNT",500) c=r[1] n=n+#r[2] until c=="0" return n'
+LUA_DEL='local c="0" local n=0 repeat local r=redis.call("SCAN",c,"MATCH",ARGV[1],"COUNT",500) c=r[1] for _,k in ipairs(r[2]) do redis.call("DEL",k) n=n+1 end until c=="0" return n'
+
+rcli() {
+    "${KCTL_NS[@]}" exec "$REDIS_POD" -- redis-cli -p "$REDIS_PORT" -n "$REDIS_DB" "$@"
+}
+
+section "Target"
+CUR_CTX=$("${KCTL[@]}" config current-context 2>/dev/null || echo "<none>")
+info "context=${CUR_CTX}  namespace=${NAMESPACE}  db=${REDIS_DB}"
+
+REDIS_POD=$("${KCTL_NS[@]}" get pod -l "app=$REDIS_NAME" \
+            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+[[ -n "$REDIS_POD" ]] || die "no Redis pod found via selector app=$REDIS_NAME in namespace $NAMESPACE"
+info "pod=${REDIS_POD}"
+
+PONG=$(rcli ping 2>&1 | tr -d '\r') || die "redis-cli ping failed: $PONG"
+[[ "$PONG" == "PONG" ]] || die "Redis returned '$PONG' instead of PONG"
+
+section "Keyspace survey (read-only)"
+DBSIZE=$(rcli dbsize | tr -d '\r')
+say "  DBSIZE (db ${REDIS_DB}): ${BOLD}${DBSIZE}${NC} keys"
+accounted=0
+for glob in "${SURVEY_PREFIXES[@]}"; do
+    n=$(rcli eval "$LUA_COUNT" 0 "$glob" | tr -d '\r')
+    accounted=$((accounted + n))
+    [[ "$n" -gt 0 || $VERBOSE -eq 1 ]] && say "    $(printf '%-22s' "$glob") ${n}"
+done
+say "    $(printf '%-22s' '<unmatched>') $((DBSIZE - accounted))"
+
+section "Action"
+if [[ -n "$PATTERN" ]]; then
+    would=$(rcli eval "$LUA_COUNT" 0 "$PATTERN" | tr -d '\r')
+    if [[ $CONFIRM -eq 0 ]]; then
+        note "DRY-RUN: would SCAN+DEL ${would} key(s) matching '${PATTERN}' — re-run with --yes to execute"
+        exit 0
+    fi
+    deleted=$(rcli eval "$LUA_DEL" 0 "$PATTERN" | tr -d '\r')
+    ok=$(rcli dbsize | tr -d '\r')
+    say "  deleted ${BOLD}${deleted}${NC} key(s) matching '${PATTERN}'; DBSIZE now ${ok}"
+else
+    if [[ $CONFIRM -eq 0 ]]; then
+        note "DRY-RUN: would FLUSHDB (all ${DBSIZE} keys in db ${REDIS_DB}) — re-run with --yes to execute"
+        exit 0
+    fi
+    rcli flushdb >/dev/null
+    ok=$(rcli dbsize | tr -d '\r')
+    say "  FLUSHDB done; DBSIZE now ${ok} (caches rebuild on demand)"
+fi

--- a/src/sam/caching/redis_ttl.py
+++ b/src/sam/caching/redis_ttl.py
@@ -3,9 +3,9 @@ RedisTTLAdapter — drop-in replacement for TTLCacheAdapter backed by Redis.
 
 Exposes the same dict-like API used by `sam.queries.usage_cache` so call
 sites are unchanged. Eviction is handled Redis-wide via `allkeys-lru`,
-not per-cache `maxsize`. Keys are namespaced under a fixed prefix so a
-single Redis DB can host this adapter and `RedisChartCache` without
-collisions.
+not per-cache `maxsize`. Keys are namespaced under a per-adapter prefix
+(derived from the adapter name by default) so a single Redis DB can host
+every adapter and `RedisChartCache` without collisions.
 """
 
 import contextlib
@@ -17,9 +17,6 @@ from typing import Any, Hashable, Optional
 import redis
 
 from sam.caching.base import CacheBase
-
-
-_DEFAULT_PREFIX = 'usage:'
 
 
 @contextlib.contextmanager
@@ -37,8 +34,16 @@ class RedisTTLAdapter(CacheBase):
     """Redis-backed cache conforming to the dict-like API of TTLCacheAdapter.
 
     Keys are pickled (call-sites use tuple keys) and namespaced under
-    `prefix:`. Per-key TTL is set on `__setitem__` so entries expire in
-    Redis the same way `cachetools.TTLCache` would.
+    `<name>:` by default (`prefix` overrides). Per-key TTL is set on
+    `__setitem__` so entries expire in Redis the same way
+    `cachetools.TTLCache` would.
+
+    The prefix drives `_encode_key` AND the `clear()`/`info()` SCANs, so
+    each adapter must own a distinct keyspace: two adapters sharing a
+    prefix would satisfy each other's lookups under the wrong TTL policy
+    and cross-wipe on `clear()`. The name-derived default guarantees that
+    as long as adapter names are unique (they are — the Admin card keys
+    off them).
 
     `maxsize` is recorded for `info()` reporting only — bounding is
     handled by Redis-wide `allkeys-lru`.
@@ -50,12 +55,12 @@ class RedisTTLAdapter(CacheBase):
                  client: redis.Redis,
                  ttl: float,
                  maxsize: Optional[int] = None,
-                 prefix: str = _DEFAULT_PREFIX):
+                 prefix: Optional[str] = None):
         self.name = name
         self._client = client
         self._ttl = float(ttl)
         self._maxsize = maxsize
-        self._prefix = prefix
+        self._prefix = prefix if prefix is not None else f'{name}:'
         # Internal lock guards only Python-side bookkeeping; cross-worker
         # consistency is provided by Redis itself.
         self._py_lock = threading.RLock()

--- a/src/sam/core/users.py
+++ b/src/sam/core/users.py
@@ -424,6 +424,28 @@ class User(Base, TimestampMixin, SessionMixin):
         """Return active projects (default)."""
         return self.active_projects()
 
+    def former_projects(self, as_of: Optional[datetime] = None) -> Dict[str, List['Project']]:
+        """Return non-current project associations, categorized.
+
+        Complements active_projects(): every project the user is linked to
+        (member, lead, or admin) that active_projects() excludes, split by why:
+
+          - 'inactive': projects whose active flag is off
+          - 'ended':    active projects where every membership has expired
+
+        Both lists are sorted by projcode.
+        """
+        active = set(self.active_projects(as_of))
+        associated = {p for p in self._projects_w_dups if p is not None}
+        associated |= set(self.led_projects) | set(self.admin_projects)
+        former = associated - active
+        return {
+            'inactive': sorted((p for p in former if not p.is_active),
+                               key=lambda p: p.projcode),
+            'ended': sorted((p for p in former if p.is_active),
+                            key=lambda p: p.projcode),
+        }
+
     def active_account_users(self, as_of: Optional[datetime] = None) -> List['AccountUser']:
         """Get currently active account users."""
         check_date = as_of or datetime.now()

--- a/src/webapp/caching/__init__.py
+++ b/src/webapp/caching/__init__.py
@@ -26,7 +26,7 @@ Decorating a chart-generating function::
 Inspecting all caches (used by the admin Configuration card)::
 
     caching.stats()            # → dict for the template
-    caching.clear('chart')     # category in {'flask','chart','usage','scans',None}
+    caching.clear('chart')     # category in {'flask','chart','usage','scans','jobs',None}
 """
 
 import logging

--- a/src/webapp/caching/flask_adapter.py
+++ b/src/webapp/caching/flask_adapter.py
@@ -22,6 +22,22 @@ _KEY_GROUPS = (
     'project_access',
 )
 
+# Keyspaces owned by the OTHER cache adapters sharing this Redis DB —
+# excluded from flask-cache introspection so their entries don't miscount
+# into the 'other' group. Must list every live non-flask adapter prefix:
+# 'chart:' covers RedisChartCache (chart:<name>:, chart:hits/misses:<name>),
+# the rest are the name-derived RedisTTLAdapter prefixes. A unit test
+# cross-checks this tuple against webapp.caching.adapters().
+_FOREIGN_PREFIXES = (
+    'chart:',
+    'allocation_usage:',
+    'fs_scans:',
+    'fs_scans_filtered:',
+    'jobs:',
+    'jobs_recent:',
+)
+_FOREIGN_PREFIXES_B = tuple(p.encode() for p in _FOREIGN_PREFIXES)
+
 
 class FlaskCacheAdapter(CacheBase):
     """Best-effort introspection of a Flask-Caching instance."""
@@ -74,7 +90,7 @@ class FlaskCacheAdapter(CacheBase):
             return None
         try:
             # Flask-Caching prefixes keys; we scan everything not owned
-            # by our chart/usage adapters (those have their own prefixes).
+            # by the chart/TTL adapters (_FOREIGN_PREFIXES).
             groups: dict[str, dict] = {
                 g: {'entries': 0, 'bytes_approx': 0}
                 for g in (*_KEY_GROUPS, 'other')
@@ -84,15 +100,15 @@ class FlaskCacheAdapter(CacheBase):
             total_entries = 0
             for raw_key in client.scan_iter(match='*', count=200):
                 # Skip keys owned by our other adapters before decoding —
-                # usage:* values are pickle-suffixed bytes that aren't
+                # TTL-adapter keys are pickle-suffixed bytes that aren't
                 # valid UTF-8, so checking on raw bytes avoids a
                 # UnicodeDecodeError on the next line.
                 if isinstance(raw_key, bytes):
-                    if raw_key.startswith(b'chart:') or raw_key.startswith(b'usage:'):
+                    if raw_key.startswith(_FOREIGN_PREFIXES_B):
                         continue
                     key = raw_key.decode('utf-8', errors='replace')
                 else:
-                    if raw_key.startswith('chart:') or raw_key.startswith('usage:'):
+                    if raw_key.startswith(_FOREIGN_PREFIXES):
                         continue
                     key = raw_key
                 total_entries += 1

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -1184,16 +1184,40 @@ _JOBS_METRIC_LABELS = {
 }
 
 
+def _jobs_bucket_segments(bucket, key):
+    """Per-bucket stacked-bar segments (active-metric units), bottom → top.
+
+    The plugin envelope carries pre-truncated top-N ``owners`` per bucket
+    with authoritative bucket totals, so — unlike the fs_scans
+    ``_bucket_segments``, which derives the long tail locally — the "other"
+    base segment here is ``bucket total − Σ owners`` (it also absorbs
+    NULL-username jobs). Owner segments follow ascending so the largest
+    owner sits at the top of the bar. Empty list when the bucket has no
+    owners (→ drawn as a single flat bar).
+    """
+    owners = bucket.get('owners') or {}
+    if not owners:
+        return []
+    vals = sorted(float((d or {}).get(key) or 0) for d in owners.values())
+    remainder = float(bucket.get(key) or 0) - sum(vals)
+    if remainder > 1e-9:
+        return [remainder] + vals
+    return vals
+
+
 def _jobs_histogram_cache_key(hist, *, metric='jobs'):
     """Hash exactly what the SVG depends on: the bucket labels, the chosen
-    metric's values, the dimension, and null_count (not the full envelope —
-    e.g. min_param/max_param don't affect the rendering). The job_count
-    positivity vector joins the key because it decides which bars carry
-    #jh-bar-<i> drill URLs — an hours-metric SVG with matching hours but a
-    different populated-band set must not be reused."""
+    metric's values and owner-segment split, the dimension, and null_count
+    (not the full envelope — e.g. min_param/max_param don't affect the
+    rendering). The job_count positivity vector joins the key because it
+    decides which bars carry #jh-bar-<i> drill URLs — an hours-metric SVG
+    with matching hours but a different populated-band set must not be
+    reused. Owner names stay out of the key: the SVG carries no owner
+    labels, so only the segment values shape it."""
     key = _JOBS_METRIC_KEYS.get(metric, 'job_count')
     buckets = (hist or {}).get('buckets') or []
-    payload = [(b.get('label'), float(b.get(key) or 0)) for b in buckets]
+    payload = [(b.get('label'), float(b.get(key) or 0),
+                tuple(_jobs_bucket_segments(b, key))) for b in buckets]
     clickable = [int(bool(b.get('job_count'))) for b in buckets]
     return _content_hash([
         payload, clickable, str((hist or {}).get('dimension', '')),
@@ -1204,11 +1228,14 @@ def _jobs_histogram_cache_key(hist, *, metric='jobs'):
 @caching.chart_cached(name='jobs_histogram', maxsize=128,
                       key_fn=_jobs_histogram_cache_key)
 def generate_jobs_histogram(hist, *, metric='jobs') -> str:
-    """Single-series bar chart over a jobs_histogram envelope.
+    """Bar chart over a jobs_histogram envelope; owner-stacked when possible.
 
     Shared by the Wait Times, Job Sizes, and Durations tabs — the envelope's
     bucket vector is already complete and ordered (zeros included), so the
-    x-axis is stable across filter changes.
+    x-axis is stable across filter changes. When buckets carry ``owners``
+    (plugin ``owners_limit``), each bar becomes a single-hue per-user stack
+    over an aggregated remainder base; otherwise the historical flat
+    single-series chart renders unchanged.
 
     Args:
         hist: plugin envelope — ``{'dimension', 'buckets':
@@ -1230,16 +1257,44 @@ def generate_jobs_histogram(hist, *, metric='jobs') -> str:
         return _empty_state('No jobs in this range')
 
     fig, ax = plt.subplots(figsize=(14, 5))
-    bars = ax.bar(range(len(labels)), vals,
-                  color=UNITY_PALETTE_10[0],
-                  edgecolor=UNITY_NCAR_NAVY, linewidth=0.5)
     # Populated bands are clickable: #jh-bar-<index> sentinels route
     # through svg-chart-links.js to the matching data-jh-bucket row in
-    # the Bucket-counts table, which lazy-loads that band's jobs.
-    # Index-keyed (not label) so the JS never parses band labels.
-    for i, (rect, b) in enumerate(zip(bars, buckets)):
-        if b.get('job_count'):
-            rect.set_url(f'#jh-bar-{i}')
+    # the bucket table, which drills into that band. Index-keyed (not
+    # label) so the JS never parses band labels. Clickability follows
+    # job_count, not the plotted metric.
+    if not any(b.get('owners') for b in buckets):
+        # Owner-less envelope (owners_limit unset, or an older plugin):
+        # the historical flat single-series chart, byte-identical.
+        bars = ax.bar(range(len(labels)), vals,
+                      color=UNITY_PALETTE_10[0],
+                      edgecolor=UNITY_NCAR_NAVY, linewidth=0.5)
+        for i, (rect, b) in enumerate(zip(bars, buckets)):
+            if b.get('job_count'):
+                rect.set_url(f'#jh-bar-{i}')
+    else:
+        # Stack per-owner segments (bottom "other" remainder + owners
+        # ascending), shaded within the band's color family — the fs_scans
+        # distribution-histogram treatment: the spread between users is
+        # legible before clicking.
+        colors = [UNITY_STACK_10[i % len(UNITY_STACK_10)]
+                  for i in range(len(labels))]
+        for i, b in enumerate(buckets):
+            segs = _jobs_bucket_segments(b, key)
+            url = f'#jh-bar-{i}' if b.get('job_count') else None
+            if not segs:
+                bar = ax.bar(i, vals[i], color=colors[i],
+                             edgecolor=UNITY_NCAR_NAVY, linewidth=0.5)
+                if url:
+                    bar.patches[0].set_url(url)
+                continue
+            shades = _shade_family(colors[i], len(segs))
+            bottom = 0.0
+            for seg_val, shade in zip(segs, shades):
+                cont = ax.bar(i, seg_val, bottom=bottom, color=shade,
+                              edgecolor='white', linewidth=0.3)
+                if url:
+                    cont.patches[0].set_url(url)
+                bottom += seg_val
     ax.set_xticks(range(len(labels)))
     ax.set_xticklabels(labels, rotation=30, ha='right')
     ax.set_ylabel(_JOBS_METRIC_LABELS.get(metric, 'Jobs'))

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -665,6 +665,10 @@ def resource_details(project):
         can_edit_threshold=can_edit_threshold,
         has_children=has_children,
         scope=scope,
+        # By Project jobs tab only makes sense when the (scoped) account
+        # tree spans more than one projcode — same expansion the jobs
+        # routes use, so tab visibility and row scoping always agree.
+        jobs_multi_project=len(_resolve_scope_projcodes(project, scope)) > 1,
         tree_data=tree_data,
         alloc_start_date=alloc_start_date,
         account_adjustments=account_adjustments,

--- a/src/webapp/jobs/cache.py
+++ b/src/webapp/jobs/cache.py
@@ -119,15 +119,8 @@ def get_cache_adapter(bucket: str = 'historical') -> Optional[CacheBase]:
             try:
                 client = make_redis_client(redis_url)
                 if client is not None:
-                    # prefix=<name>: — RedisTTLAdapter namespaces keys (and
-                    # clear()/info() scans) by prefix, NOT by name. The two
-                    # jobs buckets can legitimately hold the same key with
-                    # different TTL policies, so each needs its own keyspace
-                    # or the recent bucket's 15-min entries would satisfy
-                    # historical lookups (and vice versa) on shared Redis.
                     adapter = RedisTTLAdapter(
                         name=name, client=client, ttl=ttl, maxsize=size,
-                        prefix=f'{name}:',
                     )
                     _adapters[bucket] = adapter
                     return adapter

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -23,8 +23,8 @@ Query params (all optional unless noted):
                          (e.g. '0' = success, '1', '271')
   page                 — int ≥ 1; default 1
   per_page             — int in [10, 200]; default 50
-  sort_by              — one of {'start', 'elapsed', 'qos',
-                         'cpu_charges', 'gpu_charges'}; default None
+  sort_by              — any _DEFAULT_COLS key (e.g. 'user', 'start',
+                         'elapsed', 'qos', 'cpu_charges'); default None
                          (plugin orders by ``Job.end DESC``)
   sort_dir             — 'asc' | 'desc'; default 'desc'
 
@@ -64,19 +64,21 @@ bp = Blueprint('jobs', __name__)
 # route can reject bad input without touching the plugin.
 _VALID_MACHINES = {'derecho', 'casper'}
 
-# Default columns shown when drilled into a user+queue row. user/queue/
-# account are dropped because the row context already pins them.
+# Default columns in the jobs table. queue/account are left to the drawer
+# because the drill contexts pin them; `user` renders by default and is
+# suppressed contextually instead (see _user_col_suppressed).
 _DEFAULT_COLS = (
-    'job_id', 'name', 'qos', 'start', 'elapsed',
+    'job_id', 'user', 'name', 'qos', 'start', 'elapsed',
     'numnodes', 'numcpus', 'numgpus',
     'cpu_charges', 'gpu_charges',
 )
 
 # Every column rendered as a table header is sortable. The plugin maps
-# `job.*` / `charge.*` keys to their SQLAlchemy columns and the
-# computed `*_charges` keys to `hours × COALESCE(qos_factor, 1)`, so
-# every key in _DEFAULT_COLS resolves to a valid ORDER BY at the SQL
-# level. Built from _DEFAULT_COLS to stay in lockstep automatically.
+# `job.*` / `charge.*` keys to their SQLAlchemy columns, lookup-backed
+# keys (`user`) to a joined name column, and the computed `*_charges`
+# keys to `hours × COALESCE(qos_factor, 1)`, so every key in
+# _DEFAULT_COLS resolves to a valid ORDER BY at the SQL level. Built
+# from _DEFAULT_COLS to stay in lockstep automatically.
 _SORT_WHITELIST = set(_DEFAULT_COLS)
 
 # Extra columns revealed in the per-row "expand" drawer. Order is the
@@ -85,7 +87,7 @@ _SORT_WHITELIST = set(_DEFAULT_COLS)
 # at the top of the drawer rather than buried beside memory_charges.
 _VERBOSE_EXTRAS = (
     'exit_status', 'qos_factor',
-    'queue', 'user',
+    'queue',
     'submit', 'end', 'walltime',
     'mpiprocs', 'ompthreads',
     'reqmem', 'memory', 'vmemory',
@@ -157,6 +159,23 @@ def _visible_cols(default_cols, rows):
         if c not in _SUPPRESSIBLE
         or any((r.get(c) or 0) != 0 for r in rows)
     ]
+
+
+def _user_col_suppressed(*, pinned_user, filters, rows, total, per_page):
+    """True when the User column would be single-valued noise.
+
+    Three triggers: the mode pins a user (My Jobs), a ``user=`` filter is
+    active (the By User / per-band drills), or the whole filtered result
+    fits on one page and every row shares one username — the cheap exact
+    case; a multi-page uniform view keeps the column rather than paying a
+    distinct-count query to find out.
+    """
+    if pinned_user is not None or filters.get('user'):
+        return True
+    return bool(
+        rows and total is not None and total <= per_page
+        and len({r.get('user') for r in rows}) == 1
+    )
 
 
 def _scope_project(project) -> Project:
@@ -326,6 +345,20 @@ def _jobs_table_response(*, mode, machine, fragment_url,
                 'factor': next(iter(factors)) if len(factors) == 1 else None,
             }
 
+    # Same single-value treatment for the User column. Only the
+    # uniformity trigger needs the header badge: the pin/filter cases
+    # already surface the name via the fragment heading or the `user:`
+    # filter badge.
+    user_badge = None
+    if _user_col_suppressed(pinned_user=pinned_user, filters=filters,
+                            rows=rows, total=total,
+                            per_page=page['per_page']):
+        visible_cols = [c for c in visible_cols if c != 'user']
+        if pinned_user is None and not filters.get('user'):
+            (shared_user,) = {r.get('user') for r in rows}
+            if shared_user is not None:
+                user_badge = {'name': shared_user}
+
     column_specs = _load_column_specs()
 
     # Explorer chip strip (?chips=1): facet counts for the same filter set
@@ -377,6 +410,7 @@ def _jobs_table_response(*, mode, machine, fragment_url,
         sortable_columns=sorted(_SORT_WHITELIST),
         qos_options=template_qos_options,
         qos_badge=qos_badge,
+        user_badge=user_badge,
         fragment_url=fragment_url,
         target_id=target_id,
         roundtrip_params=_roundtrip_params(machine, target_id),
@@ -450,6 +484,19 @@ _SIZE_DIMENSIONS = ('nodes', 'cpus', 'gpus',
 
 # Rows shown in the By User table (the pie itself keeps at most 9 + Other).
 _BY_USER_LIMIT = 25
+
+# Metric pill → plugin jobs_usage_by sort_by key. Ranking must follow the
+# viewed metric or the top-N cut hides e.g. pure-GPU users behind CPU-heavy
+# ones (the Derecho GPU-Hours one-wedge bug).
+_USAGE_SORT_BY = {
+    'jobs': 'job_count',
+    'cpu_hours': 'cpu_hours',
+    'gpu_hours': 'gpu_hours',
+}
+
+# Top-N users carried per histogram bucket (chart stack segments + the
+# per-band user tier). Matches the fs_scans _AH_TOP_SEGMENTS cap.
+_HIST_OWNERS_LIMIT = 10
 
 # Filter query params round-tripped through pill/toggle re-fetches, and —
 # where the per-job fragment understands them — carried into row drill-downs.
@@ -633,6 +680,7 @@ def _render_by_user(*, mode, machine, fragment_url, jobs_fragment_url,
     try:
         usage = service.jobs_usage_by_user(
             machine, limit=_BY_USER_LIMIT,
+            sort_by=_USAGE_SORT_BY[metric],
             account_projcodes=account_projcodes, **filters,
         )
     except Exception as exc:
@@ -674,7 +722,8 @@ def _render_by_project(*, machine, fragment_url, jobs_fragment_url,
     error = None
     try:
         usage = service.jobs_usage_by_project(
-            machine, username=username, limit=_BY_USER_LIMIT, **filters,
+            machine, username=username, limit=_BY_USER_LIMIT,
+            sort_by=_USAGE_SORT_BY[metric], **filters,
         )
     except Exception as exc:
         from flask import current_app
@@ -746,6 +795,7 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
     try:
         hist = service.jobs_histogram(
             machine, dimension,
+            owners_limit=_HIST_OWNERS_LIMIT,
             account_projcodes=account_projcodes, username=username,
             **filters,
         )

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -55,7 +55,11 @@ from webapp.dashboards.charts import (
 from webapp.extensions import db
 from webapp.jobs import service
 from webapp.jobs.session import is_enabled
-from webapp.utils.rbac import Permission, require_permission
+from webapp.utils.rbac import (
+    Permission,
+    has_permission_any_facility,
+    require_permission,
+)
 
 bp = Blueprint('jobs', __name__)
 
@@ -270,6 +274,14 @@ def _jobs_table_response(*, mode, machine, fragment_url,
                 p.projcode
                 for p in _scope_project(project).get_descendants(include_self=True)
             ]
+            # `account` narrows WITHIN the server-derived tree (the
+            # By Project drill on a parent project). An out-of-tree value
+            # is ignored — the tree stays the security boundary, so a
+            # client can never widen scope with this parameter.
+            requested = (request.args.get('account') or '').strip() or None
+            if requested and requested in account_projcodes:
+                user_account = requested
+                account_projcodes = [requested]
             rows = service.search_jobs(
                 machine, project=project,
                 account_projcodes=account_projcodes, **common, **filters,
@@ -282,8 +294,7 @@ def _jobs_table_response(*, mode, machine, fragment_url,
         elif mode == 'user':
             # `account` narrows one's OWN jobs to a single projcode (the
             # By Project drill) — safe from the client in this mode only
-            # because the username pin still applies. Project mode keeps
-            # its account list server-derived.
+            # because the username pin still applies.
             user_account = (request.args.get('account') or '').strip() or None
             rows = service.search_jobs_user(
                 machine, pinned_user, account=user_account, **common, **filters,
@@ -293,11 +304,16 @@ def _jobs_table_response(*, mode, machine, fragment_url,
                 valid_qos_names=qos_options, **filters,
             )
         else:
+            # `account` narrows the machine-wide view to one projcode
+            # (the By Project drill) — only ever a restriction, and this
+            # route family is gated on VIEW_ALL_JOB_DATA.
+            user_account = (request.args.get('account') or '').strip() or None
             rows = service.search_jobs_machine(
-                machine, **common, **filters,
+                machine, account=user_account, **common, **filters,
             )
             total = service.count_jobs_machine(
-                machine, valid_qos_names=qos_options, **filters,
+                machine, account=user_account,
+                valid_qos_names=qos_options, **filters,
             )
     except Exception as exc:
         # Catch-all so a transient plugin/DB issue degrades to a banner
@@ -694,6 +710,12 @@ def _render_by_user(*, mode, machine, fragment_url, jobs_fragment_url,
         if usage else None
     other = _usage_other(usage) if usage else None
 
+    # Same gate as the admin_dashboard.user_card route the username cells
+    # link to — don't render click affordances that would 403.
+    from flask_login import current_user
+    can_view_users = has_permission_any_facility(
+        current_user, Permission.VIEW_USERS)
+
     return render_template(
         template,
         enabled=True, error=error,
@@ -703,19 +725,26 @@ def _render_by_user(*, mode, machine, fragment_url, jobs_fragment_url,
         fragment_url=fragment_url,
         jobs_fragment_url=jobs_fragment_url,
         target_id=target_id,
+        can_view_users=can_view_users,
         params=_roundtrip_params(machine, target_id),
     )
 
 
-def _render_by_project(*, machine, fragment_url, jobs_fragment_url,
-                       target_id, username=None):
-    """Renderer for the My Jobs "By Project" tab (user mode only)."""
+def _render_by_project(*, mode, machine, fragment_url, jobs_fragment_url,
+                       target_id, username=None, account_projcodes=None):
+    """Shared renderer for the By Project tab (all three modes).
+
+    Scoping mirrors the service: user mode pins ``username`` (and drops
+    any client ``user`` filter — the pin owns that dimension), project
+    mode passes the server-derived ``account_projcodes`` tree, machine
+    mode passes neither (route gated on VIEW_ALL_JOB_DATA).
+    """
     template = 'dashboards/user/partials/jobs_by_project.html'
     if not is_enabled():
         return render_template(template, enabled=False, error=None,
-                               mode='user', machine=None, target_id=target_id)
+                               mode=mode, machine=None, target_id=target_id)
 
-    filters = _parse_job_filters(include_user=False)
+    filters = _parse_job_filters(include_user=(username is None))
     metric = _parse_metric(_DEFAULT_METRIC_PIE)
 
     usage = None
@@ -723,12 +752,14 @@ def _render_by_project(*, machine, fragment_url, jobs_fragment_url,
     try:
         usage = service.jobs_usage_by_project(
             machine, username=username, limit=_BY_USER_LIMIT,
-            sort_by=_USAGE_SORT_BY[metric], **filters,
+            sort_by=_USAGE_SORT_BY[metric],
+            account_projcodes=account_projcodes, **filters,
         )
     except Exception as exc:
         from flask import current_app
         current_app.logger.exception(
-            'jobs by-project fragment failed: machine=%s', machine,
+            'jobs by-project fragment failed: mode=%s machine=%s',
+            mode, machine,
         )
         error = str(exc)
 
@@ -736,15 +767,24 @@ def _render_by_project(*, machine, fragment_url, jobs_fragment_url,
         usage, metric=metric, sentinel_prefix='job-proj') if usage else None
     other = _usage_other(usage) if usage else None
 
+    # Projcode cells link to user_dashboard.project_details_modal, gated by
+    # require_project_access. In user mode the rows are the pinned user's
+    # own projects (affiliation grants access), so the affordance always
+    # renders; elsewhere require VIEW_PROJECTS so the click can't 403.
+    from flask_login import current_user
+    can_view_projects = (mode == 'user') or has_permission_any_facility(
+        current_user, Permission.VIEW_PROJECTS)
+
     return render_template(
         template,
         enabled=True, error=error,
-        mode='user', machine=machine,
+        mode=mode, machine=machine,
         usage=usage, other=other,
         metric=metric, pie_svg=pie_svg,
         fragment_url=fragment_url,
         jobs_fragment_url=jobs_fragment_url,
         target_id=target_id,
+        can_view_projects=can_view_projects,
         params=_roundtrip_params(machine, target_id),
     )
 
@@ -856,6 +896,36 @@ def by_user_fragment(project):
         mode='project', machine=machine,
         fragment_url=url_for('jobs.by_user_fragment', projcode=project.projcode),
         jobs_fragment_url=url_for('jobs.jobs_fragment', projcode=project.projcode),
+        target_id=target_id,
+        account_projcodes=_tree_projcodes(project),
+    )
+
+
+@bp.route('/<projcode>/by-project')
+@login_required
+@require_project_access
+def by_project_fragment(project):
+    """HTMX fragment: per-projcode usage pie + rows across *project*'s tree.
+
+    Only meaningful for parent projects whose account tree spans more
+    than one projcode (the card gates the tab on that); the tree list is
+    server-derived — the same security boundary as every project-mode
+    fragment. Rows drill into the project jobs fragment narrowed by
+    ``account=<projcode>`` (validated against the tree there).
+    """
+    if not is_enabled():
+        return _render_by_project(mode='project', machine=None,
+                                  fragment_url=None,
+                                  jobs_fragment_url=None, target_id='')
+    machine = _get_machine_or_400()
+    target_id = (request.args.get('target_id') or '').strip() \
+        or f'jobs-byproj-{project.projcode}-{machine}'
+    return _render_by_project(
+        mode='project', machine=machine,
+        fragment_url=url_for('jobs.by_project_fragment',
+                             projcode=project.projcode),
+        jobs_fragment_url=url_for('jobs.jobs_fragment',
+                                  projcode=project.projcode),
         target_id=target_id,
         account_projcodes=_tree_projcodes(project),
     )
@@ -1092,6 +1162,32 @@ def by_user_machine_fragment(machine):
     )
 
 
+@bp.route('/machine/<machine>/by-project')
+@login_required
+@require_permission(Permission.VIEW_ALL_JOB_DATA)
+def by_project_machine_fragment(machine):
+    """HTMX fragment: machine-wide per-project usage pie + rows (operator).
+
+    The multi-project counterpart of By User; rows drill into the
+    machine jobs fragment narrowed by ``account=<projcode>``.
+    """
+    if not is_enabled():
+        return _render_by_project(mode='machine', machine=None,
+                                  fragment_url=None,
+                                  jobs_fragment_url=None, target_id='')
+    machine = _machine_or_404(machine)
+    target_id = (request.args.get('target_id') or '').strip() \
+        or f'jobs-byproj-machine-{machine}'
+    return _render_by_project(
+        mode='machine', machine=machine,
+        fragment_url=url_for('jobs.by_project_machine_fragment',
+                             machine=machine),
+        jobs_fragment_url=url_for('jobs.jobs_machine_fragment',
+                                  machine=machine),
+        target_id=target_id,
+    )
+
+
 def _machine_histogram(machine, *, dimension, dimension_toggle, endpoint):
     """Common body of the three machine-mode histogram routes."""
     if not is_enabled():
@@ -1206,13 +1302,14 @@ def by_project_user_fragment(machine):
     """
     from flask_login import current_user
     if not is_enabled():
-        return _render_by_project(machine=None, fragment_url=None,
+        return _render_by_project(mode='user', machine=None,
+                                  fragment_url=None,
                                   jobs_fragment_url=None, target_id='')
     machine = _machine_or_404(machine)
     target_id = (request.args.get('target_id') or '').strip() \
         or f'jobs-byproj-user-{machine}'
     return _render_by_project(
-        machine=machine,
+        mode='user', machine=machine,
         fragment_url=url_for('jobs.by_project_user_fragment', machine=machine),
         jobs_fragment_url=url_for('jobs.jobs_user_fragment', machine=machine),
         target_id=target_id,

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -796,6 +796,10 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
         hist = service.jobs_histogram(
             machine, dimension,
             owners_limit=_HIST_OWNERS_LIMIT,
+            # Which top-N survives must follow the displayed metric —
+            # hours-ranked owners cover ~1% of band GPU-hours (plugin
+            # PR #100 review data), rendering a GPU stack as all-"Other".
+            owners_sort_by=_USAGE_SORT_BY[metric],
             account_projcodes=account_projcodes, username=username,
             **filters,
         )

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -830,6 +830,18 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
     filters = _parse_job_filters()
     metric = _parse_metric(_DEFAULT_METRIC_HIST)
 
+    # User|Project owner-dimension pill — offered only where the context
+    # spans more than one project (machine mode; a project tree > 1).
+    # Elsewhere ?owners_by= is ignored, so a crafted URL can't flip a
+    # single-project pane into a redundant per-project breakdown.
+    owners_toggle = (mode == 'machine'
+                     or (mode == 'project'
+                         and account_projcodes is not None
+                         and len(account_projcodes) > 1))
+    owners_by = 'user'
+    if owners_toggle and (request.args.get('owners_by') or '').strip() == 'account':
+        owners_by = 'account'
+
     hist = None
     error = None
     try:
@@ -840,6 +852,7 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
             # hours-ranked owners cover ~1% of band GPU-hours (plugin
             # PR #100 review data), rendering a GPU stack as all-"Other".
             owners_sort_by=_USAGE_SORT_BY[metric],
+            owners_by=owners_by,
             account_projcodes=account_projcodes, username=username,
             **filters,
         )
@@ -865,6 +878,20 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
             for b in hist.get('buckets') or []
         ]
 
+    # Round-trip the non-default owner dimension through the metric /
+    # dimension pills' hx-include form (AFTER the drill URLs — the jobs
+    # fragments don't take owners_by).
+    if owners_by != 'user':
+        params = dict(params, owners_by=owners_by)
+
+    # Same affordance gates as the By User / By Project tables — never
+    # render an entity quick-view link that would 403.
+    from flask_login import current_user
+    can_view_users = has_permission_any_facility(
+        current_user, Permission.VIEW_USERS)
+    can_view_projects = (mode == 'user') or has_permission_any_facility(
+        current_user, Permission.VIEW_PROJECTS)
+
     return render_template(
         template,
         enabled=True, error=error,
@@ -873,6 +900,9 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
         metric=metric,
         dimension=dimension, dimension_toggle=dimension_toggle,
         size_dimensions=_SIZE_DIMENSIONS,
+        owners_by=owners_by, owners_toggle=owners_toggle,
+        can_view_users=can_view_users,
+        can_view_projects=can_view_projects,
         fragment_url=fragment_url,
         bucket_drills=bucket_drills,
         target_id=target_id,

--- a/src/webapp/jobs/service.py
+++ b/src/webapp/jobs/service.py
@@ -463,6 +463,7 @@ def jobs_histogram(
     dimension: str,
     *,
     owners_limit: Optional[int] = None,
+    owners_sort_by: Optional[str] = None,
     account_projcodes: Optional[Sequence[str]] = None,
     username: Optional[str] = None,
     valid_qos_names: Sequence[str] = (),
@@ -477,9 +478,11 @@ def jobs_histogram(
 
     ``owners_limit`` forwards to the plugin: each bucket gains a top-N
     per-user ``owners`` mapping (stacked chart segments + the per-band
-    user tier). It joins the cache ``opts`` so enriched and plain
-    envelopes never alias — which also naturally busts pre-upgrade
-    cache entries.
+    user tier). ``owners_sort_by`` picks WHICH top-N survives — it must
+    follow the displayed metric or a GPU-hours view gets owners ranked
+    by combined hours (top-5 measured to cover ~1% of band GPU-hours
+    machine-wide). Both join the cache ``opts`` so variants never alias
+    — which also naturally busts pre-upgrade cache entries.
 
     Results go through the jobs TTL cache: closed windows (``end`` before
     today) land in the long-lived ``historical`` bucket, open ones in
@@ -494,6 +497,8 @@ def jobs_histogram(
         kwargs['account'] = list(account_projcodes)
     if owners_limit is not None:
         kwargs['owners_limit'] = owners_limit
+    if owners_sort_by is not None:
+        kwargs['owners_sort_by'] = owners_sort_by
 
     def _compute():
         mod = get_module()

--- a/src/webapp/jobs/service.py
+++ b/src/webapp/jobs/service.py
@@ -462,6 +462,7 @@ def jobs_histogram(
     machine: str,
     dimension: str,
     *,
+    owners_limit: Optional[int] = None,
     account_projcodes: Optional[Sequence[str]] = None,
     username: Optional[str] = None,
     valid_qos_names: Sequence[str] = (),
@@ -474,6 +475,12 @@ def jobs_histogram(
     any client-supplied ``user`` filter — the pin always wins), both
     ``None`` is machine-wide (caller must be VIEW_ALL_JOB_DATA-gated).
 
+    ``owners_limit`` forwards to the plugin: each bucket gains a top-N
+    per-user ``owners`` mapping (stacked chart segments + the per-band
+    user tier). It joins the cache ``opts`` so enriched and plain
+    envelopes never alias — which also naturally busts pre-upgrade
+    cache entries.
+
     Results go through the jobs TTL cache: closed windows (``end`` before
     today) land in the long-lived ``historical`` bucket, open ones in
     ``recent``. The envelope is self-describing (``min_param`` /
@@ -485,6 +492,8 @@ def jobs_histogram(
         kwargs['user'] = username
     if account_projcodes is not None:
         kwargs['account'] = list(account_projcodes)
+    if owners_limit is not None:
+        kwargs['owners_limit'] = owners_limit
 
     def _compute():
         mod = get_module()
@@ -506,21 +515,27 @@ def jobs_usage_by_user(
     machine: str,
     *,
     limit: Optional[int] = 50,
+    sort_by: Optional[str] = None,
     account_projcodes: Optional[Sequence[str]] = None,
     valid_qos_names: Sequence[str] = (),
     **filters,
 ) -> Dict[str, Any]:
     """Cached per-user usage rollup (plugin ``jobs_usage_by('user')``).
 
-    Backs the By User pie: rows are hours-desc, ``totals`` is computed
-    upstream BEFORE the limit truncation, so the pie's "Other" slice is
-    ``totals − Σ rows``. No self-exclusion of any filter — ``account``
+    Backs the By User pie: rows are ranked by ``sort_by`` (the plugin's
+    combined-hours default when ``None``) BEFORE the limit truncation, so
+    the surviving top-N follows the viewed metric; ``totals`` is likewise
+    pre-truncation, so the pie's "Other" slice is ``totals − Σ rows``.
+    ``sort_by`` joins the cache ``opts`` — different rankings are
+    different result sets. No self-exclusion of any filter — ``account``
     scoping always applies (it's the security boundary). Same scope and
     caching rules as :func:`jobs_histogram`.
     """
     kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
     if account_projcodes is not None:
         kwargs['account'] = list(account_projcodes)
+    if sort_by is not None:
+        kwargs['sort_by'] = sort_by
 
     def _compute():
         mod = get_module()
@@ -543,6 +558,7 @@ def jobs_usage_by_project(
     *,
     username: str,
     limit: Optional[int] = 25,
+    sort_by: Optional[str] = None,
     valid_qos_names: Sequence[str] = (),
     **filters,
 ) -> Dict[str, Any]:
@@ -550,8 +566,9 @@ def jobs_usage_by_project(
     ``jobs_usage_by('account', user=username)``).
 
     Backs the My Jobs "By Project" pie: which projects the logged-in
-    user's jobs charged, hours-desc. User-mode-only by construction —
-    the username pin is mandatory and non-negotiable exactly like
+    user's jobs charged, ranked by ``sort_by`` (plugin combined-hours
+    default when ``None``). User-mode-only by construction — the
+    username pin is mandatory and non-negotiable exactly like
     :func:`search_jobs_user` (raises on empty username or a ``user``
     filter), so this can never aggregate anyone else's jobs. Same
     pre-truncation ``totals`` invariant and caching rules as
@@ -569,6 +586,8 @@ def jobs_usage_by_project(
 
     kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
     kwargs['user'] = username
+    if sort_by is not None:
+        kwargs['sort_by'] = sort_by
 
     def _compute():
         mod = get_module()

--- a/src/webapp/jobs/service.py
+++ b/src/webapp/jobs/service.py
@@ -472,6 +472,7 @@ def jobs_histogram(
     *,
     owners_limit: Optional[int] = None,
     owners_sort_by: Optional[str] = None,
+    owners_by: Optional[str] = None,
     account_projcodes: Optional[Sequence[str]] = None,
     username: Optional[str] = None,
     valid_qos_names: Sequence[str] = (),
@@ -485,11 +486,15 @@ def jobs_histogram(
     ``None`` is machine-wide (caller must be VIEW_ALL_JOB_DATA-gated).
 
     ``owners_limit`` forwards to the plugin: each bucket gains a top-N
-    per-user ``owners`` mapping (stacked chart segments + the per-band
-    user tier). ``owners_sort_by`` picks WHICH top-N survives — it must
+    per-owner ``owners`` mapping (stacked chart segments + the per-band
+    owner tier). ``owners_sort_by`` picks WHICH top-N survives — it must
     follow the displayed metric or a GPU-hours view gets owners ranked
     by combined hours (top-5 measured to cover ~1% of band GPU-hours
-    machine-wide). Both join the cache ``opts`` so variants never alias
+    machine-wide). ``owners_by='account'`` switches the owner dimension
+    from users to projects; it is forwarded ONLY when set and non-default
+    so a pre-`owners_by` plugin never sees the kwarg — the User pill path
+    keeps working against an older container, only the Project pill
+    degrades. All three join the cache ``opts`` so variants never alias
     — which also naturally busts pre-upgrade cache entries.
 
     Results go through the jobs TTL cache: closed windows (``end`` before
@@ -507,6 +512,8 @@ def jobs_histogram(
         kwargs['owners_limit'] = owners_limit
     if owners_sort_by is not None:
         kwargs['owners_sort_by'] = owners_sort_by
+    if owners_by is not None and owners_by != 'user':
+        kwargs['owners_by'] = owners_by
 
     def _compute():
         mod = get_module()

--- a/src/webapp/jobs/service.py
+++ b/src/webapp/jobs/service.py
@@ -327,6 +327,7 @@ def _count_via_sam_summary(
 def search_jobs_machine(
     machine: str,
     *,
+    account: Optional[str] = None,
     columns: Optional[Sequence[str]] = None,
     limit: Optional[int] = None,
     offset: int = 0,
@@ -335,18 +336,22 @@ def search_jobs_machine(
     valid_qos_names: Sequence[str] = (),
     **filters,
 ) -> List[Dict[str, Any]]:
-    """Machine-wide per-job rows — NO account scoping.
+    """Machine-wide per-job rows — NO account scoping by default.
 
     SECURITY: this deliberately issues an unscoped query (every user's
     jobs, cross-project). The caller MUST sit behind
     ``@require_permission(Permission.VIEW_ALL_JOB_DATA)`` — there is no
     fallback pinning here, unlike :func:`search_jobs` (project) and
-    :func:`search_jobs_user` (session user).
+    :func:`search_jobs_user` (session user). ``account`` is an optional
+    NARROWING filter (the By Project drill) — it only restricts the
+    already-authorized machine-wide view, never widens it.
     """
     mod = get_module()
     JobQueries = mod.JobQueries
 
     kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
+    if account:
+        kwargs['account'] = account
     kwargs.update({'columns': columns, 'limit': limit, 'offset': offset})
     if sort_by is not None:
         kwargs['sort_by']  = sort_by
@@ -359,10 +364,11 @@ def search_jobs_machine(
 def count_jobs_machine(
     machine: str,
     *,
+    account: Optional[str] = None,
     valid_qos_names: Sequence[str] = (),
     **filters,
 ) -> int:
-    """Machine-wide job count — NO account scoping (see search_jobs_machine).
+    """Machine-wide job count (see search_jobs_machine, incl. ``account``).
 
     Always the plugin's ``jobs_count``: the SAM-summary fast path is a
     per-project accounting table, and machine-wide requests are already
@@ -372,6 +378,8 @@ def count_jobs_machine(
     JobQueries = mod.JobQueries
 
     kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
+    if account:
+        kwargs['account'] = account
 
     with job_history_session(machine) as session:
         return JobQueries(session, machine=machine).jobs_count(**kwargs)
@@ -561,36 +569,46 @@ def jobs_usage_by_user(
 def jobs_usage_by_project(
     machine: str,
     *,
-    username: str,
+    username: Optional[str] = None,
     limit: Optional[int] = 25,
     sort_by: Optional[str] = None,
+    account_projcodes: Optional[Sequence[str]] = None,
     valid_qos_names: Sequence[str] = (),
     **filters,
 ) -> Dict[str, Any]:
-    """Cached per-project usage rollup for ONE user's jobs (plugin
-    ``jobs_usage_by('account', user=username)``).
+    """Cached per-project usage rollup (plugin ``jobs_usage_by('account')``).
 
-    Backs the My Jobs "By Project" pie: which projects the logged-in
-    user's jobs charged, ranked by ``sort_by`` (plugin combined-hours
-    default when ``None``). User-mode-only by construction — the
-    username pin is mandatory and non-negotiable exactly like
-    :func:`search_jobs_user` (raises on empty username or a ``user``
-    filter), so this can never aggregate anyone else's jobs. Same
-    pre-truncation ``totals`` invariant and caching rules as
-    :func:`jobs_usage_by_user`; cached as query type
+    Backs every "By Project" pie, scoped by mode exactly like
+    :func:`jobs_usage_by_user` scopes By User:
+
+    - **user mode**: pass ``username`` — the pin is applied server-side
+      and a client ``user`` filter beside it raises (same rule as
+      :func:`search_jobs_user`), so it can never aggregate anyone
+      else's jobs.
+    - **project mode**: pass ``account_projcodes`` (the server-derived
+      account tree) — the security boundary, always applied.
+    - **machine mode**: neither — the caller's route is gated on
+      ``VIEW_ALL_JOB_DATA``.
+
+    Rows are ranked by ``sort_by`` (plugin combined-hours default when
+    ``None``) BEFORE the limit truncation; ``totals`` is pre-truncation,
+    so "Other" is ``totals − Σ rows``. Cached as query type
     ``'usage_by_account'``.
     """
-    if not username:
+    if username is not None and not username:
         raise ValueError(
-            'jobs_usage_by_project requires a username (user pin).')
-    if 'user' in filters:
+            'jobs_usage_by_project requires a non-empty username pin.')
+    if username is not None and 'user' in filters:
         raise ValueError(
             "jobs_usage_by_project pins user server-side; "
             "remove the 'user' filter from the call."
         )
 
     kwargs = _plugin_filter_kwargs(valid_qos_names=valid_qos_names, **filters)
-    kwargs['user'] = username
+    if username is not None:
+        kwargs['user'] = username
+    if account_projcodes is not None:
+        kwargs['account'] = list(account_projcodes)
     if sort_by is not None:
         kwargs['sort_by'] = sort_by
 

--- a/src/webapp/static/js/svg-chart-links.js
+++ b/src/webapp/static/js/svg-chart-links.js
@@ -62,56 +62,17 @@
     // data-job-project (see jobs_by_project.html).
     var JOB_PROJ_PREFIX = '#job-proj-';
     // Job-history histogram (Wait Times / Job Sizes / Durations): a bar
-    // click expands the matching band's row in the Bucket-counts table
-    // (data-jh-bucket, see jobs_histogram.html), which lazy-loads that
-    // band's per-job fragment. The table sits inside a <details> that
-    // must be opened first or the row would expand invisibly.
+    // click expands the matching band's row in the bucket table
+    // (data-jh-bucket, see jobs_histogram.html), which drills into that
+    // band (per-user tier or per-job fragment).
     var BAR_JH_PREFIX = '#jh-bar-';
 
-    // Distribution histogram (Access-history / File-size tabs) → expand the
-    // matching bucket's per-user detail row. The bucket <tr> carries
-    // data-ah-bucket="<index>" and a data-bs-target pointing at its collapse
-    // row (see disk_scans_distribution.html). The lookup is scoped to the
-    // tab pane the clicked bar lives in, so the two tabs' identical
-    // #ah-bar-<index> anchors never cross-fire.
-    function openBucketRow(index, scopeEl) {
-        var root = scopeEl || document;
-        var row = root.querySelector('tr[data-ah-bucket="' + index + '"]');
-        if (!row || !window.bootstrap) return;
-        var targetSel = row.getAttribute('data-bs-target');
-        if (!targetSel) return;
-        var el = document.querySelector(targetSel);
-        if (!el) return;
-        bootstrap.Collapse.getOrCreateInstance(el, {toggle: false}).show();
-        setTimeout(function () {
-            row.scrollIntoView({behavior: 'smooth', block: 'center'});
-        }, 60);
-    }
-
-    // Pie wedge/legend → expand the entity's table row. The row carries the
-    // collapse target in data-bs-target (same attribute the chevron toggles),
-    // keyed by attr (data-owner-uid / data-group-gid). Scoped to the clicked
-    // chart's tab pane so other panes' identical sentinels never cross-fire.
-    // Jobs-histogram bar → expand the band's bucket row. Same shape as
-    // openBucketRow but keyed on data-jh-bucket, and the row lives inside
-    // a collapsed-by-default <details> that must be opened before the
-    // Bootstrap collapse (and the scroll) can be seen.
-    function openJobsBucketRow(index, scopeEl) {
-        var root = scopeEl || document;
-        var row = root.querySelector('tr[data-jh-bucket="' + index + '"]');
-        if (!row || !window.bootstrap) return;
-        var details = row.closest('details');
-        if (details) details.open = true;
-        var targetSel = row.getAttribute('data-bs-target');
-        if (!targetSel) return;
-        var el = document.querySelector(targetSel);
-        if (!el) return;
-        bootstrap.Collapse.getOrCreateInstance(el, {toggle: false}).show();
-        setTimeout(function () {
-            row.scrollIntoView({behavior: 'smooth', block: 'center'});
-        }, 60);
-    }
-
+    // Chart sentinel → expand a table row. The row carries the collapse
+    // target in data-bs-target (same attribute the row/chevron toggles),
+    // keyed by attr: histogram buckets (data-ah-bucket / data-jh-bucket,
+    // index-keyed) and pie/legend entities (data-owner-uid, data-job-user,
+    // …). Scoped to the clicked chart's tab pane so other panes' identical
+    // sentinels never cross-fire.
     function openEntityRow(attr, id, scopeEl) {
         var root = scopeEl || document;
         var row = root.querySelector('tr[' + attr + '="' + id + '"]');
@@ -213,7 +174,7 @@
             var idx = href.slice(BAR_AH_PREFIX.length);
             if (idx === '') return;
             e.preventDefault();
-            openBucketRow(idx, a.closest('.tab-pane'));
+            openEntityRow('data-ah-bucket', idx, a.closest('.tab-pane'));
             return;
         }
 
@@ -240,7 +201,7 @@
             var jhIdx = href.slice(BAR_JH_PREFIX.length);
             if (jhIdx === '') return;
             e.preventDefault();
-            openJobsBucketRow(jhIdx, a.closest('.tab-pane'));
+            openEntityRow('data-jh-bucket', jhIdx, a.closest('.tab-pane'));
             return;
         }
 

--- a/src/webapp/templates/dashboards/fragments/glossary.html
+++ b/src/webapp/templates/dashboards/fragments/glossary.html
@@ -180,3 +180,13 @@ charging (e.g. a refund or a usage reclassification). "On shared account from
 &lt;projcode&gt;" means the adjustment landed on a pooled allocation owned by
 another project.
 {%- endmacro %}
+
+{# ── Former project associations on the user card (popover) ── #}
+{% macro g_former_projects() -%}
+Projects this user is linked to but that no longer count as active:
+<br>&bull; <span class="badge bg-secondary">solid</span> — the <strong>project
+itself is inactive</strong> (deactivated)
+<br>&bull; <span class="badge bg-light text-secondary border">outline</span> —
+the project is still active, but this user's
+<strong>membership has ended</strong>.
+{%- endmacro %}

--- a/src/webapp/templates/dashboards/user/partials/jobs_by_project.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_by_project.html
@@ -73,9 +73,9 @@
         <thead class="table-light">
           <tr>
             <th class="sortable-header" data-sort="text">Project</th>
-            <th class="sortable-header text-end" data-sort="numeric">Jobs</th>
-            <th class="sortable-header text-end sort-desc" data-sort="numeric">CPU-hours</th>
-            <th class="sortable-header text-end" data-sort="numeric">GPU-hours</th>
+            <th class="sortable-header text-end{% if metric == 'jobs' %} sort-desc{% endif %}" data-sort="numeric">Jobs</th>
+            <th class="sortable-header text-end{% if metric == 'cpu_hours' %} sort-desc{% endif %}" data-sort="numeric">CPU-hours</th>
+            <th class="sortable-header text-end{% if metric == 'gpu_hours' %} sort-desc{% endif %}" data-sort="numeric">GPU-hours</th>
           </tr>
         </thead>
         {% for r in rows %}
@@ -128,7 +128,9 @@
         {% if other %}
         <tbody>
           <tr class="text-muted">
-            <td>Other <span class="small">(beyond top {{ rows | length }})</span></td>
+            <td>Other <span class="small">(beyond top {{ rows | length }} by
+              {{ {'jobs': 'jobs', 'cpu_hours': 'CPU-hours',
+                  'gpu_hours': 'GPU-hours'}[metric] }})</span></td>
             <td class="text-end">{{ other.job_count | fmt_number }}</td>
             <td class="text-end">{{ other.cpu_hours | fmt_number }}</td>
             <td class="text-end">{{ other.gpu_hours | fmt_number }}</td>

--- a/src/webapp/templates/dashboards/user/partials/jobs_by_project.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_by_project.html
@@ -1,19 +1,21 @@
 {% from 'dashboards/user/partials/_jobs_macros.html'
    import jobs_disabled, jobs_error, jobs_empty %}
 {#
-  By Project fragment — the logged-in user's per-project usage pie +
-  drillable rows (user mode only; the mirror of jobs_by_user.html, which
-  is hidden there). Context (set in
+  By Project fragment — per-project usage pie + drillable rows, the
+  mirror of jobs_by_user.html. All three modes: user (the pinned user's
+  own projects), machine (operator, whole machine), and project (a
+  parent's account tree). Context (set in
   webapp/jobs/routes.py::_render_by_project):
-    enabled, error, mode ('user'), machine,
+    enabled, error, mode, machine,
     usage   — plugin jobs_usage_by('account') envelope {rows, totals},
-              user-pinned upstream
+              scoped upstream per mode (user pin / tree / unscoped)
     other   — remainder beyond the row cap (totals are pre-truncation)
     metric  — 'jobs' | 'cpu_hours' | 'gpu_hours' (drives the pie)
     pie_svg — chart SVG (clickable #job-proj-<projcode> sentinels)
     fragment_url      — this fragment (metric pill re-fetch)
-    jobs_fragment_url — the user-mode per-job fragment (row drill target,
+    jobs_fragment_url — the mode's per-job fragment (row drill target,
                         narrowed by account=<projcode>)
+    can_view_projects — gates the projcode quick-view modal affordance
     target_id, params — container id + hidden round-trip params
 #}
 
@@ -94,7 +96,22 @@
                         aria-expanded="false" aria-controls="{{ _rid }}-row">
                   <i class="fas fa-chevron-right collapse-icon small"></i>
                 </button>
+                {% if can_view_projects | default(false) %}
+                {# Quick-view modal — in user mode the rows are the pinned
+                   user's own projects (affiliation passes the modal
+                   route's require_project_access); elsewhere the renderer
+                   gates on VIEW_PROJECTS so the click can't 403. #}
+                <button class="btn btn-link p-0"
+                        type="button" title="View project details"
+                        data-bs-toggle="modal" data-bs-target="#projectDetailsModal"
+                        hx-get="{{ url_for('user_dashboard.project_details_modal', projcode=projcode) }}"
+                        hx-target="#projectDetailsModalBody"
+                        hx-swap="innerHTML">
+                  <code>{{ projcode }}</code>
+                </button>
+                {% else %}
                 <code>{{ projcode }}</code>
+                {% endif %}
                 {% else %}
                 <span class="text-muted" title="jobs with no recorded project">(unknown)</span>
                 {% endif %}
@@ -106,11 +123,12 @@
             {% if projcode %}
             <tr class="collapse" id="{{ _rid }}-row">
               <td colspan="4" class="p-0 border-0">
-                {# Lazy-load this project's slice of MY jobs on first
-                   expand (account narrows, the server-side user pin still
-                   applies). Bind to shown.bs.collapse so a pie-wedge open
-                   triggers it too. Carries the pane's date window +
-                   shared filters into the drill. #}
+                {# Lazy-load this project's job slice on first expand —
+                   account only ever narrows the mode's already-scoped
+                   fragment (user pin / server tree / VIEW_ALL_JOB_DATA).
+                   Bind to shown.bs.collapse so a pie-wedge open triggers
+                   it too. Carries the pane's date window + shared
+                   filters into the drill. #}
                 <div class="p-2 bg-light" id="{{ _rid }}-content"
                      hx-get="{{ jobs_fragment_url }}?machine={{ machine }}&account={{ projcode }}{% if params.start %}&start={{ params.start }}{% endif %}{% if params.end %}&end={{ params.end }}{% endif %}{% if params.queue %}&queue={{ params.queue }}{% endif %}{% if params.qos %}&qos={{ params.qos }}{% endif %}{% if params.exit_status %}&exit_status={{ params.exit_status }}{% endif %}&target_id={{ _rid }}-content"
                      hx-trigger="shown.bs.collapse from:closest tr.collapse once"

--- a/src/webapp/templates/dashboards/user/partials/jobs_by_user.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_by_user.html
@@ -69,11 +69,13 @@
     <div class="table-responsive">
       <table class="table table-sm table-hover align-middle mb-0">
         <thead class="table-light">
+          {# Initial sort indicator follows the active metric pill — the
+             server ranks rows by it (and the top-N cut is taken in it). #}
           <tr>
             <th class="sortable-header" data-sort="text">User</th>
-            <th class="sortable-header text-end" data-sort="numeric">Jobs</th>
-            <th class="sortable-header text-end sort-desc" data-sort="numeric">CPU-hours</th>
-            <th class="sortable-header text-end" data-sort="numeric">GPU-hours</th>
+            <th class="sortable-header text-end{% if metric == 'jobs' %} sort-desc{% endif %}" data-sort="numeric">Jobs</th>
+            <th class="sortable-header text-end{% if metric == 'cpu_hours' %} sort-desc{% endif %}" data-sort="numeric">CPU-hours</th>
+            <th class="sortable-header text-end{% if metric == 'gpu_hours' %} sort-desc{% endif %}" data-sort="numeric">GPU-hours</th>
           </tr>
         </thead>
         {% for r in rows %}
@@ -125,7 +127,9 @@
         {% if other %}
         <tbody>
           <tr class="text-muted">
-            <td>Other <span class="small">(beyond top {{ rows | length }})</span></td>
+            <td>Other <span class="small">(beyond top {{ rows | length }} by
+              {{ {'jobs': 'jobs', 'cpu_hours': 'CPU-hours',
+                  'gpu_hours': 'GPU-hours'}[metric] }})</span></td>
             <td class="text-end">{{ other.job_count | fmt_number }}</td>
             <td class="text-end">{{ other.cpu_hours | fmt_number }}</td>
             <td class="text-end">{{ other.gpu_hours | fmt_number }}</td>

--- a/src/webapp/templates/dashboards/user/partials/jobs_by_user.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_by_user.html
@@ -12,6 +12,7 @@
     pie_svg — chart SVG (clickable #job-user-<username> sentinels)
     fragment_url      — this fragment (metric pill re-fetch)
     jobs_fragment_url — the mode's per-job fragment (row drill target)
+    can_view_users    — gates the username quick-view modal affordance
     target_id, params — container id + hidden round-trip params
 #}
 
@@ -94,7 +95,20 @@
                         aria-expanded="false" aria-controls="{{ _rid }}-row">
                   <i class="fas fa-chevron-right collapse-icon small"></i>
                 </button>
+                {% if can_view_users | default(false) %}
+                {# Quick-view modal — affordance only rendered when the
+                   viewer passes the user_card route's VIEW_USERS gate. #}
+                <button class="btn btn-link p-0"
+                        type="button" title="View user details"
+                        data-bs-toggle="modal" data-bs-target="#userDetailsModal"
+                        hx-get="{{ url_for('admin_dashboard.user_card', username=uname) }}"
+                        hx-target="#userDetailsModalBody"
+                        hx-swap="innerHTML">
+                  <code>{{ uname }}</code>
+                </button>
+                {% else %}
                 <code>{{ uname }}</code>
+                {% endif %}
                 {% else %}
                 <span class="text-muted" title="jobs with no recorded user">(unknown)</span>
                 {% endif %}

--- a/src/webapp/templates/dashboards/user/partials/jobs_card.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_card.html
@@ -16,22 +16,29 @@
                    on card-open (collapse) + tab show; machine/user modes fire
                    when their pane is shown. See feedback_persisted_collapse_htmx.
      projcode, scope  project mode only.
+     jobs_multi_project  project mode only: True when the project's account
+                  tree spans >1 projcode — gates the By Project tab (a
+                  single-project pie would be a pie of one).
      start, end   optional YYYY-MM-DD window carried into every tab (project
                   mode passes the page's date range so aggregations stay
                   bounded; url_for drops None values).
 
    In machine mode there is no account scoping (routes are gated behind
-   VIEW_ALL_JOB_DATA); in user mode the username is pinned server-side and
-   the By User tab is omitted (it would be a pie of one).
+   VIEW_ALL_JOB_DATA) and both By User and By Project render; in user mode
+   the username is pinned server-side and the By User tab is omitted (it
+   would be a pie of one) — By Project takes its slot.
 #}
 {# Optional params default to none so url_for drops them (an undefined
    name would reach url_for as Jinja Undefined and break URL building). #}
 {% set start = start | default(none) %}
 {% set end = end | default(none) %}
 {% set scope = scope | default(none) %}
+{% set jobs_multi_project = jobs_multi_project | default(false) %}
+{% set _proj_url = none %}
 {% if mode == 'machine' %}
     {% set _jobs_url  = url_for('jobs.jobs_machine_fragment',       machine=machine, start=start, end=end, target_id=cid ~ '-jobs') %}
     {% set _user_url  = url_for('jobs.by_user_machine_fragment',    machine=machine, start=start, end=end, target_id=cid ~ '-byuser') %}
+    {% set _proj_url  = url_for('jobs.by_project_machine_fragment', machine=machine, start=start, end=end, target_id=cid ~ '-byproj') %}
     {% set _wait_url  = url_for('jobs.wait_times_machine_fragment', machine=machine, start=start, end=end, target_id=cid ~ '-wait') %}
     {% set _sizes_url = url_for('jobs.job_sizes_machine_fragment',  machine=machine, start=start, end=end, target_id=cid ~ '-sizes') %}
     {% set _dur_url   = url_for('jobs.durations_machine_fragment',  machine=machine, start=start, end=end, target_id=cid ~ '-durations') %}
@@ -48,6 +55,9 @@
 {% else %}
     {% set _jobs_url  = url_for('jobs.jobs_fragment',       projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-jobs') %}
     {% set _user_url  = url_for('jobs.by_user_fragment',    projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-byuser') %}
+    {% if jobs_multi_project %}
+        {% set _proj_url = url_for('jobs.by_project_fragment', projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-byproj') %}
+    {% endif %}
     {% set _wait_url  = url_for('jobs.wait_times_fragment', projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-wait') %}
     {% set _sizes_url = url_for('jobs.job_sizes_fragment',  projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-sizes') %}
     {% set _dur_url   = url_for('jobs.durations_fragment',  projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-durations') %}
@@ -77,7 +87,8 @@
             <i class="fas fa-users me-1"></i> By User
         </button>
     </li>
-    {% else %}
+    {% endif %}
+    {% if _proj_url %}
     <li class="nav-item" role="presentation">
         <button class="nav-link" id="{{ cid }}-byproj-tab"
                 data-bs-toggle="tab" data-bs-target="#tab-{{ cid }}-byproj"
@@ -150,7 +161,8 @@
             </p>
         </div>
     </div>
-    {% else %}
+    {% endif %}
+    {% if _proj_url %}
     <div class="tab-pane fade" id="tab-{{ cid }}-byproj" role="tabpanel">
         <div id="{{ cid }}-byproj">
             <p class="text-muted small mb-0">

--- a/src/webapp/templates/dashboards/user/partials/jobs_fragment.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_fragment.html
@@ -40,7 +40,7 @@
     {%- else -%}
       {{ val | fmt_date }}
     {%- endif -%}
-  {%- elif col == 'job_id' -%}
+  {%- elif col in ('job_id', 'user') -%}
     <code class="small" title="{{ val }}">{{ val }}</code>
   {%- elif col in ('name', 'resources') -%}
     <span title="{{ val }}">{{ val }}</span>
@@ -168,6 +168,11 @@
         QoS: {{ qos_badge.name }}{% if qos_badge.factor is not none %} ({{ qos_badge.factor | fmt_factor }}){% endif %}
       </span>
     {% endif %}
+    {% if user_badge %}
+      {# Whole (single-page) result belongs to one user with no pin/filter
+         in play: the User column is suppressed, so name them here. #}
+      <span class="badge bg-light text-dark me-1">user: {{ user_badge.name }}</span>
+    {% endif %}
     <span class="ms-auto text-muted small">
       {{ total | fmt_number }} job{{ '' if total == 1 else 's' }}
     </span>
@@ -201,7 +206,11 @@
                 </button>
               </td>
               {% for col in visible_cols %}
-                <td class="{% if col in _numeric_cols %}text-end{% endif %}{% if col in ('job_id', 'name') %} text-nowrap small{% endif %}">
+                {# Long job names must not widen the auto-fit column —
+                   truncate with an ellipsis; the full name stays on the
+                   render_value title tooltip. #}
+                <td class="{% if col in _numeric_cols %}text-end{% endif %}{% if col in ('job_id', 'user') %} text-nowrap small{% endif %}{% if col == 'name' %} small text-truncate{% endif %}"
+                    {% if col == 'name' %}style="max-width: 35ch;"{% endif %}>
                   {{ render_value(col, r.get(col)) }}
                 </td>
               {% endfor %}

--- a/src/webapp/templates/dashboards/user/partials/jobs_histogram.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_histogram.html
@@ -110,69 +110,197 @@
     </p>
   {% endif %}
 
+  {# Lazy per-user jobs drill — the fs_scans dir_drill() shape: bound to
+     shown.bs.collapse (never click) so a chart-click .show() and a
+     chevron toggle both fire the fetch; `once` prevents refetch on
+     re-expand. The username rides the band drill URL exactly like the
+     By User table's drill (jobs_by_user.html). If the pane already pins
+     ?user=, the single-owner shortcut guarantees the appended duplicate
+     carries the identical value (Werkzeug reads the first) — benign. #}
+  {% macro user_jobs_drill(dt_id, uname, drill_url, band_label) %}
+  <div class="p-2 bg-light" id="{{ dt_id }}"
+       hx-get="{{ drill_url }}&user={{ uname | urlencode }}&target_id={{ dt_id }}"
+       hx-trigger="shown.bs.collapse from:closest tr.collapse once"
+       hx-swap="innerHTML">
+    <p class="text-muted small mb-0">
+      <i class="fas fa-spinner fa-spin me-1"></i>
+      Loading {{ uname }}'s jobs in the {{ band_label }} band…
+    </p>
+  </div>
+  {% endmacro %}
+
   {# Bucket table under the SVG — the same full, zero-filled vector the
-     chart renders, so counts are copy/paste-able. Populated bands are
-     expandable: the collapse row lazy-loads the mode's per-job fragment
-     filtered to that band's bounds (bucket_drills, computed in
-     _render_histogram). A bar click (#jh-bar-<i> sentinel) opens the
-     matching data-jh-bucket row via svg-chart-links.js, forcing this
-     <details> open first. #}
-  <details class="mt-1">
-    <summary class="small text-muted">Bucket counts</summary>
-    <div class="table-responsive mt-2">
-      <table class="table table-sm table-hover align-middle mb-0">
-        <thead class="table-light">
-          <tr>
-            <th>Range</th>
-            <th class="text-end">Jobs</th>
-            <th class="text-end">CPU-hours</th>
-            <th class="text-end">GPU-hours</th>
+     chart renders, so counts are copy/paste-able. Populated bands expand
+     (row click or bar click via the #jh-bar-<i> sentinel and
+     svg-chart-links.js) into a per-user tier rendered from the envelope's
+     owners (ranked by the active metric), each user lazy-loading their
+     jobs in the band (bucket_drills, computed in _render_histogram).
+     Owner-less envelopes fall back to the band → jobs single level.
+     Every collapse row carries data-no-persist: a restored auto-expand
+     would re-fire the drill fetches on reload. #}
+  {% set _mkey = 'job_count' if metric == 'jobs' else metric %}
+  <div class="small text-muted mt-2 mb-1">Bucket breakdown</div>
+  <div class="table-responsive">
+    <table class="table table-sm table-hover align-middle mb-0">
+      <thead class="table-light">
+        <tr>
+          <th>Range</th>
+          <th class="text-end">Jobs</th>
+          <th class="text-end">CPU-hours</th>
+          <th class="text-end">GPU-hours</th>
+        </tr>
+      </thead>
+      {% for b in hist.buckets %}
+        {% set drill_url = bucket_drills[loop.index0]
+           if bucket_drills else none %}
+        {% set _rid = target_id ~ '-b' ~ loop.index0 %}
+        {% set owners = b.owners or {} %}
+        {% set _ojobs = owners.values() | map(attribute='job_count') | sum %}
+        {% set _rem_jobs = b.job_count - _ojobs %}
+        {% set _single = owners | length == 1 and not _rem_jobs %}
+        {% set _expandable = drill_url and owners %}
+        <tbody>
+          {% if _expandable %}
+          <tr class="cursor-pointer"
+              data-jh-bucket="{{ loop.index0 }}"
+              data-bs-toggle="collapse" data-bs-target="#{{ _rid }}-row"
+              aria-expanded="false" aria-controls="{{ _rid }}-row"
+              title="{{ 'Show jobs in this band' if _single
+                        else 'Show top users in this band' }}">
+            <td>
+              <i class="fas fa-chevron-right collapse-icon small me-1"></i>
+              <code>{{ b.label }}</code>
+            </td>
+            <td class="text-end">{{ b.job_count | fmt_number }}</td>
+            <td class="text-end">{{ b.cpu_hours | fmt_number }}</td>
+            <td class="text-end">{{ b.gpu_hours | fmt_number }}</td>
           </tr>
-        </thead>
-        {% for b in hist.buckets %}
-          {% set drill_url = bucket_drills[loop.index0]
-             if bucket_drills else none %}
-          {% set _rid = target_id ~ '-b' ~ loop.index0 %}
-          <tbody>
-            <tr {% if not b.job_count %}class="text-muted"
-                {% else %}data-jh-bucket="{{ loop.index0 }}"
-                          data-bs-target="#{{ _rid }}-row"{% endif %}>
-              <td>
-                {% if drill_url %}
-                <button class="btn btn-sm btn-link text-decoration-none p-0 me-1"
-                        type="button" data-bs-toggle="collapse"
-                        data-bs-target="#{{ _rid }}-row"
-                        aria-expanded="false" aria-controls="{{ _rid }}-row">
-                  <i class="fas fa-chevron-right collapse-icon small"></i>
-                </button>
-                {% endif %}
-                <code>{{ b.label }}</code>
-              </td>
-              <td class="text-end">{{ b.job_count | fmt_number }}</td>
-              <td class="text-end">{{ b.cpu_hours | fmt_number }}</td>
-              <td class="text-end">{{ b.gpu_hours | fmt_number }}</td>
-            </tr>
-            {% if drill_url %}
-            <tr class="collapse" id="{{ _rid }}-row">
-              <td colspan="4" class="p-0 border-0">
-                {# Lazy-load this band's jobs on first expand — bind to
-                   shown.bs.collapse (not click) so a bar-click open
-                   triggers it too. #}
-                <div class="p-2 bg-light" id="{{ _rid }}-content"
-                     hx-get="{{ drill_url }}&target_id={{ _rid }}-content"
-                     hx-trigger="shown.bs.collapse from:closest tr.collapse once"
-                     hx-swap="innerHTML">
-                  <p class="text-muted small mb-0">
-                    <i class="fas fa-spinner fa-spin me-1"></i>
-                    Loading jobs in the {{ b.label }} band…
-                  </p>
+          <tr class="collapse" id="{{ _rid }}-row" data-no-persist>
+            <td colspan="4" class="p-0 border-0">
+              {% if _single %}
+                {# One user owns the whole band — skip the per-user tier
+                   and drill straight to their jobs (fs_scans shortcut). #}
+                {{ user_jobs_drill(_rid ~ '-content',
+                                   (owners | list | first), drill_url, b.label) }}
+              {% else %}
+                <div class="p-2 bg-light">
+                  <div class="table-responsive">
+                    <table class="table table-sm table-hover align-middle mb-0">
+                      <thead>
+                        <tr class="small text-muted">
+                          <th style="width:2rem;" class="text-end">#</th>
+                          <th>User</th>
+                          <th class="text-end">Jobs</th>
+                          <th class="text-end">CPU-hours</th>
+                          <th class="text-end">GPU-hours</th>
+                          <th class="text-end">% of band</th>
+                        </tr>
+                      </thead>
+                      {% set ranked = owners.items()
+                         | sort(attribute='1.' ~ _mkey, reverse=true) %}
+                      {% for uname, stats in ranked %}
+                        {% set _urid = _rid ~ '-u' ~ loop.index %}
+                        <tbody>
+                          <tr class="cursor-pointer"
+                              data-bs-toggle="collapse"
+                              data-bs-target="#{{ _urid }}-row"
+                              aria-expanded="false"
+                              aria-controls="{{ _urid }}-row"
+                              title="Show {{ uname }}'s jobs in this band">
+                            <td class="text-end text-muted">{{ loop.index }}</td>
+                            <td>
+                              <i class="fas fa-chevron-right collapse-icon small me-1"></i>
+                              <span class="font-monospace">{{ uname }}</span>
+                            </td>
+                            <td class="text-end">{{ stats.job_count | fmt_number }}</td>
+                            <td class="text-end">{{ stats.cpu_hours | fmt_number }}</td>
+                            <td class="text-end">{{ stats.gpu_hours | fmt_number }}</td>
+                            <td class="text-end text-muted">
+                              {% if b[_mkey] %}
+                                {{ (100 * (stats[_mkey] or 0) / b[_mkey]) | fmt_pct }}
+                              {% else %}—{% endif %}
+                            </td>
+                          </tr>
+                          <tr class="collapse" id="{{ _urid }}-row" data-no-persist>
+                            <td colspan="6" class="p-0 border-0">
+                              {{ user_jobs_drill(_urid ~ '-content',
+                                                 uname, drill_url, b.label) }}
+                            </td>
+                          </tr>
+                        </tbody>
+                      {% endfor %}
+                      {% if _rem_jobs > 0 %}
+                      <tbody>
+                        <tr class="text-muted">
+                          <td></td>
+                          <td>
+                            Other users
+                            <span class="small">(beyond top {{ owners | length }})</span>
+                          </td>
+                          <td class="text-end">{{ _rem_jobs | fmt_number }}</td>
+                          <td class="text-end">
+                            {{ (b.cpu_hours - (owners.values() | map(attribute='cpu_hours') | sum)) | fmt_number }}
+                          </td>
+                          <td class="text-end">
+                            {{ (b.gpu_hours - (owners.values() | map(attribute='gpu_hours') | sum)) | fmt_number }}
+                          </td>
+                          <td class="text-end">
+                            {% if b[_mkey] %}
+                              {{ (100 * (b[_mkey] - (owners.values() | map(attribute=_mkey) | sum)) / b[_mkey]) | fmt_pct }}
+                            {% else %}—{% endif %}
+                          </td>
+                        </tr>
+                      </tbody>
+                      {% endif %}
+                    </table>
+                  </div>
                 </div>
-              </td>
-            </tr>
-            {% endif %}
-          </tbody>
-        {% endfor %}
-      </table>
-    </div>
-  </details>
+              {% endif %}
+            </td>
+          </tr>
+          {% else %}
+          {# Owner-less bucket (no owners in the envelope, or a populated
+             band whose jobs all lack a username): the original single-level
+             band → jobs drill, markup preserved verbatim. #}
+          <tr {% if not b.job_count %}class="text-muted"
+              {% else %}data-jh-bucket="{{ loop.index0 }}"
+                        data-bs-target="#{{ _rid }}-row"{% endif %}>
+            <td>
+              {% if drill_url %}
+              <button class="btn btn-sm btn-link text-decoration-none p-0 me-1"
+                      type="button" data-bs-toggle="collapse"
+                      data-bs-target="#{{ _rid }}-row"
+                      aria-expanded="false" aria-controls="{{ _rid }}-row">
+                <i class="fas fa-chevron-right collapse-icon small"></i>
+              </button>
+              {% endif %}
+              <code>{{ b.label }}</code>
+            </td>
+            <td class="text-end">{{ b.job_count | fmt_number }}</td>
+            <td class="text-end">{{ b.cpu_hours | fmt_number }}</td>
+            <td class="text-end">{{ b.gpu_hours | fmt_number }}</td>
+          </tr>
+          {% if drill_url %}
+          <tr class="collapse" id="{{ _rid }}-row" data-no-persist>
+            <td colspan="4" class="p-0 border-0">
+              {# Lazy-load this band's jobs on first expand — bind to
+                 shown.bs.collapse (not click) so a bar-click open
+                 triggers it too. #}
+              <div class="p-2 bg-light" id="{{ _rid }}-content"
+                   hx-get="{{ drill_url }}&target_id={{ _rid }}-content"
+                   hx-trigger="shown.bs.collapse from:closest tr.collapse once"
+                   hx-swap="innerHTML">
+                <p class="text-muted small mb-0">
+                  <i class="fas fa-spinner fa-spin me-1"></i>
+                  Loading jobs in the {{ b.label }} band…
+                </p>
+              </div>
+            </td>
+          </tr>
+          {% endif %}
+          {% endif %}
+        </tbody>
+      {% endfor %}
+    </table>
+  </div>
 {% endif %}

--- a/src/webapp/templates/dashboards/user/partials/jobs_histogram.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_histogram.html
@@ -15,6 +15,10 @@
                  'memory_used' | 'memory_wasted' | 'duration'
     dimension_toggle — True only on the Job Sizes tab
     size_dimensions  — the dimension pill order
+    owners_by       — 'user' | 'account': who owns the stacked segments
+                      and the per-band tier
+    owners_toggle   — offer the User|Project pill (multi-project contexts)
+    can_view_users / can_view_projects — entity quick-view modal gates
     fragment_url, target_id, params — re-fetch plumbing
 #}
 
@@ -67,6 +71,23 @@
       </button>
       {% endfor %}
     </div>
+    {% if owners_toggle | default(false) %}
+    {# Owner-dimension pills — whether users or projects own the stacked
+       segments and the per-band tier. The explicit ?owners_by= wins over
+       the round-trip form's stale value (Werkzeug reads the first). #}
+    <div class="btn-group btn-group-sm me-1" role="group" aria-label="Owner dimension">
+      {% for ob, label in [('user', 'User'), ('account', 'Project')] %}
+      <button type="button"
+              class="btn btn-outline-secondary {% if owners_by == ob %}active{% endif %}"
+              hx-get="{{ fragment_url }}?owners_by={{ ob }}&metric={{ metric }}{% if dimension_toggle %}&dimension={{ dimension }}{% endif %}"
+              hx-target="#{{ target_id }}"
+              hx-include="#jobs-hist-params-{{ target_id }}"
+              hx-swap="innerHTML">
+        {{ label }}
+      </button>
+      {% endfor %}
+    </div>
+    {% endif %}
     <span class="ms-auto text-muted small">
       {{ hist.total_count | fmt_number }} job{{ '' if hist.total_count == 1 else 's' }}
     </span>
@@ -110,21 +131,24 @@
     </p>
   {% endif %}
 
-  {# Lazy per-user jobs drill — the fs_scans dir_drill() shape: bound to
+  {# Lazy per-owner jobs drill — the fs_scans dir_drill() shape: bound to
      shown.bs.collapse (never click) so a chart-click .show() and a
      chevron toggle both fire the fetch; `once` prevents refetch on
-     re-expand. The username rides the band drill URL exactly like the
-     By User table's drill (jobs_by_user.html). If the pane already pins
-     ?user=, the single-owner shortcut guarantees the appended duplicate
-     carries the identical value (Werkzeug reads the first) — benign. #}
-  {% macro user_jobs_drill(dt_id, uname, drill_url, band_label) %}
+     re-expand. The owner rides the band drill URL exactly like the
+     By User / By Project tables' drills — as user= for user owners,
+     account= for project owners. If the pane already pins ?user=, the
+     single-owner shortcut guarantees the appended duplicate carries the
+     identical value (Werkzeug reads the first) — benign. #}
+  {% set _okey = 'account' if owners_by | default('user') == 'account'
+     else 'user' %}
+  {% macro owner_jobs_drill(dt_id, owner, drill_url, band_label) %}
   <div class="p-2 bg-light" id="{{ dt_id }}"
-       hx-get="{{ drill_url }}&user={{ uname | urlencode }}&target_id={{ dt_id }}"
+       hx-get="{{ drill_url }}&{{ _okey }}={{ owner | urlencode }}&target_id={{ dt_id }}"
        hx-trigger="shown.bs.collapse from:closest tr.collapse once"
        hx-swap="innerHTML">
     <p class="text-muted small mb-0">
       <i class="fas fa-spinner fa-spin me-1"></i>
-      Loading {{ uname }}'s jobs in the {{ band_label }} band…
+      Loading {{ owner }}'s jobs in the {{ band_label }} band…
     </p>
   </div>
   {% endmacro %}
@@ -132,9 +156,10 @@
   {# Bucket table under the SVG — the same full, zero-filled vector the
      chart renders, so counts are copy/paste-able. Populated bands expand
      (row click or bar click via the #jh-bar-<i> sentinel and
-     svg-chart-links.js) into a per-user tier rendered from the envelope's
-     owners (ranked by the active metric), each user lazy-loading their
-     jobs in the band (bucket_drills, computed in _render_histogram).
+     svg-chart-links.js) into a per-owner tier (users, or projects under
+     the Project pill) rendered from the envelope's owners (ranked by the
+     active metric), each owner lazy-loading its jobs in the band
+     (bucket_drills, computed in _render_histogram).
      Owner-less envelopes fall back to the band → jobs single level.
      Every collapse row carries data-no-persist: a restored auto-expand
      would re-fire the drill fetches on reload. #}
@@ -166,7 +191,9 @@
               data-bs-toggle="collapse" data-bs-target="#{{ _rid }}-row"
               aria-expanded="false" aria-controls="{{ _rid }}-row"
               title="{{ 'Show jobs in this band' if _single
-                        else 'Show top users in this band' }}">
+                        else ('Show top projects in this band'
+                              if _okey == 'account'
+                              else 'Show top users in this band') }}">
             <td>
               <i class="fas fa-chevron-right collapse-icon small me-1"></i>
               <code>{{ b.label }}</code>
@@ -178,10 +205,11 @@
           <tr class="collapse" id="{{ _rid }}-row" data-no-persist>
             <td colspan="4" class="p-0 border-0">
               {% if _single %}
-                {# One user owns the whole band — skip the per-user tier
-                   and drill straight to their jobs (fs_scans shortcut). #}
-                {{ user_jobs_drill(_rid ~ '-content',
-                                   (owners | list | first), drill_url, b.label) }}
+                {# One owner holds the whole band — skip the per-owner
+                   tier and drill straight to its jobs (fs_scans
+                   shortcut). #}
+                {{ owner_jobs_drill(_rid ~ '-content',
+                                    (owners | list | first), drill_url, b.label) }}
               {% else %}
                 <div class="p-2 bg-light">
                   <div class="table-responsive">
@@ -189,7 +217,7 @@
                       <thead>
                         <tr class="small text-muted">
                           <th style="width:2rem;" class="text-end">#</th>
-                          <th>User</th>
+                          <th>{{ 'Project' if _okey == 'account' else 'User' }}</th>
                           <th class="text-end">Jobs</th>
                           <th class="text-end">CPU-hours</th>
                           <th class="text-end">GPU-hours</th>
@@ -198,24 +226,62 @@
                       </thead>
                       {% set ranked = owners.items()
                          | sort(attribute='1.' ~ _mkey, reverse=true) %}
-                      {% for uname, stats in ranked %}
+                      {% for owner, stats in ranked %}
                         {% set _urid = _rid ~ '-u' ~ loop.index %}
                         <tbody>
-                          <tr class="cursor-pointer"
-                              data-bs-toggle="collapse"
-                              data-bs-target="#{{ _urid }}-row"
-                              aria-expanded="false"
-                              aria-controls="{{ _urid }}-row"
-                              title="Show {{ uname }}'s jobs in this band">
-                            <td class="text-end text-muted">{{ loop.index }}</td>
+                          {# The collapse toggle sits on the chevron and the
+                             stat cells, never the <tr>: Bootstrap's data-api
+                             binds in the capture phase, so a nested modal
+                             button could not stop a row-level toggle (see
+                             dashboards/fragments/collapse.html). #}
+                          <tr title="Show {{ owner }}'s jobs in this band">
+                            <td class="text-end text-muted cursor-pointer"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#{{ _urid }}-row"
+                                aria-controls="{{ _urid }}-row">{{ loop.index }}</td>
                             <td>
-                              <i class="fas fa-chevron-right collapse-icon small me-1"></i>
-                              <span class="font-monospace">{{ uname }}</span>
+                              <button class="btn btn-sm btn-link text-decoration-none p-0 me-1"
+                                      type="button" data-bs-toggle="collapse"
+                                      data-bs-target="#{{ _urid }}-row"
+                                      aria-expanded="false"
+                                      aria-controls="{{ _urid }}-row">
+                                <i class="fas fa-chevron-right collapse-icon small"></i>
+                              </button>
+                              {% if _okey == 'account' and can_view_projects | default(false) %}
+                              <button class="btn btn-link p-0" type="button"
+                                      title="View project details"
+                                      data-bs-toggle="modal"
+                                      data-bs-target="#projectDetailsModal"
+                                      hx-get="{{ url_for('user_dashboard.project_details_modal', projcode=owner) }}"
+                                      hx-target="#projectDetailsModalBody"
+                                      hx-swap="innerHTML">
+                                <span class="font-monospace">{{ owner }}</span>
+                              </button>
+                              {% elif _okey == 'user' and can_view_users | default(false) %}
+                              <button class="btn btn-link p-0" type="button"
+                                      title="View user details"
+                                      data-bs-toggle="modal"
+                                      data-bs-target="#userDetailsModal"
+                                      hx-get="{{ url_for('admin_dashboard.user_card', username=owner) }}"
+                                      hx-target="#userDetailsModalBody"
+                                      hx-swap="innerHTML">
+                                <span class="font-monospace">{{ owner }}</span>
+                              </button>
+                              {% else %}
+                              <span class="font-monospace">{{ owner }}</span>
+                              {% endif %}
                             </td>
-                            <td class="text-end">{{ stats.job_count | fmt_number }}</td>
-                            <td class="text-end">{{ stats.cpu_hours | fmt_number }}</td>
-                            <td class="text-end">{{ stats.gpu_hours | fmt_number }}</td>
-                            <td class="text-end text-muted">
+                            {% for cell in [stats.job_count, stats.cpu_hours,
+                                            stats.gpu_hours] %}
+                            <td class="text-end cursor-pointer"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#{{ _urid }}-row"
+                                aria-controls="{{ _urid }}-row">{{ cell | fmt_number }}</td>
+                            {% endfor %}
+                            <td class="text-end text-muted cursor-pointer"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#{{ _urid }}-row"
+                                aria-controls="{{ _urid }}-row">
                               {% if b[_mkey] %}
                                 {{ (100 * (stats[_mkey] or 0) / b[_mkey]) | fmt_pct }}
                               {% else %}—{% endif %}
@@ -223,8 +289,8 @@
                           </tr>
                           <tr class="collapse" id="{{ _urid }}-row" data-no-persist>
                             <td colspan="6" class="p-0 border-0">
-                              {{ user_jobs_drill(_urid ~ '-content',
-                                                 uname, drill_url, b.label) }}
+                              {{ owner_jobs_drill(_urid ~ '-content',
+                                                  owner, drill_url, b.label) }}
                             </td>
                           </tr>
                         </tbody>
@@ -234,7 +300,7 @@
                         <tr class="text-muted">
                           <td></td>
                           <td>
-                            Other users
+                            Other {{ 'projects' if _okey == 'account' else 'users' }}
                             <span class="small">(beyond top {{ owners | length }})</span>
                           </td>
                           <td class="text-end">{{ _rem_jobs | fmt_number }}</td>

--- a/src/webapp/templates/dashboards/user/partials/user_card.html
+++ b/src/webapp/templates/dashboards/user/partials/user_card.html
@@ -1,4 +1,6 @@
 {% from 'dashboards/fragments/badges.html' import status_badge %}
+{% from 'dashboards/fragments/help.html' import help_icon with context %}
+{% from 'dashboards/fragments/glossary.html' import g_former_projects with context %}
 {% macro render_user_card(sam_user, is_admin=False, user_groups=None, primary_group_name=None,
                           current_shell=None, allowable_shells=None, can_edit_shell=False,
                           available_groups=None, can_edit_primary_gid=False) %}
@@ -158,6 +160,34 @@
                     {% endif %}
                 </div>
             </div>
+
+            <!-- Inactive / former projects — operators only. Solid badge =
+                 project deactivated; outline badge = active project whose
+                 membership has ended (see g_former_projects). -->
+            {% if is_admin and has_permission_any_facility(Permission.VIEW_PROJECTS) %}
+            {% set former = sam_user.former_projects() %}
+            {% if former.inactive or former.ended %}
+            <div class="stat-item stat-item-block mt-2">
+                <span class="stat-label d-block mb-1">
+                    Inactive / Former Projects: {{ help_icon(g_former_projects(), rich=True) }}
+                </span>
+                <div class="stat-value text-dark text-detail">
+                    {% for project in former.inactive %}
+                    <a href="{{ url_for('admin_dashboard.projects', projcode=project.projcode) }}"
+                       class="badge bg-secondary text-decoration-none me-1 mb-1">
+                        {{ project.projcode }}
+                    </a>
+                    {% endfor %}
+                    {% for project in former.ended %}
+                    <a href="{{ url_for('admin_dashboard.projects', projcode=project.projcode) }}"
+                       class="badge bg-light text-secondary border text-decoration-none me-1 mb-1">
+                        {{ project.projcode }}
+                    </a>
+                    {% endfor %}
+                </div>
+            </div>
+            {% endif %}
+            {% endif %}
 
             <!-- Active groups (adhoc group membership, tabbed by access branch) -->
             {% if user_groups is not none %}

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -532,6 +532,7 @@
         <div class="card-body">
             {% with mode='project', cid='jobs-hist', tablist_id='jobsCardTabs',
                     machine=jobs_machine, projcode=projcode, scope=scope,
+                    jobs_multi_project=jobs_multi_project,
                     start=start_date, end=end_date,
                     load_trigger='shown.bs.tab once, shown.bs.collapse once from:#collapseJobsHist' %}
                 {% include 'dashboards/user/partials/jobs_card.html' %}
@@ -543,6 +544,12 @@
 
 <!-- Allocation Management Modals -->
 {% include 'dashboards/user/fragments/allocation_modals.html' %}
+
+{# Entity quick-view shells for the jobs card's By User / By Project
+   username+projcode links (base_user/base_status include these globally;
+   this page extends dashboards/base.html directly). #}
+{% include 'dashboards/user/fragments/user_details_modal.html' %}
+{% include 'dashboards/shared/project_details_modal.html' %}
 
 {% endblock %}
 

--- a/tests/unit/test_flask_cache_adapter.py
+++ b/tests/unit/test_flask_cache_adapter.py
@@ -1,0 +1,141 @@
+"""
+Tests for FlaskCacheAdapter's Redis introspection and its foreign-prefix
+skip list.
+
+The flask adapter SCANs the whole Redis DB and must exclude every keyspace
+owned by the other adapters (chart + the five RedisTTLAdapter constructions),
+else their entries miscount into the flask card's 'other' group. The
+cross-check test here is the guard that a future sixth cache cannot be added
+without extending ``_FOREIGN_PREFIXES``.
+
+Uses fakeredis (no external dependencies); factory module state is
+saved/restored around each test so the shared CI Redis and other tests are
+unaffected.
+"""
+
+import pickle
+
+import fakeredis
+import pytest
+
+from webapp.caching.flask_adapter import (
+    _FOREIGN_PREFIXES,
+    _FOREIGN_PREFIXES_B,
+    FlaskCacheAdapter,
+)
+
+
+@pytest.fixture
+def redis_client():
+    """Fresh in-memory Redis for each test."""
+    return fakeredis.FakeRedis()
+
+
+def _pickled(key):
+    return pickle.dumps(key, protocol=4)
+
+
+# ---------------------------------------------------------------------------
+# Cross-check: the skip list must cover every live non-flask adapter
+# ---------------------------------------------------------------------------
+
+class TestForeignPrefixCrossCheck:
+
+    def test_bytes_tuple_mirrors_str_tuple(self):
+        assert _FOREIGN_PREFIXES_B == tuple(p.encode() for p in _FOREIGN_PREFIXES)
+
+    def test_every_ttl_adapter_prefix_is_listed(self, monkeypatch, redis_client):
+        """Init all five TTL adapters via their real factories and assert each
+        prefix appears in _FOREIGN_PREFIXES — a sixth cache added to
+        ``caching.adapters()`` without extending the tuple fails here."""
+        monkeypatch.setenv('CACHE_REDIS_URL', 'redis://fake:6379/0')
+
+        import sam.caching.redis_client as rc
+        import sam.queries.usage_cache as uc
+        import webapp.disk_scans.cache as dc
+        import webapp.jobs.cache as jc
+        for mod in (rc, uc, dc, jc):
+            monkeypatch.setattr(mod, 'make_redis_client',
+                                lambda url=None, **kw: redis_client)
+
+        saved_usage = (uc._adapter, uc._disabled)
+        saved_scans = dict(dc._adapters)
+        saved_jobs = dict(jc._adapters)
+        uc._adapter, uc._disabled = None, False
+        dc._adapters.clear()
+        jc._adapters.clear()
+        try:
+            from webapp.caching import Caching
+            facade = Caching()
+            ttl_adapters = [a for a in facade.adapters()
+                            if getattr(a, '_prefix', None) is not None]
+            # All five constructions must be live under fakeredis…
+            assert sorted(a.name for a in ttl_adapters) == [
+                'allocation_usage', 'fs_scans', 'fs_scans_filtered',
+                'jobs', 'jobs_recent',
+            ]
+            # …and every one of their keyspaces must be in the skip list.
+            for adapter in ttl_adapters:
+                assert adapter._prefix in _FOREIGN_PREFIXES, (
+                    f"adapter '{adapter.name}' prefix '{adapter._prefix}' "
+                    f"missing from flask_adapter._FOREIGN_PREFIXES — its keys "
+                    f"would miscount into the flask card's 'other' group"
+                )
+        finally:
+            uc._adapter, uc._disabled = saved_usage
+            dc._adapters.clear()
+            dc._adapters.update(saved_scans)
+            jc._adapters.clear()
+            jc._adapters.update(saved_jobs)
+
+    def test_chart_prefix_listed(self, redis_client):
+        """RedisChartCache keys (chart:<name>:, chart:hits/misses:<name>) are
+        covered by the single 'chart:' entry."""
+        from webapp.caching.redis_chart import RedisChartCache
+        cache = RedisChartCache(name='pace_chart', client=redis_client)
+        cache.put('k', '<svg/>')
+        cache.get('k')      # bump the hit counter key too
+        for raw_key in redis_client.scan_iter(match='*'):
+            assert raw_key.startswith(b'chart:')
+        assert 'chart:' in _FOREIGN_PREFIXES
+
+
+# ---------------------------------------------------------------------------
+# Introspection: foreign keys stay out of the flask groups
+# ---------------------------------------------------------------------------
+
+class TestRedisIntrospection:
+
+    def _adapter(self, client):
+        # A flask_cache object with no usable backend forces info() down the
+        # Redis-introspection path.
+        return FlaskCacheAdapter(object(), redis_client=client)
+
+    def test_foreign_keys_excluded_from_counts(self, redis_client):
+        # Foreign keys: one per adapter keyspace, pickle-suffixed (not UTF-8)
+        # like the real RedisTTLAdapter writes them.
+        for prefix in (b'allocation_usage:', b'fs_scans:', b'fs_scans_filtered:',
+                       b'jobs:', b'jobs_recent:'):
+            redis_client.set(prefix + _pickled(('k',)), b'v')
+        redis_client.set(b'chart:pace_chart:abc', b'<svg/>')
+        # Flask-cache keys: one groupable, one 'other'.
+        redis_client.set(b'flask_cache_view//api/v1/directory_access/foo', b'x')
+        redis_client.set(b'flask_cache_view//dashboards/user', b'y')
+
+        info = self._adapter(redis_client).info()
+        assert info['currsize'] == 2
+        groups = info['extras']['groups']
+        assert groups['directory_access']['entries'] == 1
+        assert groups['other']['entries'] == 1
+
+    def test_str_keys_also_skipped(self):
+        """decode_responses=True clients hand back str keys — same skip."""
+        client = fakeredis.FakeRedis(decode_responses=True)
+        client.set('jobs:notpickled', 'v')
+        client.set('chart:pace_chart:abc', '<svg/>')
+        client.set('flask_cache_view//api/v1/project_access/p', 'x')
+
+        info = self._adapter(client).info()
+        assert info['currsize'] == 1
+        assert info['extras']['groups']['project_access']['entries'] == 1
+        assert info['extras']['groups']['other']['entries'] == 0

--- a/tests/unit/test_redis_cache.py
+++ b/tests/unit/test_redis_cache.py
@@ -116,6 +116,80 @@ class TestRedisTTLAdapter:
 
 
 # ---------------------------------------------------------------------------
+# Name-derived prefixes (retirement of the shared 'usage:' default)
+# ---------------------------------------------------------------------------
+
+class TestDerivedPrefixes:
+    """Every adapter must own a distinct keyspace derived from its name.
+
+    Guards both the adapter default (``prefix`` falls back to ``f'{name}:'``)
+    and the factory call sites — a reintroduced shared prefix would resurrect
+    the cross-wipe bug where ``clear('usage')`` deleted fs_scans entries.
+    """
+
+    def test_default_prefix_derives_from_name(self, redis_client):
+        adapter = RedisTTLAdapter(name='somecache', client=redis_client, ttl=60)
+        assert adapter.info()['extras']['prefix'] == 'somecache:'
+
+    def test_explicit_prefix_overrides_derived_default(self, redis_client):
+        adapter = RedisTTLAdapter(
+            name='somecache', client=redis_client, ttl=60, prefix='x:',
+        )
+        assert adapter.info()['extras']['prefix'] == 'x:'
+
+    def test_fs_scans_bucket_prefixes(self, monkeypatch, redis_client):
+        monkeypatch.setenv('CACHE_REDIS_URL', 'redis://fake:6379/0')
+        import webapp.disk_scans.cache as dc
+        monkeypatch.setattr(dc, 'make_redis_client', lambda url=None, **kw: redis_client)
+        saved = dict(dc._adapters)
+        dc._adapters.clear()
+        try:
+            for bucket, expected in (('default', 'fs_scans:'),
+                                     ('filtered', 'fs_scans_filtered:')):
+                adapter = dc.get_cache_adapter(bucket)
+                assert isinstance(adapter, RedisTTLAdapter)
+                assert adapter.info()['extras']['prefix'] == expected
+        finally:
+            dc._adapters.clear()
+            dc._adapters.update(saved)
+
+    def test_jobs_bucket_prefixes(self, monkeypatch, redis_client):
+        monkeypatch.setenv('CACHE_REDIS_URL', 'redis://fake:6379/0')
+        import webapp.jobs.cache as jc
+        monkeypatch.setattr(jc, 'make_redis_client', lambda url=None, **kw: redis_client)
+        saved = dict(jc._adapters)
+        jc._adapters.clear()
+        try:
+            for bucket, expected in (('historical', 'jobs:'),
+                                     ('recent', 'jobs_recent:')):
+                adapter = jc.get_cache_adapter(bucket)
+                assert isinstance(adapter, RedisTTLAdapter)
+                assert adapter.info()['extras']['prefix'] == expected
+        finally:
+            jc._adapters.clear()
+            jc._adapters.update(saved)
+
+    def test_clear_does_not_cross_wipe_other_adapters(self, redis_client):
+        """The historical bug: usage and both fs_scans buckets shared 'usage:'."""
+        usage = RedisTTLAdapter(name='allocation_usage', client=redis_client, ttl=60)
+        scans = RedisTTLAdapter(name='fs_scans', client=redis_client, ttl=60)
+        filtered = RedisTTLAdapter(name='fs_scans_filtered', client=redis_client, ttl=60)
+        usage[('k',)] = 'u'
+        scans[('k',)] = 's'
+        filtered[('k',)] = 'f'
+        # info() counts are per-adapter, not the shared superset
+        assert usage.info()['currsize'] == 1
+        assert scans.info()['currsize'] == 1
+        assert filtered.info()['currsize'] == 1
+        # clearing one adapter leaves the others intact — including the
+        # prefix-of-a-prefix pair (fs_scans: must not glob fs_scans_filtered:)
+        assert scans.clear() == 1
+        assert usage[('k',)] == 'u'
+        assert filtered[('k',)] == 'f'
+        assert ('k',) not in scans
+
+
+# ---------------------------------------------------------------------------
 # RedisChartCache
 # ---------------------------------------------------------------------------
 
@@ -225,9 +299,11 @@ class TestUsageCacheBackendSwitch:
         try:
             adapter = uc.get_cache_adapter()
             assert isinstance(adapter, RedisTTLAdapter)
+            assert adapter.info()['extras']['prefix'] == 'allocation_usage:'
             # Verify it actually uses the fake client.
             adapter[('k',)] = 'v'
-            assert client.exists(b'usage:' + __import__('pickle').dumps(('k',), protocol=4))
+            assert client.exists(
+                b'allocation_usage:' + __import__('pickle').dumps(('k',), protocol=4))
         finally:
             uc._adapter = None
             uc._disabled = False

--- a/tests/unit/test_user_former_projects.py
+++ b/tests/unit/test_user_former_projects.py
@@ -1,0 +1,126 @@
+"""Tests for User.former_projects() and its user-card rendering gate.
+
+Model-layer tests build a fresh membership graph with factories (Layer 2).
+The HTTP tests follow the house convention (auth/render smoke only) and
+rely solely on committed snapshot rows — Flask routes read a separate
+db.session connection and cannot see factory rows (see
+tests/unit/test_htmx_search_active_toggle.py).
+"""
+import pytest
+from datetime import datetime, timedelta
+
+from sam.manage import add_user_to_project
+
+from factories import make_account, make_project, make_user
+
+pytestmark = pytest.mark.unit
+
+SECTION_LABEL = 'Inactive / Former Projects'
+
+
+def _project_with_account(session, **project_kwargs):
+    project = make_project(session, **project_kwargs)
+    make_account(session, project=project)
+    return project
+
+
+class TestFormerProjects:
+    """User.former_projects() bucket semantics."""
+
+    def test_current_membership_is_not_former(self, session):
+        user = make_user(session)
+        project = _project_with_account(session)
+        add_user_to_project(session, project.project_id, user.user_id)
+
+        former = user.former_projects()
+        assert former == {'inactive': [], 'ended': []}
+        assert project in user.active_projects()
+
+    def test_ended_membership_on_active_project(self, session):
+        user = make_user(session)
+        project = _project_with_account(session)
+        add_user_to_project(
+            session, project.project_id, user.user_id,
+            start_date=datetime.now() - timedelta(days=400),
+            end_date=datetime.now() - timedelta(days=30),
+        )
+
+        former = user.former_projects()
+        assert former['ended'] == [project]
+        assert former['inactive'] == []
+        assert project not in user.active_projects()
+
+    def test_membership_on_inactive_project(self, session):
+        user = make_user(session)
+        project = _project_with_account(session, active=False)
+        add_user_to_project(session, project.project_id, user.user_id)
+
+        former = user.former_projects()
+        assert former['inactive'] == [project]
+        assert former['ended'] == []
+
+    def test_led_inactive_project_without_account_rows(self, session):
+        """A lead with no AccountUser rows still sees the inactive project
+        (covers the User.all_projects gap for accountless projects)."""
+        user = make_user(session)
+        project = make_project(session, lead=user, active=False)
+
+        former = user.former_projects()
+        assert former['inactive'] == [project]
+        assert former['ended'] == []
+
+    def test_buckets_sorted_by_projcode_and_disjoint(self, session):
+        user = make_user(session)
+        active_proj = _project_with_account(session)
+        add_user_to_project(session, active_proj.project_id, user.user_id)
+
+        inactive = [_project_with_account(session, active=False) for _ in range(2)]
+        for p in inactive:
+            add_user_to_project(session, p.project_id, user.user_id)
+
+        ended = [_project_with_account(session) for _ in range(2)]
+        for p in ended:
+            add_user_to_project(
+                session, p.project_id, user.user_id,
+                start_date=datetime.now() - timedelta(days=400),
+                end_date=datetime.now() - timedelta(days=30),
+            )
+
+        former = user.former_projects()
+        assert former['inactive'] == sorted(inactive, key=lambda p: p.projcode)
+        assert former['ended'] == sorted(ended, key=lambda p: p.projcode)
+        assert active_proj not in former['inactive'] + former['ended']
+
+    def test_as_of_reclassifies_ended_membership(self, session):
+        """Before the membership's end_date the project is active, not former."""
+        user = make_user(session)
+        project = _project_with_account(session)
+        end = datetime.now() - timedelta(days=30)
+        add_user_to_project(
+            session, project.project_id, user.user_id,
+            start_date=datetime.now() - timedelta(days=400),
+            end_date=end,
+        )
+
+        as_of = end - timedelta(days=1)
+        former = user.former_projects(as_of=as_of)
+        assert former == {'inactive': [], 'ended': []}
+        assert project in user.active_projects(as_of=as_of)
+
+
+class TestUserCardFormerProjectsGate:
+    """Render/authz smoke for the user-card section (snapshot rows only)."""
+
+    def test_admin_user_card_renders(self, auth_client):
+        """benkirk (full perms) gets the card; section presence depends on
+        snapshot data, so assert only a clean render."""
+        resp = auth_client.get('/admin/user/benkirk')
+        assert resp.status_code == 200
+        assert b'Active Projects' in resp.data
+
+    def test_own_info_page_omits_section(self, auth_client):
+        """/user/info renders the shared macro with is_admin=False — the
+        operator-only section must not appear even for a full-perm user."""
+        resp = auth_client.get('/user/info')
+        assert resp.status_code == 200
+        assert SECTION_LABEL.encode() not in resp.data

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -574,9 +574,8 @@ def test_jobs_fragment_renders_rows_when_enabled(
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
     assert '12345.desched1' in body
-    # 'user' is not a default column on the per-job table (the drill-down
-    # row already pins user/queue), so benkirk appears in the verbose-row
-    # drawer instead of the main table.
+    # A single-page single-user result suppresses the User column, so
+    # benkirk surfaces via the `user:` header badge instead.
     assert 'benkirk' in body
     # Disabled banner must NOT be present on the enabled path.
     assert 'Per-job data is unavailable' not in body
@@ -2632,3 +2631,327 @@ def test_my_jobs_tab_visibility_follows_machines(app, auth_client, monkeypatch):
     _install_mock_plugin(app, monkeypatch, machines=('derecho',))
     resp = auth_client.get('/user/accounts')
     assert '/user/jobs' in resp.get_data(as_text=True)
+
+
+# ---------------------------------------------------------------------------
+# UX round 3: owner-tier histogram drill, User column, metric-ranked usage
+# ---------------------------------------------------------------------------
+
+def _sample_hist_owners(dimension='wait'):
+    """_sample_hist plus per-bucket owners (plugin owners_limit envelope).
+
+    Bucket '<1m' (10 jobs): alice 6 jobs / 30 cpu-h, bob 3 jobs / 70 cpu-h
+    → ranked alice-first on the jobs metric, bob-first on cpu_hours; 1 job
+    unattributed (the "Other users" remainder row).
+    Bucket '1-5m' (4 jobs): carol owns everything → single-owner shortcut.
+    """
+    h = _sample_hist(dimension)
+    h['buckets'][0]['owners'] = {
+        'alice': {'job_count': 6, 'cpu_hours': 30.0, 'gpu_hours': 0.0},
+        'bob':   {'job_count': 3, 'cpu_hours': 70.0, 'gpu_hours': 0.0},
+    }
+    h['buckets'][1]['owners'] = {
+        'carol': {'job_count': 4, 'cpu_hours': 40.0, 'gpu_hours': 1.0},
+    }
+    return h
+
+
+def _get_hist_body(app, auth_client, active_project, monkeypatch, query=''):
+    _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist_owners(),
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times'
+        f'?machine=derecho{query}'
+    )
+    assert resp.status_code == 200
+    return resp.get_data(as_text=True)
+
+
+def test_histogram_bucket_renders_owner_table(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Multi-owner band expands to a per-user tier ranked by the active
+    metric (jobs default → alice first; cpu_hours → bob first)."""
+    body = _get_hist_body(app, auth_client, active_project, monkeypatch)
+    assert 'alice' in body and 'bob' in body
+    assert '-b0-u1-row' in body and '-b0-u2-row' in body
+    assert body.index('alice') < body.index('bob')
+
+    body_cpu = _get_hist_body(app, auth_client, active_project, monkeypatch,
+                              query='&metric=cpu_hours')
+    assert body_cpu.index('bob') < body_cpu.index('alice')
+
+
+def test_histogram_owner_drill_appends_user(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Each owner row lazy-loads the band's jobs fragment with the band
+    bounds AND the username appended."""
+    import re
+    body = _get_hist_body(app, auth_client, active_project, monkeypatch)
+    m = re.search(r'id="[^"]*-b0-u1-content"\s+hx-get="([^"]+)"', body)
+    assert m, 'owner drill div missing'
+    url = m.group(1).replace('&amp;', '&')
+    assert 'min_eligible_secs=0' in url
+    assert 'max_eligible_secs=59' in url
+    assert 'user=alice' in url
+    assert 'machine=derecho' in url
+    assert 'target_id=' in url
+    # Owner drills bind to the Bootstrap collapse event, never click.
+    assert 'shown.bs.collapse' in body
+
+
+def test_histogram_owner_remainder_row(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Owners summing below the band totals → a muted, non-drillable
+    "Other users" row."""
+    body = _get_hist_body(app, auth_client, active_project, monkeypatch)
+    assert 'Other users' in body
+    assert 'beyond top 2' in body
+
+
+def test_histogram_single_owner_shortcut(
+    app, auth_client, active_project, monkeypatch,
+):
+    """A band wholly owned by one user skips the per-user tier and drills
+    straight to their jobs."""
+    import re
+    body = _get_hist_body(app, auth_client, active_project, monkeypatch)
+    assert '-b1-u1-row' not in body
+    m = re.search(r'id="[^"]*-b1-content"\s+hx-get="([^"]+)"', body)
+    assert m, 'single-owner drill div missing'
+    assert 'user=carol' in m.group(1).replace('&amp;', '&')
+
+
+def test_histogram_no_details_wrapper(
+    app, auth_client, active_project, monkeypatch,
+):
+    """The bucket table is always visible now — no <details> wrapper."""
+    body = _get_hist_body(app, auth_client, active_project, monkeypatch)
+    assert '<details' not in body
+    assert 'Bucket breakdown' in body
+
+
+def test_histogram_collapse_rows_no_persist(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Histogram collapse rows opt out of nav-view-persistence — a restored
+    auto-expand would re-fire the lazy drill fetches on every reload."""
+    body = _get_hist_body(app, auth_client, active_project, monkeypatch)
+    assert 'data-no-persist' in body
+
+
+def test_histogram_ownerless_fallback_keeps_single_level(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Owner-less envelope (older plugin / cached) renders the original
+    band → jobs drill with no per-user tier."""
+    import re
+    _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist(),
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times'
+        f'?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    assert re.search(r'id="[^"]*-b0-content"\s+hx-get="', body)
+    assert '-b0-u1-row' not in body
+
+
+def test_histogram_owners_limit_forwarded(
+    app, auth_client, active_project, monkeypatch,
+):
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist_owners(),
+    )
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times'
+        f'?machine=derecho'
+    )
+    _dim, kwargs = captured['last_jobs_histogram']
+    assert kwargs['owners_limit'] == 10
+
+
+# --- User column ------------------------------------------------------------
+
+def test_user_column_structure():
+    """`user` is a default (sortable) column and no longer a drawer extra."""
+    from webapp.jobs.routes import _DEFAULT_COLS, _VERBOSE_EXTRAS, \
+        _SORT_WHITELIST
+    assert 'user' in _DEFAULT_COLS
+    assert 'user' in _SORT_WHITELIST
+    assert 'user' not in _VERBOSE_EXTRAS
+
+
+def _two_user_rows():
+    return [
+        _make_row(job_id='600.desched1', user='alice'),
+        _make_row(job_id='601.desched1', user='zed'),
+    ]
+
+
+def test_user_column_visible_with_multiple_users(
+    app, auth_client, active_project, monkeypatch,
+):
+    _install_mock_plugin(
+        app, monkeypatch, jobs_search_return=_two_user_rows(),
+    )
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'sort_by=user' in body           # sortable header rendered
+    assert 'alice' in body and 'zed' in body
+
+
+def test_user_column_hidden_with_user_filter(
+    app, auth_client, active_project, monkeypatch,
+):
+    rows = [_make_row(job_id='600.desched1', user='alice')]
+    _install_mock_plugin(app, monkeypatch, jobs_search_return=rows)
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}'
+        f'?machine=derecho&user=alice'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'sort_by=user' not in body
+    # The pin is already surfaced by the user: filter badge — no user_badge.
+    assert 'user: alice' in body
+
+
+def test_user_column_hidden_in_user_mode(app, auth_client, monkeypatch):
+    _install_mock_plugin(
+        app, monkeypatch,
+        jobs_search_return=[_make_row(job_id='600.desched1', user='benkirk')],
+    )
+    resp = auth_client.get('/dashboards/user/jobs/user/derecho?machine=derecho')
+    body = resp.get_data(as_text=True)
+    assert 'sort_by=user' not in body
+
+
+def test_user_column_hidden_uniform_single_page_shows_badge(
+    app, auth_client, active_project, monkeypatch,
+):
+    """No pin, no filter, but the whole (single-page) result is one user →
+    column suppressed and the username surfaces as a header badge."""
+    rows = [_make_row(job_id='600.desched1', user='solo'),
+            _make_row(job_id='601.desched1', user='solo')]
+    _install_mock_plugin(app, monkeypatch, jobs_search_return=rows)
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'sort_by=user' not in body
+    assert 'user: solo' in body
+
+
+def test_user_column_kept_uniform_but_multipage(
+    app, auth_client, active_project, monkeypatch,
+):
+    """A uniform PAGE of a multi-page result proves nothing — the column
+    stays rather than paying a distinct-count query."""
+    rows = [_make_row(job_id='600.desched1', user='solo')]
+    _install_mock_plugin(app, monkeypatch, jobs_search_return=rows,
+                         jobs_count_return=500)
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'sort_by=user' in body
+    assert 'user: solo' not in body
+
+
+def test_user_sort_forwarded(
+    app, auth_client, active_project, monkeypatch,
+):
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_search_return=_two_user_rows(),
+    )
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}'
+        f'?machine=derecho&sort_by=user&sort_dir=asc'
+    )
+    kw = captured['last_jobs_search_kwargs']
+    assert kw['sort_by'] == 'user'
+    assert kw['sort_dir'] == 'asc'
+
+
+def test_name_column_truncates(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Long job names must not widen the column: ellipsis truncation with
+    the full name on the title tooltip."""
+    long_name = 'a_very_long_job_name_' + 'x' * 100
+    rows = [_make_row(job_id='600.desched1', user='alice', name=long_name),
+            _make_row(job_id='601.desched1', user='zed')]
+    _install_mock_plugin(app, monkeypatch, jobs_search_return=rows)
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+    )
+    body = resp.get_data(as_text=True)
+    assert 'max-width: 35ch' in body
+    assert 'text-truncate' in body
+    assert f'title="{long_name}"' in body
+
+
+# --- Metric-ranked By User / By Project -------------------------------------
+
+def test_by_user_fragment_threads_metric_sort(
+    app, auth_client, active_project, monkeypatch,
+):
+    """The metric pill decides the plugin ranking (and thus which top-N
+    survives) — the Derecho GPU-Hours one-user bug."""
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_usage_by_return=_sample_usage(),
+    )
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/by-user'
+        f'?machine=derecho'
+    )
+    _dim, kwargs = captured['last_jobs_usage_by']
+    assert kwargs['sort_by'] == 'cpu_hours'     # _DEFAULT_METRIC_PIE
+
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/by-user'
+        f'?machine=derecho&metric=gpu_hours'
+    )
+    _dim, kwargs = captured['last_jobs_usage_by']
+    assert kwargs['sort_by'] == 'gpu_hours'
+
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/by-user'
+        f'?machine=derecho&metric=jobs'
+    )
+    _dim, kwargs = captured['last_jobs_usage_by']
+    assert kwargs['sort_by'] == 'job_count'
+
+
+def test_by_project_fragment_threads_metric_sort(app, auth_client, monkeypatch):
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_usage_by_return=_sample_usage(),
+    )
+    auth_client.get(
+        '/dashboards/user/jobs/user/derecho/by-project'
+        '?machine=derecho&metric=gpu_hours'
+    )
+    _dim, kwargs = captured['last_jobs_usage_by']
+    assert _dim == 'account'
+    assert kwargs['sort_by'] == 'gpu_hours'
+
+
+def test_by_user_sort_indicator_follows_metric(
+    app, auth_client, active_project, monkeypatch,
+):
+    """The initial client-sort indicator sits on the active metric column."""
+    _install_mock_plugin(app, monkeypatch, jobs_usage_by_return=_sample_usage())
+    body = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/by-user'
+        f'?machine=derecho&metric=gpu_hours'
+    ).get_data(as_text=True)
+    import re
+    gpu_th = re.search(r'<th[^>]*sort-desc[^>]*>GPU-hours</th>', body)
+    assert gpu_th, 'sort-desc must sit on the GPU-hours header'
+    assert not re.search(r'<th[^>]*sort-desc[^>]*>CPU-hours</th>', body)

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -2937,6 +2937,126 @@ def test_histogram_owners_limit_and_sort_forwarded(
     assert kwargs['owners_sort_by'] == 'gpu_hours'
 
 
+# --- Histogram User|Project owner pill (owners_by) --------------------------
+
+def _sample_hist_project_owners(dimension='wait'):
+    """Owner keys are projcodes — the plugin owners_by='account' envelope.
+    Same numeric shape as _sample_hist_owners."""
+    h = _sample_hist(dimension)
+    h['buckets'][0]['owners'] = {
+        'SCSG0001': {'job_count': 6, 'cpu_hours': 30.0, 'gpu_hours': 0.0},
+        'UABC0002': {'job_count': 3, 'cpu_hours': 70.0, 'gpu_hours': 0.0},
+    }
+    h['buckets'][1]['owners'] = {
+        'SCSG0001': {'job_count': 4, 'cpu_hours': 40.0, 'gpu_hours': 1.0},
+    }
+    return h
+
+
+def test_histogram_owner_pill_offered_in_machine_mode(
+    app, auth_client, monkeypatch,
+):
+    _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist_owners(),
+    )
+    body = auth_client.get(
+        '/dashboards/user/jobs/machine/derecho/wait-times'
+    ).get_data(as_text=True)
+    assert 'aria-label="Owner dimension"' in body
+    assert 'owners_by=account' in body
+
+
+def test_histogram_owner_pill_hidden_in_user_mode_and_param_ignored(
+    app, auth_client, monkeypatch,
+):
+    """User mode never offers the pill, and a crafted ?owners_by=account
+    is ignored (not forwarded to the plugin)."""
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist_owners(),
+    )
+    body = auth_client.get(
+        '/dashboards/user/jobs/user/derecho/wait-times?owners_by=account'
+    ).get_data(as_text=True)
+    assert 'aria-label="Owner dimension"' not in body
+    _dim, kwargs = captured['last_jobs_histogram']
+    assert 'owners_by' not in kwargs
+
+
+def test_histogram_owner_pill_follows_project_tree_size(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Project mode offers the pill iff the account tree spans >1
+    projcode — same gate as the By Project tab."""
+    _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist_owners(),
+    )
+    body = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times'
+        '?machine=derecho'
+    ).get_data(as_text=True)
+    multi = len(active_project.get_descendants(include_self=True)) > 1
+    assert ('aria-label="Owner dimension"' in body) == multi
+
+
+def test_histogram_owners_by_forwarded_only_when_account(
+    app, auth_client, monkeypatch,
+):
+    """Soft degradation contract: the default never sends owners_by (an
+    older plugin keeps working); the Project pill sends 'account'."""
+    captured = _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist_project_owners(),
+    )
+    auth_client.get('/dashboards/user/jobs/machine/derecho/wait-times')
+    _dim, kwargs = captured['last_jobs_histogram']
+    assert 'owners_by' not in kwargs
+
+    auth_client.get(
+        '/dashboards/user/jobs/machine/derecho/wait-times?owners_by=account')
+    _dim, kwargs = captured['last_jobs_histogram']
+    assert kwargs['owners_by'] == 'account'
+
+
+def test_histogram_account_owner_tier_and_drill(
+    app, auth_client, monkeypatch,
+):
+    """The Project pill drives the whole drill: Project tier header,
+    project-modal triggers on owner cells, account= (not user=) on the
+    per-owner jobs drill, 'Other projects' remainder, and the owners_by
+    round-trip hidden input for the metric pills."""
+    import re
+    _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist_project_owners(),
+    )
+    body = auth_client.get(
+        '/dashboards/user/jobs/machine/derecho/wait-times?owners_by=account'
+    ).get_data(as_text=True)
+    assert '<th>Project</th>' in body
+    assert 'Other projects' in body
+    assert 'project-details-modal/SCSG0001' in body
+    assert 'name="owners_by" value="account"' in body
+    m = re.search(r'id="[^"]*-b0-u1-content"\s+hx-get="([^"]+)"', body)
+    assert m, 'owner drill div missing'
+    url = m.group(1).replace('&amp;', '&')
+    assert 'account=SCSG0001' in url
+    assert 'user=' not in url
+
+
+def test_histogram_user_owner_cells_offer_user_modal(
+    app, auth_client, monkeypatch,
+):
+    """Under the default User pill the owner tier's usernames carry the
+    same quick-view modal affordance as the By User table (VIEW_USERS
+    gate)."""
+    _install_mock_plugin(
+        app, monkeypatch, jobs_histogram_return=_sample_hist_owners(),
+    )
+    body = auth_client.get(
+        '/dashboards/user/jobs/machine/derecho/wait-times'
+    ).get_data(as_text=True)
+    assert 'data-bs-target="#userDetailsModal"' in body
+    assert '/admin/user/alice' in body
+
+
 # --- User column ------------------------------------------------------------
 
 def test_user_column_structure():

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -2843,15 +2843,21 @@ def test_user_column_hidden_in_user_mode(app, auth_client, monkeypatch):
 
 
 def test_user_column_hidden_uniform_single_page_shows_badge(
-    app, auth_client, active_project, monkeypatch,
+    app, auth_client, monkeypatch,
 ):
     """No pin, no filter, but the whole (single-page) result is one user →
-    column suppressed and the username surfaces as a header badge."""
+    column suppressed and the username surfaces as a header badge.
+
+    Machine mode: its count path always uses the mocked plugin
+    jobs_count. Project mode's unfiltered count takes the SAM-summary
+    fast path (a real comp_charge_summary query), so the single-page
+    premise couldn't be pinned there.
+    """
     rows = [_make_row(job_id='600.desched1', user='solo'),
             _make_row(job_id='601.desched1', user='solo')]
     _install_mock_plugin(app, monkeypatch, jobs_search_return=rows)
     resp = auth_client.get(
-        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+        '/dashboards/user/jobs/machine/derecho?machine=derecho'
     )
     body = resp.get_data(as_text=True)
     assert 'sort_by=user' not in body
@@ -2859,7 +2865,7 @@ def test_user_column_hidden_uniform_single_page_shows_badge(
 
 
 def test_user_column_kept_uniform_but_multipage(
-    app, auth_client, active_project, monkeypatch,
+    app, auth_client, monkeypatch,
 ):
     """A uniform PAGE of a multi-page result proves nothing — the column
     stays rather than paying a distinct-count query."""
@@ -2867,7 +2873,7 @@ def test_user_column_kept_uniform_but_multipage(
     _install_mock_plugin(app, monkeypatch, jobs_search_return=rows,
                          jobs_count_return=500)
     resp = auth_client.get(
-        f'/dashboards/user/jobs/{active_project.projcode}?machine=derecho'
+        '/dashboards/user/jobs/machine/derecho?machine=derecho'
     )
     body = resp.get_data(as_text=True)
     assert 'sort_by=user' in body

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -2046,7 +2046,8 @@ def test_histogram_fragment_metric_pill_roundtrip(
 # Commit 6: machine-wide family (operator) + explorer pages + Status tab
 # ---------------------------------------------------------------------------
 
-_MACHINE_FRAGMENTS = ['', '/by-user', '/wait-times', '/job-sizes', '/durations']
+_MACHINE_FRAGMENTS = ['', '/by-user', '/by-project', '/wait-times',
+                      '/job-sizes', '/durations']
 
 
 @pytest.mark.parametrize('suffix', _MACHINE_FRAGMENTS + ['/explore'])
@@ -2094,6 +2095,47 @@ def test_machine_by_user_fragment_unscoped(app, auth_client, monkeypatch):
     assert 'data-job-user="alice"' in resp.get_data(as_text=True)
     _dim, kwargs = captured['last_jobs_usage_by']
     assert 'account' not in kwargs
+
+
+def test_machine_by_project_fragment_unscoped(app, auth_client, monkeypatch):
+    """Machine-wide By Project: dimension 'account', no user pin, no
+    account scoping; rows drill into the machine jobs fragment narrowed
+    by account=."""
+    captured = _install_mock_plugin(app, monkeypatch,
+                                    jobs_usage_by_return=_PROJECT_USAGE)
+    resp = auth_client.get('/dashboards/user/jobs/machine/derecho/by-project')
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    dim, kwargs = captured['last_jobs_usage_by']
+    assert dim == 'account'
+    assert kwargs.get('user') is None      # no pin (filter dict carries None)
+    assert 'account' not in kwargs
+    assert 'data-job-project="SCSG0001"' in body
+    assert ('/dashboards/user/jobs/machine/derecho'
+            '?machine=derecho&account=SCSG0001') in body
+
+
+def test_machine_by_project_threads_metric_sort(app, auth_client, monkeypatch):
+    captured = _install_mock_plugin(app, monkeypatch,
+                                    jobs_usage_by_return=_PROJECT_USAGE)
+    auth_client.get(
+        '/dashboards/user/jobs/machine/derecho/by-project?metric=gpu_hours')
+    _dim, kwargs = captured['last_jobs_usage_by']
+    assert kwargs['sort_by'] == 'gpu_hours'
+
+
+def test_machine_jobs_fragment_account_narrows(app, auth_client, monkeypatch):
+    """?account= narrows the machine-wide table (the By Project drill) —
+    rows and count both see it, and it surfaces as the project: badge."""
+    captured = _install_mock_plugin(app, monkeypatch,
+                                    jobs_search_return=[_make_row()],
+                                    jobs_count_return=1)
+    resp = auth_client.get(
+        '/dashboards/user/jobs/machine/derecho?account=SCSG0001')
+    assert resp.status_code == 200
+    assert captured['last_jobs_search_kwargs']['account'] == 'SCSG0001'
+    assert captured['last_jobs_count_kwargs']['account'] == 'SCSG0001'
+    assert 'project: SCSG0001' in resp.get_data(as_text=True)
 
 
 def test_machine_histogram_fragment_unscoped(app, auth_client, monkeypatch):
@@ -2559,6 +2601,116 @@ def test_project_fragment_ignores_client_account_param(
     assert skw['account'] == [active_project.projcode] or \
         active_project.projcode in skw['account']
     assert 'EVIL0001' not in skw['account']
+
+
+def test_project_by_project_fragment_scoped_to_tree(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Project-mode By Project: dimension 'account' scoped by the
+    server-derived tree list, no user pin; rows drill into the
+    project-mode jobs fragment narrowed by account=."""
+    captured = _install_mock_plugin(app, monkeypatch,
+                                    jobs_usage_by_return=_PROJECT_USAGE)
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/by-project'
+        '?machine=derecho'
+    )
+    assert resp.status_code == 200
+    dim, kwargs = captured['last_jobs_usage_by']
+    assert dim == 'account'
+    assert kwargs.get('user') is None      # tree scoping, no user pin
+    assert active_project.projcode in kwargs['account']
+    assert (f'/dashboards/user/jobs/{active_project.projcode}'
+            '?machine=derecho&account=SCSG0001') in resp.get_data(as_text=True)
+
+
+def test_project_fragment_intree_account_narrows(
+    app, auth_client, active_project, monkeypatch,
+):
+    """An in-tree ?account= narrows the project table to that projcode
+    (the parent-project By Project drill) and surfaces as the badge —
+    the complement of test_project_fragment_ignores_client_account_param,
+    which pins that out-of-tree values stay ignored."""
+    captured = _install_mock_plugin(app, monkeypatch)
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}'
+        f'?machine=derecho&account={active_project.projcode}'
+    )
+    assert resp.status_code == 200
+    skw = captured['last_jobs_search_kwargs']
+    assert skw['account'] == [active_project.projcode]
+    assert f'project: {active_project.projcode}' in resp.get_data(as_text=True)
+
+
+def test_status_job_history_card_offers_both_tabs(app, auth_client, monkeypatch):
+    """Machine mode renders BOTH By User and By Project tabs."""
+    _install_mock_plugin(app, monkeypatch, machines=('derecho',))
+    body = auth_client.get('/status/job-history').get_data(as_text=True)
+    assert 'By User' in body
+    assert 'By Project' in body
+    assert '/dashboards/user/jobs/machine/derecho/by-project' in body
+
+
+def test_resource_details_modal_shells_and_by_project_gate(
+    app, auth_client, active_project, monkeypatch,
+):
+    """The project-mode host page carries both entity-modal shells (it
+    extends dashboards/base.html, which includes neither), and the By
+    Project tab renders only when the account tree spans >1 projcode."""
+    _install_mock_plugin(app, monkeypatch)
+    resp = auth_client.get(
+        f'/user/resource-details/{active_project.projcode}?resource=Derecho')
+    if resp.status_code != 200:
+        return  # snapshot doesn't have this resource — nothing to check
+    body = resp.get_data(as_text=True)
+    assert 'id="userDetailsModal"' in body
+    assert 'id="projectDetailsModal"' in body
+    multi = len(active_project.get_descendants(include_self=True)) > 1
+    assert (f'/dashboards/user/jobs/{active_project.projcode}/by-project'
+            in body) == multi
+
+
+def test_by_user_username_links_open_user_modal(app, auth_client, monkeypatch):
+    """With VIEW_USERS, usernames become quick-view modal triggers."""
+    _install_mock_plugin(app, monkeypatch, jobs_usage_by_return=_sample_usage())
+    body = auth_client.get(
+        '/dashboards/user/jobs/machine/derecho/by-user').get_data(as_text=True)
+    assert 'data-bs-target="#userDetailsModal"' in body
+    assert '/admin/user/alice' in body
+
+
+def test_by_user_no_modal_affordance_without_view_users(
+    app, client, session, multi_project_user, monkeypatch,
+):
+    """A project member without VIEW_USERS gets plain <code> usernames —
+    no affordance that would 403 at the user_card route."""
+    _install_mock_plugin(app, monkeypatch, jobs_usage_by_return=_sample_usage())
+    with client.session_transaction() as sess_data:
+        sess_data['_user_id'] = str(multi_project_user.user_id)
+        sess_data['_fresh'] = True
+    resp = None
+    for proj in multi_project_user.projects:
+        resp = client.get(
+            f'/dashboards/user/jobs/{proj.projcode}/by-user?machine=derecho')
+        if resp.status_code == 200:
+            break
+    else:
+        pytest.skip('snapshot member user has no accessible project')
+    body = resp.get_data(as_text=True)
+    assert 'data-job-user="alice"' in body      # rows render fine
+    assert 'userDetailsModal' not in body       # affordance suppressed
+
+
+def test_by_project_projcode_links_open_project_modal(
+    app, auth_client, monkeypatch,
+):
+    """User mode always renders the project quick-view affordance — the
+    rows are the pinned user's own projects."""
+    _install_mock_plugin(app, monkeypatch, jobs_usage_by_return=_PROJECT_USAGE)
+    body = auth_client.get(
+        '/dashboards/user/jobs/user/derecho/by-project').get_data(as_text=True)
+    assert 'data-bs-target="#projectDetailsModal"' in body
+    assert 'project-details-modal/SCSG0001' in body
 
 
 def test_my_jobs_card_offers_by_project_tab(app, auth_client, monkeypatch):

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -2761,9 +2761,11 @@ def test_histogram_ownerless_fallback_keeps_single_level(
     assert '-b0-u1-row' not in body
 
 
-def test_histogram_owners_limit_forwarded(
+def test_histogram_owners_limit_and_sort_forwarded(
     app, auth_client, active_project, monkeypatch,
 ):
+    """owners_limit rides every histogram call, and owners_sort_by follows
+    the metric pill — which top-N survives must match what's displayed."""
     captured = _install_mock_plugin(
         app, monkeypatch, jobs_histogram_return=_sample_hist_owners(),
     )
@@ -2773,6 +2775,14 @@ def test_histogram_owners_limit_forwarded(
     )
     _dim, kwargs = captured['last_jobs_histogram']
     assert kwargs['owners_limit'] == 10
+    assert kwargs['owners_sort_by'] == 'job_count'   # _DEFAULT_METRIC_HIST
+
+    auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times'
+        f'?machine=derecho&metric=gpu_hours'
+    )
+    _dim, kwargs = captured['last_jobs_histogram']
+    assert kwargs['owners_sort_by'] == 'gpu_hours'
 
 
 # --- User column ------------------------------------------------------------

--- a/tests/unit/test_webapp_jobs_cache.py
+++ b/tests/unit/test_webapp_jobs_cache.py
@@ -369,6 +369,33 @@ def test_service_jobs_usage_by_project_forwards_sort(app, monkeypatch):
     assert kwargs['user'] == 'benkirk'
 
 
+def test_service_jobs_usage_by_project_scopes_in_key_and_forwarded(
+    app, monkeypatch,
+):
+    """The non-user-mode scopes: account_projcodes reaches the plugin as
+    ``account`` and discriminates the cache key; the unpinned machine-mode
+    call sends neither ``user`` nor ``account``. Different scopes must
+    never satisfy each other from cache."""
+    from webapp.jobs import cache as c, service
+    c._adapters.clear()
+
+    captured = _install_agg_plugin(app, monkeypatch)
+    win = {'start': date(2026, 6, 1), 'end': date(2026, 6, 30)}
+
+    with app.app_context():
+        service.jobs_usage_by_project('derecho', **win)                 # machine
+        service.jobs_usage_by_project('derecho', **win)                 # cached
+        service.jobs_usage_by_project(
+            'derecho', account_projcodes=['SCSG0001', 'SCSG0002'], **win)  # tree
+
+    assert len(captured['usage_by']) == 2
+    _, machine_kwargs = captured['usage_by'][0]
+    assert machine_kwargs.get('user') is None   # unpinned (filter None)
+    assert 'account' not in machine_kwargs
+    _, tree_kwargs = captured['usage_by'][1]
+    assert tree_kwargs['account'] == ['SCSG0001', 'SCSG0002']
+
+
 def test_service_jobs_facets_caches_closed_window(app, monkeypatch):
     """Two identical closed-window facet calls → one plugin query; a
     different facet tuple or limit is a different key."""

--- a/tests/unit/test_webapp_jobs_cache.py
+++ b/tests/unit/test_webapp_jobs_cache.py
@@ -286,6 +286,65 @@ def test_service_jobs_usage_by_user_forwards_limit_and_account(app, monkeypatch)
     assert 'rows' in out and 'totals' in out
 
 
+def test_service_jobs_histogram_owners_limit_in_key_and_forwarded(app, monkeypatch):
+    """owners_limit reaches the plugin and discriminates the cache key —
+    an enriched envelope must never be served for a plain request (or
+    vice versa)."""
+    from webapp.jobs import cache as c, service
+    c._adapters.clear()
+
+    captured = _install_agg_plugin(app, monkeypatch)
+    win = {'start': date(2026, 6, 1), 'end': date(2026, 6, 30)}
+
+    with app.app_context():
+        service.jobs_histogram('derecho', 'wait', **win)
+        service.jobs_histogram('derecho', 'wait', owners_limit=10, **win)
+        service.jobs_histogram('derecho', 'wait', owners_limit=10, **win)
+
+    assert len(captured['histogram']) == 2      # 3rd call served from cache
+    _, plain_kwargs = captured['histogram'][0]
+    _, rich_kwargs = captured['histogram'][1]
+    assert 'owners_limit' not in plain_kwargs   # None → omitted entirely
+    assert rich_kwargs['owners_limit'] == 10
+
+
+def test_service_jobs_usage_by_sort_in_key_and_forwarded(app, monkeypatch):
+    """sort_by reaches the plugin and discriminates the cache key —
+    different rankings are different result sets."""
+    from webapp.jobs import cache as c, service
+    c._adapters.clear()
+
+    captured = _install_agg_plugin(app, monkeypatch)
+    win = {'start': date(2026, 6, 1), 'end': date(2026, 6, 30)}
+
+    with app.app_context():
+        service.jobs_usage_by_user('derecho', **win)
+        service.jobs_usage_by_user('derecho', sort_by='gpu_hours', **win)
+        service.jobs_usage_by_user('derecho', sort_by='gpu_hours', **win)
+
+    assert len(captured['usage_by']) == 2
+    _, default_kwargs = captured['usage_by'][0]
+    _, gpu_kwargs = captured['usage_by'][1]
+    assert 'sort_by' not in default_kwargs      # None → plugin default
+    assert gpu_kwargs['sort_by'] == 'gpu_hours'
+
+
+def test_service_jobs_usage_by_project_forwards_sort(app, monkeypatch):
+    from webapp.jobs import service
+
+    captured = _install_agg_plugin(app, monkeypatch)
+
+    with app.app_context():
+        service.jobs_usage_by_project(
+            'derecho', username='benkirk', sort_by='job_count',
+        )
+
+    dimension, kwargs = captured['usage_by'][0]
+    assert dimension == 'account'
+    assert kwargs['sort_by'] == 'job_count'
+    assert kwargs['user'] == 'benkirk'
+
+
 def test_service_jobs_facets_caches_closed_window(app, monkeypatch):
     """Two identical closed-window facet calls → one plugin query; a
     different facet tuple or limit is a different key."""

--- a/tests/unit/test_webapp_jobs_cache.py
+++ b/tests/unit/test_webapp_jobs_cache.py
@@ -332,6 +332,30 @@ def test_service_jobs_histogram_owners_sort_in_key_and_forwarded(app, monkeypatc
     assert gpu_kwargs['owners_sort_by'] == 'gpu_hours'
 
 
+def test_service_jobs_histogram_owners_by_in_key_and_forwarded(app, monkeypatch):
+    """owners_by='account' discriminates the cache key; the 'user' default
+    is normalized to the omitted form (same key, never forwarded) so a
+    pre-owners_by plugin keeps working on the default path."""
+    from webapp.jobs import cache as c, service
+    c._adapters.clear()
+
+    captured = _install_agg_plugin(app, monkeypatch)
+    win = {'start': date(2026, 6, 1), 'end': date(2026, 6, 30)}
+
+    with app.app_context():
+        service.jobs_histogram('derecho', 'wait', **win)
+        service.jobs_histogram('derecho', 'wait', owners_by='user', **win)
+        service.jobs_histogram('derecho', 'wait', owners_by='account', **win)
+        service.jobs_histogram('derecho', 'wait', owners_by='account', **win)
+
+    # call 2 aliases call 1 (explicit default == omitted); call 4 hits 3.
+    assert len(captured['histogram']) == 2
+    _, default_kwargs = captured['histogram'][0]
+    _, account_kwargs = captured['histogram'][1]
+    assert 'owners_by' not in default_kwargs
+    assert account_kwargs['owners_by'] == 'account'
+
+
 def test_service_jobs_usage_by_sort_in_key_and_forwarded(app, monkeypatch):
     """sort_by reaches the plugin and discriminates the cache key —
     different rankings are different result sets."""

--- a/tests/unit/test_webapp_jobs_cache.py
+++ b/tests/unit/test_webapp_jobs_cache.py
@@ -308,6 +308,30 @@ def test_service_jobs_histogram_owners_limit_in_key_and_forwarded(app, monkeypat
     assert rich_kwargs['owners_limit'] == 10
 
 
+def test_service_jobs_histogram_owners_sort_in_key_and_forwarded(app, monkeypatch):
+    """owners_sort_by discriminates the cache key — a jobs-ranked owner set
+    must never be served for a GPU-hours request."""
+    from webapp.jobs import cache as c, service
+    c._adapters.clear()
+
+    captured = _install_agg_plugin(app, monkeypatch)
+    win = {'start': date(2026, 6, 1), 'end': date(2026, 6, 30)}
+
+    with app.app_context():
+        service.jobs_histogram('derecho', 'wait', owners_limit=10,
+                               owners_sort_by='job_count', **win)
+        service.jobs_histogram('derecho', 'wait', owners_limit=10,
+                               owners_sort_by='gpu_hours', **win)
+        service.jobs_histogram('derecho', 'wait', owners_limit=10,
+                               owners_sort_by='gpu_hours', **win)
+
+    assert len(captured['histogram']) == 2
+    _, jobs_kwargs = captured['histogram'][0]
+    _, gpu_kwargs = captured['histogram'][1]
+    assert jobs_kwargs['owners_sort_by'] == 'job_count'
+    assert gpu_kwargs['owners_sort_by'] == 'gpu_hours'
+
+
 def test_service_jobs_usage_by_sort_in_key_and_forwarded(app, monkeypatch):
     """sort_by reaches the plugin and discriminates the cache key —
     different rankings are different result sets."""

--- a/tests/unit/test_webapp_jobs_charts.py
+++ b/tests/unit/test_webapp_jobs_charts.py
@@ -131,6 +131,96 @@ def test_histogram_count_vector_in_cache_key():
 
 
 # ---------------------------------------------------------------------------
+# generate_jobs_histogram — owner-stacked bars (plugin owners_limit envelope)
+# ---------------------------------------------------------------------------
+
+def _with_owners(h, owners_by_index):
+    """Attach an owners mapping to selected buckets of a _hist() envelope."""
+    for i, owners in owners_by_index.items():
+        h['buckets'][i]['owners'] = owners
+    return h
+
+
+def _owner(job_count, cpu, gpu=0.0):
+    return {'job_count': job_count, 'cpu_hours': cpu, 'gpu_hours': gpu}
+
+
+def test_histogram_stacked_when_owners_present():
+    plain = _hist()
+    rich = _with_owners(_hist(), {
+        0: {'alice': _owner(6, 60.0), 'bob': _owner(4, 40.0)},
+        1: {'alice': _owner(5, 50.0)},
+    })
+    svg_plain = generate_jobs_histogram(plain)
+    svg_rich = generate_jobs_histogram(rich)
+    assert '<svg' in svg_rich
+    assert svg_rich != svg_plain
+
+
+def test_histogram_owner_segments_follow_active_metric():
+    """Segments are cut in the ACTIVE metric: two envelopes with identical
+    job-count splits but different cpu splits share a jobs key and diverge
+    on the cpu_hours key."""
+    from webapp.dashboards.charts import _jobs_histogram_cache_key
+    a = _with_owners(_hist(), {
+        0: {'alice': _owner(5, 90.0), 'bob': _owner(5, 10.0)}})
+    b = _with_owners(_hist(), {
+        0: {'alice': _owner(5, 50.0), 'bob': _owner(5, 50.0)}})
+    assert _jobs_histogram_cache_key(a, metric='jobs') == \
+        _jobs_histogram_cache_key(b, metric='jobs')
+    assert _jobs_histogram_cache_key(a, metric='cpu_hours') != \
+        _jobs_histogram_cache_key(b, metric='cpu_hours')
+
+
+def test_histogram_owner_remainder_segment():
+    """Owners summing below the bucket total grow a pale base segment —
+    the beyond-top-N / NULL-user remainder — reflected in the key."""
+    from webapp.dashboards.charts import _jobs_histogram_cache_key, \
+        _jobs_bucket_segments
+    truncated = _with_owners(_hist(), {
+        0: {'alice': _owner(6, 60.0)}})     # bucket holds 10 jobs → 4 unattributed
+    assert _jobs_bucket_segments(truncated['buckets'][0], 'job_count') == \
+        [4.0, 6.0]
+    even = _with_owners(_hist(), {
+        0: {'alice': _owner(5, 50.0), 'bob': _owner(5, 50.0)}})
+    assert _jobs_bucket_segments(even['buckets'][0], 'job_count') == [5.0, 5.0]
+    assert _jobs_histogram_cache_key(truncated) != \
+        _jobs_histogram_cache_key(even)
+    assert '<svg' in generate_jobs_histogram(truncated)
+
+
+def test_histogram_segments_ascending_with_remainder_first():
+    from webapp.dashboards.charts import _jobs_bucket_segments
+    b = {'job_count': 20, 'cpu_hours': 200.0, 'gpu_hours': 0.0,
+         'owners': {'alice': _owner(9, 90.0), 'bob': _owner(3, 30.0),
+                    'carol': _owner(6, 60.0)}}
+    # remainder (20-18=2) first, then owners ascending
+    assert _jobs_bucket_segments(b, 'job_count') == [2.0, 3.0, 6.0, 9.0]
+    assert _jobs_bucket_segments({'job_count': 5}, 'job_count') == []
+
+
+def test_histogram_every_segment_carries_sentinel():
+    """A stacked bucket's segments all carry the SAME #jh-bar-<i> anchor
+    (click anywhere on the bar drills the band); a zero-job bucket stays
+    inert even in a stacked chart."""
+    rich = _with_owners(_hist(counts=(10, 5, 0)), {
+        0: {'alice': _owner(6, 60.0), 'bob': _owner(4, 40.0)},
+        1: {'alice': _owner(5, 50.0)},
+    })
+    svg = generate_jobs_histogram(rich)
+    assert svg.count('#jh-bar-0') >= 2
+    assert '#jh-bar-2' not in svg
+
+
+def test_histogram_flat_fallback_without_owners():
+    """Owner-less envelopes (older plugin / cached) keep the flat path:
+    same sentinels, renders fine."""
+    svg = generate_jobs_histogram(_hist(counts=(10, 5, 0)))
+    assert '<svg' in svg
+    assert '#jh-bar-0' in svg and '#jh-bar-2' not in svg
+
+
+# ---------------------------------------------------------------------------
 # generate_jobs_user_pie_chart
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Three work streams on one branch:

### 1. User card — former projects for operators (`ad5e112`)
Search user → user card gains an RBAC-gated second section (admin +
`VIEW_PROJECTS`) showing both **inactive projects** and **ended memberships
on active projects**, visually distinguished. New `User.former_projects()`
+ glossary entry + unit tests.

### 2. Job History UX round 3 (`ba6448d`, `2edf766`, `7d9e0cd`)
Follow-ups to #381/#382, in lockstep with plugin PR benkirk/hpc-usage-queries#100:

- **Stacked histograms** (fs_scans model): per-bucket owner-gradient bars,
  bucket table always visible, two-level **bin → users → user's-jobs** drill
  (lazy htmx, `data-no-persist`), single-owner shortcut, verbatim fallback
  for owner-less envelopes.
- **User column** in job tables — sortable (plugin FK-join ORDER BY), smartly
  suppressed when the view provably has one user (pin / filter /
  single-page-uniform, with a `user:` badge in the uniform case).
- **Job name column** capped at `max-width: 35ch` (tooltip already present).
- **Bug fix — By User / GPU-Hours showed one user**: plugin ranked by
  combined hours *before* top-25 truncation; now `sort_by` follows the active
  metric pill end-to-end (`jobs`, `cpu_hours`, `gpu_hours`), including
  per-bucket owner ranking (`owners_sort_by`).

### 3. Redis cache-prefix retirement (`87190fc`…`8c8d8d4`)
`RedisTTLAdapter` defaulted to a shared `'usage:'` prefix — allocation_usage
+ both fs_scans buckets cross-wiped on `clear('usage')`/`clear('scans')` and
blended `info()` counts. Now the prefix derives from the adapter name
(`allocation_usage:`, `fs_scans:`, `fs_scans_filtered:`, `jobs:`,
`jobs_recent:`); flask-cache introspection gets a `_FOREIGN_PREFIXES` skip
list with a cross-check test; new `scripts/cirrus_redis_purge.sh`
(dry-run default, `--yes` to FLUSHDB DB 0 — never touches the rate-limiter's
DB 1). Details: `docs/plans/REDIS_CACHE_PREFIXES.md`.

### 4. By Project everywhere multi-project + entity modals (`90e8a5d`)
The By Project aggregation extends beyond user mode: machine-mode cards get
BOTH By User and By Project tabs; parent-project resource-details cards get a
tree-scoped By Project tab (gated on the account tree spanning >1 projcode).
Row drills narrow the mode's jobs table via `account=` (machine: operator-gated
restriction; project: in-tree values only — the server tree stays the security
boundary). Username / projcode cells now pop the existing `#userDetailsModal` /
`#projectDetailsModal` quick-views, with affordances RBAC-gated so no rendered
link can 403. No plugin dependency. The histogram User|Project owners pill
(`144f2b8`, plugin #101 `owners_by`) completes the round: the Project pill
drives per-project stacked segments, bucket tiers, and `account=` drills —
soft-degrading (the kwarg is only sent when non-default), so no new deploy
lockstep.

## ⚠️ Deploy requirements (lockstep)

1. **Plugin**: SAM sends `owners_limit` / `owners_sort_by` unconditionally —
   the image must include hpc-usage-queries ≥ `04684f8` (PR #100). An older
   plugin TypeErrors on the jobs histogram (degrades to the error banner).
2. **Redis flush at deploy**: run `scripts/cirrus_redis_purge.sh --yes`
   (FLUSHDB on DB 0). Old `usage:*` keys are never read post-cutover; the
   app rebuilds caches on demand.

### Test Results

Full suite: **3304 passed, 30 skipped, 1 xfailed** (91 s, xdist).
Playwright-smoked on webdev: stacked GPU-ranked histograms, bin→user→jobs
drill, User column suppression, metric-ranked By User pills, former-projects
card. Purge script dry-run smoked read-only against nwc1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
