### PR TITLE
Allocation-administrator tier: a *_CONTRACTS permission family, and NUSD off the resources layer

### DIFF
--- a/src/webapp/dashboards/admin/contracts_routes.py
+++ b/src/webapp/dashboards/admin/contracts_routes.py
@@ -114,7 +114,7 @@ def _search_contracts(q, active_only):
 
 register_typeahead(
     bp, rule='/htmx/search/contracts', endpoint='htmx_search_contracts',
-    permission=Permission.VIEW_ORG_METADATA, any_facility=True,
+    permission=Permission.VIEW_CONTRACTS, any_facility=True,
     search=_search_contracts,
     template='dashboards/admin/fragments/contract_search_results_htmx.html',
     ctx_key='contracts',
@@ -123,7 +123,7 @@ register_typeahead(
 
 register_typeahead(
     bp, rule='/htmx/search/nsf-programs', endpoint='htmx_search_nsf_programs',
-    permission=Permission.VIEW_ORG_METADATA,
+    permission=Permission.VIEW_CONTRACTS,
     search=_search_nsf_programs_fk,
     template='dashboards/admin/fragments/nsf_program_search_results_fk_htmx.html',
     ctx_key='nsf_programs',
@@ -142,7 +142,7 @@ register_typeahead(
 
 @bp.route('/contract/<int:contract_id>')
 @login_required
-@require_permission_any_facility(Permission.VIEW_ORG_METADATA)
+@require_permission_any_facility(Permission.VIEW_CONTRACTS)
 def contract_card(contract_id):
     """HTML fragment for a single contract's detail card.
 
@@ -178,7 +178,7 @@ def contract_card(contract_id):
 
 @bp.route('/nsf-program/<int:nsf_program_id>/contracts')
 @login_required
-@require_permission_any_facility(Permission.VIEW_ORG_METADATA)
+@require_permission_any_facility(Permission.VIEW_CONTRACTS)
 def nsf_program_contracts(nsf_program_id):
     """The contracts under one NSF program, for the drill-down modal.
 
@@ -264,7 +264,7 @@ def _contract_create_context(form=None, **extra):
 
 @bp.route('/htmx/contracts-table')
 @login_required
-@require_permission_any_facility(Permission.VIEW_ORG_METADATA)
+@require_permission_any_facility(Permission.VIEW_CONTRACTS)
 @cache.cached(make_cache_key=user_aware_cache_key)
 def htmx_contracts_table():
     """The All Contracts table on /admin/contracts, grouped by funding source.
@@ -304,7 +304,7 @@ def htmx_contracts_table():
 
 @bp.route('/htmx/contract-create-form')
 @login_required
-@require_permission(Permission.CREATE_ORG_METADATA)
+@require_permission(Permission.CREATE_CONTRACTS)
 def htmx_contract_create_form():
     """Render the Create Contract form, optionally seeded from an award.
 
@@ -397,7 +397,7 @@ def _award_search_context(query, source_id):
 
 @bp.route('/htmx/contract-award-search')
 @login_required
-@require_permission(Permission.CREATE_ORG_METADATA)
+@require_permission(Permission.CREATE_CONTRACTS)
 def htmx_contract_award_search():
     """Free-text search across the award providers, above the Fetch button.
 
@@ -428,12 +428,12 @@ def htmx_contract_award_search():
 
 @bp.route('/htmx/contract-award-candidates')
 @login_required
-@require_permission(Permission.CREATE_ORG_METADATA)
+@require_permission(Permission.CREATE_CONTRACTS)
 def htmx_contract_award_candidates():
     """"Find Candidate Contracts" on /admin/contracts — the same search, as cards.
 
     The page-level sibling of :func:`htmx_contract_award_search`. Gated on
-    ``CREATE_ORG_METADATA`` rather than the page's own ``VIEW_ORG_METADATA``
+    ``CREATE_CONTRACTS`` rather than the page's own ``VIEW_CONTRACTS``
     because every row here leads to creating a contract, and because it
     spends two public APIs' quota per press.
 
@@ -482,7 +482,7 @@ def _nsf_source_id():
 
 @bp.route('/htmx/contract-award-lookup')
 @login_required
-@require_permission(Permission.CREATE_ORG_METADATA)
+@require_permission(Permission.CREATE_CONTRACTS)
 def htmx_contract_award_lookup():
     """Prefill the contract field block from the funding source's API.
 
@@ -579,7 +579,7 @@ def htmx_contract_award_lookup():
 
 @bp.route('/htmx/contract-program-create', methods=['POST'])
 @login_required
-@require_permission(Permission.CREATE_ORG_METADATA)
+@require_permission(Permission.CREATE_CONTRACTS)
 def htmx_contract_program_create():
     """Create an NSF program from the create-contract form and select it.
 
@@ -669,7 +669,7 @@ class _ContractCreateHandler(HtmxFormHandler):
 
 @bp.route('/htmx/contract-create', methods=['POST'])
 @login_required
-@require_permission(Permission.CREATE_ORG_METADATA)
+@require_permission(Permission.CREATE_CONTRACTS)
 def htmx_contract_create():
     """Create a new contract."""
     return _ContractCreateHandler().handle()
@@ -680,7 +680,7 @@ def htmx_contract_create():
 
 @bp.route('/htmx/contract-delete/<int:contract_id>', methods=['DELETE'])
 @login_required
-@require_permission(Permission.DELETE_ORG_METADATA)
+@require_permission(Permission.DELETE_CONTRACTS)
 def htmx_contract_delete(contract_id):
     """Soft-delete (expire) a contract."""
     contract = db.session.get(Contract, contract_id)
@@ -700,17 +700,18 @@ def htmx_contract_delete(contract_id):
 
 # ── CRUD quintets — generated from specs ───────────────────────────────────
 #
-# Endpoints, URL rules, templates, permissions, and not-found messages are
-# unchanged by the split from orgs_routes (pinned by the route-map parity
-# snapshot). Contracts still carry the *ORG_METADATA permissions: they are
-# admin metadata, and no contract-specific permission exists.
+# Endpoints, URL rules, templates and not-found messages are unchanged by the
+# split from orgs_routes (pinned by the route-map parity snapshot). The
+# permissions are not: the whole contract surface moved off *ORG_METADATA onto
+# its own *CONTRACTS family, so contract administration can be granted
+# without conferring write on organizations, institutions and AOIs.
 
 _contract_spec = partial(
     CrudSpec,
     triggers=_CONTRACT_TRIGGERS,
-    edit_permission=Permission.EDIT_ORG_METADATA,
-    create_permission=Permission.CREATE_ORG_METADATA,
-    delete_permission=Permission.DELETE_ORG_METADATA,
+    edit_permission=Permission.EDIT_CONTRACTS,
+    create_permission=Permission.CREATE_CONTRACTS,
+    delete_permission=Permission.DELETE_CONTRACTS,
 )
 
 _CONTRACT_CRUD_SPECS = (

--- a/src/webapp/dashboards/admin/projects_routes.py
+++ b/src/webapp/dashboards/admin/projects_routes.py
@@ -2249,9 +2249,9 @@ def _linked_elements_context(project):
         disk_roots=_disk_roots_for_picker(),
         can_edit_governance=can_edit_project_governance(current_user, project),
         # Gated on the contract_card route's own permission so the link
-        # can never 403 for a project lead without org-metadata access.
+        # can never 403 for a project lead without contract access.
         can_view_contracts=has_permission_any_facility(
-            current_user, Permission.VIEW_ORG_METADATA),
+            current_user, Permission.VIEW_CONTRACTS),
         errors=[],
     )
 

--- a/src/webapp/templates/dashboards/admin/contracts.html
+++ b/src/webapp/templates/dashboards/admin/contracts.html
@@ -50,7 +50,7 @@
 </div>
 
 <!-- Find Candidate Contracts (external award providers) -->
-{% if has_permission(Permission.CREATE_ORG_METADATA) %}
+{% if has_permission(Permission.CREATE_CONTRACTS) %}
 <div class="row mt-3">
     <div class="col-12">
         <div class="card inner-card">

--- a/src/webapp/templates/dashboards/admin/fragments/contract_award_candidates_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/contract_award_candidates_htmx.html
@@ -99,7 +99,7 @@
                         hx-swap="innerHTML">
                     View contract
                 </button>
-                {% elif has_permission(Permission.CREATE_ORG_METADATA) %}
+                {% elif has_permission(Permission.CREATE_CONTRACTS) %}
                 <button type="button" class="btn btn-sm btn-primary"
                         data-bs-toggle="modal" data-bs-target="#createContractModal"
                         hx-get="{{ url_for('admin_dashboard.htmx_contract_create_form',

--- a/src/webapp/templates/dashboards/admin/fragments/contract_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/contract_card.html
@@ -175,6 +175,6 @@
             modal_id='editContractModal',
             target_id='editContractFormContainer',
             title='Edit contract',
-            permission=Permission.EDIT_ORG_METADATA) }}
+            permission=Permission.EDIT_CONTRACTS) }}
     </div>
 </div>

