### PR TITLE
Selector pills: Derecho leads, and white-is-active everywhere

### DIFF
--- a/src/webapp/jobs/service.py
+++ b/src/webapp/jobs/service.py
@@ -49,16 +49,23 @@ def default_jobs_window_start() -> str:
 
 
 def job_history_machines() -> List[str]:
-    """Machines with a warmed job-history engine, sorted.
+    """Machines with a warmed job-history engine, in ``JOB_HISTORY_MACHINES`` order.
 
     Analogue of ``disk_scans.service.scan_capable_resources()`` — the
     single source for "which machines can the jobs UI offer?". Returns
     ``[]`` when the plugin is disabled, so nav items / tabs / route
     validation all degrade together.
+
+    The order is the deployment's, not the alphabet's: ``_warm()`` inserts
+    engines while iterating ``JOB_HISTORY_MACHINES`` (default
+    ``derecho,casper``), and dicts keep insertion order, so config order
+    survives — a machine whose engine failed to open just drops out. This
+    is what puts Derecho first in every subtab strip; sorting here used to
+    throw that away and lead with Casper.
     """
     if not is_enabled():
         return []
-    return sorted(get_engines().keys())
+    return list(get_engines().keys())
 
 
 def _resolve_queue_and_qos(

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -1167,6 +1167,17 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     margin-bottom: 0 !important;
 }
 
+/* Bootstrap's .card-header-tabs pulls the strip down over the header's cap
+   padding with a negative bottom margin — correct only when the tabs are the
+   header's LAST child. The usage card puts a custom date-range row after
+   them, and that negative margin dropped the tab bottoms ~16px into a ~30px
+   row, overlapping the range readout by half. Reset it whenever something
+   follows; the seamless-attach case above is unaffected because tab-content
+   is a sibling of the strip, not part of the header. */
+.card-header-tabs:not(:last-child) {
+    margin-bottom: 0;
+}
+
 .nav-tabs .nav-link {
     color: var(--ncar-blue);
     font-weight: var(--font-weight-semi-bold);

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -1097,16 +1097,48 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
    Mirrors Unity's cascade: base color set first, :not(.active) overrides inactive.
    ========================================================================= */
 
-/* Pills — recolor to NCAR blue without changing the visual treatment.
-   Used for sub-navigation inside accordions and chart-selection rows where the
-   bolder .nav-tabs invert pattern would be too aggressive. Bootstrap 5
-   implements .nav-pills via CSS custom properties, so the four overrides
-   below are sufficient — no per-state selectors needed. */
+/* Pills — same white-is-active convention as .nav-tabs below and the
+   .btn-group selector rows above, at the lighter rounded-pill weight.
+   Pills carry the machine / filesystem / chart-series choosers (jobs and
+   filesystem-scan subtabs, the allocations pie tabs, the allocation-tree
+   resource types); they used to run blue-is-active, which read backwards
+   next to every other selector on the same page.
+
+   Bootstrap 5 exposes custom properties for the ACTIVE pill only, so the
+   inactive treatment needs the explicit :not(.active) rules — mirroring
+   how .nav-tabs is written. */
 .nav-pills {
     --bs-nav-link-color: var(--ncar-blue);
     --bs-nav-link-hover-color: var(--ncar-navy);
-    --bs-nav-pills-link-active-color: #fff;
-    --bs-nav-pills-link-active-bg: var(--ncar-blue);
+    --bs-nav-pills-link-active-color: var(--ncar-blue);
+    --bs-nav-pills-link-active-bg: #fff;
+}
+
+.nav-pills .nav-link:not(.active) {
+    background-color: var(--ncar-blue);
+    color: #fff;
+}
+
+.nav-pills .nav-link:not(.active):hover {
+    background-color: var(--ncar-navy);
+    color: #fff;
+}
+
+/* Counter badges sit inside pills whose background flips with state, so they
+   have to flip too — a stock .bg-light badge vanishes on the white active
+   pill. Both declarations need !important: the background beats .badge.bg-X
+   (same as the tinted badge palette further down this file) and the color
+   beats the .text-dark / .text-* utilities, which Bootstrap ships as
+   !important. Callers therefore don't have to strip those utilities off
+   badges they drop into a pill. */
+.nav-pills .nav-link:not(.active) .badge {
+    background-color: #fff !important;
+    color: var(--ncar-blue) !important;
+}
+
+.nav-pills .nav-link.active .badge {
+    background-color: var(--ncar-blue) !important;
+    color: #fff !important;
 }
 
 .nav-tabs {

--- a/src/webapp/static/js/nav-view-persistence.js
+++ b/src/webapp/static/js/nav-view-persistence.js
@@ -403,9 +403,10 @@
     function syncDaysCard(card, days) {
         if (!days) return;
         card.querySelectorAll('[data-days-value]').forEach(function (btn) {
-            var on = btn.dataset.daysValue === days;
-            btn.classList.toggle('btn-primary', on);
-            btn.classList.toggle('btn-outline-primary', !on);
+            // Base class is always btn-outline-secondary; `active` alone
+            // decides the paint (the theme inverts .btn-group so active
+            // reads white). Only the state class toggles here.
+            btn.classList.toggle('active', btn.dataset.daysValue === days);
         });
         // The link speaks ?days=, never a date, so this stays a parameter
         // swap — no re-deriving client-side a window the server owns.

--- a/src/webapp/templates/dashboards/fragments/date_range_picker.html
+++ b/src/webapp/templates/dashboards/fragments/date_range_picker.html
@@ -60,13 +60,29 @@
 {% endmacro %}
 
 
-{% macro drp_custom(action, start_date, end_date, hidden_fields={}) %}
+{% macro drp_custom(action, start_date, end_date, hidden_fields={}, align_end=False) %}
 {#
   The GET form behind the Custom toggle. Also carries the hidden fields, so
   they travel with a custom-range submit the same way pickers.js sends them
   with a preset click. The current-range label lives here rather than in the
   strip: when a custom range is active no preset is highlighted, so this is
   the only readout of the window.
+
+  align_end decides which end of the row the inputs open at, and follows the
+  Custom button that summons them:
+
+    False (default) — the standalone card, where drp_pills sits inline and
+      Custom is mid-row. The inputs open immediately to its right, reading
+      as a continuation of the strip; the readout takes the far end.
+    True — a card header, where drp_pills is pushed right (ms-auto) in the
+      tab strip and drp_custom renders on its own row below. Left-aligned
+      inputs would open at the opposite corner from the button that opened
+      them, so the group is flushed right to land directly beneath it and
+      the readout swaps to the left.
+
+  order-first (rather than reordering the markup) keeps one DOM order for
+  both: the readout is last so it stays the form's final field, and only
+  the visual order flips.
 #}
 <form method="GET" action="{{ action }}"
       class="d-flex align-items-center gap-2 flex-grow-1 mb-0">
@@ -74,7 +90,7 @@
     <input type="hidden" name="{{ name }}" value="{{ value }}">
     {% endfor %}
 
-    <div class="drp-custom d-none d-flex align-items-center gap-2">
+    <div class="drp-custom d-none d-flex align-items-center gap-2{% if align_end %} ms-auto{% endif %}">
         <input type="date" name="start_date"
                value="{{ start_date }}"
                class="form-control form-control-sm" style="width:140px">
@@ -87,7 +103,7 @@
         </button>
     </div>
 
-    <small class="text-muted ms-auto">{{ start_date }} – {{ end_date }}</small>
+    <small class="text-muted {{ 'order-first me-auto' if align_end else 'ms-auto' }}">{{ start_date }} – {{ end_date }}</small>
 </form>
 {% endmacro %}
 

--- a/src/webapp/templates/dashboards/user/partials/jobs_card.html
+++ b/src/webapp/templates/dashboards/user/partials/jobs_card.html
@@ -292,8 +292,13 @@ tab-pane fade{{ ' show active' if key == active_tab }}
         <div class="btn-group btn-group-sm" role="group" aria-label="Time window"
              {%- if days_persist_id %} data-jobs-days-pills{% endif %}>
             {% for _d, _label in jobs_window_pills %}
+            {# btn-outline-secondary + `active` — the selector convention used
+               by the metric pills, the date presets and the machine subtabs.
+               The old btn-primary/btn-outline-primary pair rendered
+               blue-is-active, backwards against every other selector on the
+               page (same bug 19ab6c0 fixed for the metric pills). #}
             <button type="button" data-days-value="{{ _d }}"
-                    class="btn {% if days == _d %}btn-primary{% else %}btn-outline-primary{% endif %}"
+                    class="btn btn-outline-secondary{% if days == _d %} active{% endif %}"
                     hx-get="{{ _card_q }}days={{ _d }}"
                     hx-target="#{{ cid }}-card"
                     hx-swap="outerHTML">{{ _label }}</button>

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -503,12 +503,16 @@ tab-pane fade{{ ' show active' if key == usage_tab }}
         </ul>
 
         <div class="px-3 py-1 border-top">
+            {# align_end: drp_pills is ms-auto'd to the right of the tab strip
+               above, so the inputs open flush right, directly under the
+               Custom button rather than at the far opposite corner. #}
             {{ drp_custom(
                 action=url_for('user_dashboard.resource_details', projcode=projcode),
                 start_date=start_date,
                 end_date=end_date,
                 hidden_fields={'resource': resource_name, 'scope': scope,
-                               'usage_tab': usage_tab}
+                               'usage_tab': usage_tab},
+                align_end=True
             ) }}
         </div>
     </div>

--- a/tests/unit/test_webapp_jobs.py
+++ b/tests/unit/test_webapp_jobs.py
@@ -1380,17 +1380,28 @@ def test_apply_connection_settings_zero_timeout_skips_set(monkeypatch):
     assert executed == ["SET application_name = %s"]
 
 
-def test_job_history_machines_sorted_when_enabled(app, monkeypatch):
-    """Sorted engine keys when the plugin is up; [] when disabled."""
+@pytest.mark.parametrize('machines', [
+    ['derecho', 'casper'],
+    ['casper', 'derecho'],
+])
+def test_job_history_machines_follows_config_order(app, monkeypatch, machines):
+    """Engine keys come back in insertion (== JOB_HISTORY_MACHINES) order.
+
+    _warm() inserts one engine per configured machine in config order, so the
+    UI leads with whichever machine the deployment lists first (derecho by
+    default). Both orderings are exercised to pin that this tracks insertion
+    rather than any hardcoded list — the old implementation sorted, which
+    passed the first case by accident and led with Casper in production.
+    """
     from webapp.jobs import service
 
     monkeypatch.setitem(app.extensions, 'hpc_usage_queries', {
         'module':  types.SimpleNamespace(JobQueries=object),
-        'engines': {'derecho': MagicMock(), 'casper': MagicMock()},
+        'engines': {m: MagicMock() for m in machines},
         'enabled': True,
     })
     with app.app_context():
-        assert service.job_history_machines() == ['casper', 'derecho']
+        assert service.job_history_machines() == machines
 
 
 def test_job_history_machines_empty_when_disabled(app):
@@ -3683,10 +3694,17 @@ def test_card_fragment_marks_the_requested_pill_active(
     body = auth_client.get(
         _card_url(active_project.projcode, days=30)).get_data(as_text=True)
 
+    # The selected pill is the one carrying `active` — every pill keeps the
+    # same btn-outline-secondary base class (the theme inverts .btn-group so
+    # `active` paints white). Attribute order isn't guaranteed, so match the
+    # class list and the data attribute in either order.
     import re
-    assert re.search(r'btn btn-primary[^>]*data-days-value="30"', body) or \
-        re.search(r'data-days-value="30"[^>]*btn btn-primary', body)
+    assert re.search(r'btn-outline-secondary active[^>]*data-days-value="30"', body) or \
+        re.search(r'data-days-value="30"[^>]*btn-outline-secondary active', body)
     assert 'data-days-value="365"' in body      # the other pills still render
+    # ...and it's the only active one — this fragment renders a single card,
+    # so a second `active` would mean two windows look selected at once.
+    assert len(re.findall(r'btn-outline-secondary active', body)) == 1
 
 
 def test_card_fragment_unknown_days_falls_back_to_the_default(


### PR DESCRIPTION
Stacked on #393.

## Summary

Two defects in the strips that pick a machine or filesystem, plus one found while smoke-testing.

**1. Machine order — Derecho now leads.** `/user/jobs` and `/status/job-history` led with Casper. `job_history_machines()` sorted the engine keys, throwing away the order already expressed in config: `JOB_HISTORY_MACHINES` defaults to `derecho,casper` and `_warm()` inserts engines in exactly that order. It now returns insertion order, matching how the sibling helper `disk_scans.service.scan_capable_resources()` already preserves `FS_SCAN_RESOURCES` order — which is why Campaign_Store / Destor was already correct. The order is the deployment's, not the alphabet's.

**2. Pills follow white-is-active.** `.nav-pills` painted blue-is-active, the opposite of `.nav-tabs` and the `.btn-group` selector rows — so on `/user/jobs` the machine pills read backwards against the card tabs directly below them. Flipped `.nav-pills`, mirroring how `.nav-tabs` is written: custom properties for the active pill, explicit `:not(.active)` rules for the inactive one (Bootstrap gives no custom-property hook for that state).

The flip reaches all seven pill strips, so counter badges inside pills now invert with their pill — a stock `.bg-light` badge vanished on the now-white active pill. Both declarations need `!important`: the background to beat `.badge.bg-X`, the color to beat `.text-dark`, which Bootstrap ships as `!important`.

**3. Period pills.** The 30d/60d/90d/1yr group in `jobs_card.html` still used the `btn-primary`/`btn-outline-primary` pair — the same anti-pattern 19ab6c0 fixed for the metric pills, sitting in the same card and rendering blue-is-active right next to the machine pills this PR just fixed. Switched to `btn-outline-secondary` + `active`; the repaint in `nav-view-persistence.js` now toggles only `active`, since the base class no longer changes with state.

Left alone deliberately: `drp-toggle-custom` in `pickers.js` is a disclosure toggle for the custom-range panel, not a selector among peers.

## Test Results

Full suite: **3450 passed, 30 skipped, 1 xfailed** in 85s.

- `test_job_history_machines_sorted_when_enabled` → `test_job_history_machines_follows_config_order`, parametrized over both orderings so it pins insertion order rather than passing by accident on an alphabetical fixture.
- `test_card_fragment_marks_the_requested_pill_active` matches the new class pair and additionally asserts exactly one pill is active.

Playwright smoke against webdev, checking computed `background-color` / `color` on every affected strip:

| Surface | Result |
|---|---|
| `/user/jobs`, `/status/job-history` | **Derecho \| Casper**; active `#fff` bg + `#0057c2` text, inactive inverted |
| `/user/data`, `/status/filesystem-scans` | Campaign_Store / Destor order unchanged, colors flipped |
| Period pills | click still fans out across both machine subtabs and rewrites the "Open full view" `?days=` |
| `/allocations` pie tabs | now match the page tabs above them |
| Expirations sub-tabs | count badges legible on both blue and white pills |
| Allocation-tree resource types | badges invert correctly |

🤖 Generated with [Claude Code](https://claude.com/claude-code)