### PR TITLE
Grant the nusd/csg bundles CREATE_ORG_METADATA so NUSD can search and create contracts

### DIFF
--- a/src/webapp/utils/rbac.py
+++ b/src/webapp/utils/rbac.py
@@ -179,14 +179,20 @@ GROUP_PERMISSIONS: Dict[str, Set[Permission]] = {
     # ---- Real POSIX group bundles (provisional) ----
 
     # nusd: read, edit,everything + write to projects, allocations
-    # and system status. Does NOT confer write on users/groups/facilities/
-    # org_metadata (those remain admin-only). May impersonate any user
-    # whose permission set is a subset of nusd's (the can_impersonate
-    # rule blocks escalation).
+    # and system status. Also creates org metadata — contracts and NSF
+    # programs on /admin/contracts, plus organizations, institutions,
+    # mnemonic codes and areas of interest — since the contract surface
+    # is gated on CREATE_ORG_METADATA and there is no contract-specific
+    # permission (see contracts_routes.py). Does NOT confer create on
+    # users/groups/facilities/resources, and no DELETE_* at all (a
+    # contract retires by editing its end_date, which EDIT_* covers).
+    # May impersonate any user whose permission set is a subset of
+    # nusd's (the can_impersonate rule blocks escalation).
     'nusd': ALL_VIEW | ALL_EDIT | {
         Permission.ACCESS_ADMIN_DASHBOARD,
         Permission.CREATE_PROJECTS,
         Permission.CREATE_ALLOCATIONS,
+        Permission.CREATE_ORG_METADATA,
         Permission.IMPERSONATE_USERS,
     },
 

--- a/tests/unit/test_rbac.py
+++ b/tests/unit/test_rbac.py
@@ -206,6 +206,34 @@ class TestPermissionEnumSurface:
 
 
 # ---------------------------------------------------------------------------
+# Org-metadata grants per bundle
+# ---------------------------------------------------------------------------
+
+class TestOrgMetadataGrants:
+    """The contract surface (/admin/contracts — award search, contract
+    create, NSF-program create) carries no permission of its own; it is
+    gated entirely on the ``*_ORG_METADATA`` family. These pin who may
+    create org metadata, so an ``ALL_*`` refactor can't silently revert
+    or over-grant it."""
+
+    def test_nusd_can_create_org_metadata(self):
+        assert Permission.CREATE_ORG_METADATA in GROUP_PERMISSIONS['nusd']
+
+    def test_csg_can_create_org_metadata(self):
+        # csg aliases the nusd bundle (same set object).
+        assert Permission.CREATE_ORG_METADATA in GROUP_PERMISSIONS['csg']
+
+    def test_nusd_cannot_delete_org_metadata(self):
+        # Delete stays admin-only: nusd retires a contract by editing its
+        # end_date, which EDIT_ORG_METADATA already allows.
+        assert Permission.DELETE_ORG_METADATA not in GROUP_PERMISSIONS['nusd']
+
+    def test_ssg_cannot_create_org_metadata(self):
+        # ssg is read-only apart from resources / system status.
+        assert Permission.CREATE_ORG_METADATA not in GROUP_PERMISSIONS['ssg']
+
+
+# ---------------------------------------------------------------------------
 # Template context processor — can_act_on_project closure
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Users in the `nusd` POSIX group could not see the **"Find Candidate Contracts"** card on the new `/admin/contracts` page, and could not create contracts at all.

The contracts surface carries **no permission of its own** — it is gated entirely on the `*_ORG_METADATA` family (see the note at `contracts_routes.py:705`). The `nusd` bundle picks up `VIEW_ORG_METADATA` and `EDIT_ORG_METADATA` via `ALL_VIEW`/`ALL_EDIT`, but `ALL_CREATE` is deliberately absent and only `CREATE_PROJECTS` / `CREATE_ALLOCATIONS` were added back — so `CREATE_ORG_METADATA` was missing.

That single gap explains the whole symptom set:

| Surface | Gate | NUSD before |
|---|---|---|
| `/admin/contracts` page | `require_permission_any_facility(ACCESS_ADMIN_DASHBOARD)` | ✅ reachable |
| "Search Existing Contracts" typeahead | `VIEW_ORG_METADATA` | ✅ works |
| Contract detail card, All Contracts table | `VIEW_ORG_METADATA` | ✅ works |
| **"Find Candidate Contracts" card** (`contracts.html:53`) | `has_permission(CREATE_ORG_METADATA)` | ❌ **hidden** |
| Award search / candidates / lookup routes | `require_permission(CREATE_ORG_METADATA)` | ❌ 403 |
| Create-contract form + POST, create-NSF-program POST | `require_permission(CREATE_ORG_METADATA)` | ❌ 403 |
| "Create Source" / "Create Contract" buttons | `has_permission(CREATE_ORG_METADATA)` | ❌ hidden |

## Changes

- **`src/webapp/utils/rbac.py`** — add `Permission.CREATE_ORG_METADATA` to the `nusd` bundle, and update the comment above it (which asserted the opposite). `csg` aliases the same set object and picks it up too, matching the existing `# csg - same as nusd` intent.
- **`tests/unit/test_rbac.py`** — `TestOrgMetadataGrants`, four plain assertions pinning the decision so a future `ALL_*` refactor can't silently revert or over-grant it.

No route, decorator or template changes — every contract route's gate was already the right one; only the bundle was wrong. No routes added/removed/renamed, so no route-map snapshot regen.

## Decisions

- **`DELETE_ORG_METADATA` is intentionally NOT granted.** Delete stays admin-only; a contract retires by editing its `end_date`, which `EDIT_ORG_METADATA` already covers.
- **Accepted side effect:** `CREATE_ORG_METADATA` is domain-wide, so nusd/csg also gain create on the other org-metadata surfaces — organizations, institutions, mnemonic codes, areas of interest (`orgs_routes.py:301,340,392`). They already held **edit** on all of those, so this closes an edit-without-create gap rather than opening a new domain.
- **No new `*_CONTRACTS` permission family.** It would mean re-gating ~13 routes and 6 template conditionals, and — because `_perms_with_action` keys off the enum value prefix — would auto-grant `VIEW_CONTRACTS` to the group bundles while *silently dropping* it for `sureshm`, whose facility-scoped tier enumerates grants explicitly. Net regression for no gain.
- `ssg` is untouched (read-only apart from resources / system status), as is `sureshm`'s `USER_FACILITY_PERMISSIONS` entry.

## Test Results

`TestOrgMetadataGrants` added: nusd and csg have `CREATE_ORG_METADATA`; nusd does not have `DELETE_ORG_METADATA`; ssg does not have `CREATE_ORG_METADATA`.

**The full pytest suite was not run** — the environment this was authored in has neither docker (for the `mysql-test` container) nor the project conda env. Verified instead by importing the bundle directly and asserting its contents, plus `py_compile` on both changed files:

- nusd/csg gain `CREATE_ORG_METADATA`; ssg does not
- nusd retains `VIEW_`/`EDIT_ORG_METADATA` and still has **zero** `DELETE_*`
- nusd still lacks `CREATE_USERS` / `CREATE_GROUPS` / `CREATE_FACILITIES` / `CREATE_RESOURCES`
- `EXPORT_DATA not in GROUP_PERMISSIONS['nusd']` still holds — the premise of the existing impersonation test at `test_rbac.py:183`
- the contract/award test modules reference no nusd/csg user, so no 403-expectation regressions there

CI runs the suite for real. Worth a manual smoke as an `nusd` user before promoting: the card should render, award search should return rows, "Create contract" should complete, and the table's delete action should stay hidden.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FQE7U7GyRahfXWuukBXs5n)_