### PR TITLE
Restore chenghao's UOKL0055 memberships lost to an erroneous IGA closure (2026-07-28)

### DIFF
--- a/scripts/repair/RESTORED-2026-07-28.md
+++ b/scripts/repair/RESTORED-2026-07-28.md
@@ -1,0 +1,68 @@
+# Membership repair — 2026-07-28
+
+Follow-up to the 2026-07-24 batch ([`RESTORED-2026-07-24.md`](RESTORED-2026-07-24.md),
+PR #371). Same upstream defect (NCAR/sam-ldap-syncd#3): the IGA/LDAP sync
+end-dates every one of a user's `account_user` rows at a single instant, and the
+memberships are not restored when access is meant to continue.
+
+**One user repaired this pass: `chenghao` — 4 rows.**
+
+| User | Name | UPID | UID | Project | Role | Resources | Closed | Restored |
+|------|------|-----:|----:|---------|------|-----------|--------|---------:|
+| `chenghao` | Chenghao Wang | 30045 | 28535 | `UOKL0055` | **Lead** | Campaign_Store, Casper, Derecho, Derecho GPU | 2026-07-26 00:20:52 | 4 |
+
+## Why this one, and why it's a new variant
+
+This week's closures are arriving as an individual trickle (1–2/day), not the
+88-minute 27-account sweep of 2026-07-16/17. `chenghao` is the only in-scope
+membership repair from the batch.
+
+He is a **new variant** of the defect. The 2026-07-24 detector keyed on users who
+were *deactivated and then reopened* (`users.modified_time > closed_at`).
+`chenghao` was never deactivated — his account stayed `active = 1, locked = 0`
+throughout — yet all four of his `UOKL0055` memberships were end-dated at
+`2026-07-26 00:20:52`, leaving him **active with zero project access** (the login
+symptom). His `modified_time` equals the close instant, so the reopen-based rule
+skipped him. The relaxed detector — `active = 1, locked = 0`, whole-account close
+since the cutover, zero live rows, drop the `modified_time > closed_at` rule —
+catches him.
+
+The close is unambiguously erroneous: `UOKL0055` is an active project on live
+allocations (Derecho/Casper/GPU/Campaign_Store), he is its **lead**, and he
+charged jobs through 2026-06-02.
+
+## Method
+
+Identical to the 2026-07-24 batches. The four rows were pinned by
+`account_user_id` (`126720` Derecho GPU, `126722` Derecho, `126724` Casper,
+`126726` Campaign_Store), the rollback written from the pre-image *before* any
+write ([`rollback-2026-07-28.sql`](rollback-2026-07-28.sql)), then a dry run
+inside a transaction confirmed `ROW_COUNT() = 4` and was rolled back, and only
+then the same `UPDATE ... SET end_date = NULL` was committed. Clearing `end_date`
+restores the original rows, so `start_date` (2024-06-05) and all history read as
+though the close never happened.
+
+## Safety checks (re-derived immediately before applying, 2026-07-28 10:59)
+
+- **Whole-account close** — 4 memberships live at the instant, 4 ended at the
+  instant. A user-level close, not a per-project removal.
+- **Account open** — `active = 1`, `locked = 0`.
+- **Currently stranded** — 0 live rows before the repair.
+- **No supersession** — each pinned row had 0 live and 0 later-starting rows on
+  the same account, so nothing is duplicated or resurrected.
+
+## Verification (prod, post-commit)
+
+`chenghao`: `active = 1`, **4 live `UOKL0055` rows** (`end_date = NULL`, lead flag
+intact, `start_date` 2024-06-05 preserved), **0** rows still closed at the
+instant.
+
+## Not repaired here
+
+- **`hojungy`** — active, stranded on the live `NERP0001`, but the close
+  (2026-07-02) **predates the ~2026-07-16 IGA cutover**; out of scope for this
+  cohort. Revisit separately.
+- **`jyu`** — reported "can't login", but this is a correct teardown: her only
+  project `UMMM0015` is inactive with expired allocations, and its entire ~90-member
+  roster was closed together on 2026-06-03. Not the defect; not restored.
+- **`aborissov`, `meixu`** — under separate investigation; held.

--- a/scripts/repair/rollback-2026-07-28.sql
+++ b/scripts/repair/rollback-2026-07-28.sql
@@ -1,0 +1,6 @@
+-- Rollback for the 2026-07-28 restore (1 user, 4 rows).
+-- Re-applies the end_date that the restore cleared.
+-- Generated from the pre-image BEFORE any UPDATE ran.
+
+-- chenghao (4 rows): UOKL0055 — Campaign_Store, Casper, Derecho, Derecho GPU
+UPDATE account_user SET end_date = '2026-07-26 00:20:52' WHERE account_user_id IN (126720,126722,126724,126726);


### PR DESCRIPTION
## Summary

Follow-up to the 2026-07-24 repair (PR #371). Restores **4 `account_user` rows**
for **`chenghao`** (Chenghao Wang, UPID 30045) — **lead of the live project
`UOKL0055`** — that the IGA/LDAP sync (NCAR/sam-ldap-syncd#3) end-dated at
`2026-07-26 00:20:52`, leaving him **active with zero project access** (the
"can't log in" symptom).

### New variant of the defect
The 2026-07-24 cohort were *deactivated then reopened*. `chenghao` was **never
deactivated** — `active=1, locked=0` throughout — yet all four of his
memberships were closed at one instant. His `modified_time` equals the close
instant, so the reopen-based detector (`modified_time > closed_at`) skips him.
He's caught by the **relaxed** detector: `active=1, locked=0`, whole-account
close since the ~2026-07-16 cutover, zero live rows.

### What was done
- Cleared `end_date` back to `NULL` on `account_user_id` 126720 / 126722 /
  126724 / 126726 (Derecho GPU, Derecho, Casper, Campaign_Store).
- Rollback written from the pre-image **before** any write
  (`rollback-2026-07-28.sql`); a dry run inside a transaction asserted
  `ROW_COUNT() = 4` and was rolled back before the real `COMMIT`.
- `start_date` (2024-06-05) and history preserved — the rows read as though the
  close never happened.

### Safety checks (re-derived immediately before applying)
Whole-account close (4 live at instant = 4 ended) · account open · 0 live rows
pre-repair · no supersession (each row 0 live + 0 later on the same account).

### Verification (prod, post-commit)
`chenghao`: `active=1`, **4 live `UOKL0055` rows** (`end_date=NULL`, lead flag
intact), **0** rows still closed at the instant.

### Not in scope
`hojungy` (close predates the cutover), `jyu` (correct expired-project
teardown), `aborissov` / `meixu` (under separate investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)