### PR TITLE
Job-history histograms get the log y-axis switch

### DIFF
--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -1205,15 +1205,15 @@ def _jobs_bucket_segments(bucket, key):
     return vals
 
 
-def _jobs_histogram_cache_key(hist, *, metric='jobs'):
+def _jobs_histogram_cache_key(hist, *, metric='jobs', log_y=False):
     """Hash exactly what the SVG depends on: the bucket labels, the chosen
-    metric's values and owner-segment split, the dimension, and null_count
-    (not the full envelope — e.g. min_param/max_param don't affect the
-    rendering). The job_count positivity vector joins the key because it
-    decides which bars carry #jh-bar-<i> drill URLs — an hours-metric SVG
-    with matching hours but a different populated-band set must not be
-    reused. Owner names stay out of the key: the SVG carries no owner
-    labels, so only the segment values shape it."""
+    metric's values and owner-segment split, the dimension, null_count and
+    the y-scale (not the full envelope — e.g. min_param/max_param don't
+    affect the rendering). The job_count positivity vector joins the key
+    because it decides which bars carry #jh-bar-<i> drill URLs — an
+    hours-metric SVG with matching hours but a different populated-band set
+    must not be reused. Owner names stay out of the key: the SVG carries no
+    owner labels, so only the segment values shape it."""
     key = _JOBS_METRIC_KEYS.get(metric, 'job_count')
     buckets = (hist or {}).get('buckets') or []
     payload = [(b.get('label'), float(b.get(key) or 0),
@@ -1221,13 +1221,13 @@ def _jobs_histogram_cache_key(hist, *, metric='jobs'):
     clickable = [int(bool(b.get('job_count'))) for b in buckets]
     return _content_hash([
         payload, clickable, str((hist or {}).get('dimension', '')),
-        int((hist or {}).get('null_count') or 0), str(metric),
+        int((hist or {}).get('null_count') or 0), str(metric), bool(log_y),
     ])
 
 
 @caching.chart_cached(name='jobs_histogram', maxsize=128,
                       key_fn=_jobs_histogram_cache_key)
-def generate_jobs_histogram(hist, *, metric='jobs') -> str:
+def generate_jobs_histogram(hist, *, metric='jobs', log_y=False) -> str:
     """Bar chart over a jobs_histogram envelope; owner-stacked when possible.
 
     Shared by the Wait Times, Job Sizes, and Durations tabs — the envelope's
@@ -1243,6 +1243,12 @@ def generate_jobs_histogram(hist, *, metric='jobs') -> str:
             'null_count', 'total_count', …}``.
         metric: ``'jobs'`` (bucket job counts), ``'cpu_hours'`` or
             ``'gpu_hours'`` (charged hours per bucket).