--- a/src/webapp/templates/dashboards/admin/fragments/contracts_table_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/contracts_table_htmx.html
@@ -91,13 +91,13 @@
                                 target_id='editContractSourceFormContainer',
                                 title='Edit source',
                                 stop_propagation=True,
-                                permission=Permission.EDIT_ORG_METADATA) }}
+                                permission=Permission.EDIT_CONTRACTS) }}
                             {{ delete_row_button(
                                 url_for('admin_dashboard.htmx_contract_source_delete', source_id=cs.contract_source_id),
                                 confirm="Deactivate source '" ~ cs.contract_source ~ "'?",
                                 title='Deactivate contract source',
                                 stop_propagation=True,
-                                permission=Permission.DELETE_ORG_METADATA) }}
+                                permission=Permission.DELETE_CONTRACTS) }}
                         </td>
                     </tr>
                 </tbody>
@@ -159,12 +159,12 @@
                                 modal_id='editContractModal',
                                 target_id='editContractFormContainer',
                                 title='Edit contract',
-                                permission=Permission.EDIT_ORG_METADATA) }}
+                                permission=Permission.EDIT_CONTRACTS) }}
                             {{ delete_row_button(
                                 url_for('admin_dashboard.htmx_contract_delete', contract_id=c.contract_id),
                                 confirm="Expire contract '" ~ c.contract_number ~ "'? This sets the end date to today.",
                                 title='Expire contract',
-                                permission=Permission.DELETE_ORG_METADATA) }}
+                                permission=Permission.DELETE_CONTRACTS) }}
                         </td>
                     </tr>
                     {% endfor %}
@@ -182,7 +182,7 @@
             <span class="text-muted small">
                 Showing {{ contracts|length }} contract{{ 's' if contracts|length != 1 else '' }}
             </span>
-            {% if has_permission(Permission.CREATE_ORG_METADATA) %}
+            {% if has_permission(Permission.CREATE_CONTRACTS) %}
             <div class="d-flex gap-2">
                 <button class="btn  btn-primary"
                         data-bs-toggle="modal"

