### PR TITLE
Job History card: time window, empty-band suppression, identifier casing; status Events tab

### DIFF
--- a/src/webapp/config.py
+++ b/src/webapp/config.py
@@ -74,7 +74,7 @@ class SAMWebappConfig(SAMConfig):
     LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO')
     LOG_FILE  = os.getenv('LOG_FILE', '')       # empty = console only
 
-    # Google Calendar embed URL (public calendar shown on reservations tab; empty = hidden)
+    # Google Calendar embed URL (public calendar shown on the Events tab; empty = hidden)
     GOOGLE_CALENDAR_EMBED_URL = os.getenv('GOOGLE_CALENDAR_EMBED_URL', '')
 
     # Status collectors tick every ~5 minutes; a snapshot older than this many

--- a/src/webapp/dashboards/status/blueprint.py
+++ b/src/webapp/dashboards/status/blueprint.py
@@ -226,15 +226,20 @@ def job_history():
     mode — the card's fragment routes are themselves VIEW_ALL_JOB_DATA-
     gated, so this page gate is the first line, not the only one.
 
-    ``jobs_window_start`` bounds every card tab to the last 90 days by
-    default: an unbounded machine-wide aggregation measures ~200 s
-    against the plugin PG vs ~0.6 s per month-window. The explorer's
-    date fields let an operator widen deliberately.
+    ``jobs_window_start`` bounds every card tab to the default window: an
+    unbounded machine-wide aggregation measures ~200 s against the plugin
+    PG vs ~0.6 s per month-window. ``jobs_window_days`` tells the card
+    which period pill to paint active; the pills (and the explorer's date
+    fields) let an operator widen deliberately.
     """
-    from datetime import date as _date
+    from webapp.jobs.service import (
+        DEFAULT_JOBS_WINDOW_DAYS,
+        default_jobs_window_start,
+    )
     return render_template(
         'dashboards/status/job_history_page.html',
-        jobs_window_start=(_date.today() - timedelta(days=90)).isoformat(),
+        jobs_window_start=default_jobs_window_start(),
+        jobs_window_days=DEFAULT_JOBS_WINDOW_DAYS,
         **_page_context(db.session),
     )
 

--- a/src/webapp/dashboards/status/blueprint.py
+++ b/src/webapp/dashboards/status/blueprint.py
@@ -69,7 +69,7 @@ def _page_context(session):
         outages=status_queries.get_active_outages(session),
         # Needed on every page: derecho/casper render per-system
         # reservation cards, and the tab strip shows/hides the
-        # Reservations tab based on it.
+        # Events tab (and its count) based on it.
         reservations=status_queries.get_upcoming_reservations(session),
         google_calendar_embed_url=current_app.config.get('GOOGLE_CALENDAR_EMBED_URL', ''),
         now=utcnow_naive(),
@@ -196,11 +196,16 @@ def jupyterhub():
     )
 
 
-@bp.route('/reservations')
-def reservations():
-    """Upcoming reservations page (table + optional Google Calendar embed)."""
+@bp.route('/events')
+def events():
+    """Upcoming maintenance/reservation events (table + optional calendar embed).
+
+    Named for what the page shows an end user — scheduled events — rather
+    than for the PBS reservation rows that back it; the underlying data and
+    query layer keep the reservation vocabulary.
+    """
     return render_template(
-        'dashboards/status/reservations_page.html',
+        'dashboards/status/events_page.html',
         **_page_context(db.session),
     )
 

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -174,17 +174,22 @@ def my_data():
 def my_jobs():
     """My Jobs page — per-user job-history cards (one pill per machine).
 
