### PR TITLE
Derive the OIDC callback per-host (Unit 2 of the sam.hpc rollout)

### DIFF
--- a/docs/README-k8s.md
+++ b/docs/README-k8s.md
@@ -192,7 +192,7 @@ The k8s deployment authenticates via Microsoft Entra (Azure AD) OIDC. Config:
 | Env var | Source | Purpose |
 |---|---|---|
 | `AUTH_PROVIDER=oidc` | `values.yaml` | Selects OIDC provider in the Flask app |
-| `OIDC_REDIRECT_URI` | `values.yaml` | Set to `https://samuel.k8s.ucar.edu/auth/oidc/callback` |
+| `OIDC_REDIRECT_URI` | *(deliberately unset)* | Leaving it unset makes the callback follow the request host, so each ingress alias returns to itself. **Do not set it** — see below |
 | `OIDC_USERNAME_CLAIM` | `values.yaml` | Default `preferred_username`; SAM resolves on the part before `@` |
 | `OIDC_SCOPES` | `values.yaml` | Default `openid email profile` |
 | `FLASK_CONFIG=production` | `values.yaml` | Required for HTTPS — sets `SESSION_COOKIE_SECURE=True` |
@@ -205,14 +205,30 @@ The Entra app's reply URLs must include `https://samuel.k8s.ucar.edu/auth/oidc/c
 The post-logout redirect URI `https://samuel.k8s.ucar.edu/` must also be allowlisted
 (see `infrastructure/README.md` "OIDC SSO Integration" for the IT handoff checklist).
 
-Because the deployment now serves a second hostname, the **same pair must be
-registered for `sam.hpc.ucar.edu`** — reply URL
-`https://sam.hpc.ucar.edu/auth/oidc/callback` and post-logout
-`https://sam.hpc.ucar.edu/` — keeping the `samuel.k8s.ucar.edu` entries in
-place. Once both are registered, drop the static `OIDC_REDIRECT_URI` from
-`values.yaml` so the callback is derived from whichever host the user is on
-(`url_for(..., _external=True)` + `ProxyFix`); until then, login only works via
-`samuel.k8s.ucar.edu`.
+Because the deployment serves a second hostname, the **same pair is registered
+for `sam.hpc.ucar.edu`** — reply URL `https://sam.hpc.ucar.edu/auth/oidc/callback`
+and post-logout `https://sam.hpc.ucar.edu/status/` — alongside the
+`samuel.k8s.ucar.edu` entries.
+
+#### The callback is derived per-host — do not pin it
+
+`OIDC_REDIRECT_URI` is **intentionally absent** from `values.yaml`.
+`webapp/auth/blueprint.py` treats it as an override
+(`config.get('OIDC_REDIRECT_URI') or url_for('auth.oidc_callback', _external=True)`),
+and `ProxyFix(x_host=1, x_proto=1)` in `webapp/run.py` resolves that from
+`X-Forwarded-*`. So a login started on `sam.hpc.ucar.edu` returns to
+`sam.hpc.ucar.edu`, and likewise for the platform alias.
+
+Setting it back would break login on every host but the one named: Authlib
+scopes the PKCE verifier / state cookie to the origin the login **started** on,
+so a cross-host return cannot see that cookie and fails with
+`MismatchingStateError`. Two guards exist — `helm/tests/test-oidc-render.sh`
+asserts the var does not render, and
+`tests/unit/test_oidc_auth.py::test_oidc_login_callback_follows_forwarded_host`
+pins the derivation for both hosts.
+
+Logout needs no equivalent setting: it already derives
+`post_logout_redirect_uri` from the request host.
 
 ### Per-environment matrix
 
@@ -251,13 +267,10 @@ in the `incommon-cert-samuel` k8s Secret. To add another alias, append it to
 `webapp.tls.extraHosts` and to `INGRESS_HOSTS` in
 `scripts/lib/cirrus_common.sh`; cert-manager reissues to cover it.
 
-> **Interim caveat.** Until the Entra app registration lists
-> `https://sam.hpc.ucar.edu/auth/oidc/callback` as a reply URL *and*
-> `OIDC_REDIRECT_URI` is dropped from `values.yaml` (so the callback is derived
-> per-host), **login via `sam.hpc.ucar.edu` will fail** — the static redirect
-> sends the callback to `samuel.k8s.ucar.edu`, where the PKCE/state cookie set
-> on `sam.hpc` doesn't exist. Anonymous pages work fine. Log in via
-> `samuel.k8s.ucar.edu` until then.
+> **Adding an alias is not just DNS + TLS.** A new host also needs its
+> `/auth/oidc/callback` registered as an Entra reply URL, or login from it fails
+> at the IdP with `AADSTS50011`. The callback itself needs no config change —
+> it is derived per-host (see § OIDC above).
 
 ### Upgrade / Redeploy
 

