### PR TITLE
Durable view preferences: shared group_by, family-scoped metric

### DIFF
--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -701,6 +701,23 @@ def _parse_metric(default: str) -> str:
     return metric if metric in _METRICS else default
 
 
+def _parse_group_by() -> str:
+    """Owner dimension for the histograms' User|Project pill.
+
+    ``group_by=user|project`` is the app-wide spelling — the same one the
+    status dashboard's queue-load chart uses, which is what lets the
+    choice ride the shared view-preference bucket and mean the same thing
+    on both. ``owners_by=user|account`` (the plugin's own vocabulary, and
+    what this pill emitted before) is still honoured so in-flight links
+    and bookmarks keep working. Anything else falls back to 'user'.
+    """
+    raw = (request.args.get('group_by') or '').strip()
+    if raw:
+        return 'project' if raw == 'project' else 'user'
+    legacy = (request.args.get('owners_by') or '').strip()
+    return 'project' if legacy == 'account' else 'user'
+
+
 def _tree_projcodes(project) -> list:
     """(Scoped) parent + descendants — same tree expansion as jobs_fragment.
 
@@ -906,15 +923,17 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
 
     # User|Project owner-dimension pill — offered only where the context
     # spans more than one project (machine mode; a project tree > 1).
-    # Elsewhere ?owners_by= is ignored, so a crafted URL can't flip a
+    # Elsewhere the param is ignored, so a crafted URL can't flip a
     # single-project pane into a redundant per-project breakdown.
     owners_toggle = (mode == 'machine'
                      or (mode == 'project'
                          and account_projcodes is not None
                          and len(account_projcodes) > 1))
-    owners_by = 'user'
-    if owners_toggle and (request.args.get('owners_by') or '').strip() == 'account':
-        owners_by = 'account'
+    group_by = _parse_group_by() if owners_toggle else 'user'
+    # The plugin's word for a project owner is 'account'; the URL and the
+    # shared view-preference bucket speak 'project'. Translate here, at
+    # the one boundary between the two vocabularies.
+    owners_by = 'account' if group_by == 'project' else 'user'
 
     hist = None
     error = None
@@ -960,9 +979,9 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
 
     # Round-trip the non-default owner dimension through the metric /
     # dimension pills' hx-include form (AFTER the drill URLs — the jobs
-    # fragments don't take owners_by).
-    if owners_by != 'user':
-        params = dict(params, owners_by=owners_by)
+    # fragments don't take group_by).
+    if group_by != 'user':
+        params = dict(params, group_by=group_by)
 
     # Same affordance gates as the By User / By Project tables — never
     # render an entity quick-view link that would 403.
@@ -980,7 +999,7 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
         metric=metric,
         dimension=dimension, dimension_toggle=dimension_toggle,
         size_dimensions=_SIZE_DIMENSIONS,
-        owners_by=owners_by, owners_toggle=owners_toggle,
+        group_by=group_by, owners_toggle=owners_toggle,
         can_view_users=can_view_users,
         can_view_projects=can_view_projects,
         fragment_url=fragment_url,

--- a/src/webapp/static/js/nav-view-persistence.js
+++ b/src/webapp/static/js/nav-view-persistence.js
@@ -6,6 +6,8 @@
  *  1. Tab selections  — key: "tab:<tablistId>"    value: "#pane-id"
  *  2. Collapse state  — key: "collapse:<id>"      value: "1"
  *  3. Chart selectors — key: "chart:<id>"         value: JSON params
+ *     …and settings shared across surfaces (the owner dimension, each
+ *     metric family) in one bucket: "chart:__shared__"
  *  4. Scroll position — key: "nav:scroll:<path>"  (sessionStorage, one-shot)
  *
  * The job-history period pills (5) reuse the chart-selector storage under
@@ -141,95 +143,156 @@
     // Chart fragments with multiple HTMX btn-group selectors (group_by,
     // state, metric, rank_by, …) lose their selection on a full page
     // reload — the loader's hx-get defaults run again. We persist the
-    // live URL params to localStorage, keyed by the chart's stable dom
-    // id, and replay them on the next configRequest.
+    // live URL params to localStorage and replay them on the next
+    // configRequest. Which params, and where they live, is declared by
+    // the template — co-locating the key list with the buttons that own
+    // it avoids JS-side hardcoding, so adding a selector is a one-file
+    // change. Server-side validation in the route is the safety net for
+    // stale combinations.
     //
-    // Which params to persist is declared by the template via
-    // `data-chart-persist-keys` (whitespace-separated). Co-locating the
-    // key list with the buttons that own it avoids JS-side hardcoding,
-    // so adding a new selector is a one-file change. Server-side
-    // validation in the route is the safety net for stale combinations.
+    // Two channels, both whitespace-separated declarations:
+    //
+    //   data-chart-persist-id + data-chart-persist-keys="state rank_by"
+    //       a per-chart bucket keyed by the chart's stable dom id — for
+    //       settings that only mean something on that one chart.
+    //
+    //   data-chart-persist-shared="group_by metric:jobs"
+    //       ONE app-wide bucket, for settings whose vocabulary is shared
+    //       across surfaces. A bare name is a genuinely global concept:
+    //       `group_by` is user|project on the queue-load chart and on the
+    //       job histograms alike, so choosing Project in one place
+    //       pre-selects it in the other. `param:family` sends `param` on
+    //       the wire but stores it under the family-scoped key, which is
+    //       what keeps a homonym from cross-contaminating: `metric` means
+    //       jobs|cpu_hours|gpu_hours on the jobs card, jobs|cores|gpus|
+    //       nodes on the queue chart and charges|jobs|core_hours on the
+    //       usage chart, so each family remembers its own.
+    //
+    // The rule when adding one: share a key across surfaces only when the
+    // VALUE vocabularies are identical; otherwise give it a family.
+    //
+    // Saves MERGE into the bucket rather than replacing it — several
+    // elements declare different key subsets of the same bucket, and a
+    // wholesale write would drop whatever this request didn't carry.
 
     var CHART_PREFIX = 'chart:';
+    var SHARED_BUCKET = '__shared__';
 
-    function chartPersistKeys(elt) {
-        var raw = elt.dataset.chartPersistKeys;
+    /** Parse a declaration into {param, key} pairs; `metric:jobs` travels
+     *  as `metric` and is stored under `metric:jobs`. */
+    function persistSpecs(raw) {
         if (!raw) return [];
-        return raw.split(/\s+/).filter(Boolean);
+        return raw.split(/\s+/).filter(Boolean).map(function (spec) {
+            var i = spec.indexOf(':');
+            return { param: i === -1 ? spec : spec.slice(0, i), key: spec };
+        });
     }
 
-    /** Read saved selections and override hx-get parameters. Only applies to
-     *  the *loader* element itself — i.e. the wrapper div with hx-trigger="load"
-     *  that carries `data-chart-persist-id` directly. Selector buttons inside
-     *  the chart fragment have an ancestor with the marker, but `elt.matches`
-     *  ensures we don't clobber the user's deliberate click. */
-    document.addEventListener('htmx:configRequest', function (event) {
-        var elt = event.detail.elt;
-        if (!elt || !elt.matches || !elt.matches('[data-chart-persist-id]')) return;
+    function chartSpecs(elt) { return persistSpecs(elt.dataset.chartPersistKeys); }
+    function sharedSpecs(elt) { return persistSpecs(elt.dataset.chartPersistShared); }
 
-        var keys = chartPersistKeys(elt);
-        if (keys.length === 0) return;
-
-        var id = elt.dataset.chartPersistId;
+    function readBucket(id) {
         var raw = null;
-        try { raw = localStorage.getItem(CHART_PREFIX + id); } catch (_) { return; }
-        if (!raw) return;
-
+        try { raw = localStorage.getItem(CHART_PREFIX + id); } catch (_) { return null; }
+        if (!raw) return null;
         var saved;
-        try { saved = JSON.parse(raw); } catch (_) { return; }
-        if (!saved || typeof saved !== 'object') return;
+        try { saved = JSON.parse(raw); } catch (_) { return null; }
+        return (saved && typeof saved === 'object') ? saved : null;
+    }
 
-        keys.forEach(function (k) {
-            if (k in saved) event.detail.parameters[k] = saved[k];
+    /** Merge updates into a bucket, leaving keys this write didn't mention. */
+    function mergeBucket(id, updates) {
+        var bucket = readBucket(id) || {};
+        Object.keys(updates).forEach(function (k) { bucket[k] = updates[k]; });
+        try {
+            localStorage.setItem(CHART_PREFIX + id, JSON.stringify(bucket));
+        } catch (_) {}
+    }
+
+    /** Replay saved values into an outgoing request. */
+    function injectSaved(detail, id, specs) {
+        if (!specs.length) return;
+        var saved = readBucket(id);
+        if (!saved) return;
+
+        var injected = [];
+        specs.forEach(function (s) {
+            if (s.key in saved) {
+                detail.parameters[s.param] = saved[s.key];
+                injected.push(s.param);
+            }
         });
+        if (!injected.length) return;
 
-        // htmx appends `parameters` to `path` for GET requests, so any keys
-        // already encoded in the loader's hx-get URL would produce duplicate
-        // query keys (?metric=jobs&metric=cores). Werkzeug's request.args.get
-        // returns the FIRST value, which silently defeats the override. Strip
-        // the persisted keys from `path` so our parameters become authoritative.
-        var path = event.detail.path;
+        // htmx appends `parameters` to `path` for GET requests, so any param
+        // already encoded in the hx-get URL would produce a duplicate query
+        // key (?metric=jobs&metric=cores). Werkzeug's request.args.get returns
+        // the FIRST value, which silently defeats the override. Strip ours
+        // from `path` so the injected parameters become authoritative.
+        var path = detail.path;
         if (path && path.indexOf('?') !== -1) {
             var parts = path.split('?');
             var qs;
             try { qs = new URLSearchParams(parts[1]); } catch (_) { return; }
-            keys.forEach(function (k) { qs.delete(k); });
+            injected.forEach(function (p) { qs.delete(p); });
             var rest = qs.toString();
-            event.detail.path = rest ? parts[0] + '?' + rest : parts[0];
+            detail.path = rest ? parts[0] + '?' + rest : parts[0];
+        }
+    }
+
+    /** Read saved selections and override hx-get parameters. Only applies to
+     *  elements carrying a marker THEMSELVES — i.e. the loader with
+     *  hx-trigger="load", or a tab button that fetches a panel. Selector
+     *  buttons inside a persisted fragment have an ancestor with the marker,
+     *  but `elt.matches` ensures we don't clobber a deliberate click. */
+    document.addEventListener('htmx:configRequest', function (event) {
+        var elt = event.detail.elt;
+        if (!elt || !elt.matches) return;
+        if (elt.matches('[data-chart-persist-id]')) {
+            injectSaved(event.detail, elt.dataset.chartPersistId, chartSpecs(elt));
+        }
+        if (elt.matches('[data-chart-persist-shared]')) {
+            injectSaved(event.detail, SHARED_BUCKET, sharedSpecs(elt));
         }
     });
 
-    /** After a chart fragment swaps in, capture the resolved request URL —
-     *  this is the source of truth for which selector combination is now
-     *  showing. Avoids reading button DOM classes. */
-    document.addEventListener('htmx:afterSettle', function (event) {
-        var elt = event.detail.elt;
-        if (!elt) return;
-
-        var chartEl = (elt.matches && elt.matches('[data-chart-persist-id]'))
-            ? elt
-            : (elt.querySelector ? elt.querySelector('[data-chart-persist-id]') : null);
-        if (!chartEl) return;
-
-        var keys = chartPersistKeys(chartEl);
-        if (keys.length === 0) return;
-
-        var url = event.detail.xhr && event.detail.xhr.responseURL;
-        if (!url) return;
-
+    function saveFromUrl(url, id, specs) {
+        if (!specs.length) return;
         var qs;
         try { qs = new URL(url, window.location.origin).searchParams; } catch (_) { return; }
 
         var saved = {};
-        keys.forEach(function (k) {
-            if (qs.has(k)) saved[k] = qs.get(k);
+        specs.forEach(function (s) {
+            if (qs.has(s.param)) saved[s.key] = qs.get(s.param);
         });
-        if (Object.keys(saved).length === 0) return;
+        if (Object.keys(saved).length) mergeBucket(id, saved);
+    }
 
-        try {
-            localStorage.setItem(CHART_PREFIX + chartEl.dataset.chartPersistId,
-                                 JSON.stringify(saved));
-        } catch (_) {}
+    /** After a fragment swaps in, capture the resolved request URL — the
+     *  source of truth for which selector combination is now showing, and
+     *  cheaper than reading button DOM classes. htmx reports the SETTLED
+     *  element here (the swapped-in wrapper, or the target container for an
+     *  innerHTML swap) rather than the button that asked, which is what lets
+     *  a selector click persist with no click handler of its own. */
+    document.addEventListener('htmx:afterSettle', function (event) {
+        var elt = event.detail.elt;
+        if (!elt) return;
+        var url = event.detail.xhr && event.detail.xhr.responseURL;
+        if (!url) return;
+
+        function nearest(selector) {
+            if (elt.matches && elt.matches(selector)) return elt;
+            return elt.querySelector ? elt.querySelector(selector) : null;
+        }
+
+        var chartEl = nearest('[data-chart-persist-id]');
+        if (chartEl) {
+            saveFromUrl(url, chartEl.dataset.chartPersistId, chartSpecs(chartEl));
+        }
+        var sharedEl = nearest('[data-chart-persist-shared]');
+        if (sharedEl) {
+            saveFromUrl(url, SHARED_BUCKET, sharedSpecs(sharedEl));
+        }
     });
 
     // ── Job-history period pills ─────────────────────────────────────────────
@@ -256,11 +319,7 @@
 
     /** The stored window for a persist id, as a string, or null. */
     function savedDays(persistId) {
-        var raw = null;
-        try { raw = localStorage.getItem(CHART_PREFIX + persistId); } catch (_) { return null; }
-        if (!raw) return null;
-        var saved;
-        try { saved = JSON.parse(raw); } catch (_) { return null; }
+        var saved = readBucket(persistId);
         return (saved && saved[DAYS_KEY]) ? String(saved[DAYS_KEY]) : null;
     }
 
@@ -299,9 +358,7 @@
         if (!id) return;
 
         var days = btn.dataset.daysValue;
-        try {
-            localStorage.setItem(CHART_PREFIX + id, JSON.stringify({days: days}));
-        } catch (_) {}
+        mergeBucket(id, {days: days});
 
         // Siblings get the window spelled out rather than relying on the
         // injection above, so the hand-off can't race the save.

--- a/src/webapp/templates/dashboards/fragments/glossary.html
+++ b/src/webapp/templates/dashboards/fragments/glossary.html
@@ -122,6 +122,12 @@ Core-hours = cores used × wall-clock hours. The raw usage measure, before
 allocation-unit weighting.
 {%- endmacro %}
 
+{% macro g_cpu_hours() -%}
+CPU-hours = CPUs used × wall-clock hours, measured from PBS job records. Close
+kin to Core-hours, but a different source — job history, not charge summaries —
+so the two won't tie out exactly.
+{%- endmacro %}
+
 {% macro g_charges() -%}
 Allocation units drawn down by this activity over the selected date range — the
 billed amount, not a job count.

--- a/src/webapp/templates/dashboards/status/partials/system_user_proj_chart_card.html
+++ b/src/webapp/templates/dashboards/status/partials/system_user_proj_chart_card.html
@@ -45,7 +45,8 @@
              hx-trigger="load"
              hx-swap="innerHTML"
              data-chart-persist-id="upq-chart-{{ _chart_system }}"
-             data-chart-persist-keys="group_by state metric rank_by">
+             data-chart-persist-keys="state rank_by"
+             data-chart-persist-shared="group_by metric:queue">
             <div class="text-center text-muted py-5">
                 <i class="fas fa-spinner fa-spin"></i> Loading chart…
             </div>

--- a/src/webapp/templates/dashboards/status/partials/user_proj_chart.html
+++ b/src/webapp/templates/dashboards/status/partials/user_proj_chart.html
@@ -22,9 +22,16 @@
     'group_by': group_by, 'state': state, 'metric': metric,
     'hours': hours, 'rank_by': rank_by,
 } %}
+{# Two persistence channels (nav-view-persistence.js): `state` and
+   `rank_by` mean something only here, so they stay in this chart's own
+   bucket; `group_by` (user|project) is the same choice the job-history
+   histograms offer, so it rides the shared bucket and carries across —
+   and `metric` rides it family-scoped, because the word means
+   jobs|cores|gpus|nodes here but something else on every other chart. #}
 <div id="{{ chart_dom_id }}"
      data-chart-persist-id="{{ chart_dom_id }}"
-     data-chart-persist-keys="group_by state metric rank_by">
+     data-chart-persist-keys="state rank_by"
+     data-chart-persist-shared="group_by metric:queue">
     <div class="d-flex flex-wrap flex-lg-nowrap gap-2 mb-3 align-items-end">
         <div>
             <label class="form-label small text-muted mb-1 me-2">Group by</label>

--- a/src/webapp/templates/dashboards/status/queue_history.html
+++ b/src/webapp/templates/dashboards/status/queue_history.html
@@ -124,7 +124,8 @@
              hx-trigger="load"
              hx-swap="innerHTML"
              data-chart-persist-id="upq-chart-{{ system }}-{{ queue_name }}"
-             data-chart-persist-keys="group_by state metric rank_by">
+             data-chart-persist-keys="state rank_by"
+             data-chart-persist-shared="group_by metric:queue">
             <div class="text-center text-muted py-5">
                 <i class="fas fa-spinner fa-spin"></i> Loading chart…
             </div>

--- a/src/webapp/templates/dashboards/user/partials/disk_scans_card.html
+++ b/src/webapp/templates/dashboards/user/partials/disk_scans_card.html
@@ -21,6 +21,16 @@
    In resource mode project/scope/fileset are absent; the fragment templates
    treat them as optional and suppress the per-user drill-downs (which need a
    projcode) — the whole-FS drill path is Large Directories → unscoped explorer.
+
+   Panels with selectors declare them on both ends (nav-view-persistence.js):
+   on the tab button, which requests the panel, so a stored choice is
+   injected; and on the container, the element htmx reports as settled, so
+   an in-panel click persists without a click handler. The families are
+   scan-specific — `metric:disk-scan` is data|files, which is neither the
+   disk *usage* chart's bytes|files nor any other metric pill's vocabulary,
+   and `kind:disk-scan` is a unix owner|group, deliberately NOT the
+   user|project `group_by` the job and queue charts share. Large
+   directories keeps its sort/recursive settings per visit.
 #}
 {% if mode == 'resource' %}
     {% set _dirs_url  = url_for('disk_scans.directories_resource_fragment',   resource=resource_name, target_id=cid ~ '-directories') %}
@@ -61,7 +71,8 @@
                 hx-get="{{ _ent_url }}"
                 hx-target="#{{ cid }}-entities"
                 hx-swap="innerHTML"
-                hx-trigger="shown.bs.tab once">
+                hx-trigger="shown.bs.tab once"
+                data-chart-persist-shared="kind:disk-scan">
             <i class="fas fa-users me-1"></i> User / group counts
         </button>
     </li>
@@ -73,7 +84,8 @@
                 hx-get="{{ _acc_url }}"
                 hx-target="#{{ cid }}-access"
                 hx-swap="innerHTML"
-                hx-trigger="shown.bs.tab once">
+                hx-trigger="shown.bs.tab once"
+                data-chart-persist-shared="metric:disk-scan log:disk-scan">
             <i class="fas fa-clock-rotate-left me-1"></i> Access history
         </button>
     </li>
@@ -84,7 +96,8 @@
                 hx-get="{{ _files_url }}"
                 hx-target="#{{ cid }}-files"
                 hx-swap="innerHTML"
-                hx-trigger="shown.bs.tab once">
+                hx-trigger="shown.bs.tab once"
+                data-chart-persist-shared="metric:disk-scan log:disk-scan">
             <i class="fas fa-ruler me-1"></i> File sizes
         </button>
     </li>
@@ -107,7 +120,7 @@
     </div>
     {% if mode != 'user' %}
     <div class="tab-pane fade" id="tab-{{ cid }}-ent" role="tabpanel">
-        <div id="{{ cid }}-entities">
+        <div id="{{ cid }}-entities" data-chart-persist-shared="kind:disk-scan">
             <p class="text-muted small mb-0">
                 <i class="fas fa-spinner fa-spin me-1"></i> Loading…
             </p>
@@ -115,14 +128,14 @@
     </div>
     {% endif %}
     <div class="tab-pane fade" id="tab-{{ cid }}-acc" role="tabpanel">
-        <div id="{{ cid }}-access">
+        <div id="{{ cid }}-access" data-chart-persist-shared="metric:disk-scan log:disk-scan">
             <p class="text-muted small mb-0">
                 <i class="fas fa-spinner fa-spin me-1"></i> Loading access history…
             </p>
         </div>
     </div>
     <div class="tab-pane fade" id="tab-{{ cid }}-files" role="tabpanel">
-        <div id="{{ cid }}-files">
+        <div id="{{ cid }}-files" data-chart-persist-shared="metric:disk-scan log:disk-scan">
             <p class="text-muted small mb-0">
                 <i class="fas fa-spinner fa-spin me-1"></i> Loading file sizes…
             </p>

--- a/src/webapp/templates/dashboards/user/partials/jobs_by_project.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_by_project.html
@@ -1,5 +1,7 @@
 {% from 'dashboards/user/partials/_jobs_macros.html'
    import jobs_disabled, jobs_error, jobs_empty %}
+{% from 'dashboards/fragments/help.html' import term with context %}
+{% from 'dashboards/fragments/glossary.html' import g_cpu_hours with context %}
 {#
   By Project fragment — per-project usage pie + drillable rows, the
   mirror of jobs_by_user.html. All three modes: user (the pinned user's
@@ -76,7 +78,7 @@
           <tr>
             <th class="sortable-header" data-sort="text">Project</th>
             <th class="sortable-header text-end{% if metric == 'jobs' %} sort-desc{% endif %}" data-sort="numeric">Jobs</th>
-            <th class="sortable-header text-end{% if metric == 'cpu_hours' %} sort-desc{% endif %}" data-sort="numeric">CPU-hours</th>
+            <th class="sortable-header text-end{% if metric == 'cpu_hours' %} sort-desc{% endif %}" data-sort="numeric">{{ term('CPU-hours', g_cpu_hours()) }}</th>
             <th class="sortable-header text-end{% if metric == 'gpu_hours' %} sort-desc{% endif %}" data-sort="numeric">GPU-hours</th>
           </tr>
         </thead>

--- a/src/webapp/templates/dashboards/user/partials/jobs_by_user.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_by_user.html
@@ -1,5 +1,7 @@
 {% from 'dashboards/user/partials/_jobs_macros.html'
    import jobs_disabled, jobs_error, jobs_empty %}
+{% from 'dashboards/fragments/help.html' import term with context %}
+{% from 'dashboards/fragments/glossary.html' import g_cpu_hours with context %}
 {#
   By User fragment — per-user usage pie + drillable rows. Embedded via
   hx-get from the Job History card (project + machine modes; hidden in
@@ -75,7 +77,7 @@
           <tr>
             <th class="sortable-header" data-sort="text">User</th>
             <th class="sortable-header text-end{% if metric == 'jobs' %} sort-desc{% endif %}" data-sort="numeric">Jobs</th>
-            <th class="sortable-header text-end{% if metric == 'cpu_hours' %} sort-desc{% endif %}" data-sort="numeric">CPU-hours</th>
+            <th class="sortable-header text-end{% if metric == 'cpu_hours' %} sort-desc{% endif %}" data-sort="numeric">{{ term('CPU-hours', g_cpu_hours()) }}</th>
             <th class="sortable-header text-end{% if metric == 'gpu_hours' %} sort-desc{% endif %}" data-sort="numeric">GPU-hours</th>
           </tr>
         </thead>

--- a/src/webapp/templates/dashboards/user/partials/jobs_card.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_card.html
@@ -56,6 +56,20 @@
 {% macro _persist(pid) -%}
 {%- if pid %} data-chart-persist-id="{{ pid }}" data-chart-persist-keys="days"{% endif -%}
 {%- endmacro %}
+{# The panel lens — which metric, whose segments, and (Job Sizes only)
+   which dimension. Declared on both ends of every panel that has pills:
+   on the tab button, so the stored lens is injected into the panel fetch
+   (including the one a period pill's shell re-render triggers), and on
+   the panel container, which is the element htmx reports as settled — so
+   an in-panel pill click persists with no click handler of its own.
+   `metric:jobs` is family-scoped: the word means something different on
+   the queue-load and usage charts, and the families must not collide.
+   `group_by` is deliberately bare — user|project means the same thing
+   here and on the status queue-load chart, so the choice carries across.
+   The Jobs tab opts out: none of the three apply to a per-job table. #}
+{% macro _lens() -%}
+ data-chart-persist-shared="group_by metric:jobs dimension:jobs"
+{%- endmacro %}
 {# The explorer link speaks ?days= rather than a computed date so the
    cold-start sync in JS never has to re-derive a window client-side. #}
 {% set _x_start = none if days else start %}
@@ -129,7 +143,7 @@
                 hx-get="{{ _user_url }}"
                 hx-target="#{{ cid }}-byuser"
                 hx-swap="innerHTML"
-                hx-trigger="shown.bs.tab once"{{ _persist(days_persist_id) }}>
+                hx-trigger="shown.bs.tab once"{{ _persist(days_persist_id) }}{{ _lens() }}>
             <i class="fas fa-users me-1"></i> By User
         </button>
     </li>
@@ -142,7 +156,7 @@
                 hx-get="{{ _proj_url }}"
                 hx-target="#{{ cid }}-byproj"
                 hx-swap="innerHTML"
-                hx-trigger="shown.bs.tab once"{{ _persist(days_persist_id) }}>
+                hx-trigger="shown.bs.tab once"{{ _persist(days_persist_id) }}{{ _lens() }}>
             <i class="fas fa-diagram-project me-1"></i> By Project
         </button>
     </li>
@@ -154,7 +168,7 @@
                 hx-get="{{ _wait_url }}"
                 hx-target="#{{ cid }}-wait"
                 hx-swap="innerHTML"
-                hx-trigger="shown.bs.tab once"{{ _persist(days_persist_id) }}>
+                hx-trigger="shown.bs.tab once"{{ _persist(days_persist_id) }}{{ _lens() }}>
             <i class="fas fa-hourglass-half me-1"></i> Wait Times
         </button>
     </li>
@@ -165,7 +179,7 @@
                 hx-get="{{ _sizes_url }}"
                 hx-target="#{{ cid }}-sizes"
                 hx-swap="innerHTML"
-                hx-trigger="shown.bs.tab once"{{ _persist(days_persist_id) }}>
+                hx-trigger="shown.bs.tab once"{{ _persist(days_persist_id) }}{{ _lens() }}>
             <i class="fas fa-layer-group me-1"></i> Job Sizes
         </button>
     </li>
@@ -176,7 +190,7 @@
                 hx-get="{{ _dur_url }}"
                 hx-target="#{{ cid }}-durations"
                 hx-swap="innerHTML"
-                hx-trigger="shown.bs.tab once"{{ _persist(days_persist_id) }}>
+                hx-trigger="shown.bs.tab once"{{ _persist(days_persist_id) }}{{ _lens() }}>
             <i class="fas fa-stopwatch me-1"></i> Durations
         </button>
     </li>
@@ -215,7 +229,7 @@
     </div>
     {% if mode != 'user' %}
     <div class="tab-pane fade" id="tab-{{ cid }}-byuser" role="tabpanel">
-        <div id="{{ cid }}-byuser">
+        <div id="{{ cid }}-byuser"{{ _lens() }}>
             <p class="text-muted small mb-0">
                 <i class="fas fa-spinner fa-spin me-1"></i> Loading…
             </p>
@@ -224,7 +238,7 @@
     {% endif %}
     {% if _proj_url %}
     <div class="tab-pane fade" id="tab-{{ cid }}-byproj" role="tabpanel">
-        <div id="{{ cid }}-byproj">
+        <div id="{{ cid }}-byproj"{{ _lens() }}>
             <p class="text-muted small mb-0">
                 <i class="fas fa-spinner fa-spin me-1"></i> Loading…
             </p>
@@ -232,21 +246,21 @@
     </div>
     {% endif %}
     <div class="tab-pane fade" id="tab-{{ cid }}-wait" role="tabpanel">
-        <div id="{{ cid }}-wait">
+        <div id="{{ cid }}-wait"{{ _lens() }}>
             <p class="text-muted small mb-0">
                 <i class="fas fa-spinner fa-spin me-1"></i> Loading wait times…
             </p>
         </div>
     </div>
     <div class="tab-pane fade" id="tab-{{ cid }}-sizes" role="tabpanel">
-        <div id="{{ cid }}-sizes">
+        <div id="{{ cid }}-sizes"{{ _lens() }}>
             <p class="text-muted small mb-0">
                 <i class="fas fa-spinner fa-spin me-1"></i> Loading job sizes…
             </p>
         </div>
     </div>
     <div class="tab-pane fade" id="tab-{{ cid }}-durations" role="tabpanel">
-        <div id="{{ cid }}-durations">
+        <div id="{{ cid }}-durations"{{ _lens() }}>
             <p class="text-muted small mb-0">
                 <i class="fas fa-spinner fa-spin me-1"></i> Loading durations…
             </p>

--- a/src/webapp/templates/dashboards/user/partials/jobs_histogram.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_histogram.html
@@ -1,5 +1,7 @@
 {% from 'dashboards/user/partials/_jobs_macros.html'
    import jobs_disabled, jobs_error, jobs_empty %}
+{% from 'dashboards/fragments/help.html' import term with context %}
+{% from 'dashboards/fragments/glossary.html' import g_cpu_hours with context %}
 {#
   Histogram fragment — shared by the Wait Times, Job Sizes, and Durations
   tabs (identical envelope shape; only the dimension differs). Embedded
@@ -15,8 +17,12 @@
                  'memory_used' | 'memory_wasted' | 'duration'
     dimension_toggle — True only on the Job Sizes tab
     size_dimensions  — the dimension pill order
-    owners_by       — 'user' | 'account': who owns the stacked segments
-                      and the per-band tier
+    group_by        — 'user' | 'project': who owns the stacked segments
+                      and the per-band tier. The URL vocabulary, shared
+                      with the status queue-load chart; routes.py maps
+                      'project' to the plugin's 'account'. The drill URLs
+                      below still key on `account=` — that's the jobs
+                      fragment's own filter param, not this pill.
     owners_toggle   — offer the User|Project pill (multi-project contexts)
     can_view_users / can_view_projects — entity quick-view modal gates
     fragment_url, target_id, params — re-fetch plumbing
@@ -73,13 +79,13 @@
     </div>
     {% if owners_toggle | default(false) %}
     {# Owner-dimension pills — whether users or projects own the stacked
-       segments and the per-band tier. The explicit ?owners_by= wins over
+       segments and the per-band tier. The explicit ?group_by= wins over
        the round-trip form's stale value (Werkzeug reads the first). #}
     <div class="btn-group btn-group-sm me-1" role="group" aria-label="Owner dimension">
-      {% for ob, label in [('user', 'User'), ('account', 'Project')] %}
+      {% for ob, label in [('user', 'User'), ('project', 'Project')] %}
       <button type="button"
-              class="btn btn-outline-secondary {% if owners_by == ob %}active{% endif %}"
-              hx-get="{{ fragment_url }}?owners_by={{ ob }}&metric={{ metric }}{% if dimension_toggle %}&dimension={{ dimension }}{% endif %}"
+              class="btn btn-outline-secondary {% if group_by == ob %}active{% endif %}"
+              hx-get="{{ fragment_url }}?group_by={{ ob }}&metric={{ metric }}{% if dimension_toggle %}&dimension={{ dimension }}{% endif %}"
               hx-target="#{{ target_id }}"
               hx-include="#jobs-hist-params-{{ target_id }}"
               hx-swap="innerHTML">
@@ -139,7 +145,7 @@
      account= for project owners. If the pane already pins ?user=, the
      single-owner shortcut guarantees the appended duplicate carries the
      identical value (Werkzeug reads the first) — benign. #}
-  {% set _okey = 'account' if owners_by | default('user') == 'account'
+  {% set _okey = 'account' if group_by | default('user') == 'project'
      else 'user' %}
   {% macro owner_jobs_drill(dt_id, owner, drill_url, band_label) %}
   <div class="p-2 bg-light" id="{{ dt_id }}"
@@ -171,7 +177,7 @@
         <tr>
           <th>Range</th>
           <th class="text-end">Jobs</th>
-          <th class="text-end">CPU-hours</th>
+          <th class="text-end">{{ term('CPU-hours', g_cpu_hours()) }}</th>
           <th class="text-end">GPU-hours</th>
         </tr>
       </thead>

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -447,10 +447,14 @@
         <div class="card-body">
             {# Chart loads via HTMX so the metric pill selector (Charges
                / Job Count / Core-Hours) can swap the SVG in place.
-               nav-view-persistence.js round-trips the `metric` URL
-               param through localStorage via the data-chart-persist-*
-               attributes, so the analyst's choice survives page
-               reloads. #}
+               nav-view-persistence.js round-trips the `metric` URL param
+               through localStorage, so the analyst's choice survives page
+               reloads — and, being stored under the shared `metric:usage`
+               family key rather than a per-page id, follows them from one
+               project's resource page to the next. Family-scoped because
+               these values (charges|jobs|core_hours) are not the ones any
+               other chart's metric pill offers. A resource whose type
+               lacks the stored metric clamps back to charges server-side. #}
             <div id="usage-chart-wrapper"
                  hx-get="{{ url_for('user_dashboard.resource_details_usage_chart',
                                     projcode=projcode,
@@ -461,8 +465,7 @@
                                     metric='charges') }}"
                  hx-trigger="load"
                  hx-swap="innerHTML"
-                 data-chart-persist-id="usage-chart-{{ projcode }}-{{ resource_name }}"
-                 data-chart-persist-keys="metric">
+                 data-chart-persist-shared="metric:usage">
                 <div class="text-center text-muted py-5">
                     <i class="fas fa-spinner fa-spin"></i> Loading chart…
                 </div>

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -294,9 +294,11 @@
         <div class="card-body">
             {# Chart loads via HTMX so the Data Volume / File Count tab can
                swap the SVG in place. nav-view-persistence.js round-trips
-               the `metric` URL param through localStorage via the
-               data-chart-persist-* attributes (metric only — never the
-               dates, so the timeframe picker stays authoritative). #}
+               the `metric` URL param through localStorage (metric only —
+               never the dates, so the timeframe picker stays
+               authoritative). Its own `metric:disk-usage` family: bytes|
+               files is a different vocabulary from every other metric
+               pill, including the fs-scan distribution's data|files. #}
             <div id="disk-usage-chart-wrapper"
                  hx-get="{{ url_for('user_dashboard.resource_details_disk_usage_chart',
                                     projcode=projcode,
@@ -308,8 +310,7 @@
                                     metric='bytes') }}"
                  hx-trigger="load"
                  hx-swap="innerHTML"
-                 data-chart-persist-id="disk-usage-chart-{{ projcode }}-{{ resource_name }}"
-                 data-chart-persist-keys="metric">
+                 data-chart-persist-shared="metric:disk-usage">
                 <div class="text-center text-muted py-5">
                     <i class="fas fa-spinner fa-spin"></i> Loading chart…
                 </div>

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -2937,7 +2937,7 @@ def test_histogram_owners_limit_and_sort_forwarded(
     assert kwargs['owners_sort_by'] == 'gpu_hours'
 
 
-# --- Histogram User|Project owner pill (owners_by) --------------------------
+# --- Histogram User|Project owner pill (group_by) ---------------------------
 
 def _sample_hist_project_owners(dimension='wait'):
     """Owner keys are projcodes — the plugin owners_by='account' envelope.