-    ``jobs_window_start`` bounds every card tab to the last 90 days by
-    default — unbounded plugin aggregations are the expensive path; the
-    explorer's date fields widen deliberately.
+    ``jobs_window_start`` bounds every card tab to the default window —
+    unbounded plugin aggregations are the expensive path. ``jobs_window_days``
+    tells the card which period pill to paint active; the pills (and the
+    explorer's date fields) widen deliberately.
     """
     ctx = _page_context()
     if not ctx['my_jobs_available']:
         abort(404)
-    from datetime import date as _date
+    from webapp.jobs.service import (
+        DEFAULT_JOBS_WINDOW_DAYS,
+        default_jobs_window_start,
+    )
     return render_template(
         'dashboards/user/my_jobs.html',
-        jobs_window_start=(_date.today() - timedelta(days=90)).isoformat(),
+        jobs_window_start=default_jobs_window_start(),
+        jobs_window_days=DEFAULT_JOBS_WINDOW_DAYS,
         **ctx,
     )
 

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -860,6 +860,35 @@ def _bucket_drill_url(jobs_fragment_url: str, hist: dict, bucket: dict,
     return f'{jobs_fragment_url}?{urlencode(params)}'
 
 
+def _trim_leading_empty_bands(hist):
+    """Drop leading all-zero bands from a histogram envelope.
+
+    The plugin returns a complete, ordered bucket vector — zeros included —
+    which is what keeps the x-axis stable as filters change, and that's
+    worth preserving *inside* a distribution. A leading empty band is
+    different: on Job Sizes it's structural, since every job uses at least
+    one node and one CPU, so those dimensions can never fill their 0 band.
+    GPUs are the exception that keeps the rule honest — there the 0 band
+    holds the CPU-only jobs, so it survives on its own merit.
+
+    Emptiness is judged on ``job_count`` alone, never the displayed metric,
+    so flipping Jobs / CPU-hours / GPU-hours can't shift the axis under the
+    viewer (a band of real jobs charging no GPU-hours stays put).
+
+    Returns a shallow copy — the envelope is a shared cache entry and must
+    never be mutated — or *hist* itself when there's nothing to trim.
+    """
+    buckets = (hist or {}).get('buckets') or []
+    lead = 0
+    while lead < len(buckets) and not (buckets[lead].get('job_count') or 0):
+        lead += 1
+    if not lead or lead == len(buckets):
+        # Nothing to trim, or the whole range is empty — leave that to the
+        # chart's own "no jobs" placeholder rather than serving no bands.
+        return hist
+    return dict(hist, buckets=buckets[lead:])
+
+
 def _render_histogram(*, mode, machine, dimension, dimension_toggle,
                       fragment_url, target_id,
                       jobs_fragment_url=None,
@@ -908,6 +937,12 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
             mode, machine, dimension,
         )
         error = str(exc)
+
+    # Trim BEFORE the chart and the drill list: the bar sentinels
+    # (#jh-bar-<i>) and the table's data-jh-bucket indices are both
+    # positions in this bucket vector, so all three have to see the
+    # same one.
+    hist = _trim_leading_empty_bands(hist)
 
     chart_svg = generate_jobs_histogram(hist, metric=metric) if hist else None
     params = _roundtrip_params(machine, target_id)

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -8,12 +8,20 @@ Project-mode endpoints (url_prefix ``/dashboards/user/jobs``):
   GET /<projcode>/job-sizes   — resource-needs histogram (?dimension=
                                 nodes|cpus|gpus|memory)
   GET /<projcode>/durations   — elapsed-time histogram (pinned 'duration')
+  GET /<projcode>/card        — the tab shell itself, re-rendered for a new
+                                lookback (?days=); the period pills' target
 
 Jobs-tab query params: ``GET /dashboards/user/jobs/<projcode>``
 
 Query params (all optional unless noted):
   machine   (required) — 'derecho' or 'casper'
   start, end           — YYYY-MM-DD; filters on Job.end
+  days                 — lookback in days, one of
+                         service.JOBS_WINDOW_CHOICES; outranks start/end
+                         (the card's period pills, which can only append
+                         to a URL whose window was baked in at render
+                         time). Normalized back to start= before anything
+                         downstream sees it.
   user                 — limit to a single PBS username
   queue                — limit to a single queue
   qos                  — limit to a single QoS / priority class
@@ -38,7 +46,8 @@ filter cannot leak cross-project rows.
 
 from __future__ import annotations
 
-from datetime import date, datetime
+import re
+from datetime import date, datetime, timedelta
 from typing import Optional
 
 from flask import Blueprint, abort, render_template, request, url_for
@@ -121,6 +130,26 @@ def _parse_date(raw: Optional[str]) -> Optional[date]:
         return datetime.strptime(raw, '%Y-%m-%d').date()
     except ValueError:
         return None
+
+
+def _parse_days() -> Optional[int]:
+    """The card's ``?days=`` lookback pill, or None when not one of ours.
+
+    Lenient like ``_parse_metric``: an unknown or malformed value means
+    "no override", never a 400 — the value can arrive from a client's
+    localStorage, which may outlive a change to the offered windows.
+    """
+    raw = (request.args.get('days') or '').strip()
+    try:
+        days = int(raw)
+    except ValueError:
+        return None
+    return days if days in service.JOBS_WINDOW_CHOICES else None
+
+
+def _days_start(days: int) -> date:
+    """Window start for a ``?days=`` lookback (always relative to today)."""
+    return date.today() - timedelta(days=days)
 
 
 def _parse_pagination():
@@ -596,6 +625,14 @@ def _parse_job_filters(include_user: bool = True) -> dict:
         'exit_status': (request.args.get('exit_status') or '').strip() or None,
         'name':  (request.args.get('name') or '').strip() or None,
     }
+    days = _parse_days()
+    if days is not None:
+        # The card's period pill outranks any window baked into the panel
+        # URL at render time: the client-side persistence layer can only
+        # append ``days`` to a request, never rewrite the ``start`` already
+        # in the path, so precedence has to be settled here.
+        f['start'] = _days_start(days)
+        f['end'] = None
     if include_user:
         f['user'] = _resolve_user_filter()[0]
     if f['name'] is not None:
@@ -639,6 +676,14 @@ def _roundtrip_params(machine: str, target_id: str) -> dict:
         k: request.args.get(k) for k in _ROUNDTRIP_KEYS
         if (request.args.get(k) or '').strip()
     }
+    days = _parse_days()
+    if days is not None:
+        # Normalize the pill to a plain start= at the fragment boundary:
+        # in-panel pills, bar drills and explorer deep links all keep
+        # speaking start/end, so `days` stays out of _ROUNDTRIP_KEYS and
+        # never has to be understood past this point.
+        params['start'] = _days_start(days).isoformat()
+        params.pop('end', None)
     params['machine'] = machine
     params['target_id'] = target_id
     return params
@@ -1055,11 +1100,14 @@ def _panel_filters(machine: str) -> dict:
     end = (request.args.get('end') or '').strip()
     if not start and not end:
         # Unbounded windows are the expensive path (~200 s machine-wide
-        # vs ~0.6 s per month) — default the explorer to the last 90
-        # days. The field is visible in the panel; clearing it opts into
-        # the full history explicitly.
-        from datetime import timedelta
-        start = (date.today() - timedelta(days=90)).isoformat()
+        # vs ~0.6 s per month) — default the explorer to the same window
+        # the cards use. The card's "Open full view" link hands its
+        # current pill over as ?days=, so the explorer opens on the window
+        # the user was already looking at. The field is visible in the
+        # panel; clearing it opts into the full history explicitly.
+        start = _days_start(
+            _parse_days() or service.DEFAULT_JOBS_WINDOW_DAYS
+        ).isoformat()
     return {
         'start': start,
         'end':   end,
@@ -1424,3 +1472,79 @@ def explore_user_page(machine):
         filters=panel, user_search_url=_user_search_url(),
         per_page_options=_PER_PAGE_OPTIONS, target_id=target_id,
     )
+
+
+# ---------------------------------------------------------------------------
+# Card shell (period pills) — one route per mode
+# ---------------------------------------------------------------------------
+#
+# Each panel bakes its window into its own hx-get URL at render time, so
+# changing the period means re-rendering the shell that owns those URLs.
+# These routes do that and nothing else — no plugin queries — so a pill
+# click costs one cheap render and the panels re-fetch lazily as they are
+# shown. Gating mirrors each mode's panel family.
+
+# Shell params echoed straight into element ids and hx-target selectors.
+_ID_ARG_RE = re.compile(r'^[A-Za-z0-9_-]{1,64}$')
+
+
+def _id_arg(name: str, default: Optional[str] = None) -> Optional[str]:
+    """Read an id-shaped query arg; 400 on anything that isn't id-safe."""
+    raw = (request.args.get(name) or '').strip()
+    if not raw:
+        return default
+    if not _ID_ARG_RE.match(raw):
+        abort(400, f'{name} must match {_ID_ARG_RE.pattern}')
+    return raw
+
+
+def _render_card_shell(*, mode: str, machine: str, **extra):
+    """Re-render the jobs card bound to the requested ``?days=`` window."""
+    days = _parse_days() or service.DEFAULT_JOBS_WINDOW_DAYS
+    return render_template(
+        'dashboards/user/partials/jobs_card.html',
+        mode=mode, machine=machine,
+        cid=_id_arg('cid', 'jobs-card'),
+        tablist_id=_id_arg('tablist_id', 'jobsCardTabs'),
+        days_persist_id=_id_arg('days_persist_id'),
+        days=days,
+        start=_days_start(days).isoformat(),
+        end=None,
+        # The clicked card is on screen, so this fires straight away; a
+        # sibling card refreshed inside a hidden machine subtab waits until
+        # it is actually shown instead of querying for nobody.
+        load_trigger='intersect once',
+        **extra,
+    )
+
+
+@bp.route('/<projcode>/card')
+@login_required
+@require_project_access
+def jobs_card_fragment(project):
+    """HTMX fragment: *project*'s card shell rebound to a new window.
+
+    A pill is a pure lookback from today, so it drops the page's own end
+    date rather than re-anchoring the window inside it.
+    """
+    return _render_card_shell(
+        mode='project', machine=_get_machine_or_400(),
+        projcode=project.projcode,
+        scope=(request.args.get('scope') or '').strip() or None,
+        jobs_multi_project=len(_tree_projcodes(project)) > 1,
+    )
+
+
+@bp.route('/machine/<machine>/card')
+@login_required
+@require_permission(Permission.VIEW_ALL_JOB_DATA)
+def jobs_card_machine_fragment(machine):
+    """HTMX fragment: the machine-wide card shell on a new window."""
+    return _render_card_shell(mode='machine', machine=_machine_or_404(machine))
+
+
+@bp.route('/user/<machine>/card')
+@login_required
+def jobs_card_user_fragment(machine):
+    """HTMX fragment: the "My Jobs" card shell on a new window."""
+    return _render_card_shell(mode='user', machine=_machine_or_404(machine))

--- a/src/webapp/jobs/service.py
+++ b/src/webapp/jobs/service.py
@@ -12,7 +12,7 @@ return cross-project rows by forgetting a filter.
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 from typing import Any, Dict, List, Optional, Sequence
 
 from webapp.jobs import cache as jobs_cache
@@ -22,6 +22,27 @@ from webapp.jobs.session import (
     is_enabled,
     job_history_session,
 )
+
+# Lookback applied when a host doesn't ask for one. Unbounded windows are
+# the expensive path — a machine-wide aggregation measures ~200 s against
+# the plugin PG vs ~0.6 s per month-window — so every surface bounds by
+# default and widens deliberately.
+DEFAULT_JOBS_WINDOW_DAYS = 90
+
+# (days, label) for the card's period pills, exposed to templates as the
+# ``jobs_window_pills`` Jinja global. The ``?days=`` whitelist derives from
+# it so the UI can never offer a window the route would reject.
+JOBS_WINDOW_PILLS = ((30, '30d'), (60, '60d'), (90, '90d'), (365, '1 yr'))
+
+# Accepted ``?days=`` values. Anything else degrades to the default rather
+# than 400ing, so a stale localStorage value from an older pill set can't
+# break a card.
+JOBS_WINDOW_CHOICES = tuple(days for days, _ in JOBS_WINDOW_PILLS)
+
+
+def default_jobs_window_start() -> str:
+    """ISO date DEFAULT_JOBS_WINDOW_DAYS ago — the cards' default window."""
+    return (date.today() - timedelta(days=DEFAULT_JOBS_WINDOW_DAYS)).isoformat()
 
 
 def job_history_machines() -> List[str]:

--- a/src/webapp/run.py
+++ b/src/webapp/run.py
@@ -329,6 +329,11 @@ def create_app(*, config_overrides: dict | None = None):
     app.context_processor(nav_context_processor)
     app.jinja_env.globals['nav_locate'] = nav_locate
 
+    # Period pills on the job-history card, shared with the ?days= whitelist
+    # the fragment routes validate against.
+    from webapp.jobs.service import JOBS_WINDOW_PILLS
+    app.jinja_env.globals['jobs_window_pills'] = JOBS_WINDOW_PILLS
+
     # Central CDN-asset registry (pinned versions + SRI) for templates
     from webapp.vendor_assets import vendor_assets_context_processor
     app.context_processor(vendor_assets_context_processor)

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -644,6 +644,19 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     padding: .75rem 1.5rem;
 }
 
