### PR TITLE
Migrate CI off the deprecated Node 20 Actions runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Dependabot configuration
+#
+# Added because 17 GitHub Actions pins in .github/workflows/ silently drifted
+# 1-3 majors behind, which is how this repo ended up still on the deprecated
+# Node 20 Actions runtime. A weekly check keeps that from recurring.
+#
+# Scoped to GitHub Actions on purpose. Python dependencies are resolved through
+# conda-env.yaml + pyproject.toml and are exercised by the full test suite;
+# opening Dependabot PRs against them is a separate decision.
+---
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    # PRs default to staging, per the repo's git workflow.
+    target-branch: staging
+    labels:
+      - dependencies
+      - ci
+    # One PR for the whole ecosystem rather than one per action.
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+    commit-message:
+      prefix: 'ci'
+    open-pull-requests-limit: 3

--- a/.github/scripts/build_stamp.sh
+++ b/.github/scripts/build_stamp.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Emit the human-readable timestamp used to stamp container builds — the
+# BUILD_DATE build-arg baked into images (surfaced on the admin server card and
+# the build-summary page) and the cirrus helm-pin commit message.
+#
+# Mountain, not UTC: runners are UTC, but SAM is naive-Mountain throughout and
+# the prod pod already runs TZ=America/Denver, so a Mountain stamp is the one
+# that reads correctly alongside everything else.
+#
+# %Z resolves MST/MDT on its own — never hardcode an offset.
+#
+# Guarded, because the failure mode here is silent rather than loud: with no
+# tzdata, glibc does not error. It returns UTC while printing a truncated zone
+# name ("2026-07-15 America") — a wrong time wearing a plausible label, which
+# is worse than the UTC we started with. So verify the zone actually resolved,
+# and otherwise fall back to honest UTC and say so.
+#
+# The ubuntu-24.04 runner image ships tzdata, so the fallback should never
+# fire; it exists so that if it ever does, the timestamp is not quietly lying.
+#
+# Usage:  BUILD_DATE="$(.github/scripts/build_stamp.sh)"
+# The warning goes to stderr so it never contaminates the captured value.
+
+set -euo pipefail
+
+stamp="$(TZ=America/Denver date '+%Y-%m-%d %H:%M %Z')"
+
+case "${stamp}" in
+    *\ MST | *\ MDT) ;;
+    *)
+        echo "::warning::tzdata unavailable — stamping UTC instead of Mountain" >&2
+        stamp="$(date -u '+%Y-%m-%d %H:%M UTC')"
+        ;;
+esac
+
+printf '%s\n' "${stamp}"

--- a/.github/scripts/render_build_summary.py
+++ b/.github/scripts/render_build_summary.py
@@ -12,7 +12,7 @@ Each sidecar is expected to look like:
       "all_tags": ["ghcr.io/.../webapp:latest", "ghcr.io/.../webapp:main", ...],
       "digest": "sha256:...",
       "sizes": { "linux/amd64": 412345678, "linux/arm64": 401234567 },