--- a/src/webapp/templates/dashboards/admin/fragments/facility_modals.html
+++ b/src/webapp/templates/dashboards/admin/fragments/facility_modals.html
@@ -7,7 +7,11 @@
 
 {# ════════════════════════════════════════════════════════ CREATE MODALS #}
 
-{% if has_permission(Permission.CREATE_RESOURCES) %}
+{# Facility/Panel/AllocationType create routes gate on CREATE_FACILITIES
+   (facilities_routes.py CrudSpec), not CREATE_RESOURCES. No bundle holds
+   one without the other today, so this is latent rather than live — but
+   it is the same button/shell gate mismatch as organization_modals.html. #}
+{% if has_permission(Permission.CREATE_FACILITIES) %}
 {{ modal_scaffold('createFacilityModal', 'New Facility',
                   icon='plus', container_id='createFacilityFormContainer') }}
 

--- a/src/webapp/templates/dashboards/admin/fragments/organization_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/organization_card.html
@@ -267,12 +267,12 @@
                                     modal_id='editNsfProgramModal',
                                     target_id='editNsfProgramFormContainer',
                                     title='Edit NSF program',
-                                    permission=Permission.EDIT_ORG_METADATA) }}
+                                    permission=Permission.EDIT_CONTRACTS) }}
                                 {{ delete_row_button(
                                     url_for('admin_dashboard.htmx_nsf_program_delete', nsf_program_id=p.nsf_program_id),
                                     confirm="Deactivate NSF program '" ~ p.nsf_program_name ~ "'?",
                                     title='Deactivate NSF program',
-                                    permission=Permission.DELETE_ORG_METADATA) }}
+                                    permission=Permission.DELETE_CONTRACTS) }}
                             </td>
                         </tr>
                         {% else %}
@@ -285,7 +285,7 @@
                 <span class="text-muted small">
                     Showing {{ nsf_programs|length }} program{{ 's' if nsf_programs|length != 1 else '' }}
                 </span>
-                {% if has_permission(Permission.CREATE_ORG_METADATA) %}
+                {% if has_permission(Permission.CREATE_CONTRACTS) %}
                 <button class="btn  btn-primary"
                         data-bs-toggle="modal"
                         data-bs-target="#createNsfProgramModal"