+/* Identifiers inside a button render in the case they're stored in: the
+   uppercase treatment above is right for button *labels* but wrong for a
+   name the user has to match against a shell prompt or a ticket. It also
+   erases the convention that tells the two apart at a glance — projcodes
+   are uppercase (SCSG0001), usernames lowercase (benkirk) — which the
+   entity quick-view links on the job-history tables and histogram
+   drill-downs lean on. Covers both spellings in use: <code> and
+   .font-monospace. */
+.btn code,
+.btn .font-monospace {
+    text-transform: none;
+}
+
 .btn-primary {
     --bs-btn-bg: var(--ncar-blue);
     --bs-btn-border-color: var(--ncar-blue);

--- a/src/webapp/static/js/nav-view-persistence.js
+++ b/src/webapp/static/js/nav-view-persistence.js
@@ -8,6 +8,9 @@
  *  3. Chart selectors — key: "chart:<id>"         value: JSON params
  *  4. Scroll position — key: "nav:scroll:<path>"  (sessionStorage, one-shot)
  *
+ * The job-history period pills (5) reuse the chart-selector storage under
+ * key "days", plus a card-level fan-out so per-machine subtabs agree.
+ *
  * Tab / collapse handling works for both initial page load and after
  * HTMX swaps or Bootstrap modal close events.
  */
@@ -227,6 +230,112 @@
             localStorage.setItem(CHART_PREFIX + chartEl.dataset.chartPersistId,
                                  JSON.stringify(saved));
         } catch (_) {}
+    });
+
+    // ── Job-history period pills ─────────────────────────────────────────────
+    //
+    // The jobs card's 30d/60d/90d/1yr pills re-render the whole card shell,
+    // because each of its six panels bakes the window into its own hx-get
+    // URL at render time. Markup contract (jobs_card.html):
+    //
+    //   [data-jobs-days-card]    card wrapper; also carries the
+    //                            data-chart-persist-* pair above (key
+    //                            "days") and data-jobs-card-url
+    //   [data-jobs-days-pills]   the pill group inside it
+    //   [data-days-value]        each pill button
+    //   [data-jobs-explore-link] "Open full view", whose ?days= tracks them
+    //
+    // Cards sharing a persist id — the per-machine subtabs on My Jobs and
+    // Status → Job History — stay in lockstep: a click saves the window and
+    // re-renders its siblings. That fan-out goes through htmx.ajax() rather
+    // than hx-* attributes on the wrapper, because hx-target/hx-swap are
+    // inherited: declaring them on a card would hijack every descendant
+    // request that doesn't name its own target.
+
+    var DAYS_KEY = 'days';
+
+    /** The stored window for a persist id, as a string, or null. */
+    function savedDays(persistId) {
+        var raw = null;
+        try { raw = localStorage.getItem(CHART_PREFIX + persistId); } catch (_) { return null; }
+        if (!raw) return null;
+        var saved;
+        try { saved = JSON.parse(raw); } catch (_) { return null; }
+        return (saved && saved[DAYS_KEY]) ? String(saved[DAYS_KEY]) : null;
+    }
+
+    /** Paint *days* as the active pill and point the explorer link at it. */
+    function syncDaysCard(card, days) {
+        if (!days) return;
+        card.querySelectorAll('[data-days-value]').forEach(function (btn) {
+            var on = btn.dataset.daysValue === days;
+            btn.classList.toggle('btn-primary', on);
+            btn.classList.toggle('btn-outline-primary', !on);
+        });
+        // The link speaks ?days=, never a date, so this stays a parameter
+        // swap — no re-deriving client-side a window the server owns.
+        var link = card.querySelector('[data-jobs-explore-link]');
+        if (!link) return;
+        try {
+            var url = new URL(link.getAttribute('href'), window.location.origin);
+            url.searchParams.set(DAYS_KEY, days);
+            url.searchParams.delete('start');
+            url.searchParams.delete('end');
+            link.setAttribute('href', url.pathname + '?' + url.searchParams.toString());
+        } catch (_) {}
+    }
+
+    /** Save on click — synchronously, BEFORE htmx issues any request, so a
+     *  sibling's injected refetch can't read a stale window. The afterSettle
+     *  save above lands too late for that hand-off. */
+    document.addEventListener('click', function (event) {
+        var target = event.target;
+        if (!target || !target.closest) return;
+        var btn = target.closest('[data-jobs-days-pills] [data-days-value]');
+        if (!btn) return;
+        var card = btn.closest('[data-jobs-days-card]');
+        if (!card) return;              // pills opted out of persistence
+        var id = card.dataset.chartPersistId;
+        if (!id) return;
+
+        var days = btn.dataset.daysValue;
+        try {
+            localStorage.setItem(CHART_PREFIX + id, JSON.stringify({days: days}));
+        } catch (_) {}
+
+        // Siblings get the window spelled out rather than relying on the
+        // injection above, so the hand-off can't race the save.
+        document.querySelectorAll('[data-jobs-days-card]').forEach(function (other) {
+            if (other === card || other.dataset.chartPersistId !== id) return;
+            var url = other.dataset.jobsCardUrl;
+            if (!url || !window.htmx) return;
+            htmx.ajax('GET', url + (url.indexOf('?') === -1 ? '?' : '&') + DAYS_KEY + '=' + days,
+                      {target: '#' + other.id, swap: 'outerHTML'});
+        });
+    }, true);
+
+    // Cold start: the server renders the default window, so repaint the
+    // pills from storage. The panels need no repaint — the configRequest
+    // injection rewrites every panel fetch, and the route gives ?days=
+    // precedence over the ?start= baked into the URL.
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('[data-jobs-days-card]').forEach(function (card) {
+            var id = card.dataset.chartPersistId;
+            if (id) syncDaysCard(card, savedDays(id));
+        });
+    });
+
+    // A pill swaps out the card that contains it, so the tab restore wired
+    // to htmx:afterSettle — which walks the element that made the request —
+    // finds only a detached button. Restore against the live card instead,
+    // and only while it's on screen: re-showing a saved tab inside a hidden
+    // machine subtab would fire that panel's query for a card nobody is
+    // looking at.
+    document.addEventListener('htmx:load', function (event) {
+        var elt = event.detail && event.detail.elt;
+        var card = (elt && elt.closest) ? elt.closest('[data-jobs-days-card]') : null;
+        if (!card || card.offsetParent === null) return;
+        restoreTabs(card);
     });
 
     // ── Scroll preservation across full-page navigation ──────────────────────

--- a/src/webapp/templates/dashboards/status/base_status.html
+++ b/src/webapp/templates/dashboards/status/base_status.html
@@ -1,7 +1,7 @@
 {#
   Shared layout for the system status pages
   (/status/derecho, /status/casper, /status/jupyterhub,
-   /status/reservations, /status/filesystem-scans).
+   /status/filesystem-scans, /status/events).
 
   Provides the header, active-outage banner, and routable tab strip;
   each page fills {% block status_content %}. Context comes from the
@@ -107,21 +107,25 @@
 </div>
 {% endif %}
 
