### PR TITLE
Contract detail card, Search Contracts page, and cross-table linking

### DIFF
--- a/src/sam/queries/__init__.py
+++ b/src/sam/queries/__init__.py
@@ -167,7 +167,9 @@ from .admin import (
     get_institutions_with_members,
     get_aoi_groups_with_areas,
     get_areas_of_interest_with_projects,
+    get_contract_detail,
     get_contracts_with_pi,
+    get_nsf_program_contracts,
     get_nsf_programs_with_contracts,
 )
 
@@ -268,6 +270,8 @@ __all__ = [
     'get_institutions_with_members',
     'get_aoi_groups_with_areas',
     'get_areas_of_interest_with_projects',
+    'get_contract_detail',
     'get_contracts_with_pi',
+    'get_nsf_program_contracts',
     'get_nsf_programs_with_contracts',
 ]

--- a/src/sam/queries/admin.py
+++ b/src/sam/queries/admin.py
@@ -194,6 +194,80 @@ def get_contracts_with_pi(session, active_only=False):
     return q.all()
 
 
+def get_contract_detail(session, contract_id):
+    """Load one contract with everything its detail card renders.
+
+    Keyed by id rather than number: contract numbers are free text and
+    include values like ``USDA Prime Award No. 2013-67003-20652`` and
+    ``OCE- 1419584``, so unlike ``username`` / ``projcode`` they cannot key
+    a URL path.
+
+    The linked-project chain is the reason this is a separate loader from
+    ``get_contracts_with_pi`` — that one deliberately skips the source and
+    the project graph because the list view shows neither, and pulling them
+    for 2,200 rows would be expensive.
+
+    Returns:
+        Contract, or None if no such row.
+    """
+    from sam.projects.contracts import Contract, ProjectContract
+    from sam.core.users import User
+
+    return (
+        session.query(Contract)
+        .options(
+            selectinload(Contract.contract_source),
+            selectinload(Contract.nsf_program),
+            selectinload(Contract.principal_investigator)
+                .lazyload(User.accounts),
+            selectinload(Contract.principal_investigator)
+                .lazyload(User.email_addresses),
+            selectinload(Contract.contract_monitor)
+                .lazyload(User.accounts),
+            selectinload(Contract.contract_monitor)
+                .lazyload(User.email_addresses),
+            selectinload(Contract.projects)
+                .joinedload(ProjectContract.project),
+        )
+        .filter(Contract.contract_id == contract_id)
+        .first()
+    )
+
+
+def get_nsf_program_contracts(session, nsf_program_id):
+    """Load one NSF program and its contracts, for the drill-down modal.
+
+    ``get_nsf_programs_with_contracts`` loads bare contracts, which is fine
+    for a count but would N+1 here: the largest program carries 401
+    contracts and the modal shows each one's source and PI.
+
+    Returns:
+        (NSFProgram, list of Contract ordered by number) — (None, []) when
+        no such program.
+    """
+    from sam.projects.contracts import Contract, NSFProgram
+    from sam.core.users import User
+
+    program = session.get(NSFProgram, nsf_program_id)
+    if program is None:
+        return None, []
+
+    contracts = (
+        session.query(Contract)
+        .options(
+            selectinload(Contract.contract_source),
+            selectinload(Contract.principal_investigator)
+                .lazyload(User.accounts),
+            selectinload(Contract.principal_investigator)
+                .lazyload(User.email_addresses),
+        )
+        .filter(Contract.nsf_program_id == nsf_program_id)
+        .order_by(Contract.contract_number)
+        .all()
+    )
+    return program, contracts
+
+
 def get_nsf_programs_with_contracts(session, active_only=False):
     """Load all NSF programs with their associated contracts.
 

--- a/src/webapp/dashboards/admin/blueprint.py
+++ b/src/webapp/dashboards/admin/blueprint.py
@@ -137,6 +137,14 @@ def organizations():
     return render_template('dashboards/admin/organizations.html', user=current_user)
 
 
+@bp.route('/contracts')
+@login_required
+@require_permission_any_facility(Permission.ACCESS_ADMIN_DASHBOARD)
+def contracts():
+    """Admin Contracts page — search contracts, card display area."""
+    return render_template('dashboards/admin/contracts.html', user=current_user)
+
+
 @bp.route('/facilities')
 @login_required
 @require_permission_any_facility(Permission.ACCESS_ADMIN_DASHBOARD)

--- a/src/webapp/dashboards/admin/orgs_routes.py
+++ b/src/webapp/dashboards/admin/orgs_routes.py
@@ -15,7 +15,7 @@ uniqueness checks), and contract delete (retires by end_date).
 import logging
 
 from flask import render_template, request
-from flask_login import login_required
+from flask_login import current_user, login_required
 from datetime import datetime
 from functools import partial
 from sqlalchemy import func
@@ -31,6 +31,7 @@ from webapp.utils.htmx import (
 )
 from webapp.extensions import db, cache, user_aware_cache_key
 from webapp.utils.rbac import (
+    has_permission_any_facility,
     require_permission, require_permission_any_facility, Permission,
 )
 from sam.manage import management_transaction
@@ -45,7 +46,9 @@ from sam.queries.admin import (
     get_countries_with_institutions,
     get_aoi_groups_with_areas,
     get_areas_of_interest_with_projects,
+    get_contract_detail,
     get_contracts_with_pi,
+    get_nsf_program_contracts,
     get_nsf_programs_with_contracts,
 )
 from sam.schemas.forms.orgs import (
@@ -413,6 +416,73 @@ def htmx_mnemonic_code_create():
         return _reload_form([f'Error creating mnemonic code: {e}'])
 
     return htmx_success_message(_ORG_TRIGGERS, 'Saved successfully.')
+
+
+# ── Contract detail card ──────────────────────────────────────────────────
+#
+# Same shape as user_card / project_card / group_card in blueprint.py, but it
+# lives here with the rest of the contract surface. Two hosts swap the same
+# HTML: the #contractCardContainer region on /admin/contracts, and
+# #contractDetailsModalBody wherever a contract number is clickable.
+
+
+@bp.route('/contract/<int:contract_id>')
+@login_required
+@require_permission_any_facility(Permission.VIEW_ORG_METADATA)
+def contract_card(contract_id):
+    """HTML fragment for a single contract's detail card.
+
+    Keyed by id, not number: contract numbers are free text (``USDA Prime
+    Award No. 2013-67003-20652``, ``OCE- 1419584``) and cannot key a URL
+    path the way ``username`` and ``projcode`` do.
+    """
+    contract = get_contract_detail(db.session, contract_id)
+    if not contract:
+        # Warning div at 200, matching the other *_card routes: htmx swaps
+        # it into the card region or modal body rather than erroring.
+        return '<div class="alert alert-warning">Contract not found</div>'
+
+    # Active projects first, then by code. ProjectContract carries no date
+    # window of its own, so there is nothing else meaningful to sort on.
+    linked_projects = sorted(
+        contract.projects,
+        key=lambda pc: (not pc.project.active, pc.project.projcode),
+    )
+
+    return render_template(
+        'dashboards/admin/fragments/contract_card.html',
+        contract=contract,
+        linked_projects=linked_projects,
+        # Gate the cross-entity links on the *target* routes' permissions so
+        # a click can never 403 (the rule jobs_usage_panel.html states).
+        can_view_users=has_permission_any_facility(
+            current_user, Permission.VIEW_USERS),
+        can_view_projects=has_permission_any_facility(
+            current_user, Permission.VIEW_PROJECTS),
+    )
+
+
+@bp.route('/nsf-program/<int:nsf_program_id>/contracts')
+@login_required
+@require_permission_any_facility(Permission.VIEW_ORG_METADATA)
+def nsf_program_contracts(nsf_program_id):
+    """The contracts under one NSF program, for the drill-down modal.
+
+    NSFProgram carries only a name and an active flag, so it gets no detail
+    card of its own — this list is the one question the data supports, and
+    it gives the previously-dead "# Contracts" count somewhere to go.
+    """
+    program, contracts = get_nsf_program_contracts(db.session, nsf_program_id)
+    if program is None:
+        return '<div class="alert alert-warning">NSF program not found</div>'
+
+    return render_template(
+        'dashboards/admin/fragments/nsf_program_contracts_htmx.html',
+        program=program,
+        contracts=contracts,
+        can_view_users=has_permission_any_facility(
+            current_user, Permission.VIEW_USERS),
+    )
 
 
 # ── Contract Create (bespoke: award prefill + FK/uniqueness checks) ───────

--- a/src/webapp/dashboards/admin/orgs_routes.py
+++ b/src/webapp/dashboards/admin/orgs_routes.py
@@ -235,6 +235,11 @@ def htmx_organizations_card():
         is_admin=True,
         now=now,
         active_only=active_only,
+        # Gate the PI/Monitor links on the user_card route's own permission
+        # so a click can never 403. Safe under @cache.cached because the key
+        # is user-aware.
+        can_view_users=has_permission_any_facility(
+            current_user, Permission.VIEW_USERS),
     )
 
 

--- a/src/webapp/dashboards/admin/orgs_routes.py
+++ b/src/webapp/dashboards/admin/orgs_routes.py
@@ -19,6 +19,7 @@ from flask_login import current_user, login_required
 from datetime import datetime
 from functools import partial
 from sqlalchemy import func
+from sqlalchemy.orm import selectinload
 
 from webapp.utils.form_handler import FormError, HtmxFormHandler
 from webapp.utils.fk_validation import validate_fk_existence
@@ -123,6 +124,35 @@ def _search_nsf_programs_fk(q, active_only):
     if active_only:
         query = query.filter(NSFProgram.is_active)
     return query.order_by(NSFProgram.nsf_program_name).limit(15).all()
+
+
+def _search_contracts(q, active_only):
+    """Search box behind /admin/contracts.
+
+    Unlike the FK-picker sibling ``_search_contracts_for_project``, this one
+    **honours** ``active_only`` — that one has no checkbox, this one does.
+    The checkbox defaults off: only 368 of 2,225 contracts are currently
+    active, so an active-only default would hide 83% of the data behind a
+    control most operators would not think to clear.
+    """
+    query = db.session.query(Contract).options(
+        selectinload(Contract.contract_source),
+        selectinload(Contract.principal_investigator),
+    ).filter(
+        Contract.contract_number.ilike(f'%{q}%') | Contract.title.ilike(f'%{q}%')
+    )
+    if active_only:
+        query = query.filter(Contract.is_active)
+    return query.order_by(Contract.contract_number).limit(20).all()
+
+
+register_typeahead(
+    bp, rule='/htmx/search/contracts', endpoint='htmx_search_contracts',
+    permission=Permission.VIEW_ORG_METADATA, any_facility=True,
+    search=_search_contracts,
+    template='dashboards/admin/fragments/contract_search_results_htmx.html',
+    ctx_key='contracts',
+)
 
 
 register_typeahead(

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -18,7 +18,7 @@ from webapp.extensions import db
 from flask import abort, current_app
 from webapp.utils.rbac import (
     require_permission, require_permission_any_facility,
-    has_permission, has_permission_for_facility,
+    has_permission, has_permission_any_facility, has_permission_for_facility,
     Permission, user_facility_scope,
 )
 from webapp.api.access_control import (
@@ -726,7 +726,6 @@ def edit_project_page(project):
 
     can_edit_governance = can_edit_project_governance(current_user, project)
     can_modify_allocs = can_modify_allocations(current_user, project)
-    from webapp.utils.rbac import has_permission_any_facility
     can_access_admin = has_permission_any_facility(current_user, Permission.ACCESS_ADMIN_DASHBOARD)
 
     # Initial value for the Allocations tab "Active at" date picker (today).
@@ -2246,6 +2245,10 @@ def _linked_elements_context(project):
         active_directories=[pd for pd in project.directories if pd.is_active],
         disk_roots=_disk_roots_for_picker(),
         can_edit_governance=can_edit_project_governance(current_user, project),
+        # Gated on the contract_card route's own permission so the link
+        # can never 403 for a project lead without org-metadata access.
+        can_view_contracts=has_permission_any_facility(
+            current_user, Permission.VIEW_ORG_METADATA),
         errors=[],
     )
 

--- a/src/webapp/static/js/actions.js
+++ b/src/webapp/static/js/actions.js
@@ -104,6 +104,30 @@
         }
     });
 
+    /* Generalisation of the above for every other detail modal: the target
+     * shell is named by data-modal-id, content still comes from the
+     * element's own hx-get. Needed for the same reason — a link inside an
+     * already-open modal (a contract on a project card shown in
+     * #projectDetailsModal, a contract row in the NSF-program modal) must
+     * stack rather than have Bootstrap's toggle close its host. Works
+     * unchanged outside a modal, where closest('.modal.show') is null.
+     *
+     * 'show-user-details' predates this and keeps its own registration
+     * because its callers pass no data-modal-id; it could fold in later. */
+    window.registerAction('show-detail-modal', function (el, evt) {
+        evt.preventDefault();
+        var id = el.dataset.modalId;
+        if (!id) { return; }
+        var host = el.closest('.modal.show');
+        if (host && host.id !== id) {
+            bootstrap.Modal.getOrCreateInstance(host).hide();
+        }
+        var target = document.getElementById(id);
+        if (target) {
+            bootstrap.Modal.getOrCreateInstance(target).show();
+        }
+    });
+
     /* Filter-bar "Reset" buttons: reset the form, then re-submit it so
      * the htmx fragment reloads with defaults. */
     window.registerAction('form-reset-submit', function (el) {

--- a/src/webapp/templates/dashboards/admin/base_admin.html
+++ b/src/webapp/templates/dashboards/admin/base_admin.html
@@ -33,6 +33,7 @@
     {'endpoint': 'admin_dashboard.users_groups',  'label': 'Users & Groups', 'icon': 'fas fa-users'},
     {'endpoint': 'admin_dashboard.resources',     'label': 'Resources', 'icon': 'fas fa-server'},
     {'endpoint': 'admin_dashboard.organizations', 'label': 'Organizations', 'icon': 'fas fa-sitemap'},
+    {'endpoint': 'admin_dashboard.contracts',     'label': 'Contracts', 'icon': 'fas fa-file-signature'},
     {'endpoint': 'admin_dashboard.facilities',    'label': 'Facilities & Allocation Types', 'icon': 'fas fa-building'},
     {'endpoint': 'admin_dashboard.configuration', 'label': 'Configuration', 'icon': 'fas fa-sliders-h',
      'visible': has_permission(Permission.VIEW_SYSTEM_CONFIG)},

--- a/src/webapp/templates/dashboards/admin/contracts.html
+++ b/src/webapp/templates/dashboards/admin/contracts.html
@@ -1,0 +1,56 @@
+{% extends 'dashboards/admin/base_admin.html' %}
+{% from 'dashboards/fragments/search_box.html' import active_toggle_search %}
+
+{% block title %}Admin: Contracts - SAM{% endblock %}
+
+{% block admin_content %}
+
+<div class="row">
+    <div class="col-md-8">
+        <div class="card inner-card">
+            <div class="card-header d-flex justify-content-between align-items-center mb-4">
+                <h5><i class="fas fa-file-signature"></i> Search Contracts</h5>
+                {% if has_permission(Permission.CREATE_ORG_METADATA) %}
+                {# The create modal is page-level via base_admin ->
+                   organization_modals.html, so this needs no extra plumbing. #}
+                <button type="button" class="btn btn-primary"
+                        data-bs-toggle="modal"
+                        data-bs-target="#createContractModal"
+                        hx-get="{{ url_for('admin_dashboard.htmx_contract_create_form') }}"
+                        hx-target="#createContractFormContainer"
+                        hx-trigger="click">
+                    <i class="fas fa-plus"></i> Create Contract
+                </button>
+                {% endif %}
+            </div>
+            <div class="card-body">
+                {# toggle_checked=False: only 368 of 2,225 contracts are
+                   currently active, so an active-only default would hide
+                   most of the data behind a control you had to know to
+                   clear. Expired grants stay searchable as provenance. #}
+                {{ active_toggle_search(
+                    search_url=url_for('admin_dashboard.htmx_search_contracts'),
+                    input_id='contractSearchInput',
+                    results_id='contractSearchResults',
+                    label='Search by contract number or title',
+                    placeholder='Start typing a contract number or title...',
+                    toggle_id='activeContractsOnly',
+                    toggle_label='Active contracts only',
+                    toggle_checked=False) }}
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Contract Card Display Area -->
+<div class="row">
+    <div class="col-12">
+        {# The reload-url idiom concatenates an id onto a base URL. The other
+           pages get an empty base from username='' / projcode='', but an
+           <int:> converter rejects '', so build it from a placeholder. #}
+        <div id="contractCardContainer"
+             data-reload-url="{{ url_for('admin_dashboard.contract_card', contract_id=0) | replace('/0', '/') }}"></div>
+    </div>
+</div>
+
+{% endblock %}

--- a/src/webapp/templates/dashboards/admin/fragments/contract_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/contract_card.html
@@ -1,0 +1,225 @@
+{% from 'dashboards/fragments/badges.html' import status_badge %}
+{% from 'dashboards/fragments/action_buttons.html' import edit_modal_button with context %}
+{#
+  Admin: Contract detail card.
+
+  Served by admin_dashboard.contract_card and consumed by two hosts that
+  swap the same HTML: the #contractCardContainer region on /admin/contracts,
+  and #contractDetailsModalBody wherever a contract number is clickable.
+
+  A plain template rather than a render_*_card macro: the user/project/group
+  cards need that indirection because their bodies are shared with the user
+  dashboard's own templates. Contracts are admin-only metadata with one
+  renderer, so a wrapper would be indirection with nothing on the far side.
+
+  Context:
+    contract        — Contract, eager-loaded by queries.admin.get_contract_detail
+    linked_projects — ProjectContract rows, active-first (see the route)
+    can_view_users     / can_view_projects — gate the cross-entity modal links
+                       on the *target* routes' permissions so a click can't 403
+#}
+<div class="card mb-3">
+    <div class="card-header">
+        <h5 class="mb-0">
+            <i class="fas fa-file-signature"></i>
+            <span class="font-monospace">{{ contract.contract_number }}</span>
+            {% if contract.contract_source %}
+            <span class="badge bg-light text-dark border ms-2">{{ contract.contract_source.contract_source }}</span>
+            {% endif %}
+            {# An inactive contract is either not started yet or already over —
+               the two mean different things to an operator, so badge them
+               apart rather than collapsing to "inactive". #}
+            {% if contract.is_active %}
+            {{ status_badge('active', extra='ms-1') }}
+            {% elif contract.is_future %}
+            {{ status_badge('inactive', extra='ms-1', label='Not started') }}
+            {% else %}
+            {{ status_badge('expired', extra='ms-1') }}
+            {% endif %}
+        </h5>
+    </div>
+
+    <div class="card-body">
+        <div class="row g-3">
+
+            {# ── Left: the award itself ────────────────────────────── #}
+            <div class="col-lg-6">
+                <div class="project-stats-box mb-0"
+                     style="grid-template-columns: auto minmax(0, 1fr); align-content: start;">
+                    <h6><i class="fas fa-info-circle"></i> Contract Information</h6>
+
+                    <div class="stat-item stat-item-block">
+                        <span class="stat-label d-block mb-1">Title:</span>
+                        <span class="stat-value text-dark text-detail">{{ contract.title }}</span>
+                    </div>
+                    <div class="stat-item">
+                        <span class="stat-label">Source:</span>
+                        <span class="stat-value">
+                            {{ contract.contract_source.contract_source if contract.contract_source else '—' }}
+                        </span>
+                    </div>
+                    <div class="stat-item">
+                        <span class="stat-label">Start:</span>
+                        <span class="stat-value">{{ contract.start_date | fmt_date }}</span>
+                    </div>
+                    <div class="stat-item">
+                        <span class="stat-label">End:</span>
+                        <span class="stat-value">{{ contract.end_date | fmt_date }}</span>
+                    </div>
+                    <div class="stat-item stat-item-block">
+                        <span class="stat-label d-block mb-1">Award page:</span>
+                        <span class="stat-value text-detail">
+                            {% if contract.url %}
+                            <a href="{{ contract.url }}" target="_blank" rel="noopener noreferrer">
+                                {{ contract.url }} <i class="fas fa-external-link-alt fa-xs"></i>
+                            </a>
+                            {% else %}
+                            <span class="text-muted">—</span>
+                            {% endif %}
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            {# ── Right: the people and the program ─────────────────── #}
+            <div class="col-lg-6">
+                <div class="project-stats-box mb-0"
+                     style="grid-template-columns: auto minmax(0, 1fr); align-content: start;">
+                    <h6><i class="fas fa-user-tie"></i> People &amp; Program</h6>
+
+                    <div class="stat-item">
+                        <span class="stat-label">PI:</span>
+                        <span class="stat-value">
+                            {% if contract.principal_investigator %}
+                                {% if can_view_users %}
+                                <a href="#" class="text-decoration-none"
+                                   title="View user details"
+                                   data-action="show-user-details"
+                                   hx-get="{{ url_for('admin_dashboard.user_card', username=contract.principal_investigator.username) }}"
+                                   hx-target="#userDetailsModalBody" hx-swap="innerHTML">
+                                    {{ contract.principal_investigator.display_name }}
+                                    <small class="text-muted">({{ contract.principal_investigator.username }})</small>
+                                </a>
+                                {% else %}
+                                {{ contract.principal_investigator.display_name }}
+                                {% endif %}
+                            {% else %}
+                            <span class="text-muted">—</span>
+                            {% endif %}
+                        </span>
+                    </div>
+
+                    <div class="stat-item">
+                        <span class="stat-label">Monitor:</span>
+                        <span class="stat-value">
+                            {% if contract.contract_monitor %}
+                                {% if can_view_users %}
+                                <a href="#" class="text-decoration-none"
+                                   title="View user details"
+                                   data-action="show-user-details"
+                                   hx-get="{{ url_for('admin_dashboard.user_card', username=contract.contract_monitor.username) }}"
+                                   hx-target="#userDetailsModalBody" hx-swap="innerHTML">
+                                    {{ contract.contract_monitor.display_name }}
+                                    <small class="text-muted">({{ contract.contract_monitor.username }})</small>
+                                </a>
+                                {% else %}
+                                {{ contract.contract_monitor.display_name }}
+                                {% endif %}
+                            {% else %}
+                            <span class="text-muted">—</span>
+                            {% endif %}
+                        </span>
+                    </div>
+
+                    <div class="stat-item stat-item-block">
+                        <span class="stat-label d-block mb-1">NSF Program:</span>
+                        <span class="stat-value text-dark text-detail">
+                            {% if contract.nsf_program %}
+                            <a href="#" class="text-decoration-none"
+                               title="Contracts under this program"
+                               data-action="show-detail-modal"
+                               data-modal-id="nsfProgramContractsModal"
+                               hx-get="{{ url_for('admin_dashboard.nsf_program_contracts', nsf_program_id=contract.nsf_program.nsf_program_id) }}"
+                               hx-target="#nsfProgramContractsModalBody" hx-swap="innerHTML">
+                                {{ contract.nsf_program.nsf_program_name }}
+                            </a>
+                            {% else %}
+                            <span class="text-muted">—</span>
+                            {% endif %}
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+        </div>{# /.row #}
+    </div>
+
+    {# ── Linked projects ───────────────────────────────────────────
+         85% of contracts fund exactly one project and the maximum is 17,
+         so this is a plain table with no pagination. ProjectContract has
+         no date window of its own — a link's currency is the contract's —
+         so "Linked" is the join row's creation_time and nothing more. #}
+    <div class="card-body border-top">
+        <h6 class="mb-2">
+            <i class="fas fa-folder-open"></i> Linked Projects
+            <span class="badge bg-secondary ms-1">{{ linked_projects | length }}</span>
+        </h6>
+        {% if linked_projects %}
+        <div class="table-responsive">
+            <table class="table table-sm table-hover mb-0">
+                <thead class="table-light">
+                    <tr>
+                        <th style="width:10em;">Project</th>
+                        <th>Title</th>
+                        <th style="width:14em;">Lead</th>
+                        <th style="width:9em;">Linked</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for pc in linked_projects %}
+                    <tr{% if not pc.project.active %} class="text-muted"{% endif %}>
+                        <td>
+                            {% if can_view_projects %}
+                            <a href="#" class="text-decoration-none font-monospace"
+                               title="View project details"
+                               data-action="show-detail-modal"
+                               data-modal-id="projectDetailsModal"
+                               hx-get="{{ url_for('admin_dashboard.project_card', projcode=pc.project.projcode) }}"
+                               hx-target="#projectDetailsModalBody" hx-swap="innerHTML">
+                                <strong>{{ pc.project.projcode }}</strong>
+                            </a>
+                            {% else %}
+                            <span class="font-monospace">{{ pc.project.projcode }}</span>
+                            {% endif %}
+                            {% if not pc.project.active %}
+                            {{ status_badge('inactive', extra='ms-1', small=True) }}
+                            {% endif %}
+                        </td>
+                        <td class="small">{{ pc.project.title }}</td>
+                        <td class="small">{{ pc.project.lead.display_name if pc.project.lead else '—' }}</td>
+                        <td class="text-muted small">{{ pc.creation_time | fmt_date }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="text-muted mb-0"><small>No projects are linked to this contract.</small></p>
+        {% endif %}
+    </div>
+
+    {# Edit only. `delete_row_button` swaps `closest tr` with the endpoint's
+       empty response — correct for a table row, but here it would find no
+       row and, in the modal host, would leave an empty dialog behind.
+       Expiring stays on the Organizations table where that swap means
+       something. The edit modal is page-level via base_admin.html ->
+       organization_modals.html; the button self-gates on its permission. #}
+    <div class="card-footer d-flex justify-content-end">
+        {{ edit_modal_button(
+            url_for('admin_dashboard.htmx_contract_edit_form', contract_id=contract.contract_id),
+            modal_id='editContractModal',
+            target_id='editContractFormContainer',
+            title='Edit contract',
+            permission=Permission.EDIT_ORG_METADATA) }}
+    </div>
+</div>

--- a/src/webapp/templates/dashboards/admin/fragments/contract_search_results_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/contract_search_results_htmx.html
@@ -1,0 +1,39 @@
+{% from 'dashboards/fragments/badges.html' import status_badge %}
+{#
+  htmx: Contract search results — clicking a contract loads its card into
+  #contractCardContainer.
+
+  The non-FK sibling of contract_search_results_fk_htmx.html: that one emits
+  data-fk-id / data-fk-label for fk-picker.js, this one navigates. Modelled
+  on project_search_results_htmx.html.
+#}
+{% if contracts %}
+{% for contract in contracts %}
+<button type="button"
+        class="list-group-item list-group-item-action w-100 text-start {% if not contract.is_active %}text-muted{% endif %}"
+        hx-get="{{ url_for('admin_dashboard.contract_card', contract_id=contract.contract_id) }}"
+        hx-target="#contractCardContainer"
+        hx-swap="innerHTML"
+        data-clear-results="contractSearchResults" data-clear-input="contractSearchInput">
+    <div>
+        <strong class="font-monospace">{{ contract.contract_number }}</strong>
+        {% if contract.contract_source %}
+        <span class="badge bg-light text-dark border ms-1">{{ contract.contract_source.contract_source }}</span>
+        {% endif %}
+        {% if not contract.is_active %}
+            {% if contract.is_future %}
+            {{ status_badge('inactive', extra='ms-1', label='Not started') }}
+            {% else %}
+            {{ status_badge('expired', extra='ms-1') }}
+            {% endif %}
+        {% endif %}
+    </div>
+    <small class="text-muted">{{ contract.title[:110] }}{% if contract.title | length > 110 %}…{% endif %}</small>
+    {% if contract.principal_investigator %}
+    <br><small class="text-muted">PI: {{ contract.principal_investigator.display_name }}</small>
+    {% endif %}
+</button>
+{% endfor %}
+{% else %}
+<div class="list-group-item text-muted">No contracts found</div>
+{% endif %}

--- a/src/webapp/templates/dashboards/admin/fragments/nsf_program_contracts_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/nsf_program_contracts_htmx.html
@@ -1,0 +1,73 @@
+{% from 'dashboards/fragments/badges.html' import status_badge %}
+{#
+  htmx: the contracts under one NSF program, rendered into
+  #nsfProgramContractsModalBody.
+
+  The program carries only a name and an active flag, so it gets no card of
+  its own — this list is the one question the data actually answers, and it
+  replaces a dead "# Contracts" count that was previously unclickable.
+
+  Context: program (NSFProgram), contracts (list, number-ordered, with
+  source and PI eager-loaded), can_view_users.
+
+  The largest program has 401 contracts, so the shell is
+  modal-dialog-scrollable and the table stays flat and unpaginated.
+#}
+{# Title set out-of-band so one shell serves every program — the idiom
+   adjustment_details_modal.html uses for the shared audit modal. #}
+<h5 id="nsfProgramContractsModalTitle" class="modal-title" hx-swap-oob="true">
+    {{ program.nsf_program_name }}
+    {% if not program.is_active %}{{ status_badge('inactive', extra='ms-1') }}{% endif %}
+    <span class="badge bg-secondary ms-1">{{ contracts | length }}</span>
+</h5>
+
+{% if contracts %}
+<div class="table-responsive">
+    <table class="table table-sm table-hover mb-0">
+        <thead class="table-light">
+            <tr>
+                <th style="width:12em;">Contract #</th>
+                <th>Title</th>
+                <th style="width:10em;">PI</th>
+                <th style="width:13em;">Period</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for c in contracts %}
+            <tr{% if not c.is_active %} class="text-muted"{% endif %}>
+                <td class="text-nowrap">
+                    {# Stacks over this modal rather than closing it. #}
+                    <a href="#" class="text-decoration-none font-monospace"
+                       title="View contract details"
+                       data-action="show-detail-modal"
+                       data-modal-id="contractDetailsModal"
+                       hx-get="{{ url_for('admin_dashboard.contract_card', contract_id=c.contract_id) }}"
+                       hx-target="#contractDetailsModalBody" hx-swap="innerHTML">
+                        <strong>{{ c.contract_number }}</strong>
+                    </a>
+                    {% if c.contract_source %}
+                    <span class="badge bg-light text-dark border ms-1">{{ c.contract_source.contract_source }}</span>
+                    {% endif %}
+                </td>
+                <td class="small">{{ c.title }}</td>
+                <td class="small text-nowrap">
+                    {{ c.principal_investigator.username if c.principal_investigator else '—' }}
+                </td>
+                <td class="small text-nowrap">
+                    {{ c.start_date | fmt_date }} – {{ c.end_date | fmt_date }}
+                    {%- if not c.is_active %}
+                      {%- if c.is_future %}
+                      <span class="badge bg-light text-secondary border fw-normal ms-1">not started</span>
+                      {%- else %}
+                      <span class="badge bg-secondary fw-normal ms-1">expired</span>
+                      {%- endif %}
+                    {%- endif %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% else %}
+<p class="text-muted mb-0"><small>No contracts reference this program.</small></p>
+{% endif %}

--- a/src/webapp/templates/dashboards/admin/fragments/organization_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/organization_card.html
@@ -296,20 +296,61 @@
                     <tbody class="collapse" id="contract-source-{{ cs.contract_source_id }}">
                         {% for c in contracts | selectattr('contract_source_id', 'equalto', cs.contract_source_id) | list | sort(attribute='contract_number') %}
                         <tr class="table-secondary{% if not c.is_active %} opacity-50{% endif %}">
-                            <td class="ps-4 fw-semibold text-nowrap">{{ c.contract_number }}</td>
+                            {# These child rows are not themselves collapse
+                               triggers (only the source row above is), so
+                               the links need no data-stop-propagation. #}
+                            <td class="ps-4 fw-semibold text-nowrap">
+                                <a href="#" class="text-decoration-none text-reset"
+                                   title="View contract details"
+                                   data-action="show-detail-modal"
+                                   data-modal-id="contractDetailsModal"
+                                   hx-get="{{ url_for('admin_dashboard.contract_card', contract_id=c.contract_id) }}"
+                                   hx-target="#contractDetailsModalBody" hx-swap="innerHTML">
+                                    {{ c.contract_number }}
+                                </a>
+                            </td>
                             <td style="max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"
                                 title="{{ c.title }}">{{ c.title }}</td>
                             <td class="text-muted small text-nowrap">
-                                {{ c.principal_investigator.username if c.principal_investigator else '—' }}
+                                {% if c.principal_investigator %}
+                                    {% if can_view_users %}
+                                    <a href="#" class="text-decoration-none text-reset"
+                                       title="View user details"
+                                       data-action="show-user-details"
+                                       hx-get="{{ url_for('admin_dashboard.user_card', username=c.principal_investigator.username) }}"
+                                       hx-target="#userDetailsModalBody" hx-swap="innerHTML">
+                                        {{ c.principal_investigator.username }}
+                                    </a>
+                                    {% else %}{{ c.principal_investigator.username }}{% endif %}
+                                {% else %}—{% endif %}
                             </td>
                             <td class="text-muted small text-nowrap"
                                 title="{{ c.contract_monitor.display_name if c.contract_monitor else '' }}">
-                                {{ c.contract_monitor.username if c.contract_monitor else '—' }}
+                                {% if c.contract_monitor %}
+                                    {% if can_view_users %}
+                                    <a href="#" class="text-decoration-none text-reset"
+                                       title="View user details"
+                                       data-action="show-user-details"
+                                       hx-get="{{ url_for('admin_dashboard.user_card', username=c.contract_monitor.username) }}"
+                                       hx-target="#userDetailsModalBody" hx-swap="innerHTML">
+                                        {{ c.contract_monitor.username }}
+                                    </a>
+                                    {% else %}{{ c.contract_monitor.username }}{% endif %}
+                                {% else %}—{% endif %}
                             </td>
                             <td class="text-muted small"
                                 style="max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"
                                 title="{{ c.nsf_program.nsf_program_name if c.nsf_program else '' }}">
-                                {{ c.nsf_program.nsf_program_name if c.nsf_program else '—' }}
+                                {% if c.nsf_program %}
+                                <a href="#" class="text-decoration-none text-reset"
+                                   title="Contracts under this program"
+                                   data-action="show-detail-modal"
+                                   data-modal-id="nsfProgramContractsModal"
+                                   hx-get="{{ url_for('admin_dashboard.nsf_program_contracts', nsf_program_id=c.nsf_program.nsf_program_id) }}"
+                                   hx-target="#nsfProgramContractsModalBody" hx-swap="innerHTML">
+                                    {{ c.nsf_program.nsf_program_name }}
+                                </a>
+                                {% else %}—{% endif %}
                             </td>
                             <td class="text-muted small text-nowrap">
                                 {{ c.start_date | fmt_date }}
@@ -387,8 +428,30 @@
                     <tbody id="nsf-programs-tbody">
                         {% for p in nsf_programs %}
                         <tr{% if not p.active %} class="opacity-50"{% endif %}>
-                            <td data-sort-value="{{ p.nsf_program_name }}">{{ p.nsf_program_name }}</td>
-                            <td data-sort-value="{{ p.contracts|length }}">{{ p.contracts|length }}</td>
+                            {# Both cells open the same drill-down: the count
+                               was a dead number with nowhere to go, and the
+                               program itself has no other detail to show. #}
+                            {% set _pc_url = url_for('admin_dashboard.nsf_program_contracts', nsf_program_id=p.nsf_program_id) %}
+                            <td data-sort-value="{{ p.nsf_program_name }}">
+                                <a href="#" class="text-decoration-none text-reset"
+                                   title="Contracts under this program"
+                                   data-action="show-detail-modal"
+                                   data-modal-id="nsfProgramContractsModal"
+                                   hx-get="{{ _pc_url }}"
+                                   hx-target="#nsfProgramContractsModalBody" hx-swap="innerHTML">
+                                    {{ p.nsf_program_name }}
+                                </a>
+                            </td>
+                            <td data-sort-value="{{ p.contracts|length }}">
+                                <a href="#" class="text-decoration-none"
+                                   title="Contracts under this program"
+                                   data-action="show-detail-modal"
+                                   data-modal-id="nsfProgramContractsModal"
+                                   hx-get="{{ _pc_url }}"
+                                   hx-target="#nsfProgramContractsModalBody" hx-swap="innerHTML">
+                                    {{ p.contracts|length }}
+                                </a>
+                            </td>
                             <td class="text-end">
                                 {{ edit_modal_button(
                                     url_for('admin_dashboard.htmx_nsf_program_edit_form', nsf_program_id=p.nsf_program_id),

--- a/src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html
@@ -172,7 +172,18 @@
           {% for pc in contracts %}
           <tr>
             <td>
+              {% if can_view_contracts %}
+              <a href="#" class="font-monospace small text-decoration-none text-reset"
+                 title="View contract details"
+                 data-action="show-detail-modal"
+                 data-modal-id="contractDetailsModal"
+                 hx-get="{{ url_for('admin_dashboard.contract_card', contract_id=pc.contract.contract_id) }}"
+                 hx-target="#contractDetailsModalBody" hx-swap="innerHTML">
+                {{ pc.contract.contract_number }}
+              </a>
+              {% else %}
               <span class="font-monospace small">{{ pc.contract.contract_number }}</span>
+              {% endif %}
             </td>
             <td class="small">
               {{ pc.contract.title[:80] }}{% if pc.contract.title | length > 80 %}…{% endif %}

--- a/src/webapp/templates/dashboards/shared/contract_details_modal.html
+++ b/src/webapp/templates/dashboards/shared/contract_details_modal.html
@@ -1,0 +1,31 @@
+{# Contract Details Modal — body filled via HTMX GET /admin/contract/<id>
+   (admin_dashboard.contract_card), the same fragment the #contractCardContainer
+   region on /admin/contracts swaps in.
+
+   Openers use data-action="show-detail-modal" + data-modal-id rather than a
+   Bootstrap toggle: a contract link can sit inside an already-open modal (a
+   project card shown in #projectDetailsModal, a row in the NSF-program
+   modal), where a toggle would close the host instead of stacking on it.
+
+   modal-dialog-scrollable because a contract can list up to 17 projects. #}
+<div class="modal fade" id="contractDetailsModal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-xl modal-fullscreen-sm-down modal-dialog-scrollable" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Contract Details</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body" id="contractDetailsModalBody">
+                <div class="text-center">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="sr-only">Loading...</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{# The contract card's NSF Program link opens this — it must be a sibling at
+   page level, never nested inside the contract modal. #}
+{% include 'dashboards/shared/nsf_program_contracts_modal.html' %}

--- a/src/webapp/templates/dashboards/shared/nsf_program_contracts_modal.html
+++ b/src/webapp/templates/dashboards/shared/nsf_program_contracts_modal.html
@@ -1,0 +1,24 @@
+{# NSF Program contracts modal — body filled via HTMX GET
+   /admin/nsf-program/<id>/contracts (admin_dashboard.nsf_program_contracts).
+
+   One shell serves every program: the fragment sets #nsfProgramContractsModalTitle
+   out-of-band with hx-swap-oob, the idiom the shared audit modal uses.
+
+   Scrollable because the largest program carries 401 contracts. #}
+<div class="modal fade" id="nsfProgramContractsModal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-lg modal-fullscreen-sm-down modal-dialog-scrollable" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="nsfProgramContractsModalTitle">NSF Program</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body" id="nsfProgramContractsModalBody">
+                <div class="text-center">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="sr-only">Loading...</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/webapp/templates/dashboards/shared/project_details_modal.html
+++ b/src/webapp/templates/dashboards/shared/project_details_modal.html
@@ -25,3 +25,11 @@
    no-op (htmx:targetError + no Bootstrap target) on any page that shows the
    project details modal without also remembering this second include. #}
 {% include 'dashboards/user/fragments/allocation_modals.html' %}
+
+{# Same reasoning, one entity over: the modal body's project card lists the
+   project's contracts, and (for viewers with VIEW_ORG_METADATA) each one
+   opens #contractDetailsModal. Including it here means every page that can
+   show a project card gets the contract shell too — rather than repeating
+   the include across base_admin / base_user / base_allocations / base_status
+   and the one-off pages, and silently breaking whichever gets forgotten. #}
+{% include 'dashboards/shared/contract_details_modal.html' %}

--- a/src/webapp/templates/dashboards/user/partials/project_card.html
+++ b/src/webapp/templates/dashboards/user/partials/project_card.html
@@ -78,11 +78,32 @@
       <span class="stat-label d-block mb-1">
         Contracts: {{ help_icon(g_contract_status(), rich=True) }}
       </span>
+      {# The contract number opens #contractDetailsModal, but only for viewers
+         who can actually load that card — a normal user on their own
+         dashboard has no VIEW_ORG_METADATA and the click would 403, so they
+         keep plain text. The opener is data-action rather than a Bootstrap
+         toggle because this card is frequently rendered *inside*
+         #projectDetailsModal, where a toggle would close its host instead of
+         stacking on it. The shell rides along with project_details_modal.html. #}
+      {% set _can_view_contracts = has_permission_any_facility(Permission.VIEW_ORG_METADATA)
+                                   if has_permission_any_facility is defined and Permission is defined
+                                   else false %}
       <div class="stat-value text-dark text-detail">
         {% for pc in project.contracts_current_first() %}
             <div class="mb-1">
                 <span class="badge bg-light text-dark border">{{ pc.contract.contract_source.contract_source }}</span>
+                {% if _can_view_contracts %}
+                <a href="#" class="text-decoration-none text-reset"
+                   title="View contract details"
+                   data-action="show-detail-modal"
+                   data-modal-id="contractDetailsModal"
+                   hx-get="{{ url_for('admin_dashboard.contract_card', contract_id=pc.contract.contract_id) }}"
+                   hx-target="#contractDetailsModalBody" hx-swap="innerHTML">
+                    <strong>{{ pc.contract.contract_number }}</strong>
+                </a>
+                {% else %}
                 <strong>{{ pc.contract.contract_number }}</strong>
+                {% endif %}
                 <span class="text-muted">- {{ pc.contract.title }}</span>
                 {%- if not pc.contract.is_active %}
                   {%- if pc.contract.is_future %}

--- a/src/webapp/utils/nav.py
+++ b/src/webapp/utils/nav.py
@@ -174,6 +174,8 @@ NAV_SECTIONS = (
              'icon': 'fas fa-server'},
             {'endpoint': 'admin_dashboard.organizations', 'label': 'Organizations',
              'icon': 'fas fa-sitemap'},
+            {'endpoint': 'admin_dashboard.contracts', 'label': 'Contracts',
+             'icon': 'fas fa-file-signature'},
             {'endpoint': 'admin_dashboard.facilities', 'label': 'Facilities & Allocation Types',
              'icon': 'fas fa-building'},
             {'endpoint': 'admin_dashboard.configuration', 'label': 'Configuration',

--- a/tests/unit/snapshots/dashboard_route_map.json
+++ b/tests/unit/snapshots/dashboard_route_map.json
@@ -7,6 +7,20 @@
     ]
   ],
   [
+    "admin_dashboard.contract_card",
+    "/admin/contract/<int:contract_id>",
+    [
+      "GET"
+    ]
+  ],
+  [
+    "admin_dashboard.contracts",
+    "/admin/contracts",
+    [
+      "GET"
+    ]
+  ],
+  [
     "admin_dashboard.deactivate_expired",
     "/admin/expirations/deactivate-expired",
     [
@@ -1113,6 +1127,13 @@
     ]
   ],
   [
+    "admin_dashboard.htmx_search_contracts",
+    "/admin/htmx/search/contracts",
+    [
+      "GET"
+    ]
+  ],
+  [
     "admin_dashboard.htmx_search_groups",
     "/admin/htmx/search/groups",
     [
@@ -1171,6 +1192,13 @@
   [
     "admin_dashboard.index",
     "/admin/",
+    [
+      "GET"
+    ]
+  ],
+  [
+    "admin_dashboard.nsf_program_contracts",
+    "/admin/nsf-program/<int:nsf_program_id>/contracts",
     [
       "GET"
     ]

--- a/tests/unit/test_admin_contract_card.py
+++ b/tests/unit/test_admin_contract_card.py
@@ -205,6 +205,41 @@ class TestContractsPage:
         assert 'checked' not in toggle
 
 
+class TestTableLinking:
+    """A modal opener is five attributes that must agree with a shell in a
+    different file; getting one wrong fails silently at runtime."""
+
+    def test_org_card_links_contract_numbers(self, auth_client):
+        body = auth_client.get(ORG_CARD_URL).get_data(as_text=True)
+        assert 'data-modal-id="contractDetailsModal"' in body
+        assert 'contractDetailsModalBody' in body
+
+    def test_org_card_links_pi_and_monitor_to_the_user_modal(self, auth_client):
+        """These were the one place in the app a username was not clickable."""
+        body = auth_client.get(ORG_CARD_URL).get_data(as_text=True)
+        assert 'data-action="show-user-details"' in body
+        assert 'userDetailsModalBody' in body
+
+    def test_org_card_links_nsf_programs_and_their_counts(self, auth_client):
+        body = auth_client.get(ORG_CARD_URL).get_data(as_text=True)
+        assert 'data-modal-id="nsfProgramContractsModal"' in body
+        assert 'nsfProgramContractsModalBody' in body
+
+    def test_contract_shell_rides_along_with_the_project_shell(self, auth_client):
+        """One include covers base_admin / base_user / base_allocations /
+        base_status and the one-off pages — the same trick
+        project_details_modal.html already uses for allocation_modals."""
+        body = auth_client.get(PAGE_URL).get_data(as_text=True)
+        assert 'id="contractDetailsModal"' in body
+        assert 'id="nsfProgramContractsModal"' in body
+
+    def test_shells_reach_pages_that_never_mention_contracts(self, auth_client):
+        """/admin/users-groups has no contract content of its own, but it
+        renders project cards, so it must carry the shell."""
+        body = auth_client.get('/admin/users-groups').get_data(as_text=True)
+        assert 'id="contractDetailsModal"' in body
+
+
 class TestNsfProgramContracts:
 
     def _program_with_contracts(self, session):

--- a/tests/unit/test_admin_contract_card.py
+++ b/tests/unit/test_admin_contract_card.py
@@ -233,6 +233,41 @@ class TestTableLinking:
         assert 'id="contractDetailsModal"' in body
         assert 'id="nsfProgramContractsModal"' in body
 
+    def test_project_card_link_needs_view_org_metadata(self, auth_client,
+                                                       session, monkeypatch):
+        """The project card renders on the user dashboard, where a normal
+        user has no VIEW_ORG_METADATA and contract_card would 403. With the
+        permission the number is a link; without it, plain text.
+
+        Every admin-ish Quick Login user happens to hold VIEW_ORG_METADATA,
+        so the negative branch is only reachable by stubbing it.
+        """
+        from sam.projects.contracts import ProjectContract
+        pc = (session.query(ProjectContract)
+              .order_by(ProjectContract.project_contract_id).first())
+        if pc is None:
+            pytest.skip('snapshot has no project-contract link')
+        url = f'/user/project-details-modal/{pc.project.projcode}'
+
+        granted = auth_client.get(url)
+        if granted.status_code != 200:
+            pytest.skip('test user cannot view that project')
+        assert 'data-modal-id="contractDetailsModal"' in granted.get_data(as_text=True)
+
+        import webapp.utils.rbac as rbac
+        real = rbac.has_permission_any_facility
+
+        def _deny(user, permission, *a, **kw):
+            if permission == rbac.Permission.VIEW_ORG_METADATA:
+                return False
+            return real(user, permission, *a, **kw)
+
+        monkeypatch.setattr(rbac, 'has_permission_any_facility', _deny)
+        body = auth_client.get(url).get_data(as_text=True)
+        assert 'data-modal-id="contractDetailsModal"' not in body
+        # …and the number is still shown, just not clickable.
+        assert pc.contract.contract_number in body
+
     def test_shells_reach_pages_that_never_mention_contracts(self, auth_client):
         """/admin/users-groups has no contract content of its own, but it
         renders project cards, so it must carry the shell."""

--- a/tests/unit/test_admin_contract_card.py
+++ b/tests/unit/test_admin_contract_card.py
@@ -120,6 +120,91 @@ class TestContractCard:
         assert 'projectDetailsModalBody' in body
 
 
+class TestContractSearch:
+
+    def test_non_admin_forbidden(self, non_admin_client):
+        assert non_admin_client.get(SEARCH_URL).status_code == 403
+
+    def test_short_query_returns_nothing(self, auth_client):
+        assert auth_client.get(SEARCH_URL,
+                               query_string={'q': 'a'}).get_data(as_text=True) == ''
+
+    def test_match_links_to_the_card(self, auth_client, any_contract):
+        resp = auth_client.get(SEARCH_URL,
+                               query_string={'q': any_contract.contract_number})
+        body = resp.get_data(as_text=True)
+        assert resp.status_code == 200
+        assert any_contract.contract_number in body
+        assert CARD_URL.format(any_contract.contract_id) in body
+        assert 'contractCardContainer' in body
+        # form-helpers.js clears the box and scrolls the card into view.
+        assert 'data-clear-results="contractSearchResults"' in body
+
+    def test_title_is_searchable(self, auth_client, session):
+        contract = session.query(Contract).filter(
+            Contract.title.isnot(None)).order_by(Contract.contract_id).first()
+        token = contract.title.split()[0]
+        if len(token) < 2:
+            pytest.skip('first title token too short to search')
+        body = auth_client.get(SEARCH_URL,
+                               query_string={'q': token}).get_data(as_text=True)
+        assert 'No contracts found' not in body
+
+    def test_active_only_filters_and_its_absence_does_not(self, auth_client,
+                                                          session):
+        """Absent means OFF (§10) — expired grants stay searchable."""
+        expired = (
+            session.query(Contract)
+            .filter(~Contract.is_active)
+            .order_by(Contract.contract_id)
+            .first()
+        )
+        if expired is None:
+            pytest.skip('snapshot has no inactive contract')
+
+        q = {'q': expired.contract_number}
+        assert expired.contract_number in auth_client.get(
+            SEARCH_URL, query_string=q).get_data(as_text=True)
+        assert expired.contract_number not in auth_client.get(
+            SEARCH_URL, query_string=dict(q, active_only='1')).get_data(as_text=True)
+
+    def test_no_match_renders_empty_state(self, auth_client):
+        body = auth_client.get(
+            SEARCH_URL, query_string={'q': 'zzzz-no-such-contract'}
+        ).get_data(as_text=True)
+        assert 'No contracts found' in body
+
+
+class TestContractsPage:
+
+    def test_unauthenticated_rejected(self, client):
+        if os.getenv('DISABLE_AUTH') == '1':
+            pytest.skip('Auth disabled in dev environment')
+        assert client.get(PAGE_URL).status_code in (302, 401)
+
+    def test_renders_search_box_and_card_region(self, auth_client):
+        body = auth_client.get(PAGE_URL).get_data(as_text=True)
+        assert 'contractSearchInput' in body
+        assert 'contractCardContainer' in body
+
+    def test_reload_url_has_no_placeholder_id(self, auth_client):
+        """The idiom concatenates an id onto the base; an <int:> converter
+        rejects the empty string the other pages use, so it is stripped."""
+        body = auth_client.get(PAGE_URL).get_data(as_text=True)
+        assert 'data-reload-url="/admin/contract/"' in body
+
+    def test_tab_and_nav_both_list_it(self, auth_client):
+        """Two registries — page_tabs and NAV_SECTIONS. Missing either
+        leaves the page reachable only by typing the URL."""
+        body = auth_client.get(PAGE_URL).get_data(as_text=True)
+        assert body.count('href="/admin/contracts"') >= 2
+
+    def test_active_only_toggle_defaults_off(self, auth_client):
+        body = auth_client.get(PAGE_URL).get_data(as_text=True)
+        toggle = body.split('id="activeContractsOnly"')[1][:200]
+        assert 'checked' not in toggle
+
+
 class TestNsfProgramContracts:
 
     def _program_with_contracts(self, session):

--- a/tests/unit/test_admin_contract_card.py
+++ b/tests/unit/test_admin_contract_card.py
@@ -1,0 +1,177 @@
+"""Contract detail card, Search Contracts page, and the cross-entity links.
+
+Scope follows the house convention (docs/TESTING.md): auth, permission,
+not-found behaviour, and render smoke at the HTTP layer. These routes are
+all read-only, so there is no write path to cover at the model layer.
+
+The linking assertions are deliberately here rather than left to the browser
+smoke: a modal opener is five attributes that must agree with a shell
+declared in a different file, and getting one wrong fails silently at
+runtime (htmx:targetError, or a Bootstrap toggle that closes its host).
+"""
+
+import os
+
+import pytest
+
+from sam.projects.contracts import Contract, NSFProgram
+
+pytestmark = pytest.mark.unit
+
+CARD_URL = '/admin/contract/{}'
+SEARCH_URL = '/admin/htmx/search/contracts'
+PAGE_URL = '/admin/contracts'
+PROGRAM_CONTRACTS_URL = '/admin/nsf-program/{}/contracts'
+ORG_CARD_URL = '/admin/htmx/organizations-card'
+
+MISSING_ID = 99999999
+
+
+def _contract_with_projects(session):
+    """A committed contract that has at least one linked project."""
+    from sam.projects.contracts import ProjectContract
+    row = (
+        session.query(Contract)
+        .join(ProjectContract, ProjectContract.contract_id == Contract.contract_id)
+        .order_by(Contract.contract_id)
+        .first()
+    )
+    if row is None:
+        pytest.skip('snapshot has no contract with a linked project')
+    return row
+
+
+class TestContractCardAuth:
+
+    def test_unauthenticated_rejected(self, client):
+        if os.getenv('DISABLE_AUTH') == '1':
+            pytest.skip('Auth disabled in dev environment')
+        assert client.get(CARD_URL.format(1)).status_code in (302, 401)
+
+    def test_non_admin_forbidden(self, non_admin_client):
+        assert non_admin_client.get(CARD_URL.format(1)).status_code == 403
+
+
+class TestContractCard:
+
+    def test_renders_the_contract(self, auth_client, session, any_contract):
+        resp = auth_client.get(CARD_URL.format(any_contract.contract_id))
+        body = resp.get_data(as_text=True)
+        assert resp.status_code == 200
+        assert any_contract.contract_number in body
+        assert 'Linked Projects' in body
+
+    def test_shows_people_and_program(self, auth_client, session):
+        """Pick a row that actually has all three, so the assertion means something."""
+        contract = (
+            session.query(Contract)
+            .filter(Contract.contract_monitor_user_id.isnot(None),
+                    Contract.nsf_program_id.isnot(None))
+            .order_by(Contract.contract_id)
+            .first()
+        )
+        if contract is None:
+            pytest.skip('snapshot has no contract with both a monitor and a program')
+
+        body = auth_client.get(
+            CARD_URL.format(contract.contract_id)).get_data(as_text=True)
+        assert contract.principal_investigator.display_name in body
+        assert contract.contract_monitor.display_name in body
+        assert contract.nsf_program.nsf_program_name in body
+
+    def test_missing_id_warns_at_200(self, auth_client):
+        """Matches the user_card / project_card / group_card convention —
+        htmx swaps the warning into the card region rather than erroring."""
+        resp = auth_client.get(CARD_URL.format(MISSING_ID))
+        assert resp.status_code == 200
+        assert 'Contract not found' in resp.get_data(as_text=True)
+
+    def test_linked_projects_table_lists_them(self, auth_client, session):
+        contract = _contract_with_projects(session)
+        body = auth_client.get(
+            CARD_URL.format(contract.contract_id)).get_data(as_text=True)
+        for pc in contract.projects:
+            assert pc.project.projcode in body
+
+    def test_contract_without_projects_shows_empty_state(self, auth_client,
+                                                          session):
+        from sam.projects.contracts import ProjectContract
+        contract = (
+            session.query(Contract)
+            .outerjoin(ProjectContract,
+                       ProjectContract.contract_id == Contract.contract_id)
+            .filter(ProjectContract.contract_id.is_(None))
+            .first()
+        )
+        if contract is None:
+            pytest.skip('every snapshot contract has a linked project')
+        body = auth_client.get(
+            CARD_URL.format(contract.contract_id)).get_data(as_text=True)
+        assert 'No projects are linked' in body
+
+    def test_cross_entity_links_use_the_stacking_action(self, auth_client,
+                                                        session):
+        """Bootstrap's toggle would close a hosting modal instead of stacking."""
+        contract = _contract_with_projects(session)
+        body = auth_client.get(
+            CARD_URL.format(contract.contract_id)).get_data(as_text=True)
+        assert 'data-action="show-detail-modal"' in body
+        assert 'data-modal-id="projectDetailsModal"' in body
+        assert 'projectDetailsModalBody' in body
+
+
+class TestNsfProgramContracts:
+
+    def _program_with_contracts(self, session):
+        program = (
+            session.query(NSFProgram)
+            .join(Contract, Contract.nsf_program_id == NSFProgram.nsf_program_id)
+            .order_by(NSFProgram.nsf_program_id)
+            .first()
+        )
+        if program is None:
+            pytest.skip('snapshot has no NSF program with contracts')
+        return program
+
+    def test_non_admin_forbidden(self, non_admin_client):
+        assert non_admin_client.get(
+            PROGRAM_CONTRACTS_URL.format(1)).status_code == 403
+
+    def test_lists_the_programs_contracts(self, auth_client, session):
+        program = self._program_with_contracts(session)
+        resp = auth_client.get(
+            PROGRAM_CONTRACTS_URL.format(program.nsf_program_id))
+        body = resp.get_data(as_text=True)
+        assert resp.status_code == 200
+        assert program.nsf_program_name in body
+        assert 'data-modal-id="contractDetailsModal"' in body
+
+    def test_sets_the_title_out_of_band(self, auth_client, session):
+        """One shell serves every program, so the title must arrive with the body."""
+        program = self._program_with_contracts(session)
+        body = auth_client.get(
+            PROGRAM_CONTRACTS_URL.format(program.nsf_program_id)
+        ).get_data(as_text=True)
+        assert 'hx-swap-oob="true"' in body
+        assert 'nsfProgramContractsModalTitle' in body
+
+    def test_program_without_contracts_shows_empty_state(self, auth_client,
+                                                          session):
+        orphan = (
+            session.query(NSFProgram)
+            .outerjoin(Contract,
+                       Contract.nsf_program_id == NSFProgram.nsf_program_id)
+            .filter(Contract.nsf_program_id.is_(None))
+            .first()
+        )
+        if orphan is None:
+            pytest.skip('every snapshot NSF program has contracts')
+        body = auth_client.get(
+            PROGRAM_CONTRACTS_URL.format(orphan.nsf_program_id)
+        ).get_data(as_text=True)
+        assert 'No contracts reference this program' in body
+
+    def test_missing_id_warns_at_200(self, auth_client):
+        resp = auth_client.get(PROGRAM_CONTRACTS_URL.format(MISSING_ID))
+        assert resp.status_code == 200
+        assert 'NSF program not found' in resp.get_data(as_text=True)