+        log_y: use a logarithmic y-axis — the treatment the filesystem-scan
+            distribution histogram already offers. Job distributions are
+            heavily skewed (most jobs wait seconds, a few wait days), so a
+            linear axis buries the tail bands entirely. A log scale can't
+            represent a stack meaningfully, so this falls back to one solid
+            bar per band (the band's base color), keeping the drill anchors.
 
     Returns a "no jobs" placeholder div when every bucket is zero.
     """
@@ -1262,11 +1268,16 @@ def generate_jobs_histogram(hist, *, metric='jobs') -> str:
     # the bucket table, which drills into that band. Index-keyed (not
     # label) so the JS never parses band labels. Clickability follows
     # job_count, not the plotted metric.
-    if not any(b.get('owners') for b in buckets):
-        # Owner-less envelope (owners_limit unset, or an older plugin):
-        # the historical flat single-series chart, byte-identical.
+    has_owners = any(b.get('owners') for b in buckets)
+    band_colors = [UNITY_STACK_10[i % len(UNITY_STACK_10)]
+                   for i in range(len(labels))]
+    if not has_owners or log_y:
+        # Owner-less envelope (owners_limit unset, or an older plugin) — the
+        # historical flat single-series chart, byte-identical — and the log
+        # y-axis, on which a stack carries no meaning: one solid bar per
+        # band, in the band color its stack would have used.
         bars = ax.bar(range(len(labels)), vals,
-                      color=UNITY_PALETTE_10[0],
+                      color=(band_colors if has_owners else UNITY_PALETTE_10[0]),
                       edgecolor=UNITY_NCAR_NAVY, linewidth=0.5)
         for i, (rect, b) in enumerate(zip(bars, buckets)):
             if b.get('job_count'):
@@ -1276,8 +1287,7 @@ def generate_jobs_histogram(hist, *, metric='jobs') -> str:
         # ascending), shaded within the band's color family — the fs_scans
         # distribution-histogram treatment: the spread between users is
         # legible before clicking.
-        colors = [UNITY_STACK_10[i % len(UNITY_STACK_10)]
-                  for i in range(len(labels))]
+        colors = band_colors
         for i, b in enumerate(buckets):
             segs = _jobs_bucket_segments(b, key)
             url = f'#jh-bar-{i}' if b.get('job_count') else None
@@ -1298,6 +1308,8 @@ def generate_jobs_histogram(hist, *, metric='jobs') -> str:
     ax.set_xticks(range(len(labels)))
     ax.set_xticklabels(labels, rotation=30, ha='right')
     ax.set_ylabel(_JOBS_METRIC_LABELS.get(metric, 'Jobs'))
+    if log_y:
+        ax.set_yscale('log')
     ax.yaxis.set_major_formatter(fmt.mpl_number_formatter())
     ax.grid(True, axis='y', alpha=0.3)
 

--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -46,6 +46,7 @@ from webapp.disk_scans import service
 from webapp.disk_scans.scope import resolve_scan_scope, resolve_scan_scope_grouped
 from webapp.disk_scans.session import get_module, is_enabled
 from webapp.extensions import db
+from webapp.utils.htmx import is_truthy
 from webapp.utils.rbac import Permission, require_permission
 
 bp = Blueprint('disk_scans', __name__)
@@ -113,8 +114,9 @@ def _limit() -> int:
     return max(1, min(n, _MAX_LIMIT))
 
 
-def _truthy(v) -> bool:
-    return (v or '').strip().lower() in ('1', 'true', 'on', 'yes')
+#: One spelling of "checked" for the whole app — the job-history
+#: histograms' log switch reads its ``?log=`` through the same predicate.
+_truthy = is_truthy
 
 
 def _atime_recursive_flag() -> bool:

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -64,6 +64,7 @@ from webapp.dashboards.charts import (
 from webapp.extensions import db
 from webapp.jobs import service
 from webapp.jobs.session import is_enabled
+from webapp.utils.htmx import read_flag
 from webapp.utils.rbac import (
     Permission,
     has_permission_any_facility,
@@ -701,6 +702,17 @@ def _parse_metric(default: str) -> str:
     return metric if metric in _METRICS else default
 
 
+def _parse_log() -> bool:
+    """``?log=`` — the histograms' log y-axis switch.
+
+    Same predicate as the filesystem-scan distribution histogram's switch
+    (both go through ``utils.htmx.is_truthy``), so the two can't drift on
+    what counts as checked; unlike that one it is offered on every
+    histogram tab, since every job distribution is skewed enough to want it.
+    """
+    return read_flag(request.args, 'log')
+
+
 def _parse_group_by() -> str:
     """Owner dimension for the histograms' User|Project pill.
 
@@ -920,6 +932,7 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
 
     filters = _parse_job_filters()
     metric = _parse_metric(_DEFAULT_METRIC_HIST)
+    log_on = _parse_log()
 
     # User|Project owner-dimension pill — offered only where the context
     # spans more than one project (machine mode; a project tree > 1).
@@ -963,7 +976,8 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
     # same one.
     hist = _trim_leading_empty_bands(hist)
 
-    chart_svg = generate_jobs_histogram(hist, metric=metric) if hist else None
+    chart_svg = (generate_jobs_histogram(hist, metric=metric, log_y=log_on)
+                 if hist else None)
     params = _roundtrip_params(machine, target_id)
 
     # One drill URL per band (None for empty bands) — computed here, not
@@ -977,11 +991,15 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
             for b in hist.get('buckets') or []
         ]
 
-    # Round-trip the non-default owner dimension through the metric /
-    # dimension pills' hx-include form (AFTER the drill URLs — the jobs
-    # fragments don't take group_by).
+    # Round-trip the non-default owner dimension and y-scale through the
+    # metric / dimension pills' hx-include form (AFTER the drill URLs — the
+    # jobs fragments take neither). The switch itself spells ?log= out in
+    # its own URL, which wins over this stale copy: Werkzeug reads the
+    # first value and htmx appends included params after the hx-get query.
     if group_by != 'user':
         params = dict(params, group_by=group_by)