-{% set reservations_label = 'Reservations ({})'.format(reservations|length) if reservations else 'Reservations' %}
+{% set events_label = 'Events ({})'.format(reservations|length) if reservations else 'Events' %}
+{# Events stays LAST in this list on purpose: the two tabs before it are
+   RBAC/plugin-gated and drop out of the strip entirely when hidden, so
+   ordering Events last is what keeps it rightmost for every audience —
+   staff and unprivileged alike. Keep it at the end when adding tabs. #}
 {{ page_tabs([
     {'endpoint': 'status_dashboard.derecho',    'label': 'Derecho',    'icon': 'fas fa-server'},
     {'endpoint': 'status_dashboard.casper',     'label': 'Casper',     'icon': 'fas fa-hdd'},
     {'endpoint': 'status_dashboard.jupyterhub', 'label': 'JupyterHub', 'icon': 'fas fa-book'},
-    {'endpoint': 'status_dashboard.reservations',
-     'label': reservations_label,
-     'icon': 'fas fa-calendar-alt',
-     'visible': true if (reservations or google_calendar_embed_url) else false},
     {'endpoint': 'status_dashboard.filesystem_scans', 'label': 'Filesystem Scans',
      'icon': 'fas fa-magnifying-glass-chart',
      'visible': true if (fs_scan_resources and has_permission(Permission.VIEW_ALL_FILESYSTEM_DATA)) else false},
     {'endpoint': 'status_dashboard.job_history', 'label': 'Job History',
      'icon': 'fas fa-list-check',
      'visible': true if (job_history_machines and has_permission(Permission.VIEW_ALL_JOB_DATA)) else false},
+    {'endpoint': 'status_dashboard.events',
+     'label': events_label,
+     'icon': 'fas fa-calendar-alt',
+     'visible': true if (reservations or google_calendar_embed_url) else false},
 ], class='mb-4') }}
 
 {% block status_content %}{% endblock %}

--- a/src/webapp/templates/dashboards/status/events_page.html
+++ b/src/webapp/templates/dashboards/status/events_page.html
@@ -1,6 +1,6 @@
 {% extends 'dashboards/status/base_status.html' %}
 
-{% block title %}Reservations - SAM{% endblock %}
+{% block title %}Events - SAM{% endblock %}
 
 {% block status_content %}
 {% include 'dashboards/status/fragments/reservations.html' %}

--- a/src/webapp/templates/dashboards/status/partials/job_history.html
+++ b/src/webapp/templates/dashboards/status/partials/job_history.html
@@ -39,6 +39,8 @@
                 tablist_id='jobHistCardTabs' ~ loop.index,
                 machine=m,
                 start=jobs_window_start,
+                days=jobs_window_days,
+                days_persist_id='jobs-days-status',
                 load_trigger=_trigger %}
             {% include 'dashboards/user/partials/jobs_card.html' %}
         {% endwith %}

--- a/src/webapp/templates/dashboards/user/partials/jobs_card.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_card.html
@@ -22,6 +22,19 @@
      start, end   optional YYYY-MM-DD window carried into every tab (project
                   mode passes the page's date range so aggregations stay
                   bounded; url_for drops None values).
+     days        optional lookback (one of jobs_window_pills) — paints the
+                 matching period pill active. The pills re-render this whole
+                 shell via jobs.jobs_card*_fragment, which is the only way
+                 the six tabs can pick up a new window: each bakes its own
+                 into its hx-get at render time. `none` leaves no pill
+                 active, which is how project mode says "showing the page's
+                 own date range, not a lookback".
+     days_persist_id  optional localStorage key (via the shared
+                 data-chart-persist-* contract) for the chosen window.
+                 Set it and the selection follows the viewer across machine
+                 subtabs and page reloads; omit it — as resource-details
+                 does — and the pills work for the visit only, so a stored
+                 window can't quietly shadow that page's own date range.
 
    In machine mode there is no account scoping (routes are gated behind
    VIEW_ALL_JOB_DATA) and both By User and By Project render; in user mode
@@ -33,7 +46,20 @@
 {% set start = start | default(none) %}
 {% set end = end | default(none) %}
 {% set scope = scope | default(none) %}
+{% set days = days | default(none) %}
+{% set days_persist_id = days_persist_id | default(none) %}
 {% set jobs_multi_project = jobs_multi_project | default(false) %}