--- a/docs/plans/SAM_HPC_CERT_APPLY.md
+++ b/docs/plans/SAM_HPC_CERT_APPLY.md
@@ -6,9 +6,9 @@
 |---|---|
 | Unit 1 — multi-host ingress + healthcheck (PR #367) | **Deployed** |
 | Cert reissue (multi-SAN `incommon-cert-samuel`) | **Done** — see below |
-| Unit 2 — per-host OIDC callback | **In this branch**, pending deploy + smoke |
-| Step 4 — logout post-logout URI | **Untested** — needs a browser round-trip |
-| Step 5 — advertise the name | Blocked on the two above |
+| Unit 2 — per-host OIDC callback | **Deployed to CIRRUS + browser-smoked** on `cname_final` (`sha-831f083`); pending merge |
+| Step 4 — logout post-logout URI | **Tested** — needs one Entra swap, see below |
+| Step 5 — advertise the name | Blocked on the merge + the Entra swap |
 
 All commands run against namespace `sam-queries`.
 
@@ -129,28 +129,57 @@ the URL bar must stay on the originating host through the callback and land
 signed in. The unit tests mock Authlib, so only this proves the cookie
 actually survives the round-trip.
 
+**Result on `sha-831f083` (2026-07-29):**
+
+- `redirect_uri` before → both hosts emitted `https://samuel.k8s.ucar.edu/…`;
+  after → each host emits its own. `samuel.k8s` unchanged, so no regression.
+- Interactive login from **`sam.hpc`**: Entra accepted the reply URL (sign-in
+  page, not AADSTS50011), PKCE present (`code_challenge_method=S256`), callback
+  landed on `sam.hpc`, **no `MismatchingStateError`**, identity resolved with
+  admin RBAC, 0 console errors.
+- Interactive login from **`samuel.k8s`**: succeeded via Entra SSO, stayed on
+  `samuel.k8s`.
+- The landing page after login is RBAC-dependent (admins → `/admin/projects`,
+  unprivileged → their user dashboard), so assert on the **host**, not the path.
+- `scripts/cirrus_healthcheck.sh`: 35 PASS / 1 WARN / 0 FAIL (the WARN is the
+  pre-existing "no helm release object" — ArgoCD reconciles the chart).
+
 **Rollback** is restoring one line in `values.yaml`. `samuel.k8s` login is
 unaffected throughout — the derivation produces the identical URL for that host.
 
 ---
 
-## Step 4 — logout (test-first, before touching Entra)
+## Step 4 — logout — TESTED, one Entra change outstanding
 
-Entra allows only one post-logout redirect URI; it is currently the
-`samuel.k8s` value. **No code change is needed** — logout already derives
-`post_logout_redirect_uri` per-host as
+Entra allows only one post-logout redirect URI; it is currently
+`https://samuel.k8s.ucar.edu/`. **No code change is needed** — logout already
+derives `post_logout_redirect_uri` per-host as
 `url_for('status_dashboard.index', _external=True)` → `https://<host>/status/`
 (`src/webapp/auth/blueprint.py`, blueprint `url_prefix='/status'`).
 
-1. Log in **and** log out **from `sam.hpc.ucar.edu`**.
-2. If it redirects back cleanly → nothing to do. (Leading hypothesis: Entra
-   validates the post-logout URI by registered-reply-URL **origin**, and
-   `https://sam.hpc.ucar.edu/auth/oidc/callback` is already registered. Do not
-   assert this — the test is the proof.)
-3. If it strands on MS's signed-out page → have Andrew Tamagni register
-   **`https://sam.hpc.ucar.edu/status/`** — the exact emitted string,
-   host-swapped, **NOT** root `/`. Per Ben's accepted tradeoff, clean logout for
-   `sam.hpc` and degraded from `samuel.k8s` is fine.
+**Measured 2026-07-29** on the deployed branch, both legs in one browser
+session:
+
+| Logout from | Registered origin? | Emitted URI | Result |
+|---|---|---|---|
+| `samuel.k8s.ucar.edu` | yes (root `/`) | `https://samuel.k8s.ucar.edu/status/` | returned cleanly to `/status/derecho` |
+| `sam.hpc.ucar.edu` | no | `https://sam.hpc.ucar.edu/status/` | stranded on MS "You signed out of your account" |
+
+> **Entra matches the post-logout URI by ORIGIN, not exact string.** The
+> `samuel.k8s` leg proves it: a registration of root `/` accepted an emission
+> of `/status/`. An earlier reading of Microsoft's "must match exactly" docs
+> predicted the opposite and was wrong — do not re-derive this from the docs,
+> the experiment above is the evidence.
+
+**Therefore: accept the swap exactly as Entra offered it.** Registering
+**`https://sam.hpc.ucar.edu/`** (root) is sufficient; there is no need to ask
+for the longer `/status/` form. Per Ben's accepted tradeoff, clean logout on
+`sam.hpc` with `samuel.k8s` degraded to the MS signed-out page is fine — and
+that degradation is now a known, measured consequence rather than a surprise.
+
+Login is unaffected either way: reply URLs are a separate Entra list and both
+hosts are already registered there (proven by a successful interactive login on
+each host).
 
 ---
 

--- a/docs/plans/SAM_HPC_CERT_APPLY.md
+++ b/docs/plans/SAM_HPC_CERT_APPLY.md
@@ -1,169 +1,172 @@
-# `sam.hpc.ucar.edu` — cert-fix apply runbook
+# `sam.hpc.ucar.edu` — cert + per-host OIDC rollout
 
-## Context
+## Status
 
-Unit 1 of the `sam.hpc.ucar.edu` rollout (multi-host ingress + multi-host
-healthcheck, PR #367) is **deployed on CIRRUS-k8s**. The ingress serves both
-`samuel.k8s.ucar.edu` and `sam.hpc.ucar.edu` and requests a single multi-SAN
-cert (`incommon-cert-samuel`). But the InCommon/Sectigo **ACME account is
-suspended account-wide**, so the reissue cannot complete:
+| Unit | State |
+|---|---|
+| Unit 1 — multi-host ingress + healthcheck (PR #367) | **Deployed** |
+| Cert reissue (multi-SAN `incommon-cert-samuel`) | **Done** — see below |
+| Unit 2 — per-host OIDC callback | **In this branch**, pending deploy + smoke |
+| Step 4 — logout post-logout URI | **Untested** — needs a browser round-trip |
+| Step 5 — advertise the name | Blocked on the two above |
 
-- `Certificate incommon-cert-samuel`: `Ready=False` (`SecretMismatch`),
-  `Issuing=Failed`, `revision=1`, `failedIssuanceAttempts` climbing.
-- The Order errors with
-  `401 urn:ietf:params:acme:error:unauthorized: The account is currently suspended`.
-- **Wire truth today:** `samuel.k8s.ucar.edu` serves its real InCommon cert
-  (single SAN, `notAfter Oct 10 2026`) and is **unaffected**; `sam.hpc.ucar.edu`
-  serves the fake `Kubernetes Ingress Controller Fake Certificate`.
-
-This is the expected, contained interim state. `samuel.k8s.ucar.edu` keeps
-working throughout. This doc is the fast-path to finish the job **once Ben
-confirms the ACME account is unsuspended.**
-
-All commands run against namespace `sam-queries`. We cannot read ClusterIssuers
-or Capsule Tenants (Forbidden for our OIDC identity) — the suspension itself is
-an NRIT / InCommon CM concern, not something we fix from here.
+All commands run against namespace `sam-queries`.
 
 ---
 
-## Step 0 — trigger
+## Completed — the cert
 
-**Do nothing until Ben says the ACME account is unsuspended.** Waiting does not
-help: cert-manager's failed-issuance backoff (1h,2h,4h,8h,16h, cap 32h) means
-the next automatic retry could be up to ~32h out, and it will just fail again
-while suspended.
+The InCommon/Sectigo ACME account was suspended account-wide, which blocked the
+reissue. CIRRUS resolved it; cert-manager's own failed-issuance backoff then
+retried and succeeded with no manual intervention — Steps 1–2 of the original
+runbook never needed to be executed by hand.
 
----
+Verified 2026-07-29:
 
-## Step 1 — force an immediate retry (skip the backoff)
+- `Certificate incommon-cert-samuel`: `Ready=True`, `revision=2`,
+  `dnsNames=["samuel.k8s.ucar.edu","sam.hpc.ucar.edu"]`.
+- Newest Order `state=valid`.
+- **Wire truth:** both hosts serve a cert issued by
+  `InCommon Intermediate CA - DVG2C` whose SANs are
+  `sam.hpc.ucar.edu, samuel.k8s.ucar.edu`.
+- `notAfter=2027-02-13`, `renewalTime=2026-12-09`.
+- `scripts/cirrus_healthcheck.sh`: §6 (served-cert coverage) and §7 (edge
+  security headers) **green on both hosts**.
 
-Delete the failed CertificateRequest (this also clears the stale errored Order);
-the ingress-shim / cert-manager immediately creates a fresh request:
+> **The old "independent production concern" is RESOLVED.** The worry was that
+> the suspension would also block the routine `samuel.k8s.ucar.edu` renewal due
+> 2026-08-05. That renewal has happened; the next one is 2026-12-09. No NRIT /
+> InCommon CM ticket is outstanding.
 
-```bash
-kubectl -n sam-queries delete certificaterequest incommon-cert-samuel-2
-```
-
-Equivalent alternative if `cmctl` is available:
-
-```bash
-cmctl -n sam-queries renew incommon-cert-samuel
-```
-
-> The CertificateRequest name may have incremented past `-2` on a later
-> revision. Confirm the current one first:
-> `kubectl -n sam-queries get certificaterequest`.
-
----
-
-## Step 2 — verify the reissue succeeded
+Re-verify at any time with:
 
 ```bash
-# Certificate: Ready=True, revision>=2, BOTH dnsNames
 kubectl -n sam-queries get certificate incommon-cert-samuel \
   -o jsonpath='dnsNames:{.spec.dnsNames}{"\n"}revision:{.status.revision}{"\n"}{range .status.conditions[*]}{.type}={.status} {.reason}{"\n"}{end}'
 
-# Newest Order: state=valid
-kubectl -n sam-queries get order | tail -3
-
-# Ground truth on the wire — BOTH SANs present, chain verifies:
 for h in samuel.k8s.ucar.edu sam.hpc.ucar.edu; do
   echo "=== $h ==="
   echo | openssl s_client -connect ${h}:443 -servername ${h} 2>/dev/null \
     | openssl x509 -noout -subject -issuer -enddate -ext subjectAltName
 done
-```
 
-Success looks like: Certificate `Ready=True`, `revision` incremented, both
-dnsNames; newest Order `state=valid`; **both** hosts present a cert whose SANs
-include `samuel.k8s.ucar.edu` **and** `sam.hpc.ucar.edu`, issued by InCommon,
-chain verifies (no more fake cert on `sam.hpc`).
-
-Then run the full healthcheck — §6 (served-cert coverage) must now PASS on both
-hosts:
-
-```bash
 scripts/cirrus_healthcheck.sh -v
 ```
 
-The §6 check keys on the **served** SANs decoded from the Secret's `tls.crt`
-(not the requested `spec.dnsNames`), so a green §6 is real proof the browser
-sees the right cert.
-
-**If it still fails while the account is reportedly unsuspended:** capture the
-newest Order's `.status.reason`
-(`kubectl -n sam-queries get order -o wide` then describe it) and hand back to
-NRIT / InCommon CM — the block is upstream of us.
+§6 keys on the **served** SANs decoded from the Secret's `tls.crt`, not the
+requested `spec.dnsNames`, so a green §6 is real proof the browser sees the
+right cert.
 
 ---
 
-## Step 3 — Unit 2: per-host OIDC (MUST be reconstructed first)
+## Unit 2 — per-host OIDC callback
 
-Until this ships, **login from `sam.hpc.ucar.edu` fails** with Authlib
-`MismatchingStateError`: the static `OIDC_REDIRECT_URI` sends the callback to
-`samuel.k8s.ucar.edu`, a different origin where the `sam.hpc` PKCE/state cookie
-does not exist. Anonymous pages work; `samuel.k8s` is unaffected.
+**The bug it fixes.** `helm/values.yaml` pinned
+`OIDC_REDIRECT_URI=https://samuel.k8s.ucar.edu/auth/oidc/callback`, so a login
+started on `sam.hpc` was handed to Entra with a return address on the other
+host. Authlib scopes the PKCE verifier / state cookie to the origin the login
+started on, so the callback landed somewhere that cookie was invisible and died
+with `MismatchingStateError`. Anonymous pages were unaffected.
 
-⚠ **The Unit 2 branch `sam_hpc_oidc_perhost` no longer exists** (orphaned in a
-rebase, or never pushed). It has to be re-created. The change is small:
+**The change.** Delete the pin. `webapp/auth/blueprint.py` already treats it as
+an override — `config.get('OIDC_REDIRECT_URI') or url_for('auth.oidc_callback',
+_external=True)` — and `ProxyFix(x_host=1, x_proto=1)` (`webapp/run.py`)
+resolves that from `X-Forwarded-*`. No application code changed. Nothing else
+pins the external URL: there is no `SERVER_NAME`, `PREFERRED_URL_SCHEME`,
+`APPLICATION_ROOT`, or CORS allowlist anywhere in the repo.
 
-- **Remove** the static `OIDC_REDIRECT_URI` env var from `helm/values.yaml`.
-  `src/webapp/auth/blueprint.py:130` already falls back to
-  `url_for('auth.oidc_callback', _external=True)`, which `ProxyFix(x_host=1)`
-  (`src/webapp/run.py`) resolves to whichever host the user is on. Confirmed no
-  `SERVER_NAME` / `PREFERRED_URL_SCHEME` / CORS-origin pins the external URL.
-- **Tests:**
-  - `helm/tests/test-oidc-render.sh` — flip the `OIDC_REDIRECT_URI` /
-    `samuel.k8s.ucar.edu/auth/oidc/callback` assertions from `assert_contains`
-    to `assert_not_contains` (callback is derived per-host).
-  - `tests/unit/test_oidc_auth.py` — keep
-    `test_oidc_login_uses_configured_redirect_uri` (covers the config-present
-    branch); **add** `test_oidc_login_falls_back_to_request_host` asserting
-    `authorize_redirect` is called with `http://<request host>/auth/oidc/callback`
-    when `OIDC_REDIRECT_URI` is absent.
-- **Pre-req before deploying Unit 2:** cert is real (Steps 1–2 done) AND Entra
-  reply-URLs confirmed. Both login reply URLs are registered
-  (`https://sam.hpc.ucar.edu/auth/oidc/callback` + the existing samuel.k8s one).
+**Guards added,** because the failure mode is invisible to HTTP-level checks:
 
-Deploy Unit 2 via the CIRRUS `workflow_dispatch` once merged to `main`, then do
-a browser OIDC round-trip **from each host** — the URL bar must stay on the
-originating host through the callback.
+- `helm/tests/test-oidc-render.sh` — asserts `OIDC_REDIRECT_URI` and any
+  `auth/oidc/callback` literal do **not** render from `values.yaml`.
+- `tests/unit/test_oidc_auth.py::test_oidc_login_falls_back_to_request_host` —
+  the deployed branch (no config) derives the callback.
+- `…::test_oidc_login_callback_follows_forwarded_host` — parametrized over both
+  hosts, driving real `X-Forwarded-Host` through ProxyFix.
+- `…::test_oidc_login_uses_configured_redirect_uri` kept: the override branch
+  is still supported for a single-host deployment.
+
+`helm/values-local.yaml` still sets `OIDC_REDIRECT_URI: ""`. That is now a
+no-op, deliberately left in place inside its "override production OIDC envs
+back to stub" defense-in-depth block.
+
+**Pre-req, verified — no Entra change needed for login.** Replaying the live
+authorize URL with `redirect_uri` swapped to `sam.hpc` returns AADSTS**50058**
+(“needs sign-in”), identical in shape to the `samuel.k8s` response — *not*
+AADSTS**50011** (reply-URL mismatch). Entra validates reply URLs before
+rendering the sign-in page, so `https://sam.hpc.ucar.edu/auth/oidc/callback`
+is already registered.
+
+### Deploying it
+
+Two valid routes — the chart reaches CIRRUS either way:
+
+- **Any branch, on demand:** `workflow_dispatch` on
+  `build-images-cirrus-deploy.yaml` once the branch is pushed. This is the
+  fastest way to smoke Unit 2 against real Entra before merging.
+- **Automatic:** push to `main` triggers the same workflow. Either path builds
+  the webapp image, force-pushes the `cirrus` branch with the image pinned, and
+  ArgoCD reconciles.
+
+> ⚠ **The staging PR is not ceremonial.** `ci-staging.yaml` is the only place
+> `helm/tests/test-oidc-render.sh` runs, and it triggers on `pull_request` into
+> **`staging`** only — never on PRs into `main`. Merging straight to `main`
+> would never execute the render assertions above.
+
+### Verifying it
+
+```bash
+# each host must now name ITSELF as the callback
+for h in samuel.k8s.ucar.edu sam.hpc.ucar.edu; do
+  echo "=== $h ==="
+  curl -s -o /dev/null -D - "https://$h/auth/oidc/login" \
+    | grep -i '^location:' | tr '&' '\n' | grep -i redirect_uri
+done
+```
+
+Then, **in a browser from each host in turn**, a full OIDC login round-trip:
+the URL bar must stay on the originating host through the callback and land
+signed in. The unit tests mock Authlib, so only this proves the cookie
+actually survives the round-trip.
+
+**Rollback** is restoring one line in `values.yaml`. `samuel.k8s` login is
+unaffected throughout — the derivation produces the identical URL for that host.
 
 ---
 
 ## Step 4 — logout (test-first, before touching Entra)
 
-Entra allows only one post-logout redirect URI; it is currently the samuel.k8s
-value. Logout emits `post_logout_redirect_uri` derived per-host as
-`url_for('status_dashboard.index', _external=True)` →
-`https://<host>/status/` (`src/webapp/auth/blueprint.py:~209`, blueprint
-`url_prefix='/status'`).
+Entra allows only one post-logout redirect URI; it is currently the
+`samuel.k8s` value. **No code change is needed** — logout already derives
+`post_logout_redirect_uri` per-host as
+`url_for('status_dashboard.index', _external=True)` → `https://<host>/status/`
+(`src/webapp/auth/blueprint.py`, blueprint `url_prefix='/status'`).
 
 1. Log in **and** log out **from `sam.hpc.ucar.edu`**.
-2. If it redirects back cleanly → no Entra change needed (leading hypothesis:
-   Entra validates the post-logout URI by registered-reply-URL **origin**, and
-   `https://sam.hpc.ucar.edu/auth/oidc/callback` is already registered). Do not
-   assert this — the test is the proof.
-3. If it lands on MS's signed-out page instead → have Andrew Tamagni register
-   **`https://sam.hpc.ucar.edu/status/`** (exact emitted string, host-swapped —
-   NOT root `/`). Per Ben's accepted tradeoff: clean logout for `sam.hpc`,
-   degraded from `samuel.k8s`, is fine.
+2. If it redirects back cleanly → nothing to do. (Leading hypothesis: Entra
+   validates the post-logout URI by registered-reply-URL **origin**, and
+   `https://sam.hpc.ucar.edu/auth/oidc/callback` is already registered. Do not
+   assert this — the test is the proof.)
+3. If it strands on MS's signed-out page → have Andrew Tamagni register
+   **`https://sam.hpc.ucar.edu/status/`** — the exact emitted string,
+   host-swapped, **NOT** root `/`. Per Ben's accepted tradeoff, clean logout for
+   `sam.hpc` and degraded from `samuel.k8s` is fine.
 
 ---
 
 ## Step 5 — advertise
 
-Only after Steps 2–4 are all green: communicate `sam.hpc.ucar.edu` as SAM's
-user-facing hostname. `samuel.k8s.ucar.edu` stays as the platform / automation /
-healthcheck alias (parity tooling, `scripts/apis/*`, `src/cli/cmds/admin.py`
-remain on it deliberately — no 301 redirect).
+Only once Unit 2 and Step 4 are both green: communicate `sam.hpc.ucar.edu` as
+SAM's user-facing hostname. `samuel.k8s.ucar.edu` stays as the platform /
+automation / healthcheck alias — parity tooling, `scripts/apis/*`, and
+`src/cli/cmds/admin.py` remain on it deliberately, with no 301 redirect.
 
 ---
 
-## Independent production concern (do not lose track of)
+## Note for future aliases
 
-`incommon-cert-samuel` has `renewalTime=2026-08-05` and `notAfter=2026-10-10`.
-The account suspension is a live production risk **regardless of `sam.hpc`** — if
-it is not resolved before early August, the normal renewal of the
-`samuel.k8s.ucar.edu` cert also fails. This warrants a separate NRIT / InCommon
-CM ticket tracking the suspension itself.
+Adding a host is three things, not two: `webapp.tls.extraHosts` in
+`values.yaml`, `INGRESS_HOSTS` in `scripts/lib/cirrus_common.sh`, **and** an
+Entra reply-URL registration for its `/auth/oidc/callback`. The callback URL
+itself needs no config — it is derived. `src/webapp/utils/config_inspect.py`
+now reports `oidc_redirect_uri: None` in production; that is expected.

--- a/docs/plans/SAM_HPC_CERT_APPLY.md
+++ b/docs/plans/SAM_HPC_CERT_APPLY.md
@@ -177,6 +177,15 @@ for the longer `/status/` form. Per Ben's accepted tradeoff, clean logout on
 `sam.hpc` with `samuel.k8s` degraded to the MS signed-out page is fine — and
 that degradation is now a known, measured consequence rather than a surprise.
 
+**Requested 2026-07-29** — Ben asked Entra to swap the single post-logout URI
+from `https://samuel.k8s.ucar.edu/` to `https://sam.hpc.ucar.edu/`. When it
+lands, re-run BOTH legs of the table above and expect them to invert:
+`sam.hpc` returns cleanly, `samuel.k8s` strands. Anything else — e.g. both
+stranding — means the registration did not take, not that this change
+regressed. Logins must continue to work on both hosts throughout; if one
+starts failing with AADSTS50011, a *reply* URL was edited by mistake instead
+of the post-logout URI.
+
 Login is unaffected either way: reply URLs are a separate Entra list and both
 hosts are already registered there (proven by a successful interactive login on
 each host).

--- a/helm/tests/test-oidc-render.sh
+++ b/helm/tests/test-oidc-render.sh
@@ -54,13 +54,22 @@ fi
 prod_out=$(helm template "$RELEASE_NAME" "$CHART_DIR" -f "$CHART_DIR/values.yaml")
 
 assert_contains "$prod_out" "name: AUTH_PROVIDER"               "values.yaml: AUTH_PROVIDER env not rendered"
-assert_contains "$prod_out" "name: OIDC_REDIRECT_URI"           "values.yaml: OIDC_REDIRECT_URI env not rendered"
 assert_contains "$prod_out" "name: OIDC_USERNAME_CLAIM"         "values.yaml: OIDC_USERNAME_CLAIM env not rendered"
 assert_contains "$prod_out" "name: OIDC_SCOPES"                 "values.yaml: OIDC_SCOPES env not rendered"
 assert_contains "$prod_out" "name: FLASK_CONFIG"                "values.yaml: FLASK_CONFIG env not rendered"
 
-assert_contains "$prod_out" "samuel.k8s.ucar.edu/auth/oidc/callback" \
-  "values.yaml: OIDC_REDIRECT_URI value missing or wrong host"
+# The ingress serves samuel.k8s.ucar.edu AND sam.hpc.ucar.edu from one
+# multi-SAN cert, so the OIDC callback MUST be derived per-request-host rather
+# than pinned: the PKCE/state cookie is scoped to the origin the user started
+# on, and returning them to a different host fails with MismatchingStateError.
+# Unsetting OIDC_REDIRECT_URI is what activates that derivation
+# (webapp/auth/blueprint.py -> url_for(..., _external=True) + ProxyFix x_host).
+# Both assertions below guard the same regression: re-pinning the callback.
+assert_not_contains "$prod_out" "name: OIDC_REDIRECT_URI" \
+  "values.yaml: OIDC_REDIRECT_URI must stay unset so the callback follows the request host"
+
+assert_not_contains "$prod_out" "auth/oidc/callback" \
+  "values.yaml: a hard-coded OIDC callback URL would break login on every host but one"
 
 assert_contains "$prod_out" "name: OIDC_CLIENT_ID"      "values.yaml: OIDC_CLIENT_ID secretKeyRef not rendered"
 assert_contains "$prod_out" "name: OIDC_CLIENT_SECRET"  "values.yaml: OIDC_CLIENT_SECRET secretKeyRef not rendered"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -200,7 +200,14 @@ webapp:
     # OIDC SSO via Microsoft Entra. Client ID/secret/issuer and FLASK_SECRET_KEY
     # are injected via secretKeyRef from the oidcCredentials ExternalSecret below.
     AUTH_PROVIDER: "oidc"
-    OIDC_REDIRECT_URI: "https://samuel.k8s.ucar.edu/auth/oidc/callback"
+    # NO OIDC_REDIRECT_URI here, deliberately. The ingress serves two hosts
+    # (see .fqdn / .extraHosts above), and the callback must return to
+    # whichever one the user started on: the PKCE/state cookie is scoped to
+    # that origin, so a cross-host return fails with MismatchingStateError.
+    # Leaving this unset makes webapp/auth/blueprint.py derive the callback
+    # from the request host via url_for(..., _external=True), which ProxyFix
+    # (x_host/x_proto, webapp/run.py) resolves from X-Forwarded-*. Setting it
+    # would re-pin every host to one origin and break login on the others.
     OIDC_USERNAME_CLAIM: "preferred_username"
     OIDC_SCOPES: "openid email profile"
     # API keys for HPC status collectors (bcrypt hashes — safe to store here).

--- a/tests/unit/test_oidc_auth.py
+++ b/tests/unit/test_oidc_auth.py
@@ -12,6 +12,7 @@ Covers:
 """
 
 import os
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -267,11 +268,13 @@ class TestOIDCLoginRoute:
             app.extensions.pop('oauth', None)
 
     def test_oidc_login_uses_configured_redirect_uri(self, app):
-        """Configured OIDC_REDIRECT_URI is passed verbatim to authorize_redirect.
+        """A configured OIDC_REDIRECT_URI is passed verbatim to authorize_redirect.
 
-        Locks in the contract that the per-environment redirect URI from env
-        (e.g. https://samuel.k8s.ucar.edu/auth/oidc/callback) is what Authlib
-        sends to the IdP, regardless of any X-Forwarded-* header weirdness.
+        Covers the escape hatch, NOT the deployed configuration: the CIRRUS
+        chart deliberately leaves OIDC_REDIRECT_URI unset so the callback
+        follows the request host (see the fallback tests below). This branch
+        stays supported for a single-host deployment that wants to override
+        X-Forwarded-* derivation entirely.
         """
         mock_oauth = MagicMock()
         mock_redirect_resp = MagicMock()
@@ -289,6 +292,69 @@ class TestOIDCLoginRoute:
                 mock_oauth.entra.authorize_redirect.assert_called_once_with(configured_uri)
         finally:
             app.config['AUTH_PROVIDER'] = 'stub'
+            app.config['OIDC_REDIRECT_URI'] = original_redirect_uri
+            app.extensions.pop('oauth', None)
+
+    def test_oidc_login_falls_back_to_request_host(self, app):
+        """With OIDC_REDIRECT_URI unset, the callback is derived from the request.
+
+        This is the deployed configuration (helm/values.yaml carries no
+        OIDC_REDIRECT_URI), so this branch — not the configured one above — is
+        what production actually exercises.
+        """
+        with self._oidc_app(app) as mock_oauth:
+            with app.test_client() as c:
+                c.get('/auth/oidc/login')
+            mock_oauth.entra.authorize_redirect.assert_called_once_with(
+                'http://localhost/auth/oidc/callback'
+            )
+
+    @pytest.mark.parametrize(
+        'forwarded_host',
+        ['samuel.k8s.ucar.edu', 'sam.hpc.ucar.edu'],
+    )
+    def test_oidc_login_callback_follows_forwarded_host(self, app, forwarded_host):
+        """Each ingress host round-trips to ITSELF, not to a pinned origin.
+
+        The regression guard for the sam.hpc.ucar.edu CNAME rollout. Authlib
+        stores the PKCE verifier / state in a cookie scoped to the origin the
+        login STARTED on, so returning the user to a different host makes that
+        cookie invisible and the callback dies with MismatchingStateError.
+        Pinning OIDC_REDIRECT_URI to one host is exactly how that regressed.
+
+        ProxyFix(x_host=1, x_proto=1) in create_app() is what turns
+        X-Forwarded-* into the derived URL, so this drives the real mechanism
+        rather than asserting on url_for() in isolation.
+        """
+        with self._oidc_app(app) as mock_oauth:
+            with app.test_client() as c:
+                c.get(
+                    '/auth/oidc/login',
+                    headers={
+                        'X-Forwarded-Host': forwarded_host,
+                        'X-Forwarded-Proto': 'https',
+                    },
+                )
+            mock_oauth.entra.authorize_redirect.assert_called_once_with(
+                f'https://{forwarded_host}/auth/oidc/callback'
+            )
+
+    @staticmethod
+    @contextmanager
+    def _oidc_app(app):
+        """Enable OIDC with no configured redirect URI, then restore prior state."""
+        mock_oauth = MagicMock()
+        mock_oauth.entra.authorize_redirect.return_value = MagicMock(status_code=302)
+
+        app.extensions['oauth'] = mock_oauth
+        original_provider = app.config.get('AUTH_PROVIDER')
+        original_redirect_uri = app.config.get('OIDC_REDIRECT_URI', '')
+        app.config['AUTH_PROVIDER'] = 'oidc'
+        app.config['OIDC_REDIRECT_URI'] = ''
+        try:
+            yield mock_oauth
+        finally:
+            app.config['AUTH_PROVIDER'] = original_provider
             app.config['OIDC_REDIRECT_URI'] = original_redirect_uri
             app.extensions.pop('oauth', None)
 


### PR DESCRIPTION
## Summary

Login only worked from `samuel.k8s.ucar.edu`. `helm/values.yaml` pinned
`OIDC_REDIRECT_URI` to that host's callback, so a login **started** on
`sam.hpc.ucar.edu` was handed to Entra with a return address on the other
origin. Authlib scopes the PKCE verifier/state cookie to the origin the login
began on, so the callback landed where that cookie was invisible and died with
`MismatchingStateError`.

**The fix is deleting the pin — no application code changed.**
`webapp/auth/blueprint.py` already treats the config as an override
(`config.get('OIDC_REDIRECT_URI') or url_for('auth.oidc_callback', _external=True)`),
and `ProxyFix(x_host=1, x_proto=1)` resolves that from `X-Forwarded-*`. Nothing
else pins the external URL — no `SERVER_NAME`, `PREFERRED_URL_SCHEME`,
`APPLICATION_ROOT`, or CORS allowlist anywhere in the repo.

Reconstructs the lost `sam_hpc_oidc_perhost` branch (Step 3 of
`docs/plans/SAM_HPC_CERT_APPLY.md`).

## Why the guards matter

The failure is invisible to HTTP-level checks — both configurations return a
302 to Microsoft, and only the cookie scoping differs. So it is pinned from two
directions:

- `helm/tests/test-oidc-render.sh` — the two `assert_contains` that **required**
  the static URI become `assert_not_contains`, on both the env-var name and any
  `auth/oidc/callback` literal.
- `test_oidc_login_callback_follows_forwarded_host` — parametrized over both
  hosts, driving real `X-Forwarded-Host` through ProxyFix rather than asserting
  on `url_for()` in isolation.
- `test_oidc_login_falls_back_to_request_host` — pins the branch production
  actually takes; nothing previously exercised it.
- `test_oidc_login_uses_configured_redirect_uri` is **kept** — the override
  branch still serves single-host deployments, and `infrastructure/staging/ecs.tf`
  legitimately relies on it.

> ⚠ This PR must go through `staging`. `ci-staging.yaml` is the only place
> `helm/tests/test-oidc-render.sh` runs, and it triggers on PRs into `staging`
> only — never into `main`.

## Verified on CIRRUS, not just in CI

Deployed to production via `workflow_dispatch` (`sha-831f083`) and smoked in a
real browser against real Entra.

`redirect_uri` before → **both** hosts emitted `https://samuel.k8s.ucar.edu/…`;
after → each host emits its own, with `samuel.k8s` unchanged (no regression).

- Login from **`sam.hpc`**: Entra accepted the reply URL (sign-in page, not
  AADSTS50011), PKCE present (`code_challenge_method=S256`), callback stayed on
  `sam.hpc`, **no `MismatchingStateError`**, identity resolved with admin RBAC,
  0 console errors.
- Login from **`samuel.k8s`**: succeeded via Entra SSO, stayed put.
- `scripts/cirrus_healthcheck.sh`: **35 PASS / 1 WARN / 0 FAIL** (the WARN is
  the pre-existing "no helm release object" — ArgoCD reconciles the chart).

## Logout: one Entra change outstanding, and a corrected instruction

Both logout legs were measured in one session:

| Logout from | Registered origin? | Emitted | Result |
|---|---|---|---|
| `samuel.k8s.ucar.edu` | yes (root `/`) | `…/status/` | returned cleanly |
| `sam.hpc.ucar.edu` | no | `…/status/` | stranded on MS signed-out page |

The `samuel.k8s` leg proves **Entra matches by origin, not exact string** — a
root `/` registration accepted a `/status/` emission. The runbook previously
instructed asking for the exact `https://sam.hpc.ucar.edu/status/` string; that
was wrong and is corrected. Registering root **`https://sam.hpc.ucar.edu/`** is
sufficient — exactly what Entra had already offered.

Logout needed no code change; it already derives per-host. Login is unaffected
by the swap: reply URLs are a separate list and both hosts are registered.

### Test Results

`tests/unit/test_oidc_auth.py`: **52 passed** (+3).
`helm/tests/test-oidc-render.sh`: OK. `helm lint`: 0 failed.
Prod render carries no `OIDC_REDIRECT_URI`, every other OIDC var intact.

## Docs

`SAM_HPC_CERT_APPLY.md` was a runbook for a problem that no longer exists — the
ACME account was unsuspended and cert-manager's own backoff retried
successfully, so Steps 1-2 were never executed by hand. Rewritten as a record of
the completed cert work (revision 2, both SANs, `notAfter 2027-02-13`) plus the
live Unit 2 / Step 4 runbook. The "independent production concern" — that the
suspension would also block the 2026-08-05 renewal — is marked **RESOLVED**;
renewal is now 2026-12-09.

🤖 Generated with [Claude Code](https://claude.com/claude-code)