-      "build_date": "2026-05-05 14:22 UTC"
+      "build_date": "2026-05-05 08:22 MDT"
     }
 """
 

--- a/.github/workflows/_prune-workflow-runs.yaml
+++ b/.github/workflows/_prune-workflow-runs.yaml
@@ -1,0 +1,125 @@
+name: Prune old workflow runs (reusable)
+
+# Shared implementation behind `cron-clean-action-log.yaml` (monthly) and
+# `manually-clean-action-log.yaml` (on demand). Both callers do nothing but
+# supply `days-ago` and `dry-run`.
+#
+# This replaces the third-party `yanovation/delete-old-actions` action, which
+# was archived by its author and never moved off the deprecated Node 20 Actions
+# runtime. The work it did is four `gh api` calls, so we do them here and carry
+# no dependency at all.
+#
+# A reusable workflow — rather than a local composite action — because composite
+# actions must be checked out before they can run, and neither caller otherwise
+# needs the repository on disk.
+
+on:
+  workflow_call:
+    inputs:
+      days-ago:
+        # Deliberately a string: a workflow_dispatch input arrives as a string
+        # in the expression context, and feeding that to a `number`-typed
+        # workflow_call input trips GitHub's type validation.
+        description: Delete completed workflow runs older than this many days.
+        type: string
+        required: true
+      dry-run:
+        description: Log what would be deleted without deleting it.
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      token:
+        description: 'Token with `actions: write` on this repository.'
+        required: true
+
+jobs:
+  prune:
+    name: Prune runs older than ${{ inputs.days-ago }} days
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Delete old workflow runs
+        env:
+          GH_TOKEN: ${{ secrets.token }}
+          DAYS_AGO: ${{ inputs.days-ago }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          set -euo pipefail
+
+          # Values reach the script through `env:` above, never by expression
+          # interpolation into the shell source, so they cannot inject. Still
+          # reject a non-integer here so the failure names the cause.
+          case "${DAYS_AGO}" in
+            ''|*[!0-9]*)
+              echo "::error::days-ago must be a positive integer, got '${DAYS_AGO}'"
+              exit 1
+              ;;
+          esac
+
+          CUTOFF="$(date -u -d "${DAYS_AGO} days ago" +%Y-%m-%dT%H:%M:%SZ)"
+          echo "Cutoff: ${CUTOFF} (runs created before this are eligible)"
+
+          # Collect every eligible id BEFORE deleting any of them. Deleting
+          # mid-pagination shifts the remaining runs backwards across page
+          # boundaries, which silently skips roughly one run per page.
+          #
+          # Filtering happens in jq rather than via the API's `created` query
+          # param deliberately: a filter that fails to match yields nothing,
+          # whereas a query param that is ignored would yield everything.
+          #
+          # `completed` only — an in-flight run cannot be deleted, and a run
+          # still going after ${DAYS_AGO} days is stuck, not garbage.
+          mapfile -t IDS < <(
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs?per_page=100" \
+              --paginate \
+              --jq ".workflow_runs[]
+                    | select(.status == \"completed\")
+                    | select(.created_at < \"${CUTOFF}\")
+                    | .id"
+          )
+
+          echo "Eligible runs: ${#IDS[@]}"
+
+          if [ "${#IDS[@]}" -eq 0 ]; then
+            echo "Nothing to do."
+            {
+              echo "## Prune workflow runs"
+              echo ""
+              echo "No completed runs older than ${DAYS_AGO} days."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "DRY RUN — would delete ${#IDS[@]} run(s):"
+            printf '  %s\n' "${IDS[@]}"
+            {
+              echo "## Prune workflow runs (dry run)"
+              echo ""
+              echo "Would delete **${#IDS[@]}** completed run(s) older than ${DAYS_AGO} days."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # One failure (a run deleted concurrently, a transient 5xx) should not
+          # abandon the rest of the batch.
+          DELETED=0
+          FAILED=0
+          for id in "${IDS[@]}"; do
+            if gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/runs/${id}" --silent 2>/dev/null; then
+              DELETED=$((DELETED + 1))
+            else
+              echo "::warning::Failed to delete run ${id}"
+              FAILED=$((FAILED + 1))
+            fi
+          done
+
+          echo "Deleted ${DELETED}, failed ${FAILED}."
+          {
+            echo "## Prune workflow runs"
+            echo ""
+            echo "- Cutoff: completed runs created before \`${CUTOFF}\` (${DAYS_AGO} days)"
+            echo "- Deleted: **${DELETED}**"
+            echo "- Failed: **${FAILED}**"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-images-cirrus-deploy.yaml
+++ b/.github/workflows/build-images-cirrus-deploy.yaml
@@ -132,16 +132,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up QEMU (for cross-platform builds)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Extract image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.name }}
           tags: |
@@ -172,7 +172,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -227,7 +227,7 @@ jobs:
           cat "image-info-${{ matrix.name }}.json"
 
       - name: Upload image facts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: image-info-${{ matrix.name }}
           path: image-info-${{ matrix.name }}.json
@@ -245,12 +245,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Download image facts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: image-info-*
           path: image-info/
@@ -284,18 +284,20 @@ jobs:
       # actor is this GitHub App, so the push below MUST authenticate as the App.
       - name: Mint GitHub App token (cirrus deploy identity)
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.CIRRUS_DEPLOY_APP_ID }}
           private-key: ${{ secrets.CIRRUS_DEPLOY_APP_PRIVATE_KEY }}
 
       - name: Checkout triggering ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           fetch-depth: 1
-          # persist-credentials (default true) wires this App token into the git
-          # remote so the force-push step below pushes as the App.
+          # persist-credentials (default true) makes checkout persist this App
+          # token for subsequent git commands, so the force-push step below
+          # authenticates as the App. (checkout v6+ stores it in a file under
+          # $RUNNER_TEMP rather than in .git/config — push still works either way.)
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Patch helm/values.yaml with SHA image tag

--- a/.github/workflows/build-images-cirrus-deploy.yaml
+++ b/.github/workflows/build-images-cirrus-deploy.yaml
@@ -168,7 +168,25 @@ jobs:
 
       - name: Compute build date
         id: build_date
-        run: echo "value=$(date -u '+%Y-%m-%d %H:%M UTC')" >> "$GITHUB_OUTPUT"
+        # Runners are UTC; stamp Mountain instead so the build date reads the
+        # same way as the rest of SAM (naive-Mountain) and as the prod pod's
+        # TZ=America/Denver. %Z resolves to MST/MDT on its own — never
+        # hardcode an offset.
+        #
+        # Guarded: with no tzdata, glibc silently falls back to UTC *and*
+        # prints a truncated zone ("2026-07-15 America") — a wrong time
+        # wearing a plausible label. Confirm the zone actually resolved,
+        # otherwise stamp honest UTC and say so.
+        run: |
+          BUILD_DATE="$(TZ=America/Denver date '+%Y-%m-%d %H:%M %Z')"
+          case "${BUILD_DATE}" in
+            *\ MST|*\ MDT) ;;
+            *)
+              echo "::warning::tzdata unavailable — stamping UTC instead of Mountain"
+              BUILD_DATE="$(date -u '+%Y-%m-%d %H:%M UTC')"
+              ;;
+          esac
+          echo "value=${BUILD_DATE}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         id: build

--- a/.github/workflows/build-images-cirrus-deploy.yaml
+++ b/.github/workflows/build-images-cirrus-deploy.yaml
@@ -168,25 +168,9 @@ jobs:
 
       - name: Compute build date
         id: build_date
-        # Runners are UTC; stamp Mountain instead so the build date reads the
-        # same way as the rest of SAM (naive-Mountain) and as the prod pod's
-        # TZ=America/Denver. %Z resolves to MST/MDT on its own — never
-        # hardcode an offset.
-        #
-        # Guarded: with no tzdata, glibc silently falls back to UTC *and*
-        # prints a truncated zone ("2026-07-15 America") — a wrong time
-        # wearing a plausible label. Confirm the zone actually resolved,
-        # otherwise stamp honest UTC and say so.
-        run: |
-          BUILD_DATE="$(TZ=America/Denver date '+%Y-%m-%d %H:%M %Z')"
-          case "${BUILD_DATE}" in
-            *\ MST|*\ MDT) ;;
-            *)
-              echo "::warning::tzdata unavailable — stamping UTC instead of Mountain"
-              BUILD_DATE="$(date -u '+%Y-%m-%d %H:%M UTC')"
-              ;;
-          esac
-          echo "value=${BUILD_DATE}" >> "$GITHUB_OUTPUT"
+        # Mountain, not UTC — see .github/scripts/build_stamp.sh for why, and
+        # for the tzdata guard.
+        run: echo "value=$(.github/scripts/build_stamp.sh)" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         id: build
@@ -334,5 +318,5 @@ jobs:
           git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           git checkout -B cirrus
           git add helm/values.yaml
-          git commit -m "ci: pin webapp image to sha-${GITHUB_SHA:0:7} ($(date -u '+%Y-%m-%d %H:%M UTC')) [skip ci]"
+          git commit -m "ci: pin webapp image to sha-${GITHUB_SHA:0:7} ($(.github/scripts/build_stamp.sh)) [skip ci]"
           git push origin cirrus --force

--- a/.github/workflows/ci-staging.yaml
+++ b/.github/workflows/ci-staging.yaml
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: TruffleHog scan
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.96.0
         with:
           extra_args: --only-verified --results=verified,unknown
 
@@ -48,20 +48,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           lfs: true
           fetch-depth: 0
 
       - name: MegaLinter
-        uses: oxsecurity/megalinter/flavors/cupcake@v8
+        uses: oxsecurity/megalinter/flavors/cupcake@v9
         env:
           VALIDATE_ALL_CODEBASE: false
           DISABLE_ERRORS: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload MegaLinter reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: MegaLinter reports
@@ -84,10 +84,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 1.5.7
 
@@ -107,10 +107,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.14.0
 
@@ -142,12 +142,12 @@ jobs:
         run: sudo apt-get install -y mysql-client
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           lfs: true
 
       - name: Install latest Docker
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@v5
         with:
           docker-ce-version: latest
 

--- a/.github/workflows/clean-ghcr.yaml
+++ b/.github/workflows/clean-ghcr.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Prune Old Package Versions
         # Retention policy + retries + dry-run support live in

--- a/.github/workflows/cron-clean-action-log.yaml
+++ b/.github/workflows/cron-clean-action-log.yaml
@@ -9,11 +9,9 @@ on:
 
 jobs:
   delete-old-actions:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: yanovation/delete-old-actions@v1
-        with:
-          token: ${{ secrets.BENKIRK_GITHUB_TOKEN }}
-          days-ago: 60
-          dry-run: false
+    uses: ./.github/workflows/_prune-workflow-runs.yaml
+    with:
+      days-ago: '60'
+      dry-run: false
+    secrets:
+      token: ${{ secrets.BENKIRK_GITHUB_TOKEN }}

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -67,18 +67,8 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          # Mountain, not UTC — matches the rest of SAM's display convention.
-          # %Z resolves MST/MDT on its own; never hardcode an offset. Guarded
-          # because with no tzdata glibc silently returns UTC under a
-          # truncated zone name, i.e. a wrong time with a plausible label.
-          BUILD_DATE="$(TZ=America/Denver date '+%Y-%m-%d %H:%M %Z')"
-          case "${BUILD_DATE}" in
-            *\ MST|*\ MDT) ;;
-            *)
-              echo "::warning::tzdata unavailable — stamping UTC instead of Mountain"
-              BUILD_DATE="$(date -u '+%Y-%m-%d %H:%M UTC')"
-              ;;
-          esac
+          # Mountain, not UTC — see .github/scripts/build_stamp.sh.
+          BUILD_DATE="$(.github/scripts/build_stamp.sh)"
           docker build \
             -f containers/webapp/Dockerfile \
             --build-arg GIT_SHA="$IMAGE_TAG" \

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 1.5.7
 
@@ -35,7 +35,7 @@ jobs:
         run: terraform fmt -check -recursive infrastructure/staging/
 
       - name: TruffleHog scan
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.96.0
         with:
           extra_args: --only-verified --results=verified,unknown
 
@@ -46,12 +46,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           lfs: true
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -67,7 +67,18 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          BUILD_DATE="$(date -u '+%Y-%m-%d %H:%M UTC')"
+          # Mountain, not UTC — matches the rest of SAM's display convention.
+          # %Z resolves MST/MDT on its own; never hardcode an offset. Guarded
+          # because with no tzdata glibc silently returns UTC under a
+          # truncated zone name, i.e. a wrong time with a plausible label.
+          BUILD_DATE="$(TZ=America/Denver date '+%Y-%m-%d %H:%M %Z')"
+          case "${BUILD_DATE}" in
+            *\ MST|*\ MDT) ;;
+            *)
+              echo "::warning::tzdata unavailable — stamping UTC instead of Mountain"
+              BUILD_DATE="$(date -u '+%Y-%m-%d %H:%M UTC')"
+              ;;
+          esac
           docker build \
             -f containers/webapp/Dockerfile \
             --build-arg GIT_SHA="$IMAGE_TAG" \

--- a/.github/workflows/manually-clean-action-log.yaml
+++ b/.github/workflows/manually-clean-action-log.yaml
@@ -5,17 +5,21 @@ on:
     inputs:
       days-ago:
         description: Timeframe to Purge
-        type: int
+        # was `int`, which is not a valid workflow_dispatch input type
+        type: number
         required: true
         default: 1
+      dry-run:
+        description: List what would be deleted, without deleting it
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   delete-old-actions:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: yanovation/delete-old-actions@v1
-        with:
-          token: ${{ secrets.BENKIRK_GITHUB_TOKEN }}
-          days-ago: ${{ inputs.days-ago }}
-          dry-run: false
+    uses: ./.github/workflows/_prune-workflow-runs.yaml
+    with:
+      days-ago: ${{ inputs.days-ago }}
+      dry-run: ${{ inputs.dry-run }}
+    secrets:
+      token: ${{ secrets.BENKIRK_GITHUB_TOKEN }}

--- a/.github/workflows/mega-linter.yaml
+++ b/.github/workflows/mega-linter.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           #token: ${{ secrets.PAT || secrets.BENKIRK_GITHUB_TOKEN }}
           lfs: true
@@ -71,7 +71,7 @@ jobs:
 
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/latest/flavors/
-        uses: oxsecurity/megalinter/flavors/cupcake@v8
+        uses: oxsecurity/megalinter/flavors/cupcake@v9
 
         id: ml
 
@@ -98,7 +98,7 @@ jobs:
 
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: MegaLinter reports
@@ -110,7 +110,7 @@ jobs:
       # Create pull request if applicable
       # (for now works only on PR from same repository, not from forks)
       - name: Create Pull Request with applied fixes
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         id: cpr
         if: >-
           steps.ml.outputs.has_updated_sources == 1 &&
@@ -172,7 +172,7 @@ jobs:
         run: sudo chown -Rc $UID .git/
 
       - name: Commit and push applied linter fixes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         if: >-
           steps.ml.outputs.has_updated_sources == 1 &&
           (

--- a/.github/workflows/sam-ci-conda_make.yaml
+++ b/.github/workflows/sam-ci-conda_make.yaml
@@ -50,11 +50,11 @@ jobs:
           sudo apt-get install -y mysql-client
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           lfs: true
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         with:
           activate-environment: ./conda-env/
           environment-file: conda-env.yaml
@@ -68,7 +68,7 @@ jobs:
       # currently needed for e.g. COPY --exclude syntax (1.19.0 / 2025-09-30)
       # https://docs.docker.com/build/buildkit/dockerfile-release-notes/?utm_source=chatgpt.com#1190
       - name: Install latest Docker
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@v5
         with:
           docker-ce-version: latest   # or pin a version like "29.0.3"
 

--- a/.github/workflows/sam-ci-docker.yaml
+++ b/.github/workflows/sam-ci-docker.yaml
@@ -33,14 +33,14 @@ jobs:
           sudo apt-get install -y mysql-client
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           lfs: true
 
       # currently needed for e.g. COPY --exclude syntax (1.19.0 / 2025-09-30)
       # https://docs.docker.com/build/buildkit/dockerfile-release-notes/?utm_source=chatgpt.com#1190
       - name: Install latest Docker
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@v5
         with:
           docker-ce-version: latest   # or pin a version like "29.0.3"
 
@@ -162,7 +162,7 @@ jobs:
           docker compose cp webapp:/code/htmlcov ./htmlcov || echo "No coverage report generated"
 
       - name: Upload coverage HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: coverage-report-html

--- a/.github/workflows/sync-staging-to-main.yaml
+++ b/.github/workflows/sync-staging-to-main.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main (post-merge tip)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -30,13 +30,13 @@ jobs:
         run: echo "INSTALL_DIR=${{ runner.temp }}/test-install-target" >> ${GITHUB_ENV}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           lfs: true
 
       # Latest docker for compatibility with --wait, COPY --exclude, etc.
       - name: Install latest Docker
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@v5
         with:
           docker-ce-version: latest
 

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -25,6 +25,11 @@ DISABLE_LINTERS:
 
 SHOW_ELAPSED_TIME: true
 
+# v9 introduced an "LLM Advisor" that calls an external LLM to explain linter
+# findings. Pinned off explicitly rather than left to its default — a feature
+# that makes outbound network calls from CI should be an opt-in decision.
+LLM_ADVISOR_ENABLED: false
+
 # Uncomment if you want MegaLinter to detect errors but not block CI to pass
 DISABLE_ERRORS: true
 


### PR DESCRIPTION
## Summary

GitHub [deprecated the Node 20 Actions runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). The hosted runners already force-upgrade node20 actions to Node 24, so nothing was red — but every run emitted:

```
##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/checkout@v4, actions/upload-artifact@v4
```

We were riding a compatibility shim that will eventually be removed.

An audit found **no Node.js config of our own** — no `setup-node`, no `node-version:`, no `package.json`, no `.nvmrc`, no node-based image. This is a Python/Docker/Terraform/Helm repo; 100% of the Node 20 exposure came from JS runtimes baked into third-party actions. So the fix is entirely action version pins.

Every target was verified against the action's `action.yml` at the target tag (`runs.using: node24`), and every intervening release note was read. **Note the artifact actions** — `upload-artifact@v5` and `download-artifact@v5`/`v6` are *still* node20, so the intuitive single-major bump would not have solved it.

| Action | Old | New | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | **v7** | v6 moved persisted creds to `$RUNNER_TEMP`; push/fetch unaffected. v7 blocks fork checkout on `pull_request_target`/`workflow_run` — we use neither. |
| `actions/upload-artifact` | v4 | **v7** | v5 still node20 |
| `actions/download-artifact` | v4 | **v8** | v5/v6 still node20; v8 makes digest mismatch a hard error |
| `actions/create-github-app-token` | v1 | **v3** | v2 dropped snake_case inputs; we already use kebab-case |
| `conda-incubator/setup-miniconda` | v3 | **v4** | |
| `docker/setup-docker-action` | v4 | **v5** | |
| `docker/setup-qemu-action` | v3 | **v4** | |
| `docker/setup-buildx-action` | v3 | **v4** | |
| `docker/login-action` | v3 | **v4** | |
| `docker/metadata-action` | v5 | **v6** | full-line `#` comments in `tags:` still supported |
| `docker/build-push-action` | v6 | **v7** | removed `DOCKER_BUILD_*` envs; neither appears here |
| `hashicorp/setup-terraform` | v3 | **v4** | |
| `azure/setup-helm` | v4 | **v5** | |
| `aws-actions/configure-aws-credentials` | v4 | **v6** | v5 changed invalid-boolean handling; we pass no booleans |
| `peter-evans/create-pull-request` | v7 | **v8** | |
| `stefanzweifel/git-auto-commit-action` | v5 | **v7** | v6 removed 3 inputs, v7 restored them — going to v7 skips the window |

Already node24 at their current pins, deliberately left alone: `amazon-ecr-login@v2`, `amazon-ecs-render-task-definition@v1`, `amazon-ecs-deploy-task-definition@v2`.

## The one residual blocker, resolved

`yanovation/delete-old-actions@v1` was the only action with **no node24 path**: the repo is archived and its own `action.yml` description reads `[DEPRECATED, use yanovian/delete-old-actions instead]`.

Rather than follow it to a 1-star fork of the same fragility, the two log-cleanup workflows now call a local reusable workflow, `_prune-workflow-runs.yaml`, that does the same work in four `gh api` calls — no third-party dependency at all. (A reusable workflow rather than a local composite action, because composite actions must be checked out first and neither caller otherwise needs the repo on disk.)

The rewrite also fixes several latent issues:
- drops `actions/checkout` from both jobs — neither ever read the repo
- **collects run ids before deleting.** Deleting mid-`--paginate` shifts the remaining runs backwards across page boundaries, silently skipping ~one run per page
- filters `status == completed` — an in-flight run can't be deleted anyway
- adds a real `dry-run` input so it can be exercised safely
- fixes `type: int`, which is not a valid `workflow_dispatch` input type

## Also in scope

- **`.github/dependabot.yml` (new)** — weekly grouped `github-actions` updates targeting `staging`. Its absence is precisely why 17 pins drifted 1–3 majors behind unnoticed.
- **trufflehog `@main` → `@v3.96.0`** — a moving branch ref in the *unconditional* deploy-path secret scan was the one place an upstream commit landed with no gate.
- **MegaLinter cupcake v8 → v9** — a Docker action, so never node-blocked; bundled as linter-toolchain hygiene. Well contained by the existing `DISABLE_ERRORS: true`, so its 68 bumped linters report but cannot fail CI. `LLM_ADVISOR_ENABLED: false` pins off v9's new outbound-LLM feature rather than leaving a network-calling default unmanaged.

## Test Results

- All 14 changed/added YAML files parse.
- **`actionlint` reports 0 findings** across every file touched or created here. The 22 remaining repo-wide findings are pre-existing SC2086/SC2129 nits in `deploy-staging.yaml` and `test-install.yaml`, untouched by this change.
- actionlint caught a **real bug** pre-commit: a literal `${{ }}` inside a shell comment would have been evaluated as a GitHub expression. Fixed.
- All 18 target action tags confirmed to resolve to real refs.
- Prune filter validated read-only against the live repo (1,249 runs): 60d → 0 eligible, 45d → 191, 30d → 522. Monotonic — and 0 at 60d is *correct*: the cron last ran 2026-07-11 and the oldest surviving run is 2026-06-12.

**Pass condition for this PR** — zero deprecation warnings:
```bash
gh run view <run-id> --log | grep -i "Node.js 20" || echo CLEAN
```

## Verification still to do after CI goes green

Three workflows don't fire on a PR to `staging` and need a dispatch:

1. **`build-images-cirrus-deploy.yaml`** — dispatch with `images: mysql`. That leaves `webapp_built == false`, so the `update-helm` job (which force-pushes `cirrus`) is skipped: the full docker + artifact chain gets smoke-tested with zero deploy side effects.
2. **`manually-clean-action-log.yaml`** — dispatch with `dry-run: true` first.
3. **`clean-ghcr.yaml`** — dispatch; checkout-only, low risk.

**Only observable after merge** (accepted residual risk): `deploy-staging.yaml` (`configure-aws-credentials@v6`, on push to `staging`) and `sync-staging-to-main.yaml` (`checkout@v7` + `git push --force`, on PR-close to `main`). The latter is the one to watch — it is the first real exercise of checkout v7 credential persistence driving an authenticated push.

**Not verifiable at all:** the `create-pull-request@v8` / `git-auto-commit-action@v7` steps in `mega-linter.yaml` are gated behind `has_updated_sources`, which `APPLY_FIXES: none` keeps permanently dormant. Those two bumps are hygiene only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)