+{# Persisted-window markers, repeated on every tab button: the
+   configRequest handler in nav-view-persistence.js only injects into
+   elements that carry them THEMSELVES, so each tab has to opt in for its
+   panel fetch to honour a stored window. #}
+{% macro _persist(pid) -%}
+{%- if pid %} data-chart-persist-id="{{ pid }}" data-chart-persist-keys="days"{% endif -%}
+{%- endmacro %}
+{# The explorer link speaks ?days= rather than a computed date so the
+   cold-start sync in JS never has to re-derive a window client-side. #}
+{% set _x_start = none if days else start %}
+{% set _x_end = none if days else end %}
 {% set _proj_url = none %}
 {% if mode == 'machine' %}
     {% set _jobs_url  = url_for('jobs.jobs_machine_fragment',       machine=machine, start=start, end=end, target_id=cid ~ '-jobs') %}
@@ -42,14 +68,16 @@
     {% set _wait_url  = url_for('jobs.wait_times_machine_fragment', machine=machine, start=start, end=end, target_id=cid ~ '-wait') %}
     {% set _sizes_url = url_for('jobs.job_sizes_machine_fragment',  machine=machine, start=start, end=end, target_id=cid ~ '-sizes') %}
     {% set _dur_url   = url_for('jobs.durations_machine_fragment',  machine=machine, start=start, end=end, target_id=cid ~ '-durations') %}
-    {% set _full_url  = url_for('jobs.explore_machine_page',        machine=machine, start=start, end=end) %}
+    {% set _full_url  = url_for('jobs.explore_machine_page',        machine=machine, start=_x_start, end=_x_end, days=days) %}
+    {% set _card_url  = url_for('jobs.jobs_card_machine_fragment',  machine=machine, cid=cid, tablist_id=tablist_id, days_persist_id=days_persist_id) %}
 {% elif mode == 'user' %}
     {% set _jobs_url  = url_for('jobs.jobs_user_fragment',       machine=machine, start=start, end=end, target_id=cid ~ '-jobs') %}
     {% set _proj_url  = url_for('jobs.by_project_user_fragment', machine=machine, start=start, end=end, target_id=cid ~ '-byproj') %}
     {% set _wait_url  = url_for('jobs.wait_times_user_fragment', machine=machine, start=start, end=end, target_id=cid ~ '-wait') %}
     {% set _sizes_url = url_for('jobs.job_sizes_user_fragment',  machine=machine, start=start, end=end, target_id=cid ~ '-sizes') %}
     {% set _dur_url   = url_for('jobs.durations_user_fragment',  machine=machine, start=start, end=end, target_id=cid ~ '-durations') %}
-    {% set _full_url  = url_for('jobs.explore_user_page',        machine=machine, start=start, end=end) %}
+    {% set _full_url  = url_for('jobs.explore_user_page',        machine=machine, start=_x_start, end=_x_end, days=days) %}
+    {% set _card_url  = url_for('jobs.jobs_card_user_fragment',  machine=machine, cid=cid, tablist_id=tablist_id, days_persist_id=days_persist_id) %}
     {# no _user_url — the By User tab is hidden in user mode (a pie of
        one); By Project takes its slot: which projects MY jobs charged. #}
 {% else %}
@@ -61,8 +89,26 @@
     {% set _wait_url  = url_for('jobs.wait_times_fragment', projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-wait') %}
     {% set _sizes_url = url_for('jobs.job_sizes_fragment',  projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-sizes') %}
     {% set _dur_url   = url_for('jobs.durations_fragment',  projcode=projcode, machine=machine, start=start, end=end, target_id=cid ~ '-durations') %}
-    {% set _full_url  = url_for('jobs.explore_page',        projcode=projcode, machine=machine, start=start, end=end, scope=scope) %}
+    {% set _full_url  = url_for('jobs.explore_page',        projcode=projcode, machine=machine, start=_x_start, end=_x_end, days=days, scope=scope) %}
+    {% set _card_url  = url_for('jobs.jobs_card_fragment',  projcode=projcode, machine=machine, cid=cid, tablist_id=tablist_id, days_persist_id=days_persist_id, scope=scope) %}
 {% endif %}
+{# url_for always emits at least ?cid=, but don't rely on it for the pills. #}
+{% set _card_q = _card_url ~ ('&' if '?' in _card_url else '?') %}
+{# Wrapper: the pills' swap target, and — when the window persists — the
+   element the fan-out re-renders so the other cards sharing this persist
+   id (the per-machine subtabs) follow along. It deliberately carries NO
+   hx-target/hx-swap: htmx inherits both, so a pair here would capture
+   every descendant request that doesn't name its own target (a By
+   Project bucket drill, say) and swap the whole card away. The refetch
+   is issued by htmx.ajax() instead — see the job-history section of
+   nav-view-persistence.js, which reads the URL below. #}
+<div id="{{ cid }}-card"
+     {%- if days_persist_id %}
+     data-jobs-days-card
+     data-jobs-card-url="{{ _card_url }}"
+     data-chart-persist-id="{{ days_persist_id }}"
+     data-chart-persist-keys="days"
+     {%- endif %}>
 <ul class="nav nav-tabs mb-0" id="{{ tablist_id }}" role="tablist">
     <li class="nav-item" role="presentation">
         <button class="nav-link active" id="{{ cid }}-jobs-tab"
@@ -71,7 +117,7 @@
                 hx-get="{{ _jobs_url }}"
                 hx-target="#{{ cid }}-jobs"
                 hx-swap="innerHTML"
-                hx-trigger="{{ load_trigger }}">
+                hx-trigger="{{ load_trigger }}"{{ _persist(days_persist_id) }}>
             <i class="fas fa-list me-1"></i> Jobs
         </button>
     </li>
@@ -83,7 +129,7 @@
                 hx-get="{{ _user_url }}"
                 hx-target="#{{ cid }}-byuser"
                 hx-swap="innerHTML"
-                hx-trigger="shown.bs.tab once">
+                hx-trigger="shown.bs.tab once"{{ _persist(days_persist_id) }}>
             <i class="fas fa-users me-1"></i> By User
         </button>
     </li>
@@ -96,7 +142,7 @@
                 hx-get="{{ _proj_url }}"
                 hx-target="#{{ cid }}-byproj"
                 hx-swap="innerHTML"
-                hx-trigger="shown.bs.tab once">
+                hx-trigger="shown.bs.tab once"{{ _persist(days_persist_id) }}>
             <i class="fas fa-diagram-project me-1"></i> By Project
         </button>
     </li>
@@ -108,7 +154,7 @@
                 hx-get="{{ _wait_url }}"
                 hx-target="#{{ cid }}-wait"
                 hx-swap="innerHTML"
-                hx-trigger="shown.bs.tab once">
+                hx-trigger="shown.bs.tab once"{{ _persist(days_persist_id) }}>
             <i class="fas fa-hourglass-half me-1"></i> Wait Times
         </button>
     </li>
@@ -119,7 +165,7 @@
                 hx-get="{{ _sizes_url }}"
                 hx-target="#{{ cid }}-sizes"
                 hx-swap="innerHTML"
-                hx-trigger="shown.bs.tab once">
+                hx-trigger="shown.bs.tab once"{{ _persist(days_persist_id) }}>
             <i class="fas fa-layer-group me-1"></i> Job Sizes
         </button>
     </li>
@@ -130,9 +176,23 @@
                 hx-get="{{ _dur_url }}"
                 hx-target="#{{ cid }}-durations"
                 hx-swap="innerHTML"
-                hx-trigger="shown.bs.tab once">
+                hx-trigger="shown.bs.tab once"{{ _persist(days_persist_id) }}>
             <i class="fas fa-stopwatch me-1"></i> Durations
         </button>
+    </li>
+    {# Period pills ride the tab strip (ms-auto right-aligns them) so the
+       window on screen is legible from the same line as the panel names. #}
+    <li class="nav-item ms-auto d-flex align-items-center pb-1">
+        <div class="btn-group btn-group-sm" role="group" aria-label="Time window"
+             {%- if days_persist_id %} data-jobs-days-pills{% endif %}>
+            {% for _d, _label in jobs_window_pills %}
+            <button type="button" data-days-value="{{ _d }}"
+                    class="btn {% if days == _d %}btn-primary{% else %}btn-outline-primary{% endif %}"
+                    hx-get="{{ _card_q }}days={{ _d }}"
+                    hx-target="#{{ cid }}-card"
+                    hx-swap="outerHTML">{{ _label }}</button>
+            {% endfor %}
+        </div>
     </li>
 </ul>
 <div class="tab-content border border-top-0 rounded-bottom p-3"
@@ -141,7 +201,7 @@
         {% if _full_url %}
         <div class="d-flex justify-content-end mb-2">
             <a class="btn btn-sm btn-outline-primary"
-               href="{{ _full_url }}"
+               href="{{ _full_url }}" data-jobs-explore-link
                target="_blank" rel="noopener">
                 Open full view <i class="fas fa-up-right-from-square ms-1"></i>
             </a>
@@ -193,3 +253,4 @@
         </div>
     </div>
 </div>
+</div>{# /{{ cid }}-card #}

--- a/src/webapp/templates/dashboards/user/partials/my_jobs_card.html
+++ b/src/webapp/templates/dashboards/user/partials/my_jobs_card.html
@@ -42,6 +42,8 @@
                 tablist_id='myJobsCardTabs' ~ loop.index,
                 machine=m,
                 start=jobs_window_start,
+                days=jobs_window_days,
+                days_persist_id='jobs-days-my-jobs',
                 load_trigger=_trigger %}
             {% include 'dashboards/user/partials/jobs_card.html' %}
         {% endwith %}

--- a/src/webapp/utils/csp.py
+++ b/src/webapp/utils/csp.py
@@ -21,7 +21,7 @@ Design constraints (see docs/plans/implemented/CSP-discussion.md):
   <style> block already requires the HTML-injection failure that Jinja
   autoescaping prevents.
 - frame-src widens to the GOOGLE_CALENDAR_EMBED_URL origin when that
-  iframe is configured (status dashboard reservations tab).
+  iframe is configured (status dashboard Events tab).
 """
 
 from urllib.parse import urlsplit

--- a/src/webapp/utils/nav.py
+++ b/src/webapp/utils/nav.py
@@ -132,12 +132,14 @@ NAV_SECTIONS = (
              'icon': 'fas fa-hdd'},
             {'endpoint': 'status_dashboard.jupyterhub', 'label': 'JupyterHub',
              'icon': 'fas fa-book'},
-            {'endpoint': 'status_dashboard.reservations', 'label': 'Reservations',
-             'icon': 'fas fa-calendar-alt'},
             {'endpoint': 'status_dashboard.filesystem_scans', 'label': 'Filesystem Scans',
              'icon': 'fas fa-magnifying-glass-chart', 'visible': _can_view_fs_scans},
             {'endpoint': 'status_dashboard.job_history', 'label': 'Job History',
              'icon': 'fas fa-list-check', 'visible': _can_view_job_history},
+            # Last on purpose — mirrors the status tab strip, where Events sits
+            # to the right of the gated tabs (see base_status.html).
+            {'endpoint': 'status_dashboard.events', 'label': 'Events',
+             'icon': 'fas fa-calendar-alt'},
         ),
     },
     {

--- a/tests/integration/test_status_dashboard.py
+++ b/tests/integration/test_status_dashboard.py
@@ -3,7 +3,7 @@ Integration tests for System Status Dashboard.
 
 Verifies that dashboard pages render correctly (status 200) using the new
 query layer. The dashboard is routable pages — /status/ 302-redirects to
-/status/derecho, and each system (derecho, casper, jupyterhub, reservations,
+/status/derecho, and each system (derecho, casper, jupyterhub, events,
 filesystem-scans) has its own page sharing the outage banner + tab strip.
 Each test seeds minimal Derecho/Casper data into the per-worker
 SQLite tempfile via the `status_session` fixture, then issues authenticated
@@ -16,6 +16,7 @@ seeding because it ran against a per-worker MySQL `system_status_test_*`
 database. We use the same `commit()` semantics under the SQLite tempfile,
 which gets DELETE-cleaned at the start of each test by the fixture.
 """
+import re
 from datetime import timedelta
 
 import pytest
@@ -356,6 +357,95 @@ class TestStatusDashboard:
         response = auth_client.get('/status/nodetype-history/casper/cpu?hours=720')
         assert response.status_code == 200
         assert b'/status/casper?hours=720' in response.data
+
+
+def tab_strip_hrefs(body):
+    """Hrefs of the status tab strip, in render order.
+
+    The page_tabs strip is the first ``nav nav-tabs`` list on the page —
+    the others (filesystem/queue cards) live inside status_content, which
+    renders after it.
+    """
+    start = body.index('<ul class="nav nav-tabs')
+    return re.findall(r'href="([^"]+)"', body[start:body.index('</ul>', start)])
+
+
+class TestEventsTab:
+    """The Events tab (formerly "Reservations", /status/reservations).
+
+    It is data-gated like the others — hidden with no upcoming
+    reservations and no calendar embed — but when it does render it must
+    be the RIGHTMOST tab for every audience. The two tabs before it are
+    RBAC/plugin-gated and drop out of the strip entirely, so position is
+    asserted at both ends of the permission range.
+    """
+
+    CALENDAR = 'https://calendar.example.invalid/embed'
+
+    @pytest.fixture
+    def calendar(self, app, monkeypatch):
+        """Make the tab visible without seeding a reservation graph."""
+        monkeypatch.setitem(app.config, 'GOOGLE_CALENDAR_EMBED_URL', self.CALENDAR)
+
+    def test_events_page(self, auth_client, status_session, calendar):
+        """GET /status/events returns 200 and renders the events content."""
+        seed_data(status_session)
+        response = auth_client.get('/status/events')
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        assert 'Maintenance' in body
+        assert self.CALENDAR in body          # calendar embed
+        assert '<title>Events - SAM' in body
+
+    def test_tab_hidden_without_reservations_or_calendar(self, auth_client, status_session,
+                                                         app, monkeypatch):
+        """No upcoming reservations and no calendar → no tab in the strip.
+
+        The embed URL is cleared explicitly: it comes from the
+        environment, so a developer with GOOGLE_CALENDAR_EMBED_URL set in
+        .env would otherwise see the tab render here but not in CI. The
+        navbar dropdown item is ungated (as it was under the old name),
+        so this asserts on the tab strip only.
+        """
+        monkeypatch.setitem(app.config, 'GOOGLE_CALENDAR_EMBED_URL', '')
+        seed_data(status_session)
+        body = auth_client.get('/status/derecho').get_data(as_text=True)
+        assert '/status/events' not in tab_strip_hrefs(body)
+
+    def test_tab_is_rightmost_for_staff(self, auth_client, status_session,
+                                        monkeypatch, calendar):
+        """With every gated tab visible, Events still renders last."""
+        seed_data(status_session)
+        monkeypatch.setattr('webapp.disk_scans.service.scan_capable_resources',
+                            lambda app=None: ['Campaign_Store'])
+        monkeypatch.setattr('webapp.jobs.service.job_history_machines',
+                            lambda: ['derecho'])
+        hrefs = tab_strip_hrefs(auth_client.get('/status/derecho').get_data(as_text=True))
+        assert '/status/filesystem-scans' in hrefs      # gated tabs did render
+        assert '/status/job-history' in hrefs
+        assert hrefs[-1] == '/status/events'
+
+    def test_tab_is_rightmost_without_gated_tabs(self, non_admin_client, status_session,
+                                                 monkeypatch, calendar):
+        """A user who sees neither gated tab still finds Events rightmost."""
+        seed_data(status_session)
+        monkeypatch.setattr('webapp.disk_scans.service.scan_capable_resources',
+                            lambda app=None: ['Campaign_Store'])
+        monkeypatch.setattr('webapp.jobs.service.job_history_machines',
+                            lambda: ['derecho'])
+        hrefs = tab_strip_hrefs(non_admin_client.get('/status/derecho').get_data(as_text=True))
+        assert '/status/filesystem-scans' not in hrefs
+        assert '/status/job-history' not in hrefs
+        assert hrefs[-1] == '/status/events'
+
+    def test_tab_labeled_events(self, auth_client, status_session, calendar):
+        """The tab reads "Events" — the old label is gone from the strip."""
+        seed_data(status_session)
+        body = auth_client.get('/status/derecho').get_data(as_text=True)
+        start = body.index('<ul class="nav nav-tabs')
+        strip = body[start:body.index('</ul>', start)]
+        assert 'Events' in strip
+        assert 'Reservations' not in strip
 
 
 class TestStaleBanner:

--- a/tests/unit/snapshots/dashboard_route_map.json
+++ b/tests/unit/snapshots/dashboard_route_map.json
@@ -1421,6 +1421,13 @@
     ]
   ],
   [
+    "status_dashboard.events",
+    "/status/events",
+    [
+      "GET"
+    ]
+  ],
+  [
     "status_dashboard.filesystem_scans",
     "/status/filesystem-scans",
     [
@@ -1507,13 +1514,6 @@
   [
     "status_dashboard.queue_history",
     "/status/queue-history/<system>/<queue_name>",
-    [
-      "GET"
-    ]
-  ],
-  [
-    "status_dashboard.reservations",
-    "/status/reservations",
     [
       "GET"
     ]

--- a/tests/unit/test_nav.py
+++ b/tests/unit/test_nav.py
@@ -35,6 +35,12 @@ class TestNavLocate:
         assert nav_locate('auth.login') == (None, None)
         assert nav_locate(None) == (None, None)
 
+    def test_status_events_item_is_last(self):
+        """Events sits after the RBAC-gated status items, matching the tab
+        strip in base_status.html (where it must stay rightmost)."""
+        status = next(s for s in NAV_SECTIONS if s['key'] == 'status')
+        assert status['items'][-1]['label'] == 'Events'
+
     def test_registry_endpoints_exist(self, app):
         """Every registry endpoint must be a real route — catches drift when
         blueprints are renamed."""

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -3243,3 +3243,268 @@ def test_by_user_sort_indicator_follows_metric(
     gpu_th = re.search(r'<th[^>]*sort-desc[^>]*>GPU-hours</th>', body)
     assert gpu_th, 'sort-desc must sit on the GPU-hours header'
     assert not re.search(r'<th[^>]*sort-desc[^>]*>CPU-hours</th>', body)
+
+
+# ---------------------------------------------------------------------------
+# Period pills — ?days= parsing, precedence, and the card-shell routes
+# ---------------------------------------------------------------------------
+
+def _days_ago(days):
+    from datetime import date, timedelta
+    return date.today() - timedelta(days=days)
+
+
+@pytest.mark.parametrize('raw,expected', [
+    ('30', 30), ('365', 365),
+    ('7', None),        # not an offered window
+    ('abc', None), ('', None), ('90.0', None), ('-90', None),
+])
+def test_parse_days_accepts_only_offered_windows(app, raw, expected):
+    """A stale localStorage value must degrade to the default, never 400."""
+    from webapp.jobs import routes
+
+    with app.test_request_context(f'/?days={raw}'):
+        assert routes._parse_days() == expected
+
+
+def test_days_outranks_the_window_baked_into_the_url(app):
+    """The pill wins over ?start=/?end= — the client can only append days."""
+    from webapp.jobs import routes
+
+    with app.test_request_context('/?start=2020-01-01&end=2020-06-01&days=60'):
+        filters = routes._parse_job_filters()
+
+    assert filters['start'] == _days_ago(60)
+    assert filters['end'] is None
+
+
+def test_start_and_end_survive_when_no_days_given(app):
+    from datetime import date
+    from webapp.jobs import routes
+
+    with app.test_request_context('/?start=2020-01-01&end=2020-06-01'):
+        filters = routes._parse_job_filters()
+
+    assert filters['start'] == date(2020, 1, 1)
+    assert filters['end'] == date(2020, 6, 1)
+
+
+def test_roundtrip_params_normalize_days_to_a_plain_start(app):
+    """`days` is confined to the fragment boundary: panels round-trip start."""
+    from webapp.jobs import routes
+
+    with app.test_request_context('/?days=365&end=2020-06-01'):
+        params = routes._roundtrip_params('derecho', 'tgt')
+
+    assert params['start'] == _days_ago(365).isoformat()
+    assert 'end' not in params
+    assert 'days' not in params
+
+
+def test_panel_filters_default_window_follows_days(app, monkeypatch):
+    """The explorer honours the pill the card handed over in its link."""
+    _install_mock_plugin(app, monkeypatch)
+    from webapp.jobs import routes
+
+    with app.test_request_context('/?days=30'):
+        panel = routes._panel_filters('derecho')
+    assert panel['start'] == _days_ago(30).isoformat()
+
+    with app.test_request_context('/'):
+        panel = routes._panel_filters('derecho')
+    assert panel['start'] == _days_ago(
+        routes.service.DEFAULT_JOBS_WINDOW_DAYS).isoformat()
+
+
+def test_panel_route_applies_days_over_baked_start(
+    app, auth_client, active_project, monkeypatch,
+):
+    """End to end: a panel fetch carrying both uses the injected window."""
+    captured = _install_mock_plugin(app, monkeypatch,
+                                    jobs_search_return=[_make_row()])
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}'
+        '?machine=derecho&start=2020-01-01&days=365'
+    )
+    assert resp.status_code == 200
+    assert captured['last_jobs_search_kwargs']['start'] == _days_ago(365)
+
+
+def _card_url(projcode, **extra):
+    from urllib.parse import urlencode
+    params = {'machine': 'derecho', 'cid': 'jobs-hist',
+              'tablist_id': 'jobsCardTabs'}
+    params.update(extra)
+    return f'/dashboards/user/jobs/{projcode}/card?{urlencode(params)}'
+
+
+def test_card_fragment_bakes_the_window_into_every_panel_url(
+    app, auth_client, active_project, monkeypatch,
+):
+    """The shell is how the six panels learn a new window."""
+    _install_mock_plugin(app, monkeypatch)
+    resp = auth_client.get(_card_url(active_project.projcode, days=365))
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+
+    start = _days_ago(365).isoformat()
+    for suffix in ('', '/wait-times', '/job-sizes', '/durations'):
+        assert (f'/dashboards/user/jobs/{active_project.projcode}{suffix}'
+                f'?machine=derecho&amp;start={start}') in body, suffix
+    # A pill is a lookback from today, so the page's own end date is gone.
+    assert 'end=' not in body
+
+
+def test_card_fragment_marks_the_requested_pill_active(
+    app, auth_client, active_project, monkeypatch,
+):
+    _install_mock_plugin(app, monkeypatch)
+    body = auth_client.get(
+        _card_url(active_project.projcode, days=30)).get_data(as_text=True)
+
+    import re
+    assert re.search(r'btn btn-primary[^>]*data-days-value="30"', body) or \
+        re.search(r'data-days-value="30"[^>]*btn btn-primary', body)
+    assert 'data-days-value="365"' in body      # the other pills still render
+
+
+def test_card_fragment_unknown_days_falls_back_to_the_default(
+    app, auth_client, active_project, monkeypatch,
+):
+    _install_mock_plugin(app, monkeypatch)
+    body = auth_client.get(
+        _card_url(active_project.projcode, days=7)).get_data(as_text=True)
+
+    from webapp.jobs.service import DEFAULT_JOBS_WINDOW_DAYS
+    assert f'start={_days_ago(DEFAULT_JOBS_WINDOW_DAYS).isoformat()}' in body
+
+
+@pytest.mark.parametrize('bad', ['jobs hist', 'a"b', '<script>', 'x' * 65])
+def test_card_fragment_400_on_unsafe_element_ids(
+    app, auth_client, active_project, monkeypatch, bad,
+):
+    """cid/tablist_id land in element ids and hx-target selectors."""
+    _install_mock_plugin(app, monkeypatch)
+    assert auth_client.get(
+        _card_url(active_project.projcode, cid=bad)).status_code == 400
+    assert auth_client.get(
+        _card_url(active_project.projcode, tablist_id=bad)).status_code == 400
+
+
+def test_card_fragment_404_on_unknown_projcode(auth_client):
+    assert auth_client.get(_card_url('NOPE9999')).status_code == 404
+
+
+def test_card_fragment_400_on_invalid_machine(
+    app, auth_client, active_project, monkeypatch,
+):
+    _install_mock_plugin(app, monkeypatch)
+    resp = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/card?machine=gust')
+    assert resp.status_code == 400
+
+
+def test_card_fragment_persist_markers_are_opt_in(
+    app, auth_client, active_project, monkeypatch,
+):
+    """No persist id (resource details) → the window can't outlive the visit."""
+    _install_mock_plugin(app, monkeypatch)
+
+    plain = auth_client.get(
+        _card_url(active_project.projcode)).get_data(as_text=True)
+    assert 'data-jobs-days-card' not in plain
+    assert 'data-chart-persist-id' not in plain
+    assert 'data-days-value' in plain            # pills still work
+
+    kept = auth_client.get(
+        _card_url(active_project.projcode,
+                  days_persist_id='jobs-days-status')).get_data(as_text=True)
+    assert 'data-jobs-days-card' in kept
+    assert 'data-chart-persist-id="jobs-days-status"' in kept
+    assert 'data-chart-persist-keys="days"' in kept
+    assert 'data-jobs-card-url' in kept
+
+
+def test_card_wrapper_declares_no_inheritable_hx_target(
+    app, auth_client, active_project, monkeypatch,
+):
+    """htmx inherits hx-target/hx-swap.
+
+    A pair on the card wrapper would capture every descendant request that
+    doesn't name its own target — a By Project bucket drill swapped the
+    whole card away — so the sibling fan-out goes through htmx.ajax().
+    """
+    _install_mock_plugin(app, monkeypatch)
+    body = auth_client.get(
+        _card_url(active_project.projcode,
+                  days_persist_id='jobs-days-status')).get_data(as_text=True)
+
+    wrapper = body[body.index('<div id="jobs-hist-card"'):]
+    wrapper = wrapper[:wrapper.index('>') + 1]
+    assert 'hx-target' not in wrapper
+    assert 'hx-swap' not in wrapper
+
+
+def test_card_fragment_explore_link_hands_over_the_pill(
+    app, auth_client, active_project, monkeypatch,
+):
+    """The link carries ?days=, never a date the JS would have to re-derive."""
+    _install_mock_plugin(app, monkeypatch)
+    body = auth_client.get(
+        _card_url(active_project.projcode, days=365)).get_data(as_text=True)
+
+    import re
+    link = re.search(r'href="([^"]*/explore[^"]*)"', body)
+    assert link, 'explorer link missing'
+    assert 'days=365' in link.group(1)
+    assert 'start=' not in link.group(1)
+
+
+def test_card_machine_route_403_without_permission(non_admin_client):
+    resp = non_admin_client.get('/dashboards/user/jobs/machine/derecho/card')
+    assert resp.status_code == 403
+
+
+def test_card_machine_route_404_unknown_machine(app, auth_client, monkeypatch):
+    _install_mock_plugin(app, monkeypatch, machines=('derecho',))
+    resp = auth_client.get('/dashboards/user/jobs/machine/gust/card')
+    assert resp.status_code == 404
+
+
+def test_card_machine_route_renders_machine_mode_shell(
+    app, auth_client, monkeypatch,
+):
+    _install_mock_plugin(app, monkeypatch)
+    resp = auth_client.get(
+        '/dashboards/user/jobs/machine/derecho/card?days=60'
+        '&cid=jobs-m1&tablist_id=jobHistCardTabs1')
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert f'start={_days_ago(60).isoformat()}' in body
+    assert 'By User' in body                    # machine mode keeps the pie
+    assert 'id="jobs-m1-card"' in body
+
+
+def test_card_user_route_renders_without_elevated_permission(
+    app, non_admin_client, monkeypatch,
+):
+    """The My Jobs shell is @login_required only — the username is pinned."""
+    _install_mock_plugin(app, monkeypatch)
+    resp = non_admin_client.get(
+        '/dashboards/user/jobs/user/derecho/card?days=30&cid=my-jobs-m1')
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert f'start={_days_ago(30).isoformat()}' in body
+    assert '>By User' not in body               # a pie of one, hidden here
+
+
+def test_card_shell_panels_stay_lazy_after_a_refetch(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Only the visible panel refetches; the rest wait to be shown."""
+    _install_mock_plugin(app, monkeypatch)
+    body = auth_client.get(
+        _card_url(active_project.projcode, days=30)).get_data(as_text=True)
+
+    assert 'hx-trigger="intersect once"' in body
+    assert body.count('hx-trigger="shown.bs.tab once"') >= 4

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -3508,3 +3508,96 @@ def test_card_shell_panels_stay_lazy_after_a_refetch(
 
     assert 'hx-trigger="intersect once"' in body
     assert body.count('hx-trigger="shown.bs.tab once"') >= 4
+
+
+# ---------------------------------------------------------------------------
+# Job Sizes: leading empty band suppression
+# ---------------------------------------------------------------------------
+
+def _sizes_hist(first_jobs=0):
+    """A nodes-style envelope whose 0 band is empty unless asked otherwise."""
+    return {
+        'dimension': 'nodes', 'column': 'numnodes', 'unit': 'nodes',
+        'min_param': 'min_nodes', 'max_param': 'max_nodes',
+        'buckets': [
+            {'label': '0', 'lo': 0, 'hi': 0,
+             'job_count': first_jobs, 'cpu_hours': 0.0, 'gpu_hours': 0.0},
+            {'label': '1', 'lo': 1, 'hi': 1,
+             'job_count': 12, 'cpu_hours': 120.0, 'gpu_hours': 0.0},
+            {'label': '2-4', 'lo': 2, 'hi': 4,
+             'job_count': 5, 'cpu_hours': 50.0, 'gpu_hours': 3.0},
+        ],
+        'null_count': 0, 'total_count': 17 + first_jobs,
+    }
+
+
+def test_trim_drops_a_leading_empty_band():
+    """Every job uses ≥1 node, so that 0 band can never fill."""
+    from webapp.jobs.routes import _trim_leading_empty_bands
+
+    hist = _sizes_hist()
+    trimmed = _trim_leading_empty_bands(hist)
+
+    assert [b['label'] for b in trimmed['buckets']] == ['1', '2-4']
+    # The envelope is a shared cache entry — trimming must copy, not mutate.
+    assert [b['label'] for b in hist['buckets']] == ['0', '1', '2-4']
+
+
+def test_trim_keeps_a_populated_leading_band():
+    """The GPU 0 band holds the CPU-only jobs and stays."""
+    from webapp.jobs.routes import _trim_leading_empty_bands
+
+    trimmed = _trim_leading_empty_bands(_sizes_hist(first_jobs=9))
+    assert [b['label'] for b in trimmed['buckets']] == ['0', '1', '2-4']
+
+
+def test_trim_leaves_an_entirely_empty_range_alone():
+    """All-zero → the chart's own placeholder, not a bandless envelope."""
+    from webapp.jobs.routes import _trim_leading_empty_bands
+
+    hist = _sizes_hist()
+    hist['buckets'] = [dict(b, job_count=0) for b in hist['buckets']]
+    assert _trim_leading_empty_bands(hist)['buckets'] == hist['buckets']
+
+
+def test_trim_ignores_the_displayed_metric():
+    """A band of real jobs charging no GPU-hours must not shift the axis."""
+    from webapp.jobs.routes import _trim_leading_empty_bands
+
+    hist = _sizes_hist(first_jobs=4)
+    hist['buckets'][0]['cpu_hours'] = 0.0
+    hist['buckets'][0]['gpu_hours'] = 0.0
+    assert _trim_leading_empty_bands(hist)['buckets'][0]['label'] == '0'
+
+
+def test_job_sizes_fragment_hides_the_empty_zero_band(
+    app, auth_client, active_project, monkeypatch,
+):
+    _install_mock_plugin(app, monkeypatch, jobs_histogram_return=_sizes_hist())
+    body = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/job-sizes'
+        '?machine=derecho&dimension=nodes'
+    ).get_data(as_text=True)
+
+    import re
+    labels = re.findall(r'<code>([^<]+)</code>', body)
+    assert '0' not in labels
+    assert '1' in labels and '2-4' in labels
+
+
+def test_job_sizes_bar_and_row_indices_stay_aligned_after_trim(
+    app, auth_client, active_project, monkeypatch,
+):
+    """#jh-bar-<i> and data-jh-bucket=<i> both index the trimmed vector."""
+    _install_mock_plugin(app, monkeypatch, jobs_histogram_return=_sizes_hist())
+    body = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/job-sizes'
+        '?machine=derecho&dimension=nodes'
+    ).get_data(as_text=True)
+
+    import re
+    # Band 0 of the rendered chart is now the '1' band, and the row that
+    # answers a click on it must be the one carrying its counts.
+    row = re.search(r'data-jh-bucket="0".*?</tr>', body, re.S)
+    assert row, 'no bucket-0 row rendered'
+    assert '<code>1</code>' in row.group(0)


### PR DESCRIPTION
Four related UI changes, in one commit each — three on the job-history card, one on the status page tab strip.

---

## 1. Selectable time window (`289acde`)

The card's lookback was fixed at 90 days by convention — three inline literals, invisible and unchangeable from the card itself. This adds a **30d / 60d / 90d / 1 yr** pill group to the tab strip that applies to **all six panels at once**, on all three hosts (My Jobs, Status → Job History, project resource-details), with the selection **persisting across machine subtabs and page reloads**.

Because each panel bakes its window into its own `hx-get` URL at render time, a pill re-renders the card *shell* — three new query-free routes (`/<projcode>/card`, `/machine/<machine>/card`, `/user/<machine>/card`) that mirror each mode's existing gating and do no plugin work, so the panels re-fetch lazily as they're shown.

`?days=` is whitelisted against `JOBS_WINDOW_CHOICES` (derived from the same tuple the pills render from, exposed as the `jobs_window_pills` Jinja global) and outranks any `start`/`end` already in the URL — the persistence layer can only append to a request, never rewrite the path. It normalizes back to a plain `start=` in `_roundtrip_params`, so in-panel pills, bar drills and explorer links keep speaking `start`/`end` and nothing downstream learns a second vocabulary. The explorer honours `?days=` too, which is what the card's "Open full view" link hands over.

Persistence rides the existing `data-chart-persist-*` contract under key `days`. Per-machine subtabs share a persist id and stay in lockstep; the window survives a reload. **Resource-details deliberately opts out** — its pills last the visit only, so a stored window can't quietly shadow that page's own date range.

**Two things worth a reviewer's eye:**

- **The card wrapper carries no `hx-target`/`hx-swap`.** htmx inherits both, and an earlier revision with `hx-target="this"` captured every descendant request that didn't name its own target — a By Project bucket drill swapped the whole card away (caught in browser smoke, not by tests). The sibling fan-out goes through `htmx.ajax()` instead, and `test_card_wrapper_declares_no_inheritable_hx_target` pins it.
- **The pill click saves to localStorage synchronously**, before htmx issues any request — the existing `afterSettle` save lands too late for the hand-off to sibling cards.

## 2. Job Sizes hides a leading empty band (`3ef8dd7`)

The 0 band can never fill for Nodes / CPUs — every job uses at least one of each — so it rendered as a permanent empty row plus a gap at the left of the chart. GPUs is the exception worth keeping: there the 0 band holds the CPU-only jobs (933K over 90 days on Derecho), so it survives on its own merit.

`_trim_leading_empty_bands()` sits in the shared histogram renderer, so Wait Times and Durations get the same treatment if their first band ever comes back empty. Two details:

- Emptiness is judged on `job_count` alone, never the displayed metric, so flipping Jobs / CPU-hours / GPU-hours can't shift the axis under the viewer. Zeros *inside* a distribution still render — that's what keeps the x-axis stable across filter changes.
- The trim runs before both the chart and the drill list, since `#jh-bar-<i>` and the table's `data-jh-bucket` are both positions in the same bucket vector. It returns a shallow copy — the envelope is a shared cache entry.

## 3. Identifiers in a button render in their stored case (`66d0902`)

`.btn` carries `text-transform: uppercase`, which is right for button labels but wrong for the entity quick-view links: every username came out shouting and, worse, indistinguishable at a glance from a projcode. Case *is* the convention that tells them apart (`SCSG0001` vs `benkirk`), and a username also has to match what you type at a shell prompt.

CSS-only. Nothing is forced to a case — each identifier renders as stored, so projcodes stay upper and usernames stay lower without the templates having to know which they're holding. Covers both spellings in use: `<code>` in the By User / By Project tables, `.font-monospace` in the histogram band drill-downs.

## 4. Status page: Reservations → Events, moved rightmost (`bacdaca`)

The status tab strip's **Reservations** tab is now **Events**, and sits at the far right of the strip, after the gated tabs.

- Route renamed `/status/reservations` → `/status/events`, endpoint `status_dashboard.reservations` → `.events`, page template → `events_page.html`. The rename is user-facing only — the backing `resource_reservations` rows, the query layer, and the collector ingest API keep the reservation vocabulary.
- Ordered last in both `base_status.html` (tab strip) and `nav.py` (navbar dropdown + mobile offcanvas). The two tabs ahead of it are gated on `VIEW_ALL_FILESYSTEM_DATA` / `VIEW_ALL_JOB_DATA` and drop out of the strip entirely when hidden, so **ordering it last is exactly what makes it rightmost for every audience** — a comment at each list says so, since a future tab appended in the obvious place would break it.
- Data gating and the count in the label are unchanged: the tab still shows only when there are upcoming reservations or a configured calendar embed.

No redirect from the old URL — say the word if bookmarks matter and it's a three-line addition.

---

## Test Results

`3366 passed, 30 skipped, 1 xfailed` (full suite, ~2 min).

44 new tests. Job-history card (38): `?days=` whitelist and precedence, roundtrip normalization, explorer default, the card routes per mode (auth, 404, 400 on unsafe element ids, baked window, pill state, persist opt-in, explorer hand-off, inherited-attribute regression), and band trimming (trim/keep/all-empty/metric-independence plus bar↔row index alignment). Status tab (6): `TestEventsTab` pins the position at both ends of the permission range — staff sees six tabs, a non-admin sees four, Events is last in both — plus page render, data gating, and the label; `test_nav.py` pins the navbar item's position.

Browser-verified throughout: pill click re-renders and reloads the visible panel with the saved tab restored, sibling machine subtabs follow, a reload restores pills + explorer link + data window, My Jobs and Status stay independent, resource-details stores nothing; Nodes starts at the `1` band with bar 0 drilling `min_nodes=1` while GPUs keeps its 0 band; all four identifier surfaces render in the right case; and the Events tab renders rightmost both logged out (4 tabs) and as an admin (6 tabs).

Note on the route-map parity snapshot: the job-history card routes needed no regen (it pins the dashboard blueprints, and those routes live on the `jobs` blueprint), but the status rename does change it — that diff is the endpoint/rule rename and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