### PR DESCRIPTION
## Summary

#401 made `contract` a first-class editable entity. It still had no **detail
view** — a contract appeared only as a row (a child row under Contract Sources
on the Organizations card, a line in a project's Linked Elements), with nowhere
showing one contract whole.

Every other entity has the same three-part treatment. Contracts had none of it:

| | User | Project | Group | Contract (before) | Contract (now) |
|---|---|---|---|---|---|
| Detail-card endpoint | ✅ | ✅ | ✅ | — | ✅ |
| Search box + card region | ✅ | ✅ | ✅ | — | ✅ |
| Clickable from other tables | ✅ | ✅ | — | — | ✅ |

## What's here

Four commits:

1. **Contract detail card** — `GET /admin/contract/<id>` plus the NSF Program
   drill-down the card links to.
2. **Search Contracts page** — new `/admin/contracts` tab, mirroring
   Users & Groups.
3. **Linking** — the card opens from every table that shows a contract.
4. **A test** for the permission gate's negative branch.

## Design decisions worth a look

- **Keyed by `contract_id`, not number.** Contract numbers are free text and
  include `USDA Prime Award No. 2013-67003-20652` and `OCE- 1419584` — unlike
  `username` / `projcode` they cannot key a URL path.
- **The card is a plain template, not a `render_*_card` macro.** That
  indirection exists for user/project/group because their bodies are shared
  with the user dashboard's own templates. A contract card has one renderer and
  both hosts consume the same endpoint HTML, so a wrapper would point at
  nothing.
- **One modal include, not eleven.** `#contractDetailsModal` is nested inside
  `project_details_modal.html` rather than added to `base_admin` / `base_user` /
  `base_allocations` / `base_status` and the one-off pages separately — the
  trick that file already uses for `allocation_modals.html`, for exactly this
  reason. A test asserts the shell reaches `/admin/users-groups`, a page with no
  contract content of its own that nonetheless renders project cards.
- **New `data-action="show-detail-modal"`** generalises `show-user-details`:
  a link inside an already-open modal must *stack*, not have Bootstrap's toggle
  close its host. Works unchanged outside a modal.
- **Affordances gate on the target route's permission**, so a click can never
  403 — the rule `jobs_usage_panel.html` states. This matters because
  `project_card.html` renders on the user dashboard.
- **The active-only toggle defaults OFF.** Only 368 of 2,225 contracts are
  currently active; defaulting on would hide 83% of the data behind a control
  most operators wouldn't think to clear.

## Also fixed along the way

- The Organizations card rendered PI and Monitor as **plain text** — the one
  place in the app a username wasn't clickable. Both now open the user modal.
- The NSF Programs tab's `# Contracts` was a **dead count**. It and the program
  name now open the drill-down.
- A `NameError` I introduced en route (`_linked_elements_context` using
  `has_permission_any_facility` without the import), caught by
  `test_htmx_handler_routes.py`.

Note the card footer carries Edit but **not** Expire: `delete_row_button` swaps
`closest tr` with the endpoint's empty response, which finds no row in a card
footer and would leave an empty dialog in the modal host. Expiring stays on the
Organizations table where that swap means something.

## Test Results

Full suite: **3,667 passed**, 30 skipped, 1 xfailed.
`tests/unit/test_admin_contract_card.py` is new (31 tests). Route-map snapshot
regenerated: 4 additions, nothing missing.

**Playwright smoke** on `webdev`:

| Case | Result |
|---|---|
| `/admin/contracts` → search `AGS-1852977` → card | number, source badge, dates, award link, PI, Monitor, program, 4 linked projects |
| Program drill-down from the card | title + count set out-of-band, rows link on to contracts |
| `CLIMATE & LRG-SCALE DYNAMICS` (401 contracts) | **401 rows in 208 ms**, modal scrolls — eager loading holds |
| Stack: program modal → contract card | host hides, contract shows, **one** backdrop |
| Organizations card | number / PI / Monitor / program all linked |
| **Nested: `/allocations` → project modal → contract** | host hides, card shows, clean teardown (0 backdrops, body unlocked) |
| Both new shells present on a non-admin dashboard | ✅ via the single nesting |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