@@ -2963,19 +2963,19 @@ def test_histogram_owner_pill_offered_in_machine_mode(
         '/dashboards/user/jobs/machine/derecho/wait-times'
     ).get_data(as_text=True)
     assert 'aria-label="Owner dimension"' in body
-    assert 'owners_by=account' in body
+    assert 'group_by=project' in body
 
 
 def test_histogram_owner_pill_hidden_in_user_mode_and_param_ignored(
     app, auth_client, monkeypatch,
 ):
-    """User mode never offers the pill, and a crafted ?owners_by=account
+    """User mode never offers the pill, and a crafted ?group_by=project
     is ignored (not forwarded to the plugin)."""
     captured = _install_mock_plugin(
         app, monkeypatch, jobs_histogram_return=_sample_hist_owners(),
     )
     body = auth_client.get(
-        '/dashboards/user/jobs/user/derecho/wait-times?owners_by=account'
+        '/dashboards/user/jobs/user/derecho/wait-times?group_by=project'
     ).get_data(as_text=True)
     assert 'aria-label="Owner dimension"' not in body
     _dim, kwargs = captured['last_jobs_histogram']
@@ -3002,7 +3002,8 @@ def test_histogram_owners_by_forwarded_only_when_account(
     app, auth_client, monkeypatch,
 ):
     """Soft degradation contract: the default never sends owners_by (an
-    older plugin keeps working); the Project pill sends 'account'."""
+    older plugin keeps working); the Project pill sends the plugin's
+    'account' for the URL's canonical group_by=project."""
     captured = _install_mock_plugin(
         app, monkeypatch, jobs_histogram_return=_sample_hist_project_owners(),
     )