--- a/src/webapp/templates/dashboards/admin/fragments/organization_modals.html
+++ b/src/webapp/templates/dashboards/admin/fragments/organization_modals.html
@@ -7,7 +7,13 @@
 
 {# ════════════════════════════════════════════════════════ CREATE MODALS #}
 
-{% if has_permission(Permission.CREATE_RESOURCES) %}
+{# Gate matches the buttons that open these shells and the routes behind
+   them — all org-metadata create surfaces are CREATE_ORG_METADATA
+   (orgs_routes.py, contracts_routes.py). Gating on CREATE_RESOURCES here
+   (a copy of resources_modals.html) left nusd/csg holding visible create
+   buttons whose modal + htmx target were absent from the DOM: the click
+   silently no-opped with an htmx:targetError. #}
+{% if has_permission(Permission.CREATE_ORG_METADATA) %}
 {{ modal_scaffold('createOrganizationModal', 'New Organization',
                   icon='plus', container_id='createOrganizationFormContainer') }}
 

--- a/src/webapp/templates/dashboards/admin/fragments/organization_modals.html
+++ b/src/webapp/templates/dashboards/admin/fragments/organization_modals.html
@@ -8,11 +8,11 @@
 {# ════════════════════════════════════════════════════════ CREATE MODALS #}
 
 {# Gate matches the buttons that open these shells and the routes behind
-   them — all org-metadata create surfaces are CREATE_ORG_METADATA
-   (orgs_routes.py, contracts_routes.py). Gating on CREATE_RESOURCES here
-   (a copy of resources_modals.html) left nusd/csg holding visible create
-   buttons whose modal + htmx target were absent from the DOM: the click
-   silently no-opped with an htmx:targetError. #}
+   them (orgs_routes.py). Gating on CREATE_RESOURCES here — a copy of
+   resources_modals.html — left nusd/csg holding visible create buttons
+   whose modal + htmx target were absent from the DOM: the click silently
+   no-opped with an htmx:targetError. test_modal_shell_contract.py now
+   pins opener and shell to the same permission. #}
 {% if has_permission(Permission.CREATE_ORG_METADATA) %}
 {{ modal_scaffold('createOrganizationModal', 'New Organization',
                   icon='plus', container_id='createOrganizationFormContainer') }}
@@ -32,6 +32,12 @@
 {{ modal_scaffold('createAoiModal', 'New Area of Interest',
                   icon='plus', container_id='createAoiFormContainer') }}
 
+{% endif %}
+
+{# The contract surface has its own permission family — contracts,
+   sources and NSF programs are all served from contracts_routes.py — so
+   these shells gate separately from the org-metadata ones above. #}
+{% if has_permission(Permission.CREATE_CONTRACTS) %}
 {{ modal_scaffold('createContractSourceModal', 'New Contract Source',
                   icon='plus', container_id='createContractSourceFormContainer') }}
 

--- a/src/webapp/templates/dashboards/shared/project_details_modal.html
+++ b/src/webapp/templates/dashboards/shared/project_details_modal.html
@@ -27,7 +27,7 @@
 {% include 'dashboards/user/fragments/allocation_modals.html' %}
 
 {# Same reasoning, one entity over: the modal body's project card lists the
-   project's contracts, and (for viewers with VIEW_ORG_METADATA) each one
+   project's contracts, and (for viewers with VIEW_CONTRACTS) each one
    opens #contractDetailsModal. Including it here means every page that can
    show a project card gets the contract shell too — rather than repeating
    the include across base_admin / base_user / base_allocations / base_status

--- a/src/webapp/templates/dashboards/user/partials/project_card.html
+++ b/src/webapp/templates/dashboards/user/partials/project_card.html
@@ -80,12 +80,12 @@
       </span>
       {# The contract number opens #contractDetailsModal, but only for viewers
          who can actually load that card — a normal user on their own
-         dashboard has no VIEW_ORG_METADATA and the click would 403, so they
+         dashboard has no VIEW_CONTRACTS and the click would 403, so they
          keep plain text. The opener is data-action rather than a Bootstrap
          toggle because this card is frequently rendered *inside*
          #projectDetailsModal, where a toggle would close its host instead of
          stacking on it. The shell rides along with project_details_modal.html. #}
-      {% set _can_view_contracts = has_permission_any_facility(Permission.VIEW_ORG_METADATA)
+      {% set _can_view_contracts = has_permission_any_facility(Permission.VIEW_CONTRACTS)
                                    if has_permission_any_facility is defined and Permission is defined
                                    else false %}
       <div class="stat-value text-dark text-detail">

--- a/src/webapp/utils/rbac.py
+++ b/src/webapp/utils/rbac.py
@@ -84,12 +84,26 @@ class Permission(Enum):
     CREATE_GROUPS = "create_groups"
     DELETE_GROUPS = "delete_groups"
 
-    # Organizational metadata: organizations, institutions, contracts,
-    # NSF programs, areas of interest. Slowly-changing reference data.
+    # Organizational metadata: organizations, institutions, mnemonic
+    # codes, areas of interest. Slowly-changing reference data.
     VIEW_ORG_METADATA = "view_org_metadata"
     EDIT_ORG_METADATA = "edit_org_metadata"
     CREATE_ORG_METADATA = "create_org_metadata"
     DELETE_ORG_METADATA = "delete_org_metadata"
+
+    # Contracts: the awards/grants funding projects, plus their sources
+    # and NSF programs — the whole /admin/contracts surface. Carved out
+    # of ORG_METADATA because contract administration tracks allocation
+    # administration (who funds this project, through when) rather than
+    # the slowly-changing directory reference data above.
+    #
+    # DELETE_CONTRACTS is a soft retire, not a row delete: the contract
+    # route stamps ``end_date`` (contracts_routes.py) and the generated
+    # source/program deletes set ``active=False``.
+    VIEW_CONTRACTS = "view_contracts"
+    EDIT_CONTRACTS = "edit_contracts"
+    CREATE_CONTRACTS = "create_contracts"
+    DELETE_CONTRACTS = "delete_contracts"
 
     # Reports and analytics
     VIEW_REPORTS = "view_reports"
@@ -175,38 +189,81 @@ ALL_DELETE = _perms_with_action('delete')
 # to that appear here.
 #
 # Groups that don't appear in this dict simply confer no permissions.
-GROUP_PERMISSIONS: Dict[str, Set[Permission]] = {
-    # ---- Real POSIX group bundles (provisional) ----
-
-    # nusd: read, edit,everything + write to projects, allocations
-    # and system status. Also creates org metadata — contracts and NSF
-    # programs on /admin/contracts, plus organizations, institutions,
-    # mnemonic codes and areas of interest — since the contract surface
-    # is gated on CREATE_ORG_METADATA and there is no contract-specific
-    # permission (see contracts_routes.py). Does NOT confer create on
-    # users/groups/facilities/resources, and no DELETE_* at all (a
-    # contract retires by editing its end_date, which EDIT_* covers).
-    # May impersonate any user whose permission set is a subset of
-    # nusd's (the can_impersonate rule blocks escalation).
-    'nusd': ALL_VIEW | ALL_EDIT | {
+# ---- The allocation-administrator tier ----
+#
+# Provisions and manages projects, allocations and contracts end to end.
+# The defining exclusion is the **definition layer**: an allocation
+# administrator has no authority over resources, machines, queues or
+# facilities — those describe the plant, not who may use it.
+#
+# Reads everything (ALL_VIEW), edits everything except that definition
+# layer, and creates the entities its job requires.
+#
+# Deletes are enumerated positively rather than as ``ALL_DELETE - {...}``.
+# Every delete granted here is a **soft** retire — the generated CRUD
+# deletes set ``active=False`` (crud.py → handle_htmx_soft_delete) and the
+# bespoke contract delete stamps ``end_date``. The withheld ones are where
+# delete means something harsher or machine-shaped:
+#
+#   DELETE_RESOURCES   hard-deletes disk-root rows and fair-share override
+#                      rows, and decommissions machines/queues
+#   DELETE_FACILITIES  facility definitions
+#   DELETE_USERS       hard row delete via the Flask-Admin layer
+#   DELETE_GROUPS      ditto
+#
+# Failing closed matters more than the ALL_* auto-pickup here: a future
+# ``delete_*`` domain must be added deliberately, not inherited.
+#
+# Known limitation (accepted): AllocationType and Panel are
+# allocation-shaped concepts that live under the *_FACILITIES family, so
+# default allocation amounts and fair-share percentages are NOT editable
+# at this tier — see facilities_routes.py.
+_ALLOCATION_ADMIN: Set[Permission] = (
+    ALL_VIEW
+    | (ALL_EDIT - {Permission.EDIT_RESOURCES, Permission.EDIT_FACILITIES})
+    | {
         Permission.ACCESS_ADMIN_DASHBOARD,
         Permission.CREATE_PROJECTS,
         Permission.CREATE_ALLOCATIONS,
         Permission.CREATE_ORG_METADATA,
+        Permission.CREATE_CONTRACTS,
+        # Soft retires only — see the note above.
+        Permission.DELETE_PROJECTS,
+        Permission.DELETE_ALLOCATIONS,
+        Permission.DELETE_ORG_METADATA,
+        Permission.DELETE_CONTRACTS,
         Permission.IMPERSONATE_USERS,
-    },
+    }
+)
 
-    # hsg: read-only across the board,
-    # resources permissions, and edit system status (for outages...)
+
+GROUP_PERMISSIONS: Dict[str, Set[Permission]] = {
+    # ---- Real POSIX group bundles (provisional) ----
+
+    # nusd: the allocation-administrator tier, unmodified. Deliberately
+    # holds nothing over the resource/facility definition layer — NUSD's
+    # job is allocations and contracts, and they should not have to think
+    # about machines or queues.
+    #
+    # May impersonate any user whose permission set is a subset of nusd's
+    # (the can_impersonate rule blocks escalation). Note nusd is now a
+    # strict subset of csg, so nusd cannot impersonate a csg user.
+    'nusd': _ALLOCATION_ADMIN,
+
+    # csg: the allocation-administrator tier PLUS edit on resources —
+    # CSG runs the plant, so machines, queues, disk roots and per-facility
+    # fair-share overrides stay editable. Create/delete of resources is
+    # still withheld (ssg holds CREATE_RESOURCES for that).
+    'csg': _ALLOCATION_ADMIN | {Permission.EDIT_RESOURCES},
+
+    # ssg: read-only across the board, plus resource create/edit and
+    # edit system status (for outages...)
     'ssg': ALL_VIEW | {
         Permission.ACCESS_ADMIN_DASHBOARD,
         Permission.EDIT_RESOURCES, Permission.CREATE_RESOURCES,
         Permission.EDIT_SYSTEM_STATUS
     },
 }
-
-# csg - same as nusd
-GROUP_PERMISSIONS['csg'] = GROUP_PERMISSIONS['nusd']
 
 # Per-user permission overrides
 #
@@ -276,6 +333,11 @@ USER_FACILITY_PERMISSIONS: Dict[str, Dict[str, Set[Permission]]] = {
             # confer.
             Permission.VIEW_RESOURCES,
             Permission.VIEW_ORG_METADATA,
+            # Enumerated tiers do NOT get the ALL_VIEW auto-pickup that
+            # group bundles do, so a new *_CONTRACTS family had to be
+            # added here by hand or this tier would silently lose the
+            # contracts card. Any future VIEW_* domain needs the same.
+            Permission.VIEW_CONTRACTS,
             Permission.VIEW_FACILITIES,
             Permission.VIEW_USERS,
             Permission.VIEW_GROUPS,

--- a/tests/unit/test_admin_contract_card.py
+++ b/tests/unit/test_admin_contract_card.py
@@ -261,13 +261,13 @@ class TestTableLinking:
         assert 'id="contractDetailsModal"' in body
         assert 'id="nsfProgramContractsModal"' in body
 
-    def test_project_card_link_needs_view_org_metadata(self, auth_client,
-                                                       session, monkeypatch):
+    def test_project_card_link_needs_view_contracts(self, auth_client,
+                                                    session, monkeypatch):
         """The project card renders on the user dashboard, where a normal
-        user has no VIEW_ORG_METADATA and contract_card would 403. With the
+        user has no VIEW_CONTRACTS and contract_card would 403. With the
         permission the number is a link; without it, plain text.
 
-        Every admin-ish Quick Login user happens to hold VIEW_ORG_METADATA,
+        Every admin-ish Quick Login user happens to hold VIEW_CONTRACTS,
         so the negative branch is only reachable by stubbing it.
         """
         from sam.projects.contracts import ProjectContract
@@ -286,7 +286,7 @@ class TestTableLinking:
         real = rbac.has_permission_any_facility
 
         def _deny(user, permission, *a, **kw):
-            if permission == rbac.Permission.VIEW_ORG_METADATA:
+            if permission == rbac.Permission.VIEW_CONTRACTS:
                 return False
             return real(user, permission, *a, **kw)
 

--- a/tests/unit/test_modal_shell_contract.py
+++ b/tests/unit/test_modal_shell_contract.py
@@ -403,6 +403,110 @@ def test_project_details_fragment_targets_resolve(auth_client, active_project):
 
 
 # ---------------------------------------------------------------------------
+# 4. Permission-gate parity: a visible opener must have a visible shell
+# ---------------------------------------------------------------------------
+#
+# Checks 1-3 resolve ids *textually* — they see the ``modal_scaffold(...)``
+# call and are satisfied, never evaluating the ``{% if has_permission(...) %}``
+# wrapped around it. So a shell can be gated on one permission while the button
+# opening it is gated on another, and the id resolves statically while the DOM
+# is empty at runtime for anyone holding only the opener's permission.
+#
+# That is not hypothetical: ``organization_modals.html`` gated every create
+# shell on CREATE_RESOURCES (copied from ``resources_modals.html``) while the
+# contract/org create buttons and their routes gate on CREATE_ORG_METADATA.
+# When PR #410 granted nusd/csg CREATE_ORG_METADATA, those groups got visible
+# "Create contract" / "Create Source" / "New Organization" buttons whose modal
+# and htmx target were both absent — the click no-opped with an
+# htmx:targetError and no request at all.
+#
+# Only one direction is dangerous: an opener visible to someone the shell is
+# hidden from. A shell that is *ungated* can never go missing, so those pairs
+# are skipped rather than pinned.
+
+_IF_TAG = re.compile(r'{%-?\s*(if|elif|else|endif)\b([^%]*)%}')
+_HAS_PERM = re.compile(r'has_permission(?:_any_facility)?\(\s*Permission\.([A-Z_]+)\s*\)')
+
+# Fragments that are themselves served only behind the shell's own permission,
+# so an ungated opener inside them is unreachable without it. Value is the
+# permission the serving route requires.
+GATE_PARITY_ROUTE_GATED = {
+    'dashboards/admin/fragments/bulk_deactivate_project_directories_form_htmx.html': 'DELETE_PROJECTS',
+    'dashboards/admin/fragments/bulk_deactivate_project_directories_preview_htmx.html': 'DELETE_PROJECTS',
+    'dashboards/admin/fragments/queue_cleanup_preview_htmx.html': 'DELETE_RESOURCES',
+}
+
+
+def _guard_at(src, pos):
+    """Permission guarding offset `pos`, tracking ``{% if %}`` nesting.
+
+    Returns the innermost ``has_permission(Permission.X)`` in force, or None
+    when nothing at that point is permission-gated.
+    """
+    stack = []
+    for m in _IF_TAG.finditer(src):
+        if m.start() >= pos:
+            break
+        kind, cond = m.group(1), m.group(2)
+        if kind == 'if':
+            found = _HAS_PERM.search(cond)
+            stack.append(found.group(1) if found else None)
+        elif kind == 'elif' and stack:
+            found = _HAS_PERM.search(cond)
+            stack[-1] = found.group(1) if found else None
+        elif kind == 'else' and stack:
+            stack[-1] = None
+        elif kind == 'endif' and stack:
+            stack.pop()
+    live = [s for s in stack if s]
+    return live[-1] if live else None
+
+
+def _shell_guards():
+    """{shell id: (defining template, guarding permission or None)}."""
+    guards = {}
+    for template, src in TEMPLATES.items():
+        for m in _SCAFFOLD.finditer(src):
+            guard = _guard_at(src, m.start())
+            for shell_id in [m.group(1)] + _CONTAINER_KWARG.findall(m.group(2)):
+                guards[shell_id] = (template, guard)
+    return guards
+
+
+def test_modal_openers_are_gated_like_their_shells():
+    """A button's permission gate must match the gate on the shell it opens."""
+    shell_guards = _shell_guards()
+    mismatches = []
+    for template, src in TEMPLATES.items():
+        for m in _TARGET.finditer(src):
+            ref = m.group(1)
+            if ref not in shell_guards:
+                continue
+            shell_template, shell_guard = shell_guards[ref]
+            if shell_guard is None:
+                continue          # always in the DOM — cannot go missing
+            opener_guard = _guard_at(src, m.start())
+            if opener_guard == shell_guard:
+                continue
+            if GATE_PARITY_ROUTE_GATED.get(template) == shell_guard:
+                continue          # route already enforces the same permission
+            mismatches.append(
+                f'  #{ref}\n'
+                f'      shell  gated on {shell_guard}  ({shell_template})\n'
+                f'      opener gated on {opener_guard or "nothing"}  ({template})'
+            )
+
+    assert not mismatches, (
+        'Modal openers are visible to users the shell is hidden from — the '
+        'click will silently no-op with an htmx:targetError:\n\n'
+        + '\n'.join(sorted(mismatches))
+        + '\n\nGate the shell on the same permission its openers (and the '
+          'routes behind them) use. If the opener fragment is only ever served '
+          'behind that permission, add it to GATE_PARITY_ROUTE_GATED instead.'
+    )
+
+
+# ---------------------------------------------------------------------------
 # Script order in dashboards/base.html
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_rbac.py
+++ b/tests/unit/test_rbac.py
@@ -210,27 +210,132 @@ class TestPermissionEnumSurface:
 # ---------------------------------------------------------------------------
 
 class TestOrgMetadataGrants:
-    """The contract surface (/admin/contracts — award search, contract
-    create, NSF-program create) carries no permission of its own; it is
-    gated entirely on the ``*_ORG_METADATA`` family. These pin who may
-    create org metadata, so an ``ALL_*`` refactor can't silently revert
-    or over-grant it."""
+    """Who may create and retire org metadata (organizations, institutions,
+    mnemonic codes, AOIs). Pinned so an ``ALL_*`` refactor can't silently
+    revert or over-grant it. Contracts are a separate family — see
+    :class:`TestContractGrants`."""
 
     def test_nusd_can_create_org_metadata(self):
         assert Permission.CREATE_ORG_METADATA in GROUP_PERMISSIONS['nusd']
 
     def test_csg_can_create_org_metadata(self):
-        # csg aliases the nusd bundle (same set object).
         assert Permission.CREATE_ORG_METADATA in GROUP_PERMISSIONS['csg']
 
-    def test_nusd_cannot_delete_org_metadata(self):
-        # Delete stays admin-only: nusd retires a contract by editing its
-        # end_date, which EDIT_ORG_METADATA already allows.
-        assert Permission.DELETE_ORG_METADATA not in GROUP_PERMISSIONS['nusd']
+    def test_nusd_can_delete_org_metadata(self):
+        # The generated org-metadata deletes are soft (active=False, via
+        # handle_htmx_soft_delete), so the allocation-admin tier holds them.
+        assert Permission.DELETE_ORG_METADATA in GROUP_PERMISSIONS['nusd']
 
     def test_ssg_cannot_create_org_metadata(self):
         # ssg is read-only apart from resources / system status.
         assert Permission.CREATE_ORG_METADATA not in GROUP_PERMISSIONS['ssg']
+
+
+# ---------------------------------------------------------------------------
+# Contracts: a permission family of its own
+# ---------------------------------------------------------------------------
+
+class TestContractGrants:
+    """The /admin/contracts surface (award search, contract create, sources,
+    NSF programs) carries its own ``*_CONTRACTS`` family, carved out of
+    ``*_ORG_METADATA`` so contract administration can be granted without
+    conferring write on organizations, institutions and AOIs."""
+
+    @pytest.mark.parametrize('action', ['VIEW', 'EDIT', 'CREATE', 'DELETE'])
+    def test_family_is_complete(self, action):
+        assert hasattr(Permission, f'{action}_CONTRACTS')
+
+    @pytest.mark.parametrize('bundle', ['nusd', 'csg'])
+    @pytest.mark.parametrize('perm', [
+        Permission.VIEW_CONTRACTS, Permission.EDIT_CONTRACTS,
+        Permission.CREATE_CONTRACTS, Permission.DELETE_CONTRACTS,
+    ])
+    def test_allocation_admin_bundles_hold_full_contract_crud(self, bundle, perm):
+        assert perm in GROUP_PERMISSIONS[bundle]
+
+    def test_ssg_is_read_only_on_contracts(self):
+        assert Permission.VIEW_CONTRACTS in GROUP_PERMISSIONS['ssg']
+        for perm in (Permission.EDIT_CONTRACTS, Permission.CREATE_CONTRACTS,
+                     Permission.DELETE_CONTRACTS):
+            assert perm not in GROUP_PERMISSIONS['ssg']
+
+    def test_facility_scoped_tier_keeps_contract_read(self):
+        """The regression this family's introduction could have caused.
+
+        ``_perms_with_action`` is lexical, so group bundles built from
+        ``ALL_VIEW`` picked up ``VIEW_CONTRACTS`` for free — but
+        ``USER_FACILITY_PERMISSIONS`` enumerates its grants explicitly and
+        would have silently lost the contracts card. It has to be listed
+        by hand, and any future VIEW_* domain does too.
+        """
+        assert Permission.VIEW_CONTRACTS in rbac.USER_FACILITY_PERMISSIONS['sureshm']['WNA']
+
+    def test_facility_scoped_tier_gets_no_contract_write(self):
+        granted = rbac.USER_FACILITY_PERMISSIONS['sureshm']['WNA']
+        for perm in (Permission.EDIT_CONTRACTS, Permission.CREATE_CONTRACTS,
+                     Permission.DELETE_CONTRACTS):
+            assert perm not in granted
+
+
+# ---------------------------------------------------------------------------
+# The allocation-administrator tier
+# ---------------------------------------------------------------------------
+
+class TestAllocationAdminTier:
+    """nusd and csg are the allocation-administrator tier: full authority
+    over projects, allocations and contracts, none over the resource /
+    facility *definition* layer. csg additionally keeps EDIT_RESOURCES."""
+
+    @pytest.mark.parametrize('bundle', ['nusd', 'csg'])
+    @pytest.mark.parametrize('perm', [
+        Permission.EDIT_FACILITIES, Permission.CREATE_FACILITIES,
+        Permission.DELETE_FACILITIES, Permission.CREATE_RESOURCES,
+        Permission.DELETE_RESOURCES,
+    ])
+    def test_definition_layer_is_withheld(self, bundle, perm):
+        assert perm not in GROUP_PERMISSIONS[bundle]
+
+    def test_nusd_cannot_edit_resources(self):
+        # The change of direction: ALL_EDIT is lexical over 'edit_', so nusd
+        # previously held EDIT_RESOURCES implicitly and could edit machines,
+        # queues and fair-share overrides.
+        assert Permission.EDIT_RESOURCES not in GROUP_PERMISSIONS['nusd']
+
+    def test_csg_keeps_edit_resources(self):
+        # CSG runs the plant; NUSD does not.
+        assert Permission.EDIT_RESOURCES in GROUP_PERMISSIONS['csg']
+
+    def test_csg_and_nusd_are_no_longer_the_same_object(self):
+        # They aliased the same set until csg diverged on EDIT_RESOURCES;
+        # mutating one would otherwise mutate the other.
+        assert GROUP_PERMISSIONS['csg'] is not GROUP_PERMISSIONS['nusd']
+        assert GROUP_PERMISSIONS['nusd'] < GROUP_PERMISSIONS['csg']
+
+    @pytest.mark.parametrize('bundle', ['nusd', 'csg'])
+    @pytest.mark.parametrize('perm', [
+        Permission.DELETE_PROJECTS, Permission.DELETE_ALLOCATIONS,
+        Permission.DELETE_ORG_METADATA, Permission.DELETE_CONTRACTS,
+    ])
+    def test_soft_deletes_are_granted(self, bundle, perm):
+        """Every delete granted here retires a row (active=False or an
+        end_date stamp) rather than removing it."""
+        assert perm in GROUP_PERMISSIONS[bundle]
+
+    @pytest.mark.parametrize('bundle', ['nusd', 'csg'])
+    @pytest.mark.parametrize('perm', [
+        Permission.DELETE_RESOURCES,   # hard-deletes disk roots + overrides
+        Permission.DELETE_FACILITIES,
+        Permission.DELETE_USERS,       # hard row delete via Flask-Admin
+        Permission.DELETE_GROUPS,
+    ])
+    def test_hard_and_machine_deletes_are_withheld(self, bundle, perm):
+        assert perm not in GROUP_PERMISSIONS[bundle]
+
+    def test_no_bundle_gets_system_admin(self):
+        for name, granted in GROUP_PERMISSIONS.items():
+            if name == 'admin-testing-only':   # synthetic test fixture
+                continue
+            assert Permission.SYSTEM_ADMIN not in granted, name
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #410, in two commits: a narrow bug fix, then the RBAC change it exposed.

## 1. The dead create button (`84b35c0`)

#410 granted nusd/csg `CREATE_ORG_METADATA` so the **Find Candidate Contracts** card would render. It did — but clicking **+ Create contract** did nothing.

Not an RBAC gap. The buttons and all 13 contract routes gate on `CREATE_ORG_METADATA`, while the modal shells in `organization_modals.html` were gated on `CREATE_RESOURCES` — a copy of `resources_modals.html`. For a group holding the former and not the latter, `#createContractModal` and `#createContractFormContainer` were both absent from the DOM: Bootstrap failed silently, htmx raised `htmx:targetError`, and **no request was ever issued**. Same break hit Create Source, New NSF Program, New Organization, New Institution, New Mnemonic Code and the AOI create buttons.

`facility_modals.html` carries the identical mismatch (should be `CREATE_FACILITIES`). Latent today — no bundle holds one without the other — fixed for consistency.

**Why CI missed it.** The three existing checks in `test_modal_shell_contract.py` resolve ids *textually*: they see the `modal_scaffold(...)` call and are satisfied, never evaluating the `{% if has_permission(...) %}` wrapped around it. New check #4 walks Jinja if/elif/else nesting and compares the permission guarding each shell against the one guarding every button that targets it. Only the dangerous direction is flagged — an opener visible to someone the shell is hidden from. Ungated shells can never go missing, so those pairs are skipped; two fragments served only behind the shell's own permission are allowlisted.

## 2. The allocation-administrator tier (`51638b7`)

Investigating the above surfaced a larger problem. `nusd` is `ALL_VIEW | ALL_EDIT | {...}`, and `_perms_with_action` matches lexically on the enum value prefix `edit_` — so `ALL_EDIT` silently includes `EDIT_RESOURCES` and `EDIT_FACILITIES`. **NUSD could edit machines, queues, disk roots and per-facility fair-share overrides**, confirmed in-browser at 243 edit affordances on `/admin/resources`.

So this is a privilege *reduction*, not an addition.

### A contracts permission family

`VIEW_/EDIT_/CREATE_/DELETE_CONTRACTS`, carved out of `*_ORG_METADATA`, so contract administration can be granted without conferring write on organizations, institutions, mnemonic codes and AOIs. Re-gates 15 sites in `contracts_routes.py`, 8 templates, and the `can_view_contracts` mirror in `projects_routes.py`. NSF programs and contract sources move with contracts (they are served from `contracts_routes.py`); organizations/institutions/AOIs keep `*_ORG_METADATA`.

#410 rejected this family for a specific reason: `_perms_with_action` would auto-grant it to group bundles via `ALL_VIEW`/`ALL_EDIT` while **silently dropping it** for `sureshm`, whose facility-scoped tier enumerates grants explicitly. That is handled head-on — `VIEW_CONTRACTS` is added to that tier by hand, with a comment and a regression test naming the trap for the next `VIEW_*` domain.

### The tier

| Bundle | Shape |
|---|---|
| `nusd` | The tier unmodified. Loses `EDIT_RESOURCES` / `EDIT_FACILITIES`. |
| `csg` | The tier **plus `EDIT_RESOURCES`** — CSG runs the plant. |
| `ssg` | Untouched. |

The two bundles previously aliased one set object and now diverge, so `nusd` is a strict subset of `csg` — meaning **nusd can no longer impersonate a csg user**. Correct under the no-escalation rule, but a behavior change worth noting.

Both gain soft deletes: `DELETE_PROJECTS`, `DELETE_ALLOCATIONS`, `DELETE_ORG_METADATA`, `DELETE_CONTRACTS`. Every one retires a row rather than removing it — `active=False` via `handle_htmx_soft_delete`, or an `end_date` stamp. Withheld: `DELETE_RESOURCES` (hard-deletes disk-root and fair-share override rows, decommissions machines/queues), `DELETE_FACILITIES`, `DELETE_USERS` and `DELETE_GROUPS` (hard row deletes via the Flask-Admin layer).

Deletes are enumerated positively rather than as `ALL_DELETE - {...}`: failing closed matters more than the `ALL_*` auto-pickup, so a future `delete_*` domain has to be granted deliberately.

## Decisions

- **Accepted limitation.** `AllocationType` and `Panel` are allocation-shaped concepts that live under the `*_FACILITIES` family, so default allocation amounts and fair-share percentages are **not** editable at this tier. Recorded in the bundle comment.
- **`CREATE_ALLOCATIONS` / `DELETE_ALLOCATIONS` are dead permissions** — no webapp route reads either; allocation add/renew/extend all gate on `EDIT_ALLOCATIONS`. Granted here for semantic correctness, but they enforce nothing today. Making the allocation tier meaningful would mean re-gating those routes — deliberately out of scope.
- **No route added, removed or renamed** — decorator arguments only — so the route-map parity snapshot is unchanged.

## Test Results

Full suite: **4005 passed, 32 skipped, 1 xfailed** in 83s.

New `TestContractGrants` and `TestAllocationAdminTier` pin the family, the tier's exclusions, the soft/hard delete split, the csg/nusd divergence, and the facility-scoped `VIEW_CONTRACTS` add. Updated `TestOrgMetadataGrants` (nusd now holds `DELETE_ORG_METADATA`) and the `contract_card` permission stub. The new modal-gate check was verified to fail against the pre-fix template and pass after.

Browser smoke on the dev server, both tiers:

- **tfair (nusd)** — `/admin/resources` edit affordances **243 → 10**, and the survivors are wallclock exemptions (`EDIT_USERS`), not the definition layer; the page still loads read-only. On `/admin/contracts` the create modal opens and loads its form prefilled from the NSF Awards API, `POST /admin/htmx/contract-create` returns 200 with inline field errors (previously the click issued no request at all), and the expire soft-retire affordance now appears. Zero console errors.
- **sureshm (WNA facility-scoped)** — still sees all 393 contracts with zero create/edit/expire affordances: the enumerated-tier trap avoided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
