### PR TITLE
Resource-details usage card: History | By User tabs

### DIFF
--- a/docs/plans/RESOURCE_DETAILS_USAGE_TABS.md
+++ b/docs/plans/RESOURCE_DETAILS_USAGE_TABS.md
@@ -1,0 +1,155 @@
+# Resource-details usage card — History | By User tabs
+
+Status: **in progress** — single PR vs `staging`, branch `job_history_top_cards_redux`.
+
+## Framing
+
+`/user/resource-details/<projcode>?resource=Derecho` is SAM's *own* compute-usage
+view: it reads `comp_charge_summary` directly and needs no `hpc-usage-queries`
+plugin. The SAM-side content had grown into three sibling collapse cards, with the
+date-range picker stranded above an unrelated project tree:
+
+```
+date_range_picker (own card)   <- controls everything below, but…
+Project Hierarchy              <- …this sits between it and its targets
+Usage Trend      (#collapseUsage,   bar chart, lazy htmx fragment)
+Historical Usage (#collapseCharges, daily table, rendered inline)
+Usage by User    (#collapseUsers,   per-user table, rendered inline)
+```
+
+Three cards is a lot of vertical scroll for one question asked two ways — *when*
+was the resource used, and *by whom*. The plugin-backed Job History card
+immediately below already answers that as one card with tabs plus a period control
+in the tab strip, which left the SAM-side section reading as the odd one out.
+
+After:
+
+```
+Project Hierarchy                                   <- moved ABOVE the card
++-------------------------------------------------------------+
+| [History] [By User]    Epoch 7d 30d [90d] 6mo 1yr  [Custom]  |
++-------------------------------------------------------------+
+|  History : stacked/flat bar chart + Historical Usage table   |
+|  By User : NEW usage pie + Usage by User table               |
++-------------------------------------------------------------+
+Job History (plugin card, unchanged)
+```
+
+## Decisions
+
+1. **The pills keep full-page navigation.** `pickers.js` still computes
+   `start_date`/`end_date` and reloads. That window governs the tree badges, this
+   card *and* the Job History card — one control, one reload, nothing goes stale.
+   An htmx card-shell swap (the jobs-card model) would have left the tree badges
+   and the jobs card showing the *previous* window on the same screen.
+2. **The pills render inside the tab strip**, right-aligned, `Custom` toggling a
+   thin date-input row beneath. This is what forced the `date_range_picker` split
+   below; the macro had baked its own `card` wrapper.
+3. **Tree badges stay window-scoped.** `get_charges_by_projcode` still runs over
+   the selected range; the tree card header says so, since tree-above-pills would
+   otherwise imply independence.
+4. **The History chart stays stacked-by-user.** Its legend username links now
+   activate the By User pane before expanding the row, instead of being dropped in
+   favour of the pie.
+
+## What this reuses
+
+Nearly all of it already existed; the feature is mostly assembly.
+
+| Need | Existing thing |
+|---|---|
+| Card tabs w/ server-side active tab | `_trig`/`_tabcls`/`_panecls`, `partials/jobs_card.html` |
+| Pills in a tab strip | `jobs_card.html` (`<li class="nav-item ms-auto">`) |
+| Pie w/ clickable wedges + legend | `generate_disk_entity_pie_chart`, `dashboards/charts.py` |
+| Top-N + inert "Other" slice | `_pie_cumulative_keep`, `charts.py` |
+| Wedge → row click wiring | `svg-chart-links.js` — `#usage-user-<name>` **already existed** for the stacked legend, so the pie added no new sentinel |
+| Per-user data | `get_user_summary_for_project`, `sam/queries/charges.py` — already fetched by the page |
+| Metric persistence | the `metric:usage` family, whose vocabulary is already `charges\|jobs\|core_hours` |
+
+The fragment registrar (`webapp/utils/fragments.py`) is deliberately **not** used:
+its own docstring says a family this small stays a bespoke route.
+
+## Persistence contract
+
+The part most likely to regress, and the one real design decision.
+
+| State | Channel |
+|---|---|
+| Period (pills / Custom / Epoch) | `?start_date=`/`?end_date=`; `markActive` repaints |
+| Metric (Charges/Jobs/Core-Hours) | `chart:__shared__` bucket, family `metric:usage` |
+| Which usage tab | `?usage_tab=`, kept live by the tab ⇄ URL sync |
+| Month / row expansions | `collapse:<id>` (`data-no-persist` rows opt out) |
+
+**Why the tab does not use the `tab:<tablistId>` localStorage channel.**
+`restoreTabs` runs on `DOMContentLoaded` — the same event htmx initializes on. If
+localStorage said `byuser` while the server rendered `history` active, the History
+pane's `hx-trigger="load"` chart would fire *and* the restore would then show By
+User, firing its chart too: two chart fetches per load, one of them invisible, in
+a load-order race. The URL is also strictly stronger — it survives bookmarking,
+link-sharing and back/forward, not just F5.
+
+So a tablist marked `data-tab-url-param` is server-driven and **opts out** of the
+localStorage channel (two one-line guards in `saveActiveTab`/`restoreTabs`), and
+`syncTabParam` keeps three writers in step on `shown.bs.tab`: the address bar
+(`history.replaceState`), every `.drp-hidden` JSON block (`pickers.js` reads it at
+*click* time, so the pills follow for free), and `[data-tab-param-link]` hrefs plus
+same-named hidden inputs. Without that last part you would click By User, click a
+pill, and land back on History.
+
+`replaceState` is safe beside the scroll-preserve machinery: `nav:scroll:` keys on
+the pathname only.
+
+**The payoff:** exactly one chart request per page load. Only the server-active
+pane gets `hx-trigger="load"`.
+
+**One correction found in live smoke.** The inactive pane was originally
+`shown.bs.tab once`, which left the two panes able to contradict each other:
+pick Core-Hours on By User, switch to History, and History was still the Charges
+chart it had rendered on load — with its own metric pill saying "Charges" while
+the other pane said "Core-Hours". The metric is a *shared* family precisely
+because it means the same thing on both, so disagreement is a bug in the model,
+not a caching trade-off. Both panes now refetch on every `shown.bs.tab` (no
+`once`); the persisted metric is injected on each request, so whichever pane you
+land on is current. A warm refetch measured ~90-110 ms against the dev DB — the
+chart SVGs are content-hash cached — which is the right price for two views that
+can never disagree.
+
+`usage_tab` is deliberately *not* named `active_tab`: the jobs blueprint already
+owns `?active_tab=`, and this page hosts a jobs card.
+
+## Non-goals
+
+- `resource_details_disk.html` keeps its own standalone picker card. DISK has
+  capacity semantics, not burn-rate, and its own template.
+- The Job History card is untouched, including its `tab:jobsCardTabs` localStorage
+  behaviour — the tab-sync opt-out is marker-driven, so it does not leak.
+- No fragment registrar, no card-shell fragment route, no changes to the
+  legacy-compat API blueprints.
+- The three per-card collapses (`#collapseUsage`/`#collapseCharges`/
+  `#collapseUsers`) are gone rather than reproduced per pane; the tabs serve the
+  same "hide what I'm not reading" purpose. Their stale `collapse:` localStorage
+  keys are inert.
+
+## Order
+
+| # | Commit | Gate |
+|---|---|---|
+| 0 | this doc | — |
+| 1 | split `date_range_picker` into `drp_pills` + `drp_custom` | disk page renders byte-identical |
+| 2 | `generate_user_usage_pie_chart` | unit render, sentinels present |
+| 3 | shared usage-fragment prologue + `resource_details_user_pie` route | usage-chart route unchanged in behaviour |
+| 4 | `activateOwningTab` in `svg-chart-links.js` | existing bar/legend clicks still work |
+| 5 | tab ⇄ URL sync in `nav-view-persistence.js` | jobs card tabs still restore |
+| 6 | the tabbed usage card + tree move | route-map parity snapshot regen |
+| 7 | tests | full suite |
+
+## Verification
+
+Live smoke on `docker compose up webdev --watch` (`:5050`), four shapes:
+multi-user/multi-child tree, single-user project (By User tab absent), an archive
+resource (charges-only metrics), and Derecho GPU (jobs-machine mapping).
+
+Persistence matrix — click, then reload, and check the tab *and* the window
+survive: pill, Epoch, Custom→Apply, tree node. Plus: metric carries across tabs;
+stale `?usage_tab=byuser` clamps to History on a single-user project; DevTools
+shows exactly one chart request per load; month expansions still restore.