+    if log_on:
+        params = dict(params, log='1')
 
     # Same affordance gates as the By User / By Project tables — never
     # render an entity quick-view link that would 403.
@@ -996,7 +1014,7 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
         enabled=True, error=error,
         mode=mode, machine=machine,
         hist=hist, chart_svg=chart_svg,
-        metric=metric,
+        metric=metric, log_on=log_on,
         dimension=dimension, dimension_toggle=dimension_toggle,
         size_dimensions=_SIZE_DIMENSIONS,
         group_by=group_by, owners_toggle=owners_toggle,

--- a/src/webapp/templates/dashboards/user/partials/jobs_card.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_card.html
@@ -56,19 +56,25 @@
 {% macro _persist(pid) -%}
 {%- if pid %} data-chart-persist-id="{{ pid }}" data-chart-persist-keys="days"{% endif -%}
 {%- endmacro %}
-{# The panel lens — which metric, whose segments, and (Job Sizes only)
-   which dimension. Declared on both ends of every panel that has pills:
-   on the tab button, so the stored lens is injected into the panel fetch
-   (including the one a period pill's shell re-render triggers), and on
-   the panel container, which is the element htmx reports as settled — so
-   an in-panel pill click persists with no click handler of its own.
+{# The panel lens — which metric, whose segments, (Job Sizes only) which
+   dimension, and (histograms only) the y-scale. Declared on both ends of
+   every panel that has pills: on the tab button, so the stored lens is
+   injected into the panel fetch (including the one a period pill's shell
+   re-render triggers), and on the panel container, which is the element
+   htmx reports as settled — so an in-panel pill click persists with no
+   click handler of its own.
    `metric:jobs` is family-scoped: the word means something different on
    the queue-load and usage charts, and the families must not collide.
+   `log:jobs` likewise — its vocabulary (0|1) is shared with the
+   filesystem-scan histograms, but a log axis is a per-chart reading aid,
+   not a lens onto the same question, so the two stay independent.
    `group_by` is deliberately bare — user|project means the same thing
    here and on the status queue-load chart, so the choice carries across.
-   The Jobs tab opts out: none of the three apply to a per-job table. #}
+   One list for every panel: a key a panel doesn't offer (dimension and
+   log on the By User / By Project pies) is simply not read by its route.
+   The Jobs tab opts out: none of the four apply to a per-job table. #}
 {% macro _lens() -%}
- data-chart-persist-shared="group_by metric:jobs dimension:jobs"
+ data-chart-persist-shared="group_by metric:jobs dimension:jobs log:jobs"
 {%- endmacro %}
 {# The explorer link speaks ?days= rather than a computed date so the
    cold-start sync in JS never has to re-derive a window client-side. #}

--- a/src/webapp/templates/dashboards/user/partials/jobs_histogram.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_histogram.html
@@ -13,6 +13,7 @@
                  gpu_hours, null_count, total_count, unit)
     chart_svg  — rendered SVG (or an empty-state div)
     metric     — 'jobs' | 'cpu_hours' | 'gpu_hours'
+    log_on     — log y-axis (?log=); solid bars instead of the owner stack
     dimension  — 'wait' | 'nodes' | 'cpus' | 'gpus' | 'memory' |
                  'memory_used' | 'memory_wasted' | 'duration'
     dimension_toggle — True only on the Job Sizes tab
@@ -94,6 +95,27 @@
       {% endfor %}
     </div>
     {% endif %}
+    {# Log-scale switch — the filesystem-scan histograms' affordance, and for
+       the same reason: job distributions are long-tailed (most jobs wait
+       seconds, a handful wait days), so a linear axis flattens every band
+       past the first into nothing. It spells ?log= out explicitly, which
+       beats the round-trip form's copy (Werkzeug reads the first value);
+       the pills carry no ?log= of their own and inherit it from that form.
+       A log y-axis can't stack, so this trades the per-user gradient for
+       legible small bands (see charts.py::generate_jobs_histogram). #}
+    <div class="form-check form-switch form-check-inline mb-0 me-1"
+         title="Log y-axis — reveals small bands but flattens the per-owner breakdown">
+      <input class="form-check-input" type="checkbox" role="switch"
+             id="jobs-hist-log-{{ target_id }}"
+             {% if log_on %}checked{% endif %}
+             hx-get="{{ fragment_url }}?log={{ '0' if log_on else '1' }}&metric={{ metric }}{% if dimension_toggle %}&dimension={{ dimension }}{% endif %}"
+             hx-target="#{{ target_id }}"
+             hx-include="#jobs-hist-params-{{ target_id }}"
+             hx-swap="innerHTML">
+      <label class="form-check-label small text-muted" for="jobs-hist-log-{{ target_id }}">
+        Log scale
+      </label>
+    </div>
     <span class="ms-auto text-muted small">
       {{ hist.total_count | fmt_number }} job{{ '' if hist.total_count == 1 else 's' }}
     </span>

--- a/src/webapp/utils/htmx.py
+++ b/src/webapp/utils/htmx.py
@@ -5,11 +5,28 @@ from webapp.extensions import db
 from sam.manage import management_transaction
 
 
-#: Values an "Active only" checkbox may arrive as. Templates emit ``1``
-#: (see the ``active_toggle_search`` macro and the admin card toggles) but
-#: the set is deliberately permissive: a checkbox copy-pasted with the
-#: wrong spelling should still work rather than silently fail open.
+#: Values a checkbox / switch may arrive as. Templates emit ``1`` (see the
+#: ``active_toggle_search`` macro, the admin card toggles and the charts'
+#: log-scale switches) but the set is deliberately permissive: a checkbox
+#: copy-pasted with the wrong spelling should still work rather than
+#: silently fail open.
 _TRUTHY = frozenset({'1', 'true', 'on', 'yes'})
+
+
+def is_truthy(raw):
+    """Is a raw query/form value one of the affirmative spellings above?"""
+    return str(raw or '').strip().lower() in _TRUTHY
+
+
+def read_flag(args, name, default=False):
+    """Read a boolean toggle off a request args/form mapping.
+
+    The general form of :func:`read_active_only` — same absent-means-off
+    reasoning (htmx omits an unchecked box entirely), and the same escape
+    hatch for switches with no checkbox behind them.
+    """
+    raw = args.get(name)
+    return default if raw is None else is_truthy(raw)
 
 
 def read_active_only(args, default=False):
@@ -32,10 +49,7 @@ def read_active_only(args, default=False):
     Returns:
         bool
     """
-    raw = args.get('active_only')
-    if raw is None:
-        return default
-    return str(raw).strip().lower() in _TRUTHY
+    return read_flag(args, 'active_only', default)
 
 
 def htmx_success(template, triggers, *, toast=None, toast_variant='success', **ctx):

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -3612,13 +3612,110 @@ def test_job_sizes_bar_and_row_indices_stay_aligned_after_trim(
 
 
 # ---------------------------------------------------------------------------
+# Log y-axis switch — parity with the filesystem-scan distribution
+# histograms. Offered on every histogram tab (job distributions are all
+# long-tailed), rides the round-trip form so the other pills keep it, and
+# persists through the shared lens.
+# ---------------------------------------------------------------------------
+
+_HIST_TABS = ('wait-times', 'job-sizes', 'durations')
+
+
+@pytest.mark.parametrize('tab', _HIST_TABS)
+def test_histogram_tabs_offer_the_log_switch_off_by_default(
+    app, auth_client, active_project, monkeypatch, tab,
+):
+    _install_mock_plugin(app, monkeypatch,
+                         jobs_histogram_return=_sample_hist())
+    body = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/{tab}?machine=derecho'
+    ).get_data(as_text=True)
+
+    assert 'Log scale' in body
+    assert 'id="jobs-hist-log-' in body
+    # Off by default, and the switch offers the ON direction.
+    assert 'log=1' in body
+    assert 'checked' not in body
+
+
+def test_log_on_renders_and_offers_the_way_back(
+    app, auth_client, active_project, monkeypatch,
+):
+    """?log=1 → a chart still renders (solid bars), the switch reflects the
+    state, the band drill anchors survive, and clicking it turns log off."""
+    _install_mock_plugin(app, monkeypatch,
+                         jobs_histogram_return=_sample_hist())
+    body = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times'
+        '?machine=derecho&log=1'
+    ).get_data(as_text=True)
+
+    assert '<svg' in body
+    assert 'checked' in body
+    assert '#jh-bar-0' in body
+    assert 'log=0' in body
+
+
+def test_log_rides_the_roundtrip_form_so_the_other_pills_keep_it(
+    app, auth_client, active_project, monkeypatch,
+):
+    """The metric / dimension / owner pills carry no ?log= of their own —
+    they inherit it from the hidden params form they hx-include. Absent when
+    off, so a stale `1` can never outlive the switch."""
+    _install_mock_plugin(app, monkeypatch,
+                         jobs_histogram_return=_sample_hist())
+    url = (f'/dashboards/user/jobs/{active_project.projcode}/wait-times'
+           '?machine=derecho')
+
+    on = auth_client.get(url + '&log=1').get_data(as_text=True)
+    assert '<input type="hidden" name="log" value="1">' in on
+
+    off = auth_client.get(url).get_data(as_text=True)
+    assert 'name="log"' not in off
+
+
+def test_log_does_not_leak_into_the_band_drill_urls(
+    app, auth_client, active_project, monkeypatch,
+):
+    """Drill URLs are built before the y-scale joins the params — the jobs
+    table has no log axis and should not be asked about one."""
+    _install_mock_plugin(app, monkeypatch,
+                         jobs_histogram_return=_sample_hist())
+    body = auth_client.get(
+        f'/dashboards/user/jobs/{active_project.projcode}/wait-times'
+        '?machine=derecho&log=1'
+    ).get_data(as_text=True)
+
+    import re
+    drills = re.findall(r'hx-get="([^"]*min_eligible_secs[^"]*)"', body)
+    assert drills, 'no band drill URLs rendered'
+    assert not [d for d in drills if 'log=' in d]
+
+
+@pytest.mark.parametrize('query,expected', [
+    ('log=1', True),
+    ('log=true', True),
+    ('log=on', True),
+    ('log=0', False),
+    ('log=', False),
+    ('log=nonsense', False),
+    ('', False),
+])
+def test_parse_log(app, query, expected):
+    from webapp.jobs.routes import _parse_log
+    with app.test_request_context(f'/?{query}'):
+        assert _parse_log() is expected
+
+
+# ---------------------------------------------------------------------------
 # Shared view lens — the panels' metric / owner / dimension pills persist
 # through the app-wide bucket (nav-view-persistence.js `data-chart-persist-
 # shared`), so a selection survives a period-pill re-render, carries to the
 # sibling panels, and comes back on reload.
 # ---------------------------------------------------------------------------
 
-_LENS = 'data-chart-persist-shared="group_by metric:jobs dimension:jobs"'
+_LENS = ('data-chart-persist-shared='
+         '"group_by metric:jobs dimension:jobs log:jobs"')
 
 
 def _tag_for(body, needle):

--- a/tests/unit/test_webapp_jobs_charts.py
+++ b/tests/unit/test_webapp_jobs_charts.py
@@ -131,6 +131,40 @@ def test_histogram_count_vector_in_cache_key():
 
 
 # ---------------------------------------------------------------------------
+# generate_jobs_histogram — log y-axis
+# ---------------------------------------------------------------------------
+
+def test_histogram_log_scale_renders_and_differs_from_linear():
+    linear = generate_jobs_histogram(_hist())
+    log = generate_jobs_histogram(_hist(), log_y=True)
+    assert '<svg' in log
+    assert log != linear
+
+
+def test_histogram_log_scale_keeps_bucket_sentinels():
+    """The bars stop stacking on a log axis but stay drillable."""
+    svg = generate_jobs_histogram(_hist(counts=(10, 5, 0)), log_y=True)
+    assert '#jh-bar-0' in svg
+    assert '#jh-bar-1' in svg
+    assert '#jh-bar-2' not in svg
+
+
+def test_histogram_log_scale_in_cache_key():
+    """Same envelope, different y-scale → distinct cache entries."""
+    from webapp.dashboards.charts import _jobs_histogram_cache_key
+    a = _jobs_histogram_cache_key(_hist())
+    b = _jobs_histogram_cache_key(_hist(), log_y=True)
+    assert a != b
+
+
+def test_histogram_log_scale_empty_envelope_still_short_circuits():
+    assert 'No jobs in this range' in generate_jobs_histogram(None, log_y=True)
+    assert 'No jobs in this range' in generate_jobs_histogram(
+        _hist(counts=(0, 0, 0), cpu_hours=(0, 0, 0), gpu_hours=(0, 0, 0)),
+        log_y=True)
+
+
+# ---------------------------------------------------------------------------
 # generate_jobs_histogram — owner-stacked bars (plugin owners_limit envelope)
 # ---------------------------------------------------------------------------
 
@@ -210,6 +244,21 @@ def test_histogram_every_segment_carries_sentinel():
     svg = generate_jobs_histogram(rich)
     assert svg.count('#jh-bar-0') >= 2
     assert '#jh-bar-2' not in svg
+
+
+def test_histogram_log_scale_unstacks_owner_bars():
+    """A log axis can't represent a stack, so an owners envelope collapses to
+    one solid bar per band — one anchor per bucket instead of one per
+    segment — while the linear render of the same envelope keeps its
+    gradient."""
+    rich = _with_owners(_hist(counts=(10, 5, 0)), {
+        0: {'alice': _owner(6, 60.0), 'bob': _owner(4, 40.0)},
+        1: {'alice': _owner(5, 50.0)},
+    })
+    log = generate_jobs_histogram(rich, log_y=True)
+    assert '<svg' in log
+    assert log.count('#jh-bar-0') == 1
+    assert generate_jobs_histogram(rich).count('#jh-bar-0') >= 2
 
 
 def test_histogram_flat_fallback_without_owners():


### PR DESCRIPTION
The filesystem-scan distribution histograms have offered a log y-axis since the fs_scans card shipped; the job-history histograms — whose distributions are the more skewed of the two — did not. This is that last parity gap, on the same markup and with the same trade-off.

## Why all three tabs

Every job distribution is long-tailed. On a 90-day Casper window the under-1-minute wait band holds 1.16M of 1.65M jobs, so on a linear axis every other band is a few pixels tall — the "1–2d" and ">2d" bands, the ones worth looking at, read as empty. So the switch is offered on Wait Times, Job Sizes *and* Durations, rather than gated the way the fs_scans one is (there, only the file-size tab needed it).

| linear | log |
|---|---|
| one visible bar | twelve legible ones |

## What log does to the bars

A log axis can't represent a stack, so `log_y` renders one solid bar per band — in the color that band's stack would have used — and keeps the `#jh-bar-<i>` drill anchors. The owners stay in the envelope either way, so a band click still expands to its per-owner tier; only the bars lose the per-user gradient. Same trade the fs_scans histogram makes, and the switch's tooltip says so. The y-scale joins the chart cache key.

## Plumbing

`?log=` follows the pills already there: it rides the hidden round-trip form, so a metric / dimension / owner click preserves it, while the switch spells the param out in its own URL and wins over that stale copy (Werkzeug reads the first value, htmx appends included params after the hx-get query). It joins `params` **after** the band drill URLs are built — the jobs table has no log axis and shouldn't be asked about one; a test pins that.

The setting persists through the shared lens (#386) as `log:jobs`. Family-scoped rather than a bare `log`: its vocabulary (`0|1`) is identical everywhere, which is the *necessary* condition for sharing, not a sufficient one — a log axis is a per-chart reading aid, not a lens onto the same question, so the fs_scans switch stays independent of this one.

## Preparatory commit

`read_active_only` already owned the app's permissive truthy set; `disk_scans` carried a private copy as `_truthy`, and this switch would have made three. `22e0a2f` promotes the predicate to `utils.htmx.is_truthy` (+ a general `read_flag(args, name, default)`), has `read_active_only` delegate, and points disk_scans' name at the shared one so its seven call sites are untouched. No behaviour change — the two switches now literally cannot drift on what counts as checked.

## Test Results

`3394 passed, 30 skipped, 1 xfailed` (full suite).

18 new tests: the switch on each histogram tab and its default-off state; the log render keeping its band anchors and offering the way back; the round-trip-form hand-off (present when on, **absent when off**, so a stale `1` can't outlive the switch); no `log=` in the drill URLs; `_parse_log` across the accepted spellings; and at the chart layer, distinct output and cache key per scale, the owner stack collapsing to one anchor per band, and the empty-envelope short-circuit under log.

Browser-verified on Status → Job History (Casper, 90d): a metric pill click, a period-pill shell re-render and a full page reload all keep the switch on, `chart:__shared__` picks up `log:jobs`, and the band drill still opens its per-project tier under log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