@@ -3010,6 +3011,13 @@ def test_histogram_owners_by_forwarded_only_when_account(
     _dim, kwargs = captured['last_jobs_histogram']
     assert 'owners_by' not in kwargs
 
+    auth_client.get(
+        '/dashboards/user/jobs/machine/derecho/wait-times?group_by=project')
+    _dim, kwargs = captured['last_jobs_histogram']
+    assert kwargs['owners_by'] == 'account'
+
+    # The plugin's own spelling still works — bookmarks and any URL built
+    # before the rename keep resolving to the same view.
     auth_client.get(
         '/dashboards/user/jobs/machine/derecho/wait-times?owners_by=account')
     _dim, kwargs = captured['last_jobs_histogram']
@@ -3021,19 +3029,19 @@ def test_histogram_account_owner_tier_and_drill(
 ):
     """The Project pill drives the whole drill: Project tier header,
     project-modal triggers on owner cells, account= (not user=) on the
-    per-owner jobs drill, 'Other projects' remainder, and the owners_by
+    per-owner jobs drill, 'Other projects' remainder, and the group_by
     round-trip hidden input for the metric pills."""
     import re
     _install_mock_plugin(
         app, monkeypatch, jobs_histogram_return=_sample_hist_project_owners(),
     )
     body = auth_client.get(
-        '/dashboards/user/jobs/machine/derecho/wait-times?owners_by=account'
+        '/dashboards/user/jobs/machine/derecho/wait-times?group_by=project'
     ).get_data(as_text=True)
     assert '<th>Project</th>' in body
     assert 'Other projects' in body
     assert 'project-details-modal/SCSG0001' in body
-    assert 'name="owners_by" value="account"' in body
+    assert 'name="group_by" value="project"' in body
     m = re.search(r'id="[^"]*-b0-u1-content"\s+hx-get="([^"]+)"', body)
     assert m, 'owner drill div missing'
     url = m.group(1).replace('&amp;', '&')
@@ -3601,3 +3609,89 @@ def test_job_sizes_bar_and_row_indices_stay_aligned_after_trim(
     row = re.search(r'data-jh-bucket="0".*?</tr>', body, re.S)
     assert row, 'no bucket-0 row rendered'
     assert '<code>1</code>' in row.group(0)
+
+
+# ---------------------------------------------------------------------------
+# Shared view lens — the panels' metric / owner / dimension pills persist
+# through the app-wide bucket (nav-view-persistence.js `data-chart-persist-
+# shared`), so a selection survives a period-pill re-render, carries to the
+# sibling panels, and comes back on reload.
+# ---------------------------------------------------------------------------
+
+_LENS = 'data-chart-persist-shared="group_by metric:jobs dimension:jobs"'
+
+
+def _tag_for(body, needle):
+    """The single HTML tag containing `needle`."""
+    i = body.index(needle)
+    return body[body.rindex('<', 0, i):body.index('>', i) + 1]
+
+
+def test_lens_declared_on_both_ends_of_every_pill_panel(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Tab button (injects on fetch) and container (saves on settle).
+
+    Both ends are required: the button is what requests the panel, and the
+    container is the element htmx reports as settled, which is what lets an
+    in-panel pill click persist without a click handler.
+    """
+    _install_mock_plugin(app, monkeypatch)
+    body = auth_client.get(
+        _card_url(active_project.projcode,
+                  days_persist_id='jobs-days-status')).get_data(as_text=True)
+
+    for panel in ('byuser', 'wait', 'sizes', 'durations'):
+        assert _LENS in _tag_for(body, f'id="jobs-hist-{panel}-tab"'), panel
+        assert _LENS in _tag_for(body, f'id="jobs-hist-{panel}"'), panel
+
+
+def test_lens_not_declared_on_the_jobs_tab(
+    app, auth_client, active_project, monkeypatch,
+):
+    """The per-job table has none of the three pills — no reason to carry
+    the lens into its URL."""
+    _install_mock_plugin(app, monkeypatch)
+    body = auth_client.get(
+        _card_url(active_project.projcode)).get_data(as_text=True)
+
+    assert _LENS not in _tag_for(body, 'id="jobs-hist-jobs-tab"')
+    assert _LENS not in _tag_for(body, 'id="jobs-hist-jobs"')
+
+
+def test_lens_is_independent_of_window_persistence(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Resource-details opts out of a *stored window* (it would shadow the
+    page's own date range) — that says nothing about the lens, which has no
+    such conflict and persists everywhere."""
+    _install_mock_plugin(app, monkeypatch)
+    body = auth_client.get(
+        _card_url(active_project.projcode)).get_data(as_text=True)
+
+    assert 'data-chart-persist-id' not in body      # no window persistence
+    assert _LENS in body                            # lens regardless
+
+
+# --- Canonical group_by parsing --------------------------------------------
+
+@pytest.mark.parametrize('query,expected', [
+    ('group_by=project', 'project'),
+    ('group_by=user', 'user'),
+    ('owners_by=account', 'project'),   # the plugin's spelling, still honoured
+    ('owners_by=user', 'user'),
+    ('group_by=nonsense', 'user'),
+    ('', 'user'),
+])
+def test_parse_group_by(app, query, expected):
+    from webapp.jobs.routes import _parse_group_by
+    with app.test_request_context(f'/?{query}'):
+        assert _parse_group_by() == expected
+
+
+def test_parse_group_by_prefers_the_canonical_spelling(app):
+    """Both present (a stale round-trip form beside a fresh pill click):
+    group_by wins, so the click a user just made is what renders."""
+    from webapp.jobs.routes import _parse_group_by
+    with app.test_request_context('/?group_by=user&owners_by=account'):
+        assert _parse_group_by() == 'user'


### PR DESCRIPTION
Selector pills reverted to server defaults on every reload, and on the job-history card they were also lost whenever the period pill re-rendered the shell. Rather than patch that one card, this makes pill state durable app-wide, on a rule that says which settings may be shared and which may not.

## The finding that shaped it

An inventory of every pill in the app:

| Concept | Surface → param | Vocabulary |
|---|---|---|
| Owner dimension | jobs card → `owners_by` | `user` \| `account` |
| | queue-load chart → `group_by` | `user` \| `project` |
| | disk scans → `kind` | `owner` \| `group` *(unix group ≠ project)* |
| Metric | jobs card → `metric` | `jobs` \| `cpu_hours` \| `gpu_hours` |
| | queue-load → `metric` | `jobs` \| `cores` \| `gpus` \| `nodes` |
| | usage chart → `metric` | `charges` \| `jobs` \| `core_hours` |
| | disk usage → `metric` | `bytes` \| `files` |
| | scan distribution → `metric` | `data` \| `files` |
| Lookback | jobs card → `days` | 30/60/90/365 |
| | status charts → `hours` | 6h…30d |
| Sort | pace chart / disk dirs → `sort_by` | disjoint vocabularies |

**Exactly one concept generalizes** — the owner dimension. Both pills already read "User"/"Project"; only the internal spelling differed, because the jobs card followed the *plugin's* `owners_by=account` and the queue chart follows system_status's `group_by=project`.

Everything else is a trap rather than an opportunity. `metric` is a **homonym** with five disjoint vocabularies — "Charges" cannot mean anything on a queue-load chart, and one global `metric` would silently reset one surface when you touched another. `days` vs `hours` is one concept at two granularities (historical vs operational): sharing it would push a queue chart to 90 days. `sort_by`'s `size` means different things in each place.

Hence the rule, written into the JS section comment: **share a key across surfaces only when the value vocabularies are identical; otherwise give it a family.**

## 1. The contract (`092df85`)

- **Saves merge** into their bucket instead of replacing it. Several elements now declare different key subsets of one bucket, and a wholesale write would drop whatever the current request didn't carry. The day-pill click save merges too — it wrote `{days: …}` flat, which would have erased the lens stored beside it.
- **New `data-chart-persist-shared`** channel: one app-wide bucket (`chart:__shared__`). A bare name is a genuinely global concept; `param:family` travels as `param` but is stored under the family key. Same two hooks as the per-chart channel, and the two coexist on one element without interacting.

## 2. Job History card (`47d7abd`)

Every pill-bearing panel declares the lens at **both ends**: on the tab button, which requests the panel (so a stored choice is injected, including on the shell re-render a period pill triggers), and on the panel container, which is the element htmx reports as settled — that second half is what persists an in-panel click with **no click handler at all**. I probed this rather than assumed it: htmx 2.0.4 puts the settled element in `detail.elt`, not the requester, for both `outerHTML` and `innerHTML` swaps.

The Jobs tab opts out (a per-job table has none of the three pills). Persistence is independent of the *window* opt-out: resource-details still stores no window — it would shadow that page's own date range — but does keep the lens, which has no such conflict.

**Canonical `group_by`.** The owner pill now emits `group_by=user|project` and `_parse_group_by` translates to the plugin's `owners_by=account` at the one boundary that talks to it. `owners_by=` is still honoured so existing links resolve; when both appear the canonical spelling wins (a fresh click beats a stale round-trip form).

Also adds a `g_cpu_hours` glossary entry on the CPU-hours column headers. **I did not rename `core_hours` → `cpu_hours`**: it's a SAM DB column (`comp_charge_summary`, `hpc_activity`), a glossary term, ~145 references — and a genuinely different measurement (charge summaries vs PBS job records), so one spelling would imply the two numbers tie out. The glossary entry says so instead.

## 3. The other charts (`e947e3c`)

Queue-load chart: `group_by` shared, `metric:queue` family-scoped, `state`/`rank_by` left per-chart. Usage charts: `metric:usage` and `metric:disk-usage`, previously keyed per projcode+resource, now follow you between project pages (a resource type lacking the stored metric already clamps server-side). Scan card: `metric:disk-scan` + `log:disk-scan` shared by Access history and File sizes; `kind:disk-scan` on User/group counts — deliberately *not* joined to `group_by`, since that's a unix group, not a project. Large directories keeps sort/recursive per visit.

**Behaviour change for review:** the three queue-load charts (derecho / casper / per-queue) previously remembered a `group_by` and `metric` each and now share one of each. Their old per-chart buckets keep those keys as inert leftovers — no migration, they're simply never read again.

## Test Results

`3376 passed, 30 skipped, 1 xfailed` (full suite).

10 new tests: the lens declared on both ends of each pill panel and absent from the Jobs tab, independence from window persistence, and `_parse_group_by` across canonical / plugin / junk spellings. No JS harness exists in this repo, so the JS is covered by browser smoke, as the period pills were.

Browser-verified end to end. After choosing Project + GPU-hours on the job histograms the Casper queue-load chart opens on Project, while its own metric stays independent; the bucket lands as `{group_by: project, metric:jobs: gpu_hours, dimension:jobs: cpus, metric:queue: cores, metric:usage: core_hours, metric:disk-scan: files}`, each family moving only when its own pill is clicked. Core-Hours chosen on SCSG0001's usage chart is pre-selected on CESM0002's; Files chosen on a scan distribution survives a reload; and on the jobs card a period-pill re-render keeps the lens while a full reload restores metric, owner, dimension, window and tab together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