--- a/src/webapp/dashboards/charts.py
+++ b/src/webapp/dashboards/charts.py
@@ -1162,6 +1162,96 @@ def generate_disk_entity_pie_chart(entity_data: List[Dict], kind: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# 5c. Per-user usage pie (compute resource-details "By User" tab)
+#
+# SAM's own comp_charge_summary rollup, not the job-history plugin. Same shape
+# as the disk entity pie above — ~90% cumulative share, inert "Other" — but the
+# click sentinel is ``#usage-user-<username>``, which is the prefix the stacked
+# Usage Trend legend has always used. Reusing it means svg-chart-links.js needs
+# no new table entry and both charts drill into the same Usage-by-User row.
+# ---------------------------------------------------------------------------
+
+
+def _user_usage_pie_cache_key(user_data, metric):
+    # metric selects which column is plotted AND what the legend numbers say,
+    # but it isn't part of the default content_hash(args[0]) key — include it
+    # so charges/jobs/core_hours variants never alias in the LRU.
+    return _content_hash([user_data, metric])
+
+
+@caching.chart_cached(name='user_usage_pie_chart', maxsize=64,
+                      key_fn=_user_usage_pie_cache_key)
+def generate_user_usage_pie_chart(user_data: List[Dict], metric: str = 'charges') -> str:
+    """Pie of ``metric`` by username for the resource-details By User tab.
+
+    Args:
+        user_data: rows from ``get_user_summary_for_project`` — dicts carrying
+            'username' plus the three metric keys ('charges', 'jobs',
+            'core_hours'), which are also the accepted ``metric`` values.
+        metric: which column to plot.
+
+    Returns:
+        SVG string ready for template rendering.
+    """
+    rows = [d for d in (user_data or []) if float(d.get(metric) or 0) > 0]
+    if not rows:
+        return _empty_state('No user activity recorded for this period')
+
+    data = sorted(rows, key=lambda d: float(d[metric]), reverse=True)
+    values_desc = [float(d[metric]) for d in data]
+    keep = _pie_cumulative_keep(values_desc)
+
+    names = [d['username'] for d in data[:keep]]
+    values = list(values_desc[:keep])
+    colors = list(UNITY_PALETTE_10[:keep])
+
+    n_others = len(data) - keep
+    if n_others > 0:
+        names.append(None)                     # inert slice — no set_url
+        values.append(sum(values_desc[keep:]))
+        colors.append(UNITY_NCAR_GRAY_LIGHT)
+
+    legend_labels = [
+        f'{n or f"Other ({n_others})"} ({fmt.number(v)})'
+        for n, v in zip(names, values)
+    ]
+
+    fig, ax = plt.subplots(figsize=(7, 4))
+    wedges, _texts, autotexts = ax.pie(
+        values,
+        labels=None,
+        autopct=lambda p: fmt.pct(p, decimals=1) if p >= 5 else '',
+        startangle=_PIE_START_ANGLE,
+        counterclock=False,
+        colors=colors,
+        pctdistance=0.85,
+    )
+    for at, wedge_color in zip(autotexts, colors):
+        at.set_color(_autopct_color_for(wedge_color))
+        at.set_fontweight('bold')
+        at.set_fontsize(8)
+
+    legend = ax.legend(wedges, legend_labels, loc='center left',
+                       bbox_to_anchor=(1.0, 0.5), fontsize=9)
+
+    # Clickable wedges + legend entries → expand that user's row in the table
+    # below. Skip the "Other" slice (name is None).
+    leg_patches = legend.get_patches()
+    leg_texts = legend.get_texts()
+    for i, name in enumerate(names):
+        if name is None:
+            continue
+        url = f'#usage-user-{name}'
+        wedges[i].set_url(url)
+        if i < len(leg_patches):
+            leg_patches[i].set_url(url)
+        if i < len(leg_texts):
+            leg_texts[i].set_url(url)
+
+    return _fig_to_svg(fig)
+
+
+# ---------------------------------------------------------------------------
 # Job-history charts (jobs card: Wait Times / Job Sizes / Durations + By User)
 #
 # Inputs are the hpc-usage-queries plugin envelopes verbatim (see

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -10,6 +10,8 @@ JavaScript API calls for improved performance and simplicity.
 from flask import Blueprint, abort, render_template, request, flash, redirect, url_for, session, jsonify, make_response, current_app
 from flask_login import login_required, current_user
 from datetime import datetime, date, timedelta
+from typing import NamedTuple
+
 from marshmallow import ValidationError
 
 from sam.schemas.forms.user import (
@@ -59,6 +61,7 @@ from webapp.api.access_control import (
 from ..charts import (
     generate_usage_timeseries_matplotlib,
     generate_usage_timeseries_stacked_by_user,
+    generate_user_usage_pie_chart,
     generate_disk_usage_stacked_area,
 )
 from webapp.utils.scope import resolve_scope_project, resolve_scope_projcodes
@@ -578,19 +581,19 @@ def resource_details(project):
 
         tree_data = _build_node(tree_root)
 
-    # Note: the Usage Trend chart is now loaded via HTMX
-    # (resource_details_usage_chart route below) so the metric pill
-    # selector — Charges / Job Count / Core-Hours — can swap the SVG
-    # in place. The parent template just renders a loader div.
-
-    # Which metric pills are available depends on resource type.
-    # Disk/Archive summaries don't carry num_jobs / core_hours, so
-    # those metric variants are suppressed for non-compute resources.
-    usage_chart_metrics = ['charges']
-    if detail_data.get('daily_jobs') is not None:
-        usage_chart_metrics.append('jobs')
-    if detail_data.get('daily_core_hours') is not None:
-        usage_chart_metrics.append('core_hours')
+    # Note: both usage-card charts load via HTMX (the
+    # resource_details_usage_chart / resource_details_user_pie routes below)
+    # so the metric pill selector — Charges / Job Count / Core-Hours — can
+    # swap the SVG in place. The parent template just renders loader divs,
+    # and only the open pane's fires on load.
+    #
+    # The By User pane is suppressed for a single user, where a pie of one
+    # and a table restating the Historical Usage totals say nothing. Decided
+    # here rather than in the template so the tab strip and the server's
+    # choice of open pane cannot disagree — the same discipline
+    # jobs.routes.panel_relevance() applies to the jobs card.
+    show_by_user = len(user_breakdown) > 1
+    usage_tab = _parse_usage_tab(show_by_user)
 
     # Extract allocation start date for the "Epoch" date picker preset
     alloc_start = detail_data['resource_summary'].get('start_date')
@@ -656,7 +659,8 @@ def resource_details(project):
         daily_breakdown=daily_breakdown,
         monthly_user_counts=monthly_user_counts,
         date_span_days=(end_date - start_date).days,
-        usage_chart_metrics=usage_chart_metrics,
+        show_by_user=show_by_user,
+        usage_tab=usage_tab,
         rolling_30=rolling_30,
         rolling_90=rolling_90,
         rolling_is_inheriting=rolling_is_inheriting,
@@ -786,7 +790,6 @@ def resource_details_day_subtree(project):
     )
 
 
-_VALID_USAGE_CHART_METRIC = {'charges', 'jobs', 'core_hours'}
 _USAGE_CHART_DATA_KEY = {
     'charges':    'daily_charges',
     'jobs':       'daily_jobs',
@@ -795,25 +798,75 @@ _USAGE_CHART_DATA_KEY = {
 
 _VALID_DISK_USAGE_CHART_METRIC = {'bytes', 'files'}
 
+# Which pane of the usage card is open. Server-side input rather than
+# something the client restores after load: only the active pane's chart
+# carries hx-trigger="load", so a wrong default would fetch a chart nobody is
+# looking at (and, with a client-side restore racing it, fetch both). Named
+# `usage_tab` and not `active_tab` because the jobs blueprint already owns
+# ?active_tab= and this page hosts a jobs card.
+_USAGE_TABS = ('history', 'byuser')
 
-@bp.route('/resource-details/usage-chart/<projcode>')
-@login_required
-@require_project_access(include_ancestors=True)
-def resource_details_usage_chart(project):
-    """HTMX fragment: Usage Trend chart for the selected metric.
 
-    Loaded by the resource-details page on initial render and re-fetched
-    when the analyst toggles a metric pill (Charges / Job Count /
-    Core-Hours). Each metric variant has its own ``chart_cached`` entry
-    keyed on the daily series hash + metric tag.
+def _parse_usage_tab(show_by_user: bool = True) -> str:
+    """``?usage_tab=`` — 'history' | 'byuser'. Unknown values fall back.
+
+    Also clamps to 'history' when the By User pane isn't rendered, so a stale
+    link into a project that has since dropped to one user can't select a tab
+    that has no button.
+    """
+    tab = (request.args.get('usage_tab') or '').strip()
+    if tab not in _USAGE_TABS:
+        return 'history'
+    if tab == 'byuser' and not show_by_user:
+        return 'history'
+    return tab
+
+
+def _available_usage_metrics(detail_data) -> list:
+    """Metric pills this resource type can offer.
+
+    Disk/archive summaries carry no num_jobs / core_hours, so those variants
+    are suppressed rather than rendering empty charts.
+    """
+    available = ['charges']
+    if detail_data and detail_data.get('daily_jobs') is not None:
+        available.append('jobs')
+    if detail_data and detail_data.get('daily_core_hours') is not None:
+        available.append('core_hours')
+    return available
+
+
+class _UsageFragmentCtx(NamedTuple):
+    """Resolved query string shared by the two usage-card chart fragments."""
+    resource_name: str
+    metric: str
+    start_date: datetime
+    end_date: datetime
+    scope: str
+    detail_data: dict
+    available: list
+
+    def template_context(self) -> dict:
+        """The keys both chart partials render (pills + baked fragment URLs)."""
+        return {
+            'metric': self.metric,
+            'available_metrics': self.available,
+            'resource_name': self.resource_name,
+            'scope': self.scope,
+            'start_date': self.start_date.strftime('%Y-%m-%d'),
+            'end_date': self.end_date.strftime('%Y-%m-%d'),
+        }
+
+
+def _usage_fragment_ctx(project) -> _UsageFragmentCtx:
+    """Shared prologue for the Usage Trend and By User chart fragments.
+
+    Both are re-fetched by the same metric pills over the same window and
+    scope, so they parse and validate their query string identically.
     """
     resource_name = (request.args.get('resource') or '').strip()
     if not resource_name:
         abort(400, 'resource is required')
-
-    metric = request.args.get('metric', 'charges')
-    if metric not in _VALID_USAGE_CHART_METRIC:
-        metric = 'charges'
 
     try:
         start_date = (parse_input_start_date(request.args['start_date'])
@@ -836,38 +889,60 @@ def resource_details_usage_chart(project):
         scope_projcode=scope,
     )
 
-    # Available metrics depend on resource type — disk/archive lack jobs / core_hours.
-    available = ['charges']
-    if detail_data and detail_data.get('daily_jobs') is not None:
-        available.append('jobs')
-    if detail_data and detail_data.get('daily_core_hours') is not None:
-        available.append('core_hours')
+    # Available metrics depend on resource type; an unsupported request (a
+    # stale persisted `metric`, say) clamps to charges rather than 400ing.
+    available = _available_usage_metrics(detail_data)
+    metric = request.args.get('metric', 'charges')
     if metric not in available:
         metric = 'charges'
+
+    return _UsageFragmentCtx(
+        resource_name=resource_name,
+        metric=metric,
+        start_date=start_date,
+        end_date=end_date,
+        scope=scope,
+        detail_data=detail_data,
+        available=available,
+    )
+
+
+@bp.route('/resource-details/usage-chart/<projcode>')
+@login_required
+@require_project_access(include_ancestors=True)
+def resource_details_usage_chart(project):
+    """HTMX fragment: Usage Trend chart for the selected metric.
+
+    Loaded by the resource-details page's History pane and re-fetched when
+    the analyst toggles a metric pill (Charges / Job Count / Core-Hours).
+    Each metric variant has its own ``chart_cached`` entry keyed on the daily
+    series hash + metric tag.
+    """
+    ctx = _usage_fragment_ctx(project)
 
     # Stacked-by-user variant: each daily bar is segmented by the top-10
     # users over the whole window + "Others", ranked by the displayed metric.
     # Falls back to the flat single-series bars when the period has <= 1 user
-    # (a 1-colour stack is pointless and the Usage by User card is hidden
-    # there too) or for non-compute resources, where comp_charge_summary
-    # yields no per-user rows.
-    scope_projcodes = resolve_scope_projcodes(project, scope)
+    # (a 1-colour stack is pointless and the By User pane is hidden there
+    # too) or for non-compute resources, where comp_charge_summary yields no
+    # per-user rows.
+    scope_projcodes = resolve_scope_projcodes(project, ctx.scope)
     stacked = get_daily_user_usage_for_project(
-        db.session, scope_projcodes, resource_name, start_date, end_date,
-        metric=metric,
+        db.session, scope_projcodes, ctx.resource_name,
+        ctx.start_date, ctx.end_date, metric=ctx.metric,
     )
     named_series = [s for s in stacked['series'] if s['label'] != 'Others']
 
     if len(named_series) > 1:
-        svg = generate_usage_timeseries_stacked_by_user(stacked, metric=metric)
+        svg = generate_usage_timeseries_stacked_by_user(stacked, metric=ctx.metric)
         has_data = True
         is_stacked = True
     else:
-        series = (detail_data or {}).get(_USAGE_CHART_DATA_KEY[metric])
+        series = (ctx.detail_data or {}).get(_USAGE_CHART_DATA_KEY[ctx.metric])
         svg = generate_usage_timeseries_matplotlib(
             series or {'dates': [], 'values': []},
             link_to_day_rows=True,
-            metric=metric,
+            metric=ctx.metric,
         )
         has_data = bool(series and series.get('values'))
         is_stacked = False
@@ -875,15 +950,41 @@ def resource_details_usage_chart(project):
     return render_template(
         'dashboards/user/partials/usage_chart.html',
         chart_svg=svg,
-        metric=metric,
-        available_metrics=available,
         projcode=project.projcode,
-        resource_name=resource_name,
-        scope=scope,
-        start_date=start_date.strftime('%Y-%m-%d'),
-        end_date=end_date.strftime('%Y-%m-%d'),
         has_data=has_data,
         is_stacked=is_stacked,
+        **ctx.template_context(),
+    )
+
+
+@bp.route('/resource-details/user-pie/<projcode>')
+@login_required
+@require_project_access(include_ancestors=True)
+def resource_details_user_pie(project):
+    """HTMX fragment: By User pie for the selected metric.
+
+    Sibling of the Usage Trend fragment above — same window, same scope, same
+    metric pills. Wedge and legend clicks emit ``#usage-user-<username>``,
+    which svg-chart-links.js already routes to the Usage by User row in the
+    same pane.
+    """
+    ctx = _usage_fragment_ctx(project)
+
+    user_breakdown = get_user_summary_for_project(
+        db.session,
+        resolve_scope_projcodes(project, ctx.scope),
+        ctx.resource_name,
+        ctx.start_date,
+        ctx.end_date,
+    )
+    svg = generate_user_usage_pie_chart(user_breakdown, metric=ctx.metric)
+
+    return render_template(
+        'dashboards/user/partials/user_pie_chart.html',
+        chart_svg=svg,
+        projcode=project.projcode,
+        has_data=any(float(u.get(ctx.metric) or 0) > 0 for u in user_breakdown),
+        **ctx.template_context(),
     )
 
 

--- a/src/webapp/jobs/service.py
+++ b/src/webapp/jobs/service.py
@@ -49,16 +49,23 @@ def default_jobs_window_start() -> str:
 
 
 def job_history_machines() -> List[str]:
-    """Machines with a warmed job-history engine, sorted.
+    """Machines with a warmed job-history engine, in ``JOB_HISTORY_MACHINES`` order.
 
     Analogue of ``disk_scans.service.scan_capable_resources()`` — the
     single source for "which machines can the jobs UI offer?". Returns
     ``[]`` when the plugin is disabled, so nav items / tabs / route
     validation all degrade together.
+
+    The order is the deployment's, not the alphabet's: ``_warm()`` inserts
+    engines while iterating ``JOB_HISTORY_MACHINES`` (default
+    ``derecho,casper``), and dicts keep insertion order, so config order
+    survives — a machine whose engine failed to open just drops out. This
+    is what puts Derecho first in every subtab strip; sorting here used to
+    throw that away and lead with Casper.
     """
     if not is_enabled():
         return []
-    return sorted(get_engines().keys())
+    return list(get_engines().keys())
 
 
 def _resolve_queue_and_qos(

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -1097,16 +1097,48 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
    Mirrors Unity's cascade: base color set first, :not(.active) overrides inactive.
    ========================================================================= */
 
-/* Pills — recolor to NCAR blue without changing the visual treatment.
-   Used for sub-navigation inside accordions and chart-selection rows where the
-   bolder .nav-tabs invert pattern would be too aggressive. Bootstrap 5
-   implements .nav-pills via CSS custom properties, so the four overrides
-   below are sufficient — no per-state selectors needed. */
+/* Pills — same white-is-active convention as .nav-tabs below and the
+   .btn-group selector rows above, at the lighter rounded-pill weight.
+   Pills carry the machine / filesystem / chart-series choosers (jobs and
+   filesystem-scan subtabs, the allocations pie tabs, the allocation-tree
+   resource types); they used to run blue-is-active, which read backwards
+   next to every other selector on the same page.
+
+   Bootstrap 5 exposes custom properties for the ACTIVE pill only, so the
+   inactive treatment needs the explicit :not(.active) rules — mirroring
+   how .nav-tabs is written. */
 .nav-pills {
     --bs-nav-link-color: var(--ncar-blue);
     --bs-nav-link-hover-color: var(--ncar-navy);
-    --bs-nav-pills-link-active-color: #fff;
-    --bs-nav-pills-link-active-bg: var(--ncar-blue);
+    --bs-nav-pills-link-active-color: var(--ncar-blue);
+    --bs-nav-pills-link-active-bg: #fff;
+}
+
+.nav-pills .nav-link:not(.active) {
+    background-color: var(--ncar-blue);
+    color: #fff;
+}
+
+.nav-pills .nav-link:not(.active):hover {
+    background-color: var(--ncar-navy);
+    color: #fff;
+}
+
+/* Counter badges sit inside pills whose background flips with state, so they
+   have to flip too — a stock .bg-light badge vanishes on the white active
+   pill. Both declarations need !important: the background beats .badge.bg-X
+   (same as the tinted badge palette further down this file) and the color
+   beats the .text-dark / .text-* utilities, which Bootstrap ships as
+   !important. Callers therefore don't have to strip those utilities off
+   badges they drop into a pill. */
+.nav-pills .nav-link:not(.active) .badge {
+    background-color: #fff !important;
+    color: var(--ncar-blue) !important;
+}
+
+.nav-pills .nav-link.active .badge {
+    background-color: var(--ncar-blue) !important;
+    color: #fff !important;
 }
 
 .nav-tabs {
@@ -1133,6 +1165,17 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
    Bootstrap utility specificity. */
 .nav-tabs:has(+ .tab-content) {
     margin-bottom: 0 !important;
+}
+
+/* Bootstrap's .card-header-tabs pulls the strip down over the header's cap
+   padding with a negative bottom margin — correct only when the tabs are the
+   header's LAST child. The usage card puts a custom date-range row after
+   them, and that negative margin dropped the tab bottoms ~16px into a ~30px
+   row, overlapping the range readout by half. Reset it whenever something
+   follows; the seamless-attach case above is unaffected because tab-content
+   is a sibling of the strip, not part of the header. */
+.card-header-tabs:not(:last-child) {
+    margin-bottom: 0;
 }
 
 .nav-tabs .nav-link {

--- a/src/webapp/static/js/nav-view-persistence.js
+++ b/src/webapp/static/js/nav-view-persistence.js
@@ -403,9 +403,10 @@
     function syncDaysCard(card, days) {
         if (!days) return;
         card.querySelectorAll('[data-days-value]').forEach(function (btn) {
-            var on = btn.dataset.daysValue === days;
-            btn.classList.toggle('btn-primary', on);
-            btn.classList.toggle('btn-outline-primary', !on);
+            // Base class is always btn-outline-secondary; `active` alone
+            // decides the paint (the theme inverts .btn-group so active
+            // reads white). Only the state class toggles here.
+            btn.classList.toggle('active', btn.dataset.daysValue === days);
         });
         // The link speaks ?days=, never a date, so this stays a parameter
         // swap — no re-deriving client-side a window the server owns.

--- a/src/webapp/static/js/nav-view-persistence.js
+++ b/src/webapp/static/js/nav-view-persistence.js
@@ -13,6 +13,11 @@
  * The job-history period pills (5) reuse the chart-selector storage under
  * key "days", plus a card-level fan-out so per-machine subtabs agree.
  *
+ * One deliberate exception to (1): a tablist marked data-tab-url-param keeps
+ * its state in the query string instead, and this file's job for it is to
+ * keep the URL and every same-route link in step. See the tab ⇄ URL-param
+ * sync section for why the two channels must not both be live.
+ *
  * Tab / collapse handling works for both initial page load and after
  * HTMX swaps or Bootstrap modal close events.
  */
@@ -33,6 +38,9 @@
         var trigger = event.target;
         var tablist = trigger.closest('[role="tablist"]');
         if (!tablist || !tablist.id) return;
+        // URL-driven tablists own their state in the query string — see the
+        // tab ⇄ URL-param sync below for why the two channels can't coexist.
+        if (tablist.hasAttribute('data-tab-url-param')) return;
         var paneSelector = getPaneSelector(trigger);
         if (paneSelector && paneSelector.startsWith('#')) {
             try {
@@ -43,7 +51,7 @@
 
     /** Restore saved tab selections within a root element (document or swapped fragment). */
     function restoreTabs(root) {
-        root.querySelectorAll('[role="tablist"][id]').forEach(function (tablist) {
+        root.querySelectorAll('[role="tablist"][id]:not([data-tab-url-param])').forEach(function (tablist) {
             var saved = null;
             try { saved = localStorage.getItem(STORAGE_PREFIX + tablist.id); } catch (_) {}
             if (!saved) return;
@@ -76,6 +84,74 @@
     document.addEventListener('hidden.bs.modal', function (event) {
         restoreTabs(event.target);
     });
+
+    // ── Tab ⇄ URL-param sync ─────────────────────────────────────────────────
+    //
+    // Markup contract:
+    //   [role="tablist"][data-tab-url-param="usage_tab"]  the tablist
+    //   [data-tab-param-value="byuser"]                   on each tab button
+    //   [data-tab-param-link]                             same-route <a>s baked
+    //                                                     at render time
+    //
+    // A tablist marked data-tab-url-param is SERVER-driven: the route reads
+    // that query param to decide which pane renders active, and therefore
+    // which pane's lazy chart carries hx-trigger="load". Two consequences.
+    //
+    // 1. It opts out of the tab:<id> localStorage channel above. restoreTabs
+    //    runs on DOMContentLoaded — the same event htmx initializes on — so a
+    //    stored tab disagreeing with the server's would show one pane while
+    //    the other pane's chart had already fired: two fetches per load, one
+    //    of them invisible, in a load-order race. The URL is the stronger
+    //    channel anyway; it survives bookmarking and link-sharing, not just F5.
+    //
+    // 2. Clicking a tab has to update everything that will reload this route,
+    //    or the next pill click would bounce the analyst back to the server's
+    //    tab. Three writers, one source of truth (the pane just opened):
+    //      a. the address bar, so a plain reload reopens the same pane;
+    //      b. every .drp-hidden block — pickers.js reads it at CLICK time, so
+    //         patching it is enough for the date presets and Epoch;
+    //      c. [data-tab-param-link] hrefs (the project-tree nodes) and hidden
+    //         inputs of the same name (the custom-range form).
+
+    function syncTabParam(event) {
+        var trigger = event.target;
+        if (!trigger.closest) return;
+        var tablist = trigger.closest('[role="tablist"][data-tab-url-param]');
+        if (!tablist) return;
+        var name = tablist.dataset.tabUrlParam;
+        var value = trigger.dataset.tabParamValue;
+        if (!name || !value) return;
+
+        // (a) address bar — replaceState, so we don't grow the back stack.
+        // Safe beside the scroll-preserve keys, which use the pathname only.
+        try {
+            var here = new URL(window.location.href);
+            here.searchParams.set(name, value);
+            history.replaceState(history.state, '', here.toString());
+        } catch (_) {}
+
+        // (b) the JSON blocks pickers.js reads when a preset is clicked.
+        document.querySelectorAll('script.drp-hidden').forEach(function (block) {
+            var data;
+            try { data = JSON.parse(block.textContent); } catch (_) { return; }
+            if (!data || !(name in data)) return;   // not this picker's param
+            data[name] = value;
+            block.textContent = JSON.stringify(data);
+        });
+
+        // (c) render-time links back to this route, and the custom-range form.
+        document.querySelectorAll('[data-tab-param-link]').forEach(function (link) {
+            try {
+                var url = new URL(link.href, window.location.origin);
+                url.searchParams.set(name, value);
+                link.href = url.toString();
+            } catch (_) {}
+        });
+        document.querySelectorAll('input[type="hidden"][name="' + name + '"]')
+            .forEach(function (input) { input.value = value; });
+    }
+
+    document.addEventListener('shown.bs.tab', syncTabParam);
 
     // ── Collapse (expanded row) persistence ──────────────────────────────────
 

--- a/src/webapp/static/js/svg-chart-links.js
+++ b/src/webapp/static/js/svg-chart-links.js
@@ -79,6 +79,22 @@
     // index-keyed) and pie/legend entities (data-owner-uid, data-job-user,
     // …). Scoped to the clicked chart's tab pane so other panes' identical
     // sentinels never cross-fire.
+    // A chart link may target a row in a DIFFERENT tab pane: the stacked
+    // Usage Trend chart lives in the resource-details History pane, but its
+    // legend usernames address rows in the By User pane. Opening a collapse
+    // inside a hidden pane would "work" invisibly, so activate the owning
+    // pane first. No-op for same-pane links and for charts outside any tabs.
+    function activateOwningTab(el) {
+        if (!window.bootstrap || !el.closest) return;
+        var pane = el.closest('.tab-pane');
+        if (!pane || !pane.id || pane.classList.contains('active')) return;
+        var trigger = document.querySelector(
+            '[data-bs-toggle="tab"][data-bs-target="#' + pane.id + '"]');
+        if (trigger) {
+            try { bootstrap.Tab.getOrCreateInstance(trigger).show(); } catch (_) {}
+        }
+    }
+
     function openEntityRow(attr, id, scopeEl) {
         var root = scopeEl || document;
         var row = root.querySelector('tr[' + attr + '="' + id + '"]');
@@ -95,6 +111,7 @@
     function openDayRow(isoDate) {
         var row = document.querySelector('tr[data-date="' + isoDate + '"]');
         if (!row || !window.bootstrap) return;
+        activateOwningTab(row);
 
         // 3-level mode: parent month <tbody> must be expanded first
         // so the day <tr> is rendered before we try to open it.
@@ -132,24 +149,22 @@
         }, 60);
     }
 
-    // Legend username → expand that user's row in the Usage by User card.
-    // The user row's first <td> carries data-sort-value="<username>"
+    // Username → expand that user's row in the Usage by User table. Two
+    // charts address it: the By User pie (same pane) and the stacked Usage
+    // Trend legend (History pane), hence activateOwningTab. The user row's
+    // first <td> carries data-sort-value="<username>"
     // (resource_details.html), scoped to #users-table. Looking up by username
     // (not the render-time uid) is robust to the table's client-side
-    // re-sorting. The card body (#collapseUsers) is opened first in case the
-    // analyst collapsed it. Single-triple users render inline with no
-    // collapse target — we just scroll to them.
+    // re-sorting. Single-triple users render inline with no collapse target
+    // — we just scroll to them.
     function openUserRow(username) {
         if (!window.bootstrap) return;
-        var card = document.getElementById('collapseUsers');
-        if (card) {
-            bootstrap.Collapse.getOrCreateInstance(card, {toggle: false}).show();
-        }
         var cell = document.querySelector(
             '#users-table td[data-sort-value="' + username + '"]');
         if (!cell) return;
         var row = cell.closest('tr');
         if (!row) return;
+        activateOwningTab(row);
         var sel = row.getAttribute('data-bs-target');
         if (sel) {
             var el = document.querySelector(sel);

--- a/src/webapp/templates/dashboards/fragments/date_range_picker.html
+++ b/src/webapp/templates/dashboards/fragments/date_range_picker.html
@@ -60,13 +60,29 @@
 {% endmacro %}
 
 
-{% macro drp_custom(action, start_date, end_date, hidden_fields={}) %}
+{% macro drp_custom(action, start_date, end_date, hidden_fields={}, align_end=False) %}
 {#
   The GET form behind the Custom toggle. Also carries the hidden fields, so
   they travel with a custom-range submit the same way pickers.js sends them
   with a preset click. The current-range label lives here rather than in the
   strip: when a custom range is active no preset is highlighted, so this is
   the only readout of the window.
+
+  align_end decides which end of the row the inputs open at, and follows the
+  Custom button that summons them:
+
+    False (default) — the standalone card, where drp_pills sits inline and
+      Custom is mid-row. The inputs open immediately to its right, reading
+      as a continuation of the strip; the readout takes the far end.
+    True — a card header, where drp_pills is pushed right (ms-auto) in the
+      tab strip and drp_custom renders on its own row below. Left-aligned
+      inputs would open at the opposite corner from the button that opened
+      them, so the group is flushed right to land directly beneath it and
+      the readout swaps to the left.
+
+  order-first (rather than reordering the markup) keeps one DOM order for
+  both: the readout is last so it stays the form's final field, and only
+  the visual order flips.
 #}
 <form method="GET" action="{{ action }}"
       class="d-flex align-items-center gap-2 flex-grow-1 mb-0">
@@ -74,7 +90,7 @@
     <input type="hidden" name="{{ name }}" value="{{ value }}">
     {% endfor %}
 
-    <div class="drp-custom d-none d-flex align-items-center gap-2">
+    <div class="drp-custom d-none d-flex align-items-center gap-2{% if align_end %} ms-auto{% endif %}">
         <input type="date" name="start_date"
                value="{{ start_date }}"
                class="form-control form-control-sm" style="width:140px">
@@ -87,7 +103,7 @@
         </button>
     </div>
 
-    <small class="text-muted ms-auto">{{ start_date }} – {{ end_date }}</small>
+    <small class="text-muted {{ 'order-first me-auto' if align_end else 'ms-auto' }}">{{ start_date }} – {{ end_date }}</small>
 </form>
 {% endmacro %}
 

--- a/src/webapp/templates/dashboards/fragments/date_range_picker.html
+++ b/src/webapp/templates/dashboards/fragments/date_range_picker.html
@@ -1,6 +1,100 @@
+{#
+  Date-range picker, in three pieces so the same behaviour can render either
+  as a standalone card or inline in a card-header tab strip.
+
+    date_range_picker(...)  the standalone card — unchanged public shape,
+                            used by the disk resource-details page.
+    drp_pills(...)          just the preset buttons + the Custom toggle.
+    drp_custom(...)         just the <form>: hidden fields, the (hidden until
+                            toggled) date inputs, and the current-range label.
+
+  Callers that compose the two halves themselves own the `.drp` root and its
+  contract, because static/js/pickers.js scopes every button via
+  closest('.drp'): the root needs `data-action-url`, `data-start`, optionally
+  `data-epoch`, and a <script type="application/json" class="drp-hidden">
+  block. See dashboards/user/resource_details.html, where `.drp` is the card
+  header so it can enclose both the tab strip (holding the pills) and the
+  custom-range row below it.
+
+  Two pickers.js contracts that look cosmetic but are not:
+    * `.drp-custom` is toggled with `d-none`, not a Bootstrap collapse.
+    * markActive() paints the active preset by swapping
+      `btn-outline-secondary` → `btn-secondary active`, so preset buttons must
+      keep that starting class alongside data-action/data-days.
+#}
+
+{% macro drp_pills(epoch_date=None, presets=None) %}
+{#
+  Preset buttons + the Custom toggle. Both kinds are type="button": presets
+  navigate via pickers.js (reading .drp-hidden at click time), and the toggle
+  only shows/hides the inputs — neither submits, so this macro does not need
+  to sit inside drp_custom's <form>.
+
+  data-scroll-preserve: nav-view-persistence.js snapshots scrollY on click
+  (capture phase, before pickers.js does the full-page nav) and restores it on
+  reload, so changing the range doesn't jump back to the top. Same mechanism
+  the queue-history time picker uses.
+#}
+<div class="btn-group btn-group-sm" role="group" aria-label="Date range presets">
+    {% if epoch_date %}
+    <button type="button"
+            class="btn btn-outline-secondary"
+            data-action="drp-epoch"
+            data-scroll-preserve>Epoch</button>
+    {% endif %}
+    {% set presets = presets or [('7d', 7), ('30d', 30), ('90d', 90), ('6mo', 180), ('1yr', 365)] %}
+    {% for label, days in presets %}
+    <button type="button"
+            class="btn btn-outline-secondary"
+            data-action="drp-days"
+            data-days="{{ days }}"
+            data-scroll-preserve>{{ label }}</button>
+    {% endfor %}
+</div>
+
+<button type="button"
+        class="btn btn-sm btn-outline-primary"
+        data-action="drp-toggle-custom">
+    <i class="fas fa-calendar-alt"></i> Custom
+</button>
+{% endmacro %}
+
+
+{% macro drp_custom(action, start_date, end_date, hidden_fields={}) %}
+{#
+  The GET form behind the Custom toggle. Also carries the hidden fields, so
+  they travel with a custom-range submit the same way pickers.js sends them
+  with a preset click. The current-range label lives here rather than in the
+  strip: when a custom range is active no preset is highlighted, so this is
+  the only readout of the window.
+#}
+<form method="GET" action="{{ action }}"
+      class="d-flex align-items-center gap-2 flex-grow-1 mb-0">
+    {% for name, value in hidden_fields.items() %}
+    <input type="hidden" name="{{ name }}" value="{{ value }}">
+    {% endfor %}
+
+    <div class="drp-custom d-none d-flex align-items-center gap-2">
+        <input type="date" name="start_date"
+               value="{{ start_date }}"
+               class="form-control form-control-sm" style="width:140px">
+        <span class="text-muted">→</span>
+        <input type="date" name="end_date"
+               value="{{ end_date }}"
+               class="form-control form-control-sm" style="width:140px">
+        <button type="submit" class="btn btn-sm btn-primary" data-scroll-preserve>
+            <i class="fas fa-check"></i> Apply
+        </button>
+    </div>
+
+    <small class="text-muted ms-auto">{{ start_date }} – {{ end_date }}</small>
+</form>
+{% endmacro %}
+
+
 {% macro date_range_picker(action, start_date, end_date, hidden_fields={}, epoch_date=None, presets=None) %}
 {#
-  Compact date range picker with quick-select presets and optional custom inputs.
+  Compact standalone card.
 
   Parameters:
     action        - form action URL (e.g. url_for('user_dashboard.resource_details'))
@@ -23,61 +117,12 @@
      {%- if epoch_date %} data-epoch="{{ epoch_date }}"{% endif %}>
     <script type="application/json" class="drp-hidden">{{ hidden_fields | tojson }}</script>
     <div class="card-body py-2">
-        <form method="GET" action="{{ action }}">
-            {% for name, value in hidden_fields.items() %}
-            <input type="hidden" name="{{ name }}" value="{{ value }}">
-            {% endfor %}
-            <div class="d-flex align-items-center flex-wrap gap-2">
-                <i class="fas fa-calendar text-muted"></i>
-
-                <!-- Quick-select preset buttons -->
-                <div class="btn-group btn-group-sm" role="group" aria-label="Date range presets">
-                    {# data-scroll-preserve: nav-view-persistence.js snapshots
-                       scrollY on click (capture phase, before pickers.js does
-                       the full-page nav) and restores it on reload, so changing
-                       the range doesn't jump back to the top. Same mechanism the
-                       queue-history time picker uses. #}
-                    {% if epoch_date %}
-                    <button type="button"
-                            class="btn btn-outline-secondary"
-                            data-action="drp-epoch"
-                            data-scroll-preserve>Epoch</button>
-                    {% endif %}
-                    {% set presets = presets or [('7d', 7), ('30d', 30), ('90d', 90), ('6mo', 180), ('1yr', 365)] %}
-                    {% for label, days in presets %}
-                    <button type="button"
-                            class="btn btn-outline-secondary"
-                            data-action="drp-days"
-                            data-days="{{ days }}"
-                            data-scroll-preserve>{{ label }}</button>
-                    {% endfor %}
-                </div>
-
-                <!-- Custom date range toggle -->
-                <button type="button"
-                        class="btn btn-outline-primary"
-                        data-action="drp-toggle-custom">
-                    <i class="fas fa-calendar-alt"></i> Custom
-                </button>
-
-                <!-- Custom date inputs (hidden until toggled) -->
-                <div class="drp-custom d-none d-flex align-items-center gap-2">
-                    <input type="date" name="start_date"
-                           value="{{ start_date }}"
-                           class="form-control form-control-sm" style="width:140px">
-                    <span class="text-muted">→</span>
-                    <input type="date" name="end_date"
-                           value="{{ end_date }}"
-                           class="form-control form-control-sm" style="width:140px">
-                    <button type="submit" class="btn  btn-primary" data-scroll-preserve>
-                        <i class="fas fa-check"></i> Apply
-                    </button>
-                </div>
-
-                <!-- Current range display -->
-                <small class="text-muted ms-auto">{{ start_date }} – {{ end_date }}</small>
-            </div>
-        </form>
+        <div class="d-flex align-items-center flex-wrap gap-2">
+            <i class="fas fa-calendar text-muted"></i>
+            {{ drp_pills(epoch_date=epoch_date, presets=presets) }}
+            {{ drp_custom(action=action, start_date=start_date,
+                          end_date=end_date, hidden_fields=hidden_fields) }}
+        </div>
     </div>
 </div>
 {% endmacro %}

--- a/src/webapp/templates/dashboards/user/partials/_resource_details_macros.html
+++ b/src/webapp/templates/dashboards/user/partials/_resource_details_macros.html
@@ -2,6 +2,55 @@
    partials (user_subtree.html, day_subtree.html). Extracted from
    resource_details.html so the partials can {% import %} them. #}
 
+{# Metric selector shared by the usage card's two chart fragments (Usage
+   Trend bars, By User pie). Each pill re-fetches its own fragment with a
+   different `metric=`, so the server re-renders pills + chart + caption as
+   one unit and the active pill always matches what's drawn.
+
+   Both fragments' wrappers carry data-chart-persist-shared="metric:usage",
+   so whichever pane the analyst last set the metric on, the other opens
+   showing the same one — the vocabulary (charges|jobs|core_hours) is
+   identical, which is the bar for sharing a persistence family.
+
+   Hidden entirely for resources offering only `charges` (disk/archive
+   summaries carry no num_jobs / core_hours). #}
+{% macro metric_pills(endpoint, available_metrics, metric, target,
+                      projcode, resource_name, scope, start_date, end_date) %}
+{% set _LABELS = {
+    'charges':    'Charges',
+    'jobs':       'Job Count',
+    'core_hours': 'Core-Hours',
+} %}
+{% if available_metrics | length > 1 %}
+<div class="d-flex justify-content-center mb-2">
+    <div class="btn-group btn-group-sm" role="group" aria-label="Metric">
+        {# btn-outline-secondary + `active` — the selector-pill convention
+           everywhere else (jobs_usage_panel, jobs_histogram, and the date
+           presets in this same card header). The Unity theme paints `.active`
+           white and leaves the unselected ones filled blue, which reads
+           backwards against stock Bootstrap; the pre-split markup here used
+           btn-primary/btn-outline-primary and so came out inverted relative
+           to the presets sitting directly above it. #}
+        {% for opt in available_metrics %}
+        <button type="button"
+                class="btn btn-outline-secondary{% if metric == opt %} active{% endif %}"
+                hx-get="{{ url_for(endpoint,
+                                   projcode=projcode,
+                                   resource=resource_name,
+                                   scope=scope,
+                                   start_date=start_date,
+                                   end_date=end_date,
+                                   metric=opt) }}"
+                hx-target="{{ target }}"
+                hx-swap="innerHTML">
+            {{ _LABELS[opt] }}
+        </button>
+        {% endfor %}
+    </div>
+</div>
+{% endif %}
+{% endmacro %}
+
 {# Per-job drill-down — used by every leaf (user, queue, date) row.
    The button toggles the collapse keyed by *jid*; the row carries
    the htmx fetch wired to the jobs fragment. Filter kwargs default

--- a/src/webapp/templates/dashboards/user/partials/jobs_card.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_card.html
@@ -292,8 +292,13 @@ tab-pane fade{{ ' show active' if key == active_tab }}
         <div class="btn-group btn-group-sm" role="group" aria-label="Time window"
              {%- if days_persist_id %} data-jobs-days-pills{% endif %}>
             {% for _d, _label in jobs_window_pills %}
+            {# btn-outline-secondary + `active` — the selector convention used
+               by the metric pills, the date presets and the machine subtabs.
+               The old btn-primary/btn-outline-primary pair rendered
+               blue-is-active, backwards against every other selector on the
+               page (same bug 19ab6c0 fixed for the metric pills). #}
             <button type="button" data-days-value="{{ _d }}"
-                    class="btn {% if days == _d %}btn-primary{% else %}btn-outline-primary{% endif %}"
+                    class="btn btn-outline-secondary{% if days == _d %} active{% endif %}"
                     hx-get="{{ _card_q }}days={{ _d }}"
                     hx-target="#{{ cid }}-card"
                     hx-swap="outerHTML">{{ _label }}</button>

--- a/src/webapp/templates/dashboards/user/partials/usage_chart.html
+++ b/src/webapp/templates/dashboards/user/partials/usage_chart.html
@@ -1,40 +1,19 @@
-{# Usage Trend chart fragment — loaded by the resource-details page
-   and re-rendered when a metric pill (Charges / Job Count / Core-Hours)
-   is clicked. The pill group's hx-get points back at the same route
-   with a different `metric=` so the server re-renders pills + chart +
-   caption as one unit (active pill class follows the new metric).
+{# Usage Trend chart fragment — the History pane of the resource-details
+   usage card. Loaded when that pane is the open one (or on first show) and
+   re-rendered when a metric pill is clicked; see metric_pills for how the
+   selection persists across the two panes.
 
    The bar chart's `set_url('#day-bar-YYYY-MM-DD')` anchors are wired
-   regardless of metric; svg-chart-links.js handles the click and
-   expands the matching day row in Historical Usage. #}
+   regardless of metric; svg-chart-links.js handles the click and expands the
+   matching day row in the Historical Usage table below. The stacked variant
+   additionally links legend usernames to `#usage-user-<name>`, which lands in
+   the *other* pane — activateOwningTab switches to it first. #}
 
-{% set _LABELS = {
-    'charges':    'Charges',
-    'jobs':       'Job Count',
-    'core_hours': 'Core-Hours',
-} %}
+{% from 'dashboards/user/partials/_resource_details_macros.html' import metric_pills with context %}
 
-{% if available_metrics | length > 1 %}
-<div class="d-flex justify-content-center mb-2">
-    <div class="btn-group btn-group-sm" role="group" aria-label="Metric">
-        {% for opt in available_metrics %}
-        <button type="button"
-                class="btn btn-{% if metric == opt %}primary{% else %}outline-primary{% endif %}"
-                hx-get="{{ url_for('user_dashboard.resource_details_usage_chart',
-                                   projcode=projcode,
-                                   resource=resource_name,
-                                   scope=scope,
-                                   start_date=start_date,
-                                   end_date=end_date,
-                                   metric=opt) }}"
-                hx-target="#usage-chart-wrapper"
-                hx-swap="innerHTML">
-            {{ _LABELS[opt] }}
-        </button>
-        {% endfor %}
-    </div>
-</div>
-{% endif %}
+{{ metric_pills('user_dashboard.resource_details_usage_chart',
+                available_metrics, metric, '#usage-chart-wrapper',
+                projcode, resource_name, scope, start_date, end_date) }}
 
 <div class="chart-container">
     {{ chart_svg | safe }}
@@ -43,8 +22,8 @@
 {% if has_data %}
 <div class="text-muted small text-center mt-2">
     <i class="fas fa-hand-pointer me-1"></i>
-    Click a bar to expand that day in <em>Historical Usage</em> below.
-    {% if is_stacked %}Click a username in the legend to expand that user in <em>Usage by User</em>.{% endif %}
+    Click a bar to expand that day in the table below.
+    {% if is_stacked %}Click a username in the legend to open that user in the <em>By User</em> tab.{% endif %}
     Reload the page to reset all selections.
 </div>
 {% endif %}

--- a/src/webapp/templates/dashboards/user/partials/user_pie_chart.html
+++ b/src/webapp/templates/dashboards/user/partials/user_pie_chart.html
@@ -1,0 +1,26 @@
+{# By User pie fragment — the By User pane of the resource-details usage
+   card, and the sibling of usage_chart.html: same window, same scope, same
+   metric pills.
+
+   Wedges and legend entries carry `#usage-user-<username>` sentinels, which
+   svg-chart-links.js routes to that user's row in the Usage by User table
+   below (the same handler the stacked Usage Trend legend uses). The "Other"
+   slice is inert. #}
+
+{% from 'dashboards/user/partials/_resource_details_macros.html' import metric_pills with context %}
+
+{{ metric_pills('user_dashboard.resource_details_user_pie',
+                available_metrics, metric, '#user-pie-wrapper',
+                projcode, resource_name, scope, start_date, end_date) }}
+
+<div class="chart-container">
+    {{ chart_svg | safe }}
+</div>
+
+{% if has_data %}
+<div class="text-muted small text-center mt-2">
+    <i class="fas fa-hand-pointer me-1"></i>
+    Click a wedge to expand that user in the table below.
+    Reload the page to reset all selections.
+</div>
+{% endif %}

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -503,12 +503,16 @@ tab-pane fade{{ ' show active' if key == usage_tab }}
         </ul>
 
         <div class="px-3 py-1 border-top">
+            {# align_end: drp_pills is ms-auto'd to the right of the tab strip
+               above, so the inputs open flush right, directly under the
+               Custom button rather than at the far opposite corner. #}
             {{ drp_custom(
                 action=url_for('user_dashboard.resource_details', projcode=projcode),
                 start_date=start_date,
                 end_date=end_date,
                 hidden_fields={'resource': resource_name, 'scope': scope,
-                               'usage_tab': usage_tab}
+                               'usage_tab': usage_tab},
+                align_end=True
             ) }}
         </div>
     </div>

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -357,27 +357,26 @@
 </div>
 {% endif %}
 
-{% from 'dashboards/fragments/date_range_picker.html' import date_range_picker %}
-{{ date_range_picker(
-    action=url_for('user_dashboard.resource_details', projcode=projcode),
-    start_date=start_date,
-    end_date=end_date,
-    hidden_fields={'resource': resource_name, 'scope': scope},
-    epoch_date=alloc_start_date
-) }}
-
+{# The tree comes before the usage card, not after the date picker: it picks
+   the *scope* the card reports on, so it reads as an input to the card. The
+   window still applies to its badges — hence the header note. #}
 {% if has_children and tree_data %}
 {# Recursive macro — mimics the existing tree-list style from the project card #}
 {% macro render_tree_node(node) %}
 {% set is_selected = (node.projcode == scope) %}
 {% set is_clickable = node.subtree_charges > 0 %}
+{# usage_tab rides along so re-scoping doesn't dump the analyst back on
+   History; data-tab-param-link lets nav-view-persistence.js keep these hrefs
+   current when the tab changes without a reload. #}
 {% set node_url = url_for('user_dashboard.resource_details',
                            projcode=projcode, resource=resource_name,
                            scope=node.projcode,
-                           start_date=start_date, end_date=end_date) %}
+                           start_date=start_date, end_date=end_date,
+                           usage_tab=usage_tab) %}
 <li style="{{ 'background: #fff3cd; border-left-color: #ffc107; font-weight: bold;' if is_selected else '' }}">
     {% if is_clickable %}
-    <a href="{{ node_url }}" class="d-flex align-items-center gap-2 text-decoration-none text-body">
+    <a href="{{ node_url }}" data-tab-param-link
+       class="d-flex align-items-center gap-2 text-decoration-none text-body">
     {% else %}
     <span class="d-flex align-items-center gap-2 text-muted" style="cursor: default;" title="No {{ resource_name }} usage">
     {% endif %}
@@ -419,7 +418,7 @@
     <div class="card-header cursor-pointer" data-bs-toggle="collapse" data-bs-target="#collapseTree" aria-expanded="true">
         <h5 class="mb-0">
             <i class="fas fa-sitemap"></i> Project Hierarchy
-            <small class="text-muted fw-normal ms-2">Click a project to scope the charts below</small>
+            <small class="text-muted fw-normal ms-2">Click a project to scope the usage card below — badges show charges in the selected window</small>
             <i class="fas fa-chevron-down float-end transition-smooth"></i>
         </h5>
     </div>
@@ -433,86 +432,147 @@
 </div>
 {% endif %}
 
-<!-- Usage Trend Chart Card -->
+{# ── Usage card: History | By User ────────────────────────────────────────
+   One card for one question asked two ways — *when* the resource was used
+   and *by whom* — sharing a single time window.
+
+   The card header is the `.drp` root, so it can enclose both the tab strip
+   (which holds the date presets, right-aligned) and the custom-range row
+   below them. pickers.js scopes every picker button via closest('.drp').
+
+   `usage_tab` is server-side: only the open pane's chart carries
+   hx-trigger="load", so exactly one chart is fetched per page load. That is
+   also why this tablist is marked data-tab-url-param and opts out of the
+   tab:<id> localStorage channel — see nav-view-persistence.js, which keeps
+   the address bar, the .drp-hidden block and the tree links in step as the
+   analyst switches panes. #}
+{% from 'dashboards/fragments/date_range_picker.html' import drp_pills, drp_custom %}
+
+{% macro _tabcls(key) -%}
+nav-link{{ ' active' if key == usage_tab }}
+{%- endmacro %}
+{% macro _panecls(key) -%}
+tab-pane fade{{ ' show active' if key == usage_tab }}
+{%- endmacro %}
+{# Only the open pane fires on load, so a page view costs exactly one chart
+   request. Both panes also refetch on every `shown.bs.tab` — deliberately
+   NOT `once`: the metric pills write to a shared persistence family, so
+   picking Core-Hours here and switching panes must not leave the other one
+   still showing Charges with its own pill disagreeing. A warm refetch is
+   ~100ms (chart SVGs are content-hash cached), which is the right price for
+   two views that can never contradict each other. #}
+{% macro _trig(key) -%}
+{{ 'load, ' if key == usage_tab }}shown.bs.tab from:#usage-{{ key }}-tab
+{%- endmacro %}
+
 <div class="card mb-4">
-    <div class="card-header cursor-pointer" data-bs-toggle="collapse" data-bs-target="#collapseUsage" aria-expanded="true">
-        <h5 class="mb-0">
-            <i class="fas fa-chart-area"></i> Usage Trend
-            {% if has_children and scope != projcode %}
-            <small class="text-muted fw-normal ms-2">{{ scope }}</small>
+    <div class="card-header p-0 drp"
+         data-action-url="{{ url_for('user_dashboard.resource_details', projcode=projcode) }}"
+         data-start="{{ start_date }}"
+         {%- if alloc_start_date %} data-epoch="{{ alloc_start_date }}"{% endif %}>
+        <script type="application/json" class="drp-hidden">{{
+            {'resource': resource_name, 'scope': scope, 'usage_tab': usage_tab} | tojson
+        }}</script>
+
+        <ul class="nav nav-tabs card-header-tabs mx-2 mt-2" id="usageCardTabs"
+            role="tablist" data-tab-url-param="usage_tab">
+            <li class="nav-item" role="presentation">
+                <button class="{{ _tabcls('history') }}" id="usage-history-tab"
+                        data-bs-toggle="tab" data-bs-target="#tab-usage-history"
+                        type="button" role="tab" data-tab-param-value="history">
+                    <i class="fas fa-chart-area me-1"></i> History
+                </button>
+            </li>
+            {% if show_by_user %}
+            <li class="nav-item" role="presentation">
+                <button class="{{ _tabcls('byuser') }}" id="usage-byuser-tab"
+                        data-bs-toggle="tab" data-bs-target="#tab-usage-byuser"
+                        type="button" role="tab" data-tab-param-value="byuser">
+                    <i class="fas fa-users me-1"></i> By User
+                </button>
+            </li>
             {% endif %}
-            <i class="fas fa-chevron-down float-end transition-smooth"></i>
-        </h5>
+            {% if has_children and scope != projcode %}
+            <li class="nav-item d-flex align-items-center ms-2">
+                <small class="text-muted">{{ scope }}</small>
+            </li>
+            {% endif %}
+            <li class="nav-item ms-auto d-flex align-items-center pb-1 gap-2">
+                {{ drp_pills(epoch_date=alloc_start_date) }}
+            </li>
+        </ul>
+
+        <div class="px-3 py-1 border-top">
+            {{ drp_custom(
+                action=url_for('user_dashboard.resource_details', projcode=projcode),
+                start_date=start_date,
+                end_date=end_date,
+                hidden_fields={'resource': resource_name, 'scope': scope,
+                               'usage_tab': usage_tab}
+            ) }}
+        </div>
     </div>
-    <div id="collapseUsage" class="collapse show">
-        <div class="card-body">
-            {# Chart loads via HTMX so the metric pill selector (Charges
-               / Job Count / Core-Hours) can swap the SVG in place.
-               nav-view-persistence.js round-trips the `metric` URL param
-               through localStorage, so the analyst's choice survives page
-               reloads — and, being stored under the shared `metric:usage`
-               family key rather than a per-page id, follows them from one
-               project's resource page to the next. Family-scoped because
-               these values (charges|jobs|core_hours) are not the ones any
-               other chart's metric pill offers. A resource whose type
-               lacks the stored metric clamps back to charges server-side. #}
-            <div id="usage-chart-wrapper"
-                 hx-get="{{ url_for('user_dashboard.resource_details_usage_chart',
-                                    projcode=projcode,
-                                    resource=resource_name,
-                                    scope=scope,
-                                    start_date=start_date,
-                                    end_date=end_date,
-                                    metric='charges') }}"
-                 hx-trigger="load"
-                 hx-swap="innerHTML"
-                 data-chart-persist-shared="metric:usage">
-                <div class="text-center text-muted py-5">
-                    <i class="fas fa-spinner fa-spin"></i> Loading chart…
+
+    <div class="tab-content">
+        <div class="{{ _panecls('history') }}" id="tab-usage-history" role="tabpanel"
+             aria-labelledby="usage-history-tab">
+            <div class="card-body">
+                {# The metric choice (Charges / Job Count / Core-Hours) is
+                   stored under the shared `metric:usage` family key rather
+                   than a per-page id, so it follows the analyst from one
+                   project's resource page to the next — and, because the
+                   pie below joins the same family, across the two panes.
+                   Family-scoped because these values are not the ones any
+                   other chart's metric pill offers. A resource whose type
+                   lacks the stored metric clamps back to charges
+                   server-side. #}
+                <div id="usage-chart-wrapper"
+                     hx-get="{{ url_for('user_dashboard.resource_details_usage_chart',
+                                        projcode=projcode,
+                                        resource=resource_name,
+                                        scope=scope,
+                                        start_date=start_date,
+                                        end_date=end_date,
+                                        metric='charges') }}"
+                     hx-trigger="{{ _trig('history') }}"
+                     hx-swap="innerHTML"
+                     data-chart-persist-shared="metric:usage">
+                    <div class="text-center text-muted py-5">
+                        <i class="fas fa-spinner fa-spin"></i> Loading chart…
+                    </div>
                 </div>
+                {{ daily_breakdown_table(daily_breakdown, 'charges-table', date_span_days) }}
             </div>
         </div>
-    </div>
-</div>
 
-<!-- Historical Usage Card -->
-<div class="card mb-4">
-    <div class="card-header cursor-pointer" data-bs-toggle="collapse" data-bs-target="#collapseCharges" aria-expanded="true">
-        <h5 class="mb-0">
-            <i class="fas fa-table"></i> Historical Usage
-            {% if has_children and scope != projcode %}
-            <small class="text-muted fw-normal ms-2">{{ scope }}</small>
-            {% endif %}
-            <i class="fas fa-chevron-down float-end transition-smooth"></i>
-        </h5>
-    </div>
-    <div id="collapseCharges" class="collapse show">
-        <div class="card-body">
-            {{ daily_breakdown_table(daily_breakdown, 'charges-table', date_span_days) }}
+        {# By User is suppressed for a single user (server-side `show_by_user`),
+           where a pie of one and a table restating the History totals say
+           nothing. #}
+        {% if show_by_user %}
+        <div class="{{ _panecls('byuser') }}" id="tab-usage-byuser" role="tabpanel"
+             aria-labelledby="usage-byuser-tab">
+            <div class="card-body">
+                <div id="user-pie-wrapper"
+                     hx-get="{{ url_for('user_dashboard.resource_details_user_pie',
+                                        projcode=projcode,
+                                        resource=resource_name,
+                                        scope=scope,
+                                        start_date=start_date,
+                                        end_date=end_date,
+                                        metric='charges') }}"
+                     hx-trigger="{{ _trig('byuser') }}"
+                     hx-swap="innerHTML"
+                     data-chart-persist-shared="metric:usage">
+                    <div class="text-center text-muted py-5">
+                        <i class="fas fa-spinner fa-spin"></i> Loading chart…
+                    </div>
+                </div>
+                {{ user_breakdown_table(user_breakdown, 'users-table') }}
+            </div>
         </div>
+        {% endif %}
     </div>
 </div>
-
-<!-- User Breakdown Card — suppressed for a single user, where it just
-     restates the Historical Usage totals. -->
-{% if user_breakdown | length > 1 %}
-<div class="card mb-4">
-    <div class="card-header cursor-pointer" data-bs-toggle="collapse" data-bs-target="#collapseUsers" aria-expanded="true">
-        <h5 class="mb-0">
-            <i class="fas fa-users"></i> Usage by User
-            {% if has_children and scope != projcode %}
-            <small class="text-muted fw-normal ms-2">{{ scope }}</small>
-            {% endif %}
-            <i class="fas fa-chevron-down float-end transition-smooth"></i>
-        </h5>
-    </div>
-    <div id="collapseUsers" class="collapse show">
-        <div class="card-body">
-            {{ user_breakdown_table(user_breakdown, 'users-table') }}
-        </div>
-    </div>
-</div>
-{% endif %}
 
 <!-- Job History Card — per-job drill + aggregation tabs from the
      hpc-usage-queries plugin. Only for resources that map onto a plugin

--- a/tests/unit/snapshots/dashboard_route_map.json
+++ b/tests/unit/snapshots/dashboard_route_map.json
@@ -1932,6 +1932,13 @@
     ]
   ],
   [
+    "user_dashboard.resource_details_user_pie",
+    "/user/resource-details/user-pie/<projcode>",
+    [
+      "GET"
+    ]
+  ],
+  [
     "user_dashboard.resource_details_user_subtree",
     "/user/resource-details/user-subtree/<projcode>",
     [

--- a/tests/unit/test_resource_details_partials.py
+++ b/tests/unit/test_resource_details_partials.py
@@ -214,6 +214,134 @@ class TestDaySubtreeRoute:
 
 
 # ---------------------------------------------------------------------------
+# /user/resource-details/user-pie/<projcode>  (By User pane chart)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def _mock_user_summary(monkeypatch):
+    """Patch get_user_summary_for_project with a multi-user rollup."""
+    captured = {'kwargs': None}
+
+    def _fake(session, projcode, resource, start, end):
+        captured['kwargs'] = {
+            'projcode': projcode, 'resource': resource,
+            'start': start, 'end': end,
+        }
+        return [
+            {'username': 'alice', 'jobs': 20, 'core_hours': 150.0, 'charges': 80.0,
+             'queue_count': 2, 'date_count': 3, 'any_queue': 'main',
+             'any_date': '2026-04-01'},
+            {'username': 'bob', 'jobs': 10, 'core_hours': 50.0, 'charges': 30.0,
+             'queue_count': 1, 'date_count': 1, 'any_queue': 'gpu',
+             'any_date': '2026-04-02'},
+        ]
+
+    monkeypatch.setattr(
+        'webapp.dashboards.user.blueprint.get_user_summary_for_project', _fake,
+    )
+    return captured
+
+
+class TestUserPieRoute:
+    """The By User pane's chart fragment — sibling of the Usage Trend one.
+
+    Its wedges must emit ``#usage-user-<username>`` sentinels, because
+    svg-chart-links.js routes that prefix (and only that prefix) to the
+    Usage-by-User table row. A renamed sentinel breaks the drill-down
+    silently, so it is asserted rather than assumed.
+    """
+
+    def test_renders_pie_with_user_sentinels(
+        self, auth_client, active_project, _mock_user_summary,
+    ):
+        resp = auth_client.get(
+            f'/user/resource-details/user-pie/{active_project.projcode}'
+            '?resource=Derecho&start_date=2026-04-01&end_date=2026-04-30'
+        )
+        assert resp.status_code == 200
+        body = resp.get_data(as_text=True)
+        assert '#usage-user-alice' in body
+        assert '#usage-user-bob' in body
+        assert _mock_user_summary['kwargs']['resource'] == 'Derecho'
+
+    def test_missing_resource_returns_400(self, auth_client, active_project):
+        resp = auth_client.get(
+            f'/user/resource-details/user-pie/{active_project.projcode}'
+        )
+        assert resp.status_code == 400
+
+    def test_invalid_date_returns_400(self, auth_client, active_project):
+        resp = auth_client.get(
+            f'/user/resource-details/user-pie/{active_project.projcode}'
+            '?resource=Derecho&start_date=not-a-date'
+        )
+        assert resp.status_code == 400
+
+    def test_no_activity_renders_empty_state(
+        self, auth_client, active_project, monkeypatch,
+    ):
+        monkeypatch.setattr(
+            'webapp.dashboards.user.blueprint.get_user_summary_for_project',
+            lambda *a, **kw: [],
+        )
+        resp = auth_client.get(
+            f'/user/resource-details/user-pie/{active_project.projcode}'
+            '?resource=Derecho'
+        )
+        assert resp.status_code == 200
+        assert 'No user activity recorded' in resp.get_data(as_text=True)
+
+    def test_unsupported_metric_clamps_to_charges(
+        self, auth_client, active_project, _mock_user_summary,
+    ):
+        """A persisted `metric` a resource can't serve must not 400.
+
+        The metric lives in an app-wide localStorage family shared with other
+        surfaces, so a stale value arrives routinely; the pane clamps.
+        """
+        resp = auth_client.get(
+            f'/user/resource-details/user-pie/{active_project.projcode}'
+            '?resource=Derecho&metric=bogus'
+        )
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# ?usage_tab= — which pane the usage card opens on
+# ---------------------------------------------------------------------------
+
+class TestUsageTabParsing:
+    """`usage_tab` is server-side because only the open pane's chart carries
+    ``hx-trigger="load"`` — an unvalidated value would render a tab strip with
+    nothing active and fetch no chart at all.
+    """
+
+    @pytest.mark.parametrize('raw,expected', [
+        ('history', 'history'),
+        ('byuser', 'byuser'),
+        ('', 'history'),
+        ('nonsense', 'history'),
+        (None, 'history'),
+    ])
+    def test_valid_and_unknown_values(self, app, raw, expected):
+        from webapp.dashboards.user.blueprint import _parse_usage_tab
+
+        qs = '' if raw is None else f'?usage_tab={raw}'
+        with app.test_request_context(f'/user/resource-details/X{qs}'):
+            assert _parse_usage_tab(show_by_user=True) == expected
+
+    def test_byuser_clamps_when_pane_is_hidden(self, app):
+        """A single-user project renders no By User button; a stale link
+        selecting it must fall back rather than activate a missing tab."""
+        from webapp.dashboards.user.blueprint import _parse_usage_tab
+
+        with app.test_request_context(
+            '/user/resource-details/X?usage_tab=byuser'
+        ):
+            assert _parse_usage_tab(show_by_user=False) == 'history'
+
+
+# ---------------------------------------------------------------------------
 # /user/resource-details/<projcode>  (main page — access control)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -1380,17 +1380,28 @@ def test_apply_connection_settings_zero_timeout_skips_set(monkeypatch):
     assert executed == ["SET application_name = %s"]
 
 
-def test_job_history_machines_sorted_when_enabled(app, monkeypatch):
-    """Sorted engine keys when the plugin is up; [] when disabled."""
+@pytest.mark.parametrize('machines', [
+    ['derecho', 'casper'],
+    ['casper', 'derecho'],
+])
+def test_job_history_machines_follows_config_order(app, monkeypatch, machines):
+    """Engine keys come back in insertion (== JOB_HISTORY_MACHINES) order.
+
+    _warm() inserts one engine per configured machine in config order, so the
+    UI leads with whichever machine the deployment lists first (derecho by
+    default). Both orderings are exercised to pin that this tracks insertion
+    rather than any hardcoded list — the old implementation sorted, which
+    passed the first case by accident and led with Casper in production.
+    """
     from webapp.jobs import service
 
     monkeypatch.setitem(app.extensions, 'hpc_usage_queries', {
         'module':  types.SimpleNamespace(JobQueries=object),
-        'engines': {'derecho': MagicMock(), 'casper': MagicMock()},
+        'engines': {m: MagicMock() for m in machines},
         'enabled': True,
     })
     with app.app_context():
-        assert service.job_history_machines() == ['casper', 'derecho']
+        assert service.job_history_machines() == machines
 
 
 def test_job_history_machines_empty_when_disabled(app):
@@ -3683,10 +3694,17 @@ def test_card_fragment_marks_the_requested_pill_active(
     body = auth_client.get(
         _card_url(active_project.projcode, days=30)).get_data(as_text=True)
 
+    # The selected pill is the one carrying `active` — every pill keeps the
+    # same btn-outline-secondary base class (the theme inverts .btn-group so
+    # `active` paints white). Attribute order isn't guaranteed, so match the
+    # class list and the data attribute in either order.
     import re
-    assert re.search(r'btn btn-primary[^>]*data-days-value="30"', body) or \
-        re.search(r'data-days-value="30"[^>]*btn btn-primary', body)
+    assert re.search(r'btn-outline-secondary active[^>]*data-days-value="30"', body) or \
+        re.search(r'data-days-value="30"[^>]*btn-outline-secondary active', body)
     assert 'data-days-value="365"' in body      # the other pills still render
+    # ...and it's the only active one — this fragment renders a single card,
+    # so a second `active` would mean two windows look selected at once.
+    assert len(re.findall(r'btn-outline-secondary active', body)) == 1
 
 
 def test_card_fragment_unknown_days_falls_back_to_the_default(


### PR DESCRIPTION
## Summary

Folds the three SAM-side usage cards on `/user/resource-details/<projcode>` into
one card with **History | By User** tabs sharing a single time window, and moves
the project tree above it.

This is SAM's own `comp_charge_summary` rollup — no `hpc-usage-queries` plugin
involved.

**Before:** the `date_range_picker` card, then Project Hierarchy, then Usage
Trend / Historical Usage / Usage by User as three sibling collapse cards — the
picker separated from everything it controlled by an unrelated tree.

**After:**

```
Project Hierarchy                                   <- picks the scope; reads as an input
+-------------------------------------------------------------+
| [History] [By User]    Epoch 7d 30d [90d] 6mo 1yr  [Custom]  |
+-------------------------------------------------------------+
|  History : stacked/flat bar chart + Historical Usage table   |
|  By User : NEW usage pie + Usage by User table               |
+-------------------------------------------------------------+
Job History (plugin card, unchanged)
```

Plan doc: `docs/plans/RESOURCE_DETAILS_USAGE_TABS.md`.

## Decisions

1. **Pills keep full-page navigation.** The window governs the tree badges, this
   card *and* the Job History card — one control, one reload, nothing goes
   stale. An htmx card-shell swap would have left the tree and jobs card showing
   the previous window on the same screen.
2. **Pills render in the tab strip**, which is what forced the
   `date_range_picker` split — the macro had baked its own `card` wrapper.
3. **Tree badges stay window-scoped**; the card header now says so, since
   tree-above-pills would otherwise imply independence.
4. **The History chart stays stacked-by-user.** Its legend usernames now
   activate the By User pane before expanding the row.

## Persistence contract

The one real design decision, documented in the plan doc and in
`nav-view-persistence.js`.

A tablist marked `data-tab-url-param` keeps its state in `?usage_tab=` and
**opts out** of the `tab:<tablistId>` localStorage channel. `restoreTabs` runs on
`DOMContentLoaded` — the same event htmx initializes on — so a stored tab
disagreeing with the server's would show one pane while the other pane's chart
had already fired: two fetches per load, one invisible, in a load-order race.
The URL is also the stronger channel (bookmarking, link-sharing, back/forward).

`syncTabParam` then keeps three writers in step on `shown.bs.tab`: the address
bar (`replaceState`), every `.drp-hidden` block (pickers.js reads it at *click*
time, so the presets follow for free), and `[data-tab-param-link]` hrefs plus
same-named hidden inputs. Without that last one you click a tab, click a date
pill, and land back on the server's tab.

The jobs card carries no marker, so its localStorage behaviour is untouched.

**Trade-off found in live smoke:** the inactive pane was originally
`shown.bs.tab once`, which let the panes contradict each other — pick Core-Hours
on By User, switch to History, and History still showed Charges with its own
pill disagreeing. The metric is a *shared* family precisely because it means the
same thing on both, so both panes now refetch on tab show. A warm refetch is
~90-110 ms (chart SVGs are content-hash cached). Page load still costs **exactly
one** chart request.

## Notable pieces

- `generate_user_usage_pie_chart` reuses the `#usage-user-<username>` sentinel
  the stacked legend already emitted, so `svg-chart-links.js` needed **no** new
  `ROW_SENTINELS` entry.
- `_usage_fragment_ctx()` — shared prologue for the two chart fragments;
  `resource_details_user_pie` is the one added route (snapshot regenerated,
  278 → 279).
- `show_by_user` moved from a template `{% if %}` to the route, so the tab strip
  and the server's choice of open pane cannot disagree — the discipline
  `jobs.routes.panel_relevance()` applies. A stale `?usage_tab=byuser` on a
  single-user project clamps to History.
- `usage_tab`, not `active_tab`: the jobs blueprint already owns `?active_tab=`
  and this page hosts a jobs card.
- Table ids `charges-table` / `users-table` unchanged — JS and tests key on them.
- Metric pills switched to `btn-outline-secondary` + `active`, the selector
  convention used by `jobs_usage_panel`, `jobs_histogram` and the date presets.
  The previous `btn-primary`/`btn-outline-primary` pair rendered **inverted**
  against the presets directly above it. This fixes the pre-existing Usage Trend
  pills too, not just the new pie.

## Non-goals

`resource_details_disk.html` keeps its standalone picker card; the Job History
card is untouched; no fragment registrar, no card-shell fragment route, no
legacy-compat API changes. The three per-card collapses are gone rather than
reproduced per pane — their stale `collapse:` localStorage keys are inert.

## Test Results

`3449 passed, 30 skipped, 1 xfailed` — full suite, `-n auto`.

New coverage in `tests/unit/test_resource_details_partials.py`: the pie fragment
(sentinels asserted, not assumed — a renamed sentinel breaks the drill-down
silently), 400s, empty state, stale-metric clamping, and `?usage_tab=` parsing
including the single-user clamp.

## Live smoke (webdev :5050, Playwright)

Zero console errors/warnings. Verified: tab switch; tab surviving reload, date
pill, Epoch, Custom→Apply and tree-node click; bar→day drill with 3-level month
nesting and no spurious collapse persistence; stacked-legend click jumping panes
and expanding the row; pie wedge→row with lazy subtree fetch; metric coherence
across panes both live and across reloads; single-user project rendering one tab;
jobs card still using `tab:jobsCardTabs` and not touching the URL; disk
resource-details picker unchanged.

One intentional cosmetic change reaches the disk page: the picker's Custom and
Apply buttons gain `btn-sm` to match the presets beside them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
