### PR TITLE
Tablet chart layout: a third profile between mobile and desktop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -579,23 +579,34 @@ bespoke).
 `apply_tick_fontsize()` → `draw()` → `decorate()` → `add_legend()` →
 `finish()` → SVG.
 
-### The `layout` axis (desktop / mobile)
+### The `layout` axis (mobile / tablet / desktop)
 
-Every chart renders at two figure sizes. Desktop is the identity — it
-reproduces pre-axis output byte for byte. Mobile exists because an 18in figure
-scaled into a phone card puts 9-11pt labels on screen at ~2px, which no CSS
-can fix.
+Every chart renders at three figure sizes, banded on Bootstrap breakpoints:
+**mobile ≤767.98px · tablet 768–1199.98px · desktop ≥1200px**. Desktop is the
+identity — it reproduces pre-axis output byte for byte. The other two exist
+because an 18in figure scaled into a small card puts 9-11pt labels on screen
+at ~2px (phone) or ~6px (iPad portrait), which no CSS can fix.
+
+Mobile is a redesign — legend below, one 9pt size for every text role, capped
+entries. **Tablet is desktop with a smaller figure**: `TABLET_DEFAULTS` names
+only `max_legend_entries` and `max_ticks`, so placement, rotation and all four
+font sizes inherit desktop's per-family values.
 
 | | |
 |---|---|
-| **Declare** | `LAYOUTS = profile(desktop_figsize, mobile_figsize, **desktop_kwargs, mobile={...})`. Keyword args configure **desktop**; mobile overrides go in the `mobile` dict — a bare keyword that collides with a desktop parameter silently configures desktop. |
-| **Consume** | `layout.figsize` / `base_fontsize` / `legend_placement` / `max_legend_entries` / `max_ticks` / `label_rotation` / `legend_fontsize`. Helpers on `BaseChart`: `legend_kwargs()`, `legend_entry_cap()`, `label_kw()`. |
-| **Transport** | `static/js/layout-axis.js` sets a `sam_layout` cookie **and** injects `?layout=` into every htmx request; routes read `webapp.utils.htmx.read_layout()`. Both are needed — 9 of 18 call sites render in a full-page GET that htmx never touches. |
+| **Declare** | `LAYOUTS = profile(desktop_figsize, mobile_figsize, tablet_figsize, **desktop_kwargs, mobile={...}, tablet={...})`. Keyword args configure **desktop**; overrides go in the `mobile`/`tablet` dicts — a bare keyword that collides with a desktop parameter silently configures desktop. |
+| **Consume** | `layout.figsize` / `base_fontsize` / `legend_placement` / `max_legend_entries` / `max_ticks` / `label_rotation`, plus `legend_fontsize` / `axis_label_fontsize` / `tick_fontsize`, each `int | None` where **None means defer to the chart's own attribute**. Helpers on `BaseChart`: `legend_kwargs()`, `legend_entry_cap()`, `label_kw()`. |
+| **Transport** | `static/js/layout-axis.js` sets a `sam_layout` cookie **and** injects `?layout=` into every htmx request; routes read `webapp.utils.htmx.read_layout()`. Both are needed — 9 of 18 call sites render in a full-page GET that htmx never touches. Two media queries, **narrowest asked first**. |
 | **Cache** | `chart_view` composes `layout` into the chart key; `user_aware_cache_key` composes it into cached *HTML*. Forget the latter and a cached page serves one layout to everyone. |
 
 `render()` sets `self.layout` before `prepare()`, so data-shaping hooks can
 consult it — pies cap **slices** on mobile rather than legend rows, because an
 unlabelled wedge is also an unlabelled drill target.
+
+Sizing rule: aim the tight-bbox intrinsic width at the **narrowest card the
+family actually renders into** (viewport − 144px on the status pages, − 82px
+on the jobs cards), and measure it — the bbox is a function of the legend
+contents, so it cannot be derived from figsize.
 
 ### Date axes
 
@@ -609,17 +620,19 @@ A **categorical** axis of pre-formatted period strings (the jobs timeline
 plots band indices) calls `fmt.compact_date_labels()` on the labels instead —
 same vocabulary, and unparsable grains come back unchanged.
 
-Design + measurements: `docs/plans/MOBILE_CHARTS.md`.
+Design + measurements: `docs/plans/MOBILE_CHARTS.md`,
+`docs/plans/TABLET_CHARTS.md`.
 
 ### Adding a chart
 
 1. Subclass the closest family; set `cache_name`, `cache_maxsize`,
-   `empty_message`, `LAYOUTS = profile((w, h), (mobile_w, mobile_h))`.
+   `empty_message`, `LAYOUTS = profile((w, h), (mobile_w, mobile_h),
+   (tablet_w, tablet_h))`.
 2. `cache_key` is a **staticmethod over the raw constructor arguments** — a
    cache hit must never construct the chart or run `prepare()`.
 3. Bind with `chart_view(...)` in `__init__.py`, add to `__all__`.
 4. Add a case to `tests/unit/chart_samples.py` (a gate requires one). It is
-   fingerprinted at **both** layouts automatically.
+   fingerprinted at **every** layout automatically.
 5. Pass `layout=read_layout()` at the call site. Fragments registered through
    `utils/fragments.py` get it for free.
 
@@ -653,8 +666,12 @@ a row drill — row drills resolve within the clicked chart's pane.
    `jobs_metrics.py` — enforced by `test_chart_module_boundaries.py`.
 ❌ **DON'T** reorder the `chart_view` calls: that order is the admin Caching
    card's row order, and cache names are Redis key prefixes.
-❌ **DON'T** put a mobile override in `profile()`'s bare keywords — those are
-   desktop. Use `mobile={...}`, which validates against `Layout`'s fields.
+❌ **DON'T** put a mobile or tablet override in `profile()`'s bare keywords —
+   those are desktop. Use `mobile={...}` / `tablet={...}`, which validate
+   against `Layout`'s fields.
+❌ **DON'T** accept a `layout` argument in a fragment renderer and then call a
+   delegate without it — the fragment still renders, at desktop, forever.
+   `test_renderers_forward_the_layout_they_are_given` is the gate.
 ❌ **DON'T** cap a legend without passing `ordered=True` to `link_legend` — it
    zips bands against patches by position, and a capped legend is no longer
    `reversed(bands)`. The fingerprint proves href *strings*, not the artists
@@ -669,7 +686,8 @@ a row drill — row drills resolve within the clicked chart's pane.
    entries serve old-code SVGs for up to 600 s.
 
 Design + rationale: `docs/plans/CHART_ARCHITECTURE.md` (the hierarchy),
-`docs/plans/MOBILE_CHARTS.md` (the layout axis).
+`docs/plans/MOBILE_CHARTS.md` + `docs/plans/TABLET_CHARTS.md` (the layout
+axis).
 
 ---
 

--- a/docs/plans/CHART_ARCHITECTURE.md
+++ b/docs/plans/CHART_ARCHITECTURE.md
@@ -359,6 +359,13 @@ instance method, so a cache hit never constructs the chart or runs `prepare()`.
 
 ### 4. Two render axes: `layout` and `theme`
 
+> **As shipped:** `layout` has three values, not two — `mobile` (PR 2,
+> `MOBILE_CHARTS.md`) and `tablet` (`TABLET_CHARTS.md`) beside `desktop`. The
+> `Layout` sketch below also gained `legend_fontsize`, `axis_label_fontsize`
+> and `tick_fontsize`, each `int | None` where None means "defer to the
+> chart's own attribute" — that is what lets one desktop profile reproduce
+> four per-family legend sizes byte for byte. Everything else here holds.
+
 Both are orthogonal, both default to today's behaviour, both must enter the cache
 key. `layout` and `theme` are unclaimed names — `variant` already means "the
 per-metric cached rendering" in existing prose, and `preset` belongs to the

--- a/docs/plans/DARK_MODE.md
+++ b/docs/plans/DARK_MODE.md
@@ -1,0 +1,609 @@
+# Application-wide dark mode
+
+**Status: PROPOSED (2026-08-01), verified against source 2026-08-01.**
+This is **PR 3** of the four-PR roadmap declared in
+`docs/plans/CHART_ARCHITECTURE.md` § *Roadmap*, which deferred it to "a
+separate planning session". This is that session. No code has been written.
+
+| # | PR | Depends on | State |
+|---|---|---|---|
+| 1 | Chart architecture refactor | — | branch `chart-architecture-refactor` |
+| 2 | Mobile-friendly charts | 1 | not started |
+| **3** | **App-wide dark mode** ← *this document* | — (parallel to 2) | this plan |
+| 4 | Dark-mode charts | 1 **and** 3 | not started |
+
+All line references are against the working tree at 2026-08-01 and were
+re-verified while writing; where this document contradicts a count in
+`CHART_ARCHITECTURE.md`, the correction and its reason are recorded in
+Appendix C.
+
+---
+
+## Summary
+
+Three findings set the architecture, and two of them are constraints the app
+already imposes on itself:
+
+1. **The CSP is nonce-free by design** (`webapp/utils/csp.py`, `script-src
+   'self'`, no `'unsafe-inline'`, enforced by `test_template_csp_lint.py`
+   whose debt ratchet is at `{}`). The industry-standard dark-mode bootstrap
+   — an inline `<script>` in `<head>` that reads `localStorage` and sets the
+   theme attribute before first paint — **is not available to us** as
+   written. (A *hash*-blessed inline script would technically be; see
+   § *Is the nonce-free CSP a problem?* for why that is a real option we
+   still don't want.)
+2. **Charts are server-rendered SVG, cached in Redis.** The colours are baked
+   into the bytes. The server must therefore know the theme at render time;
+   no client-side-only mechanism can theme them.
+
+Both constraints point at the same answer, which is why this is a cheap
+feature rather than an awkward one: **a cookie, read server-side, rendered
+into `<html data-bs-theme="…">`.** One mechanism satisfies both, and it is
+FOUC-free *by construction* rather than by racing the paint.
+
+3. **Bootstrap 5.3.3 is already vendored with a complete, unused
+   `[data-bs-theme=dark]` block** — 15 selectors covering body, borders,
+   links, forms, navbar, dropdowns, accordions, tables and code. Most of SAM's
+   chrome is Bootstrap components driven by `--bs-*` variables, so a large
+   fraction of the app flips for free the moment the attribute is set.
+
+The corrected inventory (§ *What actually has to change*) is materially
+smaller than `CHART_ARCHITECTURE.md` estimated: **≈15 CSS declarations and
+≈130 template class attributes**, not "83 hardcoded-white sites" plus an
+unknown. The single largest utility-class usage in the app — `text-muted`,
+624 occurrences — is **already theme-correct** in Bootstrap 5.3.3 and needs
+no change at all.
+
+The one piece of genuine refactoring this needs, and the thing worth doing
+even if dark mode were cancelled, is § *The token layer*: SAM's design tokens
+are named by **value** (`--text-dark`, `--bg-light`) rather than by **role**.
+A token literally named `--text-dark` whose dark-mode value must be near-white
+is not survivable. That rename is cheap — 28 `var()` callsites, all in CSS,
+**zero in templates** — and it is the foundation everything else sits on.
+
+---
+
+## What PR 1 already bought
+
+The chart refactor is not merely "unblocking" this work; it pre-solved the two
+things that would otherwise be discovered late and expensively.
+
+**The chrome/data colour split.** `charts/theme.py` establishes that the
+`UNITY_*` palettes encode *data* (a wedge, a band) and are theme-invariant,
+while everything a `Theme` carries is *chrome* (text, spines, grid, edges,
+blend target). That distinction is exactly the one the CSS layer needs and
+does not currently make, and § *The token layer* below adopts the same split:
+tier-1 primitives are the brand constants, tier-2 semantic tokens are chrome.
+
+**The cache-aliasing trap, closed structurally.** `charts/base.py:chart_view`
+composes `layout` and `theme` into the cache key in one place, with a docstring
+explaining that both `caching/chart.py` and `redis_chart.py` default to a key
+function that *ignores every argument except the first positional one* — so a
+`theme=` kwarg would have been silently dropped and the first-rendered theme's
+SVG served to every user, globally, across pods. PR 4 inherits a correct key
+without doing anything. **This plan must not undo that**, and § *Caching*
+extends the same reasoning to the five fully-rendered-HTML cache entries.
+
+`Theme.DARK` already exists with starting values. It is explicitly *not*
+shippable — Appendix B of the chart plan records the two decisions a mechanical
+swap cannot make, and both are still open. They are restated in § *Design
+decisions* below because they belong to PR 4, not here.
+
+---
+
+## The theme carrier
+
+### Decision: a cookie, rendered server-side
+
+```
+Cookie:  sam_theme = "light" | "dark"
+         SameSite=Lax; Max-Age=31536000; Path=/; Secure (prod)
+         NOT HttpOnly — the toggle sets it from JS
+```
+
+- No PII, no session coupling, no server state. Safe to send on every request.
+- Read in a `before_request`/context processor into `g.theme`; exposed to Jinja.
+- Rendered directly onto the root element of **both** page shells:
+  `templates/dashboards/base.html:2` and `templates/auth/login.html:2` (the
+  only two `<html>` tags the app owns — `templates/errors/429.html` inherits,
+  and `admin/master.html` is Flask-Admin's, see § *Out of scope*).
+
+```jinja
+<html lang="en" data-bs-theme="{{ theme }}">
+```
+
+The theme is therefore correct in the **first byte of HTML**. There is no
+flash to prevent, no `<head>` script to nonce, no `localStorage` read racing
+the paint, and nothing for the CSP to forbid. The constraint that looked like
+an obstacle produced the better design.
+
+### The toggle
+
+A control in the navbar utility menu (`base.html:62-85`, beside the user
+dropdown; mobile gets it in the offcanvas drawer). Behaviour lives in a new
+`static/js/theme-toggle.js`, loaded alongside the existing 16 scripts at
+`base.html:219-234` — **external, not inline**, because
+`test_template_csp_lint.py` will fail the build otherwise, and correctly so.
+
+On click:
+
+1. Write the cookie.
+2. `document.documentElement.dataset.bsTheme = next` — the CSS flips instantly.
+3. **Reload the page.**
+
+Step 3 is the part worth arguing about, so: charts are server-rendered SVG with
+baked colours, and there are 16 of them across the dashboards. The alternatives
+are to leave them stale until the next navigation (visibly wrong — a light chart
+on a dark page is worse than a brief reload), or to hunt down and re-issue every
+chart fragment's htmx request (fragile, and it re-derives knowledge that
+`nav-view-persistence.js` already owns). A reload re-renders everything
+server-side in one pass, in the correct theme, from warm Redis entries after
+the first user. Steps 1–2 still run first so the reload paints the new theme
+rather than flashing the old one.
+
+### Is the nonce-free CSP a problem?
+
+Short answer: **no, and it should not be revisited for this feature.** It is
+worth writing down why, because "the CSP blocks the standard approach" reads
+like a limitation being worked around, and it isn't.
+
+**What the constraint actually forbids is one thing:** a *pre-paint,
+client-side* theme decision. That only matters if the theme lives somewhere
+only the client can read — i.e. `localStorage`. Ours lives in a cookie, which
+the server reads on the way in, so the constraint never binds. Everything else
+about the feature is unaffected.
+
+**Why nonces genuinely can't come back.** A nonce is per-request by
+definition; five routes cache fully-rendered HTML in Redis. A nonce baked into
+a cached response is stale on every subsequent hit, and the browser blocks the
+script — so this is a correctness incompatibility, not a stylistic preference.
+Restoring nonces means giving up rendered-HTML caching on the app's most
+expensive pages (the allocations dashboard, the orgs card), or post-processing
+cached HTML to rewrite the nonce on the way out, which is exactly the kind of
+drift-prone coupling `csp.py` was built to avoid.
+
+**Hashes are the honest caveat.** `script-src` also accepts
+`'sha256-<digest>'`, which is a hash of the script *content* and therefore
+static — fully compatible with cached HTML. A tiny inline theme bootstrap
+could legitimately be blessed that way. We still don't want it: it buys
+nothing the cookie doesn't already give us, and it introduces a hash that must
+be kept in sync with the script body by hand. Silent, total failure of that
+script on drift, in the one code path that runs before anything else on the
+page — against zero benefit. Noted so a future reader doesn't rediscover
+hashes and assume they were overlooked.
+
+**What it costs elsewhere is small and already paid.** Behaviour must live in
+a static JS file — which is where the repo already puts it (16 static scripts,
+every inline handler extracted, lint ratchet empty). The toggle follows the
+house pattern rather than fighting it. And note `style-src` retains
+`'unsafe-inline'`: the 301 inline `style=` attributes are unaffected, and if
+dark mode ever needed an inline colour it would be allowed. The restriction is
+on *script* only.
+
+**The one real price** is `auto` / `prefers-color-scheme` below — and it is
+one extra page load on a user's first-ever visit, not a recurring tax.
+
+### `auto` (follow the OS) — deferred to a follow-up, deliberately
+
+`prefers-color-scheme` is a client-side media query; the server cannot read it,
+so an `auto` cookie value would render light server-side and be corrected by
+JS on load — reintroducing exactly the flash the cookie design eliminates.
+
+The clean version, if it's wanted later: on a request with **no** `sam_theme`
+cookie at all, `theme-toggle.js` sets the cookie from `matchMedia` and reloads
+**once**. Every subsequent visit is cookie-driven and flash-free. The cost is a
+single extra load on a user's first-ever visit, not on every page. Ship
+explicit `light|dark` first; add this after the surfaces are proven.
+
+---
+
+## The token layer
+
+This is the refactoring the request asked about, and the only structural change
+in the plan.
+
+### The problem
+
+`static/css/variables.css` is one flat `:root` block mixing three different
+kinds of thing, with the semantic ones named after their **light-mode values**:
+
+```css
+--bg-light:     #f6f7f6;   /* actually: the page surface */
+--text-dark:    #323133;   /* actually: primary body text */
+--bg-gray-light:  #f8f9fa; /* actually: a recessed/secondary surface */
+--bg-gray-medium: #e9ecef;
+--border-color: #E2E8F0;
+```
+
+`dashboard.css:13-21` sets `body { background-color: var(--bg-light); color:
+var(--text-dark); }`. In dark mode `--text-dark` must resolve to near-white and
+`--bg-light` to near-black. A maintainer reading `color: var(--text-dark)` in
+six months has no way to know whether that means "the dark colour" (invariant)
+or "the body text colour" (flips). That ambiguity is how theme bugs get
+written, and it will not be caught by any test.
+
+### The fix — three tiers
+
+```css
+/* ---- Tier 1: primitives. Brand constants. Theme-INVARIANT.
+        Component CSS must never reference these directly. ---- */
+:root {
+    --ncar-space-blue: #011837;
+    --ncar-blue:       #0057c2;
+    /* … the existing 14 brand colours, unchanged … */
+}
+
+/* ---- Tier 2: semantic/role tokens. The ONLY thing component CSS uses.
+        Defined twice — once per theme. ---- */
+:root {
+    --surface-page:      #f6f7f6;
+    --surface-card:      #ffffff;
+    --surface-raised:    #ffffff;   /* tabs, panels, chips, inputs */
+    --surface-sunken:    #f8f9fa;   /* recessed wells, thead */
+    --text-primary:      #323133;
+    --text-secondary:    #718096;
+    --text-on-brand:     #ffffff;   /* invariant: white on saturated fills */
+    --border-default:    #E2E8F0;
+    --shadow-sm: …
+}
+
+:root[data-bs-theme="dark"] {
+    --surface-page:      #14181d;
+    --surface-card:      #1b2733;   /* == charts/theme.py Theme.DARK targets */
+    --surface-raised:    #222c38;
+    --surface-sunken:    #11151a;
+    --text-primary:      #e9ecef;
+    --text-secondary:    #adb5bd;
+    --text-on-brand:     #ffffff;   /* unchanged — see below */
+    --border-default:    #39414b;
+}
+
+/* ---- Tier 3: the Bootstrap bridge. Makes Bootstrap components and our own
+        CSS agree on one set of surfaces instead of two. ---- */
+:root {
+    --bs-body-bg:     var(--surface-page);
+    --bs-body-color:  var(--text-primary);
+    --bs-border-color: var(--border-default);
+}
+```
+
+`--text-on-brand` is a tier-2 token that is deliberately **invariant**. It is
+the answer to the 26 `color: #fff` declarations in § *What actually has to
+change* — white text on an NCAR-blue button is correct in both themes, and
+giving that case a *name* is what stops a future contributor from "fixing" it
+into a theme-dependent token and breaking every button in light mode.
+
+The dark `--surface-card` value is `#1b2733` on purpose: it is already
+`Theme.DARK.legend_face` / `shade_toward` / `segment_edge` in
+`charts/theme.py:266-276`. Charts sit inside cards, and PR 4's blend targets
+have to match the surface they blend into. Picking the value here, once, is
+what makes PR 4 mechanical.
+
+### Sizing
+
+The rename is far cheaper than it looks, which is the argument for doing it
+first rather than deferring it:
+
+| Token | `var()` uses in CSS | in templates |
+|---|---|---|
+| `--bg-light` | 4 | **0** |
+| `--text-dark` | 4 | **0** |
+| `--bg-gray-light` | 10 | **0** |
+| `--bg-gray-medium` | 5 | **0** |
+| `--border-color` | 4 | **0** |
+| `--color-gray-muted` | 1 | **0** |
+
+**28 callsites, all in `static/css/`, none in Jinja.** A mechanical
+find-and-replace with zero template blast radius.
+
+### Keep the palette single-sourced
+
+The brand palette is currently **triplicated** — `variables.css`, the
+`UNITY_NCAR_*` scalars in `charts/theme.py:126-136`, and the stack tints in
+`UNITY_STACK_20`. `CHART_ARCHITECTURE.md` called consolidation "a build-step
+question, not a chart question" and deferred it; it is not a dark-mode question
+either, and this plan does **not** propose a build step.
+
+It does propose the cheap half: a test asserting the tier-1 hex values in
+`variables.css` and the `UNITY_NCAR_*` scalars agree. There is direct precedent
+— `test_chart_theme.py` already asserts `Theme.LIGHT` matches the module-level
+rcParams for exactly this reason ("so a dark theme never has to fight a stale
+global"). Same argument, one layer out.
+
+---
+
+## What actually has to change
+
+### CSS: the whites, correctly partitioned
+
+`CHART_ARCHITECTURE.md` reports "**83** hardcoded `#fff`/`#ffffff`/`white`
+occurrences across the app CSS". That count is accurate, and it overstates the
+work by roughly 5×, because the three kinds of white behave completely
+differently:
+
+| Kind | Count | Verdict |
+|---|---|---|
+| `color: #fff` on a saturated brand fill (buttons, badges, active tabs, modal headers) | 26 | **Correct as-is.** Rename to `var(--text-on-brand)` for legibility; no value change, in either theme. |
+| `--bs-*: #fff` component-variable overrides | 22 | Mostly button *foregrounds* → same as above. **3 are real surfaces**: `--bs-card-bg` (`dashboard.css:577`), `--bs-card-cap-bg` (`:580`), `--bs-nav-pills-link-active-bg` (`:1114`). |
+| `background-color: #fff` — true page surfaces | **12** | **The actual work.** |
+
+The 12 surfaces, in full:
+
+| Site | What it is |
+|---|---|
+| `dashboard.css:29` | `.navbar` |
+| `dashboard.css:35` | `.navbar-light` |
+| `dashboard.css:1135` | inactive nav-pill badge |
+| `dashboard.css:1184` | `.nav-tabs .nav-link` |
+| `dashboard.css:1204` | `.nav-tabs .nav-link.active` |
+| `dashboard.css:1211` | `.tab-content` panel |
+| `dashboard.css:1233` | facet bar |
+| `dashboard.css:1280` | `.facet-chip:hover` |
+| `dashboard.css:1423` | `.filter-sidebar` inputs |
+| `auth.css:36`, `:168`, `:177` | login card + panels |
+
+Add the 3 card variables and that is **15 declarations** to token-swap. The
+card case is, as the chart plan noted, genuinely two lines.
+
+Two pastels are *not* whites and need the § *Design decisions* treatment:
+`auth.css:105` `#fff8e1` and `status.css:24` `#fff3cd`.
+
+### Templates: the Bootstrap utility classes
+
+This is the larger surface, and it is where the theme-invariant utilities bite.
+Bootstrap 5.3's `[data-bs-theme=dark]` block redefines `--bs-body-*`,
+`--bs-secondary-*`, `--bs-tertiary-*`, `--bs-emphasis-*` and `--bs-border-color`
+— but **not** `--bs-light-rgb`, `--bs-dark-rgb` or `--bs-secondary-rgb`
+(verified: 0 occurrences in the dark block). So `.bg-light` stays `#f8f9fa` and
+`.text-dark` stays `#212529` on a dark page.
+
+| Class | Occurrences | Verdict |
+|---|---|---|
+| `text-muted` | **624** | **Free.** 5.3.3 defines it as `color: var(--bs-secondary-color)`, which the dark block *does* redefine. No change — the app's single biggest utility usage is already correct. |
+| `text-dark` | 84 attrs | 64 co-occur with a `bg-*` class (a chip on a saturated fill) → **correct, leave**. **20 bare → break**, migrate to `text-body-emphasis`. |
+| `table-light` | 49 | **All break** — `.table-light` hardcodes `--bs-table-bg:#f8f9fa; --bs-table-color:#000`. 35 on `<thead>`, 6 on `<tr>`, 1 `<tfoot>`. |
+| `bg-light` | 59 | ~23 are `badge bg-light text-dark` pairs → `bg-body-secondary text-body-emphasis`; the rest are surfaces → `bg-body-secondary` / `bg-body-tertiary`. |
+| `bg-secondary` | 56 | `--bs-secondary-rgb` is not redefined, but these carry white text on `#6c757d` — legible in both themes. **Leave.** |
+| `text-white`, `bg-dark`, `border-light` | 11 / 0 / 0 | On brand fills or unused. Leave. |
+
+**≈130 attributes across three classes.** Mechanical, but it must be done by
+reading each site — `text-dark` in particular is 76 % false positives, and a
+blind sed would wreck every badge in the app.
+
+One declared side effect: `bg-light` (`#f8f9fa`) → `bg-body-secondary`
+(`#e9ecef` in light) is a **visible light-mode shift**. It is small and it is
+the right direction (those surfaces become properly recessed), but it must be
+declared in the commit that makes it rather than discovered in review.
+
+### Inline styles
+
+301 `style=` attributes exist, and `csp.py` keeps `'unsafe-inline'` in
+`style-src` for exactly that reason. Only **15** mention a colour or
+background. Those 15 get audited; the other 286 are widths, tree-depth padding
+and `z-index` and are theme-irrelevant. No CSP change.
+
+---
+
+## Design decisions a mechanical swap cannot make
+
+Each of these needs a human answer before D7. None blocks the commits before it.
+
+1. **The page watermark — resolved: keep it, unchanged.** `dashboard.css:15`
+   tiles `img/UCAR-Waves-Lines-Only-66.png` across every page at 53 % size.
+   Inspected rather than assumed (2026-08-01): it is a **1029×3088 RGBA PNG
+   that is 99.3 % fully transparent**, and every visible pixel is the *same
+   single colour* — `rgb(250,161,25)` = `#faa119`, which is exactly
+   `--ncar-orange` — laid down at α ≈ 84/255 (33 %).
+
+   That makes it already theme-safe. It is not a light-mode graphic; it is
+   transparent line art in a mid-saturation warm brand accent, which holds up
+   against a near-white page and a near-black one alike. On dark it composites
+   to a muted amber that is, if anything, *less* obtrusive than on light. No
+   dark variant, no `invert()`, no `background-image: none`.
+
+   Two notes for whoever implements D7. First, `opacity` does not apply to a
+   background image independently, so if the dark rendering wants tuning the
+   lever is `background-blend-mode` or a layered gradient — **not** a filter on
+   `body`, which would drag every descendant with it. Second, the asset being
+   a single flat brand colour is *why* this works; if it is ever replaced with
+   a multi-tone or baked-on-white graphic, this decision has to be re-made.
+   Verify visually at D7 and revisit only if it actually reads badly.
+
+2. **The logos.** `logo-ncar.png` and `NSF_Official_logo.png` are dark navy
+   marks. NSF and UCAR both publish reversed/white variants — this is a brand
+   request, not a CSS problem, and it should be started early because it has
+   external lead time. Interim fallback: keep the navbar a light chip in dark
+   mode (defensible — many dark UIs keep a branded header band).
+
+3. **The navbar.** It is `#fff` today (`:29,:35`). In dark mode a near-black
+   navbar on a near-black page loses the header entirely. Recommendation:
+   `--surface-raised`, one step lighter than the page, plus the existing
+   `border-top` on the nav row.
+
+4. **Status badges.** `status.css:17-32` — `.status-online` / `.status-degraded`
+   / `.status-offline` are hardcoded pastel background + dark text + pastel
+   border triplets. Bootstrap 5.3 ships exactly the right primitives:
+   `--bs-success-bg-subtle` / `--bs-success-text-emphasis` /
+   `--bs-success-border-subtle`, all redefined in the dark block. Rewrite the
+   three rules onto those variables and they become theme-correct with no dark
+   block of their own. Same treatment for `auth.css:105` (`#fff8e1` →
+   `--bs-warning-bg-subtle`) and the alert/badge tints in `dashboard.css`.
+
+5. **Charts** (PR 4, restated here so it isn't rediscovered): `UNITY_PALETTE_10[8]`
+   is space blue `#011837` used as a **pie wedge fill** — on a dark page it
+   vanishes while still carrying a white percentage label. And the `alpha=0.85`
+   stackplots composite against the *page*, so every band desaturates on dark.
+   Both are data-colour decisions, which is why they can't be solved by the
+   `Theme` chrome axis. Flagging them now because the tier-2 `--surface-card`
+   value chosen in D1 is the number PR 4 will blend against.
+
+---
+
+## Caching
+
+Two cache layers touch rendered bytes, and they need opposite treatment.
+
+**Chart caches — already correct.** `chart_view._key` composes the theme name
+into the key (PR 1). PR 4's chart-fragment routes just pass `theme=g.theme`.
+Nothing to do here. Note for whoever ships PR 4: chart entries are the bulk of
+Redis, and dark mode doubles the working set. The `svg.fonttype='none'` change
+in PR 1 cut SVG size 40–77 %, which mostly pays for it, but the `maxmemory`
+rationale should be revisited with real numbers rather than assumed.
+
+**Fully-rendered HTML caches — need a decision.** Five routes cache complete
+HTML under `user_aware_cache_key` (`extensions.py:26`):
+`allocations/blueprint.py:307,622`, `admin/orgs_routes.py:105,175`,
+`admin/contracts_routes.py:268`.
+
+Today all five are table/card fragments with no chart SVG and no
+`data-bs-theme` in their output, so their bytes are genuinely
+theme-independent — theming reaches them by CSS inheritance from the root
+attribute, which lives in the page shell, not the fragment. Strictly, the key
+needs no theme component.
+
+**Recommendation: add `theme` to `user_aware_cache_key` anyway.** The
+invariant "no cached fragment ever contains a theme-dependent byte" is real
+today and completely invisible tomorrow — the failure mode is a chart added to
+the allocations dashboard fragment, after which one user's dark SVG is served
+to every light-mode user with the same facility scope, and it will present as
+an intermittent rendering bug rather than a caching bug. The cost is at most
+5 extra key partitions on 5 routes. This is the same argument `chart_view`'s
+docstring makes about the aliasing trap, and it should be resolved the same
+way: make the wrong thing inexpressible.
+
+---
+
+## Commit plan
+
+Ordered so that **D3 makes dark mode visible and broken**, and every commit
+after it is verifiable in both themes rather than reasoned about. D0–D2 are
+provably no-op in light mode.
+
+| # | Commit | Visual change | Gate |
+|---|---|---|---|
+| **D0** | `tests/unit/test_css_tokens.py` — lint: no raw hex in `background-color` / `color` / `border-color` outside `variables.css`; allowlist the current sites so it passes at HEAD and shrinks per commit | none | new test green |
+| **D1** | Token layer: three tiers, role names, tier-1 ↔ `charts/theme.py` agreement test. Light values byte-identical | **none** | D0 allowlist shrinks; browser-smoke green |
+| **D2** | Bootstrap bridge (`--bs-body-bg`, `--bs-body-color`, `--bs-border-color`, `--bs-card-bg`, `--bs-card-cap-bg` → tier 2) | **none** | as above |
+| **D3** | Carrier: cookie, context processor, `data-bs-theme` on both roots, `theme-toggle.js`, navbar + offcanvas control, empty `:root[data-bs-theme="dark"]` block | Bootstrap's own dark appears; app CSS still light → **deliberately broken, and now inspectable** | CSP lint green (external JS); route-map parity |
+| **D4** | The 15 surface declarations → tier-2 tokens | none in light | visual diff both themes |
+| **D5** | Utility-class codemod: 49 `table-light`, 20 bare `text-dark`, 59 `bg-light` | **declared** light-mode shift on `bg-light` surfaces | reviewed site-by-site |
+| **D6** | Semantic colour sets → Bootstrap subtle/emphasis pairs: `status.css` badges, `auth.css`, alert/badge tints, the 15 colour-bearing inline styles | none in light | — |
+| **D7** | The dark palette values + design decisions 2–4 (navbar, logos-or-fallback, status badges). Watermark needs no code — verify visually | **dark mode ships** | e2e sweep in both themes |
+| **D8** | `theme` into `user_aware_cache_key`; e2e fixture parameterized over the cookie | none | full suite |
+
+PR 4 (dark charts) unblocks after D7.
+
+---
+
+## Testing
+
+**Existing gates that will fire, and how to stay on the right side of them:**
+
+- `tests/unit/test_template_csp_lint.py` — forbids inline `<script>`. The
+  toggle *must* be external JS. This is the gate that enforces the whole
+  server-rendered design; if someone "fixes" a perceived flash with an inline
+  head script, this catches it.
+- `tests/unit/test_route_map_parity.py` — pins every dashboard
+  `(endpoint, rule, methods)` triple. If the toggle is implemented as a POST
+  route rather than a client-side cookie write, regen with `ROUTE_MAP_REGEN=1`
+  and commit the snapshot in the same commit. (Client-side write avoids the
+  route entirely and is the recommendation.)
+- `tests/unit/test_chart_fingerprints.py` — unaffected until PR 4, since no
+  chart call passes `theme=` before then. A fingerprint delta in D0–D8 is a bug.
+
+**New coverage:**
+
+- `test_css_tokens.py` (D0) — the raw-colour lint, with a shrinking allowlist.
+  Its value is mostly *after* this work: it is what stops the next 83 whites.
+- A Jinja test asserting both `<html>` roots carry `data-bs-theme` and that it
+  round-trips from the cookie. Cheap, and it covers the login page, which is
+  otherwise easy to forget (separate shell, separate CSS).
+- `e2e/` already has a Playwright console sweep (`test_console_sweep.py`) and a
+  CI workflow (`browser-smoke.yaml`). Parameterize the fixture over the
+  `sam_theme` cookie so every swept page renders twice.
+
+**On contrast checking — the honest gap.** Pixel snapshots would be noisy and
+high-maintenance for a 257-template app. Recommendation: an axe-core pass (or a
+small computed-contrast assertion) over a handful of representative surfaces —
+card body, table header, navbar, a status badge, a form control — in both
+themes. That catches the failure mode that actually matters (unreadable text)
+without pinning appearance. Anything more ambitious should wait until the
+surfaces have settled.
+
+---
+
+## Explicitly not in scope
+
+- **Flask-Admin** (`templates/admin/master.html`). It extends Flask-Admin's own
+  base, which is Bootstrap **3** with glyphicons — a different framework
+  generation with its own theming model. It is gated behind the
+  `FLASK_ADMIN_ENABLED` kill-switch and off in prod/public. Theming it means
+  either overriding a vendored BS3 theme or migrating the whole admin surface;
+  neither belongs in this PR. It will render light-on-light and that is
+  accepted.
+- **Chart dark rendering** (PR 4). This plan ships the `--surface-card` value
+  PR 4 blends against and nothing else chart-side.
+- **Mobile layout** (PR 2), which is parallel and independent.
+- **The legacy-compat API blueprints** — JSON only, no HTML, per the standing
+  repo rule.
+- **Notification email templates** (`src/cli/templates/`). Mail clients have
+  their own dark-mode handling (and their own CSS support matrix); it is a
+  separate problem with a separate test story.
+- **A CSS build step.** The palette triplication is real (§ *Keep the palette
+  single-sourced*) and is addressed with a test, not a toolchain. Introducing
+  Sass/PostCSS to a vendored-assets, CSP-locked, no-npm-in-CI app is a much
+  larger decision than dark mode should be allowed to make.
+
+---
+
+## Appendix A — verified counts (2026-08-01)
+
+| Measure | Value | How |
+|---|---|---|
+| `<html>` tags the app owns | 2 | `base.html:2`, `login.html:2` |
+| App CSS files | 7 (6 + `variables.css`) | `static/css/` |
+| `background-color: #fff` surfaces | 12 | `grep -E 'background(-color)?:\s*(#fff|#ffffff|white)'` |
+| `color: #fff` on brand fills | 26 | — |
+| `--bs-*: #fff` overrides | 22 | 3 are surfaces |
+| Bootstrap dark-block selectors | 15 | vendored `bootstrap.min.css` |
+| `--bs-secondary-rgb` in dark block | **0** | why `.bg-secondary` is invariant |
+| `text-muted` | 624 | already correct |
+| `text-dark` attrs / bare | 84 / **20** | 64 co-occur with `bg-*` |
+| `table-light` | 49 | 35 `thead`, 6 `tr`, 1 `tfoot` |
+| `bg-light` | 59 | ~23 badge pairs |
+| Inline `style=` / colour-bearing | 301 / **15** | — |
+| Value-named token `var()` callsites | 28 (CSS), **0** (templates) | the rename surface |
+| Fully-rendered-HTML cache routes | 5 | `user_aware_cache_key` |
+| Watermark PNG: transparent / visible | 99.3 % / **0.7 %** | RGBA, 1029×3088 |
+| Watermark: distinct visible colours | **1** — `#faa119` (`--ncar-orange`) @ α≈33 % | why it needs no dark variant |
+
+## Appendix B — the two constraints, and why they are load-bearing
+
+Recorded because both look like obstacles and both improved the design.
+
+**Nonce-free CSP** (`utils/csp.py`, `docs/plans/implemented/CSP-discussion.md`).
+The policy is nonce-free because the rendered-HTML cache routes would serve a
+stale nonce on every hit, and the browser would block the script — a
+correctness incompatibility, not a preference. That rules out the standard
+`<head>` bootstrap script as normally written, and thereby forces the theme
+decision onto the server, where it has to be anyway for charts. A client-side
+design would have satisfied neither constraint and would have flashed. See
+§ *Is the nonce-free CSP a problem?* for the full assessment, including why
+content-**hash**-blessed inline script — which *is* cache-compatible, unlike a
+nonce — is available and still not worth taking.
+
+**Server-rendered cached charts.** 16 matplotlib charts render to inline SVG
+with baked colours, cached in Redis by content hash. No CSS can retheme them.
+This is what makes the cookie mandatory rather than merely convenient, and it
+is why `data-bs-theme` alone — the pure-Bootstrap answer — is insufficient for
+this app specifically.
+
+## Appendix C — corrections to `CHART_ARCHITECTURE.md`
+
+Recorded per that document's own convention.
+
+| # | It said | Actually | Impact |
+|---|---|---|---|
+| 1 | "83 hardcoded-white sites" as the scope of the CSS work | 83 is correct as a count, but **26 are foreground-on-brand (correct as-is)** and 22 are `--bs-*` overrides of which only 3 are surfaces. The real surface work is **12 declarations + 3 card variables**. | Scope estimate ~5× high. The nine `background-color: #fff` sites it lists for `dashboard.css` are exactly right. |
+| 2 | (not stated) | The template-side utility classes — `table-light` (49), bare `text-dark` (20), `bg-light` (59) — are a **larger** surface than the CSS whites, and were not inventoried. | ~130 attributes of unbudgeted work. Partly offset by `text-muted` × 624 being free. |
+| 3 | "PR 3 has a real head start" from Bootstrap's unused dark block | True, and stronger than implied: `text-muted`, the app's most-used utility, is already theme-correct. But the same block **does not** redefine `--bs-light-rgb` / `--bs-dark-rgb` / `--bs-secondary-rgb`, which is precisely why item 2 exists. | Head start is real; it is not uniform. |

--- a/docs/plans/MOBILE_CHARTS.md
+++ b/docs/plans/MOBILE_CHARTS.md
@@ -245,9 +245,14 @@ the same 32 sample cases). Both layouts together are 1.76× desktop alone, not
 actually requested in both layouts inside the 600s TTL, which desktop-majority
 traffic makes well under 1.76×.
 
+*(Superseded by the tablet pass, which measured the third profile at 0.86×
+desktop: three layouts are 2.60× desktop alone and six combinations land near
+5.2×. `helm/values.yaml` carries the current arithmetic.)*
+
 `cache_maxsize` bounds only the **no-Redis fallback** — under Redis, eviction
 is instance-global `allkeys-lru`. The three tightest budgets were raised
-(`facility_pie_chart` 32→48, `nodetype_history` and `queue_history` 64→96);
+(`facility_pie_chart` 32→48, `nodetype_history` and `queue_history` 64→96;
+raised again to 72 and 144 for `tablet`);
 the rest had slack.
 
 ---
@@ -281,10 +286,11 @@ than assuming it.
 - **The jobs explorer's 20px overflow** — pre-existing, a table, not a chart.
 - **Per-surface figure tuning.** Every family has one mobile profile; a
   surface whose card is unusually narrow or wide still gets the family's.
-- **Tablet — the real gap, and measured rather than guessed.** One
-  breakpoint, two profiles, so anything at 768px or wider gets `desktop`.
-  An earlier draft of this doc asserted "scale ~0.65, legible" without
-  measuring. It is worse than that:
+- **Tablet — the real gap, and measured rather than guessed.**
+  **CLOSED by the tablet pass — see `TABLET_CHARTS.md`.** Left below as the
+  measurement that motivated it. One breakpoint, two profiles, so anything at
+  768px or wider got `desktop`. An earlier draft of this doc asserted
+  "scale ~0.65, legible" without measuring. It is worse than that:
 
   | viewport | client px | scale | smallest label |
   |---|---|---|---|
@@ -309,5 +315,12 @@ than assuming it.
 
   One profile cannot serve both: mobile's 4.0in figure would upscale to
   ~1.7x in a 753px card and render 9pt text at ~15px.
+
+  The tablet pass took this and cost what this section predicted: a third
+  entry in `LAYOUTS`, in `_LAYOUTS`, and in the sender, plus tuning. Two
+  things it did not predict — `Layout.is_mobile` had to go (a boolean asked
+  of a three-value vocabulary), and the three jobs histogram panels turned
+  out never to have received the axis at all, so phones had been getting the
+  desktop figure on those tabs since this pass shipped.
 - **`theme`** — PR 3 and PR 4. The cookie rail built here is the one they
   should reuse; `user_aware_cache_key` already has the slot beside `l:`.

--- a/docs/plans/TABLET_CHARTS.md
+++ b/docs/plans/TABLET_CHARTS.md
@@ -1,6 +1,12 @@
 # Tablet chart layout — the third profile
 
-**Status: NOT STARTED. Handoff doc, written 2026-08-01** at the end of the
+**Status: IMPLEMENTED 2026-08-01** on `chart-ipad-profile`, stacked on
+PR #416. Commits T1-T5. The answers to the open questions and the places the
+work departed from this plan are recorded at the bottom; everything above that
+is the handoff doc as written, kept because its measurements are the reason
+for the design.
+
+**Originally: NOT STARTED. Handoff doc, written 2026-08-01** at the end of the
 mobile pass (PR #416), which is where the gap was measured.
 
 Adds a `tablet` layout profile between `mobile` and `desktop`. The machinery
@@ -274,3 +280,108 @@ a retarget.
    three discrete ones — more accurate, but it puts a measured pixel width in
    the cache key, which fragments the cache badly. The discrete-profile answer
    is almost certainly right; recorded so nobody re-derives it from scratch.
+
+---
+
+## As built — answers, deviations, and what this plan missed
+
+Implemented on `chart-ipad-profile` (stacked on PR #416) in five commits,
+T1-T5. Full suite green; fingerprint deltas confined to `@tablet` keys in
+every commit that declared one.
+
+### The four open questions
+
+1. **Upper boundary — 1200.** Measured on `/status/derecho`, where the chart's
+   card is the viewport less 144px and the desktop figure's smallest label is
+   12 user-units:
+
+   | clientWidth | card | smallest label |
+   |---|---|---|
+   | 785 | 641 | 6.0px |
+   | 1009 | 865 | 8.1px |
+   | 1185 | 1041 | 9.7px |
+   | 1265 | 1121 | 10.4px |
+
+   Desktop clears 9px at ~1110 and 10px at ~1217. This plan said "if it lands
+   at 1280, use `xxl` (1400)". It lands between the two, and `xl` won anyway:
+   `xxl` would hand every 1280 laptop a figure sized for a 640px card. 1200
+   measures 9.7px, which is inside the noise of the 10px target.
+
+2. **`legend_placement='right'` survives** — comfortably, at every tablet
+   width. It is not overridden; `TABLET_DEFAULTS` says nothing about
+   placement, so it inherits desktop's.
+
+3. **Landscape iPad at 1024 is tablet**, falling out of (1). It reads
+   10-13px there.
+
+4. **Discrete profiles were right.** Nothing encountered argued for a
+   container-width parameter.
+
+### Deviations
+
+- **`PieChart`'s tablet figure IS its desktop figure.** A pie trims to its own
+  square, so its tight bbox is ~360pt where the wide families' is near their
+  declared inches — every surface already gives a pie more width than it can
+  use (measured 10.7px, 13.8px and 16.6px at a 768 viewport). Shrinking it
+  would make the jobs pie smaller on screen and the allocations pie's labels
+  larger. The ordering assertions are therefore `mobile < tablet <= desktop`,
+  non-strict at the desktop end, and the aspect-ratio test skips a figure that
+  is unchanged rather than scaled.
+
+- **`TABLET_DEFAULTS` is two fields, not a mobile-shaped block.** Everything
+  absent inherits *desktop*, which is the whole design: a tablet is a small
+  desktop. The per-family type hierarchy the phone had to flatten survives.
+
+- **Fonts are not overridden at all.** With the chart always filling its card,
+  on-screen label size is `fontsize x card / bbox` — so font size and figure
+  size are one knob, not two, and the plan's "~9.3in figure" arithmetic was
+  replaced by measuring each family against the card it renders into.
+
+- **The gutter CSS split in two.** The negative margin extends to the whole
+  tablet band (worth 625 -> 657px and 9.0 -> 9.4px on the status page);
+  `width: 100%` stays on phones only, because no tablet figure needs
+  upscaling and extending it would only inflate the pies.
+
+- **`Layout.is_mobile` retirement grew two fields, not one.** `label_kw()` and
+  `apply_tick_fontsize()` needed `axis_label_fontsize` *and* `tick_fontsize`
+  as separate `int | None` fields, because `UserProjectAreaChart` labels at
+  13pt and ticks at 12pt and desktop has to reproduce both.
+
+### What this plan did not predict
+
+**Three fragments never received the axis at all.** `_panel_histogram` in
+`webapp/jobs/routes.py` accepted `layout` and dropped it, so Wait Times, Job
+Sizes and Durations rendered the 18in desktop figure at every viewport — a
+mobile-pass bug that had been shipping since PR #416, found only because
+shrinking the tablet figure changed nothing on screen.
+`test_renderers_forward_the_layout_they_are_given` now gates that last hop:
+a renderer that accepts `layout` and calls another layout-aware callable must
+forward it. Renderers that draw no chart are exempt by construction — they
+call nothing that takes one — so there is no allowlist to rot.
+
+### Measured result, at a 768 viewport (min on-screen label px)
+
+| surface | before | after |
+|---|---|---|
+| /status/derecho stacked, 625px card | 6.0 | 9.4 |
+| /status/partition-history dual panel | 6.4 | 10.7 |
+| /status/queue-history dual panel | 8.1 | 10.5 |
+| jobs explorer timeline | 6.5 | 10.4 |
+| jobs explorer histograms | 8.8 (stuck at desktop) | 11.0 |
+| /status/filesystem-scans distribution | — | 10.7 |
+| /allocations pace | 5.9 | 9.2-10.6 |
+| pies (unchanged by design) | 10.7-16.6 | 10.7-16.6 |
+
+Across the band the same chart reads 9.4px at 768 and 15.4px at 1199, filling
+its card at both ends. At a 1215px window the cookie flips to `desktop` and
+the 18in figure returns at 9.8px; at 390px `mobile` still measures 9.8px.
+
+### Cache
+
+Measured across the 32 sample cases: desktop 562 KB, tablet 483 KB (0.86x),
+mobile 417 KB (0.74x) — three layouts are **2.60x** desktop alone, and six
+combinations with the theme axis land near **5.2x**, up from the 3.1x
+`helm/values.yaml` budgeted for four. Still comfortably inside 192 MB against
+a base that dropped 58% with `svg.fonttype: none`. The three tightest
+`cache_maxsize` budgets were raised again: `facility_pie_chart` 48 -> 72,
+`nodetype_history` and `queue_history` 96 -> 144.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -51,18 +51,34 @@ topologySpread:
 # ~15 KB; the live jobs timeline measures ~35 KB and its histogram ~10 KB.
 #
 # maxmemory is DELIBERATELY NOT reduced to match. The freed headroom is
-# earmarked for the layout and theme render axes. The mobile pass has now
-# spent half of that earmark, and it came in cheaper than the "up to 4x"
-# this comment previously budgeted: a mobile SVG is a ~4in figure rather
-# than an 18in one, so it carries fewer path points and less text, and
-# measures **0.76x** its desktop twin (411 KB vs 542 KB across the same 32
-# sample cases). Both layouts together are 1.76x desktop alone, not 2x.
-# Extrapolating, all four combinations should land near 3.1x rather than 4x
-# — still comfortably inside 192 MB against a base that dropped 58%.
+# earmarked for the layout and theme render axes, and both layout passes came
+# in cheaper than the "up to 4x" this comment originally budgeted: a smaller
+# figure carries fewer path points and less text, so it costs less than its
+# desktop twin rather than the same. Measured across the same 32 sample cases:
 #
-# Note the multiplier applies only to charts actually *requested* in both
-# layouts inside the 600s TTL. Desktop remains the overwhelming majority of
-# traffic, so the real working set grows well under 1.76x.
+#   desktop  562 KB  1.00x
+#   tablet   483 KB  0.86x
+#   mobile   417 KB  0.74x
+#   ------------------------
+#   all three         2.60x
+#
+# The layout axis is therefore complete at 2.6x, not the 3x a third profile
+# suggests. With the theme axis doubling that, six combinations land near
+# **5.2x** — up from the 3.1x this comment budgeted for four. Against a base
+# that dropped 58% when charts switched to `svg.fonttype: none`, 5.2x of the
+# post-drop base is ~2.2x of the pre-drop one, which is what 192 MB was
+# already sized for.
+#
+# Note the multiplier applies only to charts actually *requested* in more than
+# one combination inside the 600s TTL. Desktop-light remains the overwhelming
+# majority of traffic, so the real working set grows well under 2.6x.
+#
+# One caveat specific to the tablet profile: `PieChart` declares tablet *as*
+# its desktop figure (a pie's bbox is already narrower than any card that
+# renders one), so the five pies pay for a duplicate cache entry holding
+# byte-identical SVG. That is ~5% of the chart working set, and the
+# alternative — a layout that renders identically but keys differently —
+# would be a special case in `chart_view._key` for no measured gain.
 #
 # Headroom is the safe direction anyway because
 # allkeys-lru is instance-GLOBAL: under pressure it is free to evict the

--- a/src/webapp/dashboards/charts/base.py
+++ b/src/webapp/dashboards/charts/base.py
@@ -79,13 +79,15 @@ class BaseChart:
     #: eviction is instance-global `allkeys-lru` — so it only bounds the
     #: no-Redis fallback, where overflowing costs a re-render rather than
     #: correctness. A live second layout splits every chart's key space, so
-    #: the three tightest budgets were raised when `mobile` shipped; the rest
-    #: had enough slack. Sizes are per-chart because the working sets differ
+    #: the three tightest budgets were raised when `mobile` shipped and again
+    #: when `tablet` did; the rest had enough slack. Sizes are per-chart
+    #: because the working sets differ
     #: by two orders of magnitude (one facility pie vs the jobs explorer's
     #: per-filter-set fanout).
     cache_maxsize: int = 128
 
-    #: `{'desktop': Layout, 'mobile': Layout}` — build with `layout.profile`.
+    #: `{'desktop': Layout, 'mobile': Layout, 'tablet': Layout}` — build with
+    #: `layout.profile`.
     LAYOUTS: dict = None
 
     # --- rendering defaults ----------------------------------------------

--- a/src/webapp/dashboards/charts/base.py
+++ b/src/webapp/dashboards/charts/base.py
@@ -114,9 +114,9 @@ class BaseChart:
     #: existed.
     axis_label_fontsize = None
 
-    #: Tick-label size on desktop, or None to take `layout.base_fontsize`
-    #: (which is the rcParams value, so None and 11 are the same picture).
-    #: Mobile always takes the layout's.
+    #: Tick-label size when the layout does not dictate one, or None to take
+    #: `layout.base_fontsize` (which is the rcParams value on desktop, so None
+    #: and 11 are the same picture).
     tick_fontsize = None
 
     # --- lifecycle hooks (override what differs) -------------------------
@@ -223,9 +223,14 @@ class BaseChart:
 
         Returned as a dict rather than a value because `fontsize=None` is not
         the same as omitting it.
+
+        The layout wins where it states a size, and defers where it does not —
+        the rule `legend_fontsize` already used. This used to read
+        `layout.is_mobile`, which was a boolean asked of a vocabulary that now
+        has three values; expressing it as None-means-defer means a new
+        profile needs no new branch here.
         """
-        size = (layout.base_fontsize if layout.is_mobile
-                else self.axis_label_fontsize)
+        size = layout.axis_label_fontsize or self.axis_label_fontsize
         return {'fontsize': size} if size is not None else {}
 
     def apply_date_axis(self, ax, layout):
@@ -261,9 +266,12 @@ class BaseChart:
         because a chart that forgets is invisible until someone looks at a
         phone. Desktop's `base_fontsize` equals the rcParams `font.size`, so
         this is a no-op there and the desktop fingerprints do not move.
+
+        Three-way fallback, same None-means-defer rule as `label_kw`: the
+        layout's size, else the chart's own, else the layout's base size.
         """
-        size = (layout.base_fontsize if layout.is_mobile
-                else (self.tick_fontsize or layout.base_fontsize))
+        size = (layout.tick_fontsize or self.tick_fontsize
+                or layout.base_fontsize)
         for ax in (axes if isinstance(axes, (tuple, list)) else (axes,)):
             ax.tick_params(labelsize=size)
 

--- a/src/webapp/dashboards/charts/dualpanel.py
+++ b/src/webapp/dashboards/charts/dualpanel.py
@@ -109,7 +109,11 @@ class NodetypeHistoryChart(DualPanelTimeSeriesChart):
     empty_message = 'No history data available for this node type'
     #: Two stacked panels need real vertical room on a phone — this is the
     #: tallest mobile figure in the package, and still barely enough.
-    LAYOUTS = profile((18, 10), (4.0, 4.7))
+    #: Tablet: this is the chart the tablet band exists for. The status pages
+    #: nest cards, so their chart gets the viewport less 144px — 624px at a
+    #: 768 viewport, where the 18in figure reads 6.0px. 12in lands the tight
+    #: bbox at ~736pt, i.e. 9.3px in that card.
+    LAYOUTS = profile((18, 10), (4.0, 4.7), (12, 7.2))
 
     @staticmethod
     def cache_key(history_data):
@@ -172,7 +176,10 @@ class QueueHistoryChart(DualPanelTimeSeriesChart):
     #: Raised from 64 for the second layout profile.
     cache_maxsize = 96
     empty_message = 'No history data available for this queue'
-    LAYOUTS = profile((14, 8), (4.0, 4.2))
+    #: Tablet: same 624px card as its sibling, and the same ~736pt target —
+    #: which this family reaches at the same 12in despite starting 4in
+    #: narrower, because the legend is what the tight bbox is made of.
+    LAYOUTS = profile((14, 8), (4.0, 4.2), (12, 7.2))
 
     @staticmethod
     def cache_key(history_data):

--- a/src/webapp/dashboards/charts/dualpanel.py
+++ b/src/webapp/dashboards/charts/dualpanel.py
@@ -104,8 +104,8 @@ class NodetypeHistoryChart(DualPanelTimeSeriesChart):
 
     cache_name = 'nodetype_history'
     #: One entry per node type; can be O(10s) across all machines. Raised
-    #: from 64 for the second layout profile.
-    cache_maxsize = 96
+    #: 64 -> 96 for the second layout profile, 96 -> 144 for the third.
+    cache_maxsize = 144
     empty_message = 'No history data available for this node type'
     #: Two stacked panels need real vertical room on a phone — this is the
     #: tallest mobile figure in the package, and still barely enough.
@@ -173,8 +173,8 @@ class QueueHistoryChart(DualPanelTimeSeriesChart):
 
     cache_name = 'queue_history'
     #: One entry per queue; queue counts can be O(10s) across all resources.
-    #: Raised from 64 for the second layout profile.
-    cache_maxsize = 96
+    #: Raised 64 -> 96 for the second layout profile, 96 -> 144 for the third.
+    cache_maxsize = 144
     empty_message = 'No history data available for this queue'
     #: Tablet: same 624px card as its sibling, and the same ~736pt target —
     #: which this family reaches at the same 12in despite starting 4in

--- a/src/webapp/dashboards/charts/histogram.py
+++ b/src/webapp/dashboards/charts/histogram.py
@@ -57,7 +57,10 @@ def bucket_segments(owners, metric='data'):
 class CategoricalStackChart(BaseChart):
     """One bar per bucket; each bar a shaded single-hue stack."""
 
-    LAYOUTS = profile((14, 5), (4.0, 2.6), label_rotation=30)
+    #: Tablet: 12in puts the tight bbox at ~731pt, 10.3px in the 686px jobs
+    #: card at a 768 viewport. This family starts narrower than the others
+    #: (14in) so it needs the least shrinking.
+    LAYOUTS = profile((14, 5), (4.0, 2.6), (12, 4.6), label_rotation=30)
     grid = {'axis': 'y', 'alpha': 0.3}
 
     bar_edge_width = 0.5

--- a/src/webapp/dashboards/charts/histogram.py
+++ b/src/webapp/dashboards/charts/histogram.py
@@ -57,10 +57,11 @@ def bucket_segments(owners, metric='data'):
 class CategoricalStackChart(BaseChart):
     """One bar per bucket; each bar a shaded single-hue stack."""
 
-    #: Tablet: 12in puts the tight bbox at ~731pt, 10.3px in the 686px jobs
-    #: card at a 768 viewport. This family starts narrower than the others
-    #: (14in) so it needs the least shrinking.
-    LAYOUTS = profile((14, 5), (4.0, 2.6), (12, 4.6), label_rotation=30)
+    #: Tablet: 11in puts the tight bbox at ~796pt, 9.5px in the 687px jobs
+    #: card at a 768 viewport. 12in measured 8.9px there — this family looks
+    #: like it needs the least shrinking (it starts at 14in, not 18) but its
+    #: per-bucket owner segments give it a full-height legend to carry.
+    LAYOUTS = profile((14, 5), (4.0, 2.6), (11, 4.2), label_rotation=30)
     grid = {'axis': 'y', 'alpha': 0.3}
 
     bar_edge_width = 0.5

--- a/src/webapp/dashboards/charts/layout.py
+++ b/src/webapp/dashboards/charts/layout.py
@@ -75,18 +75,31 @@ class Layout:
     #: mobile overrides.
     legend_fontsize: int | None = None
 
-    @property
-    def is_mobile(self) -> bool:
-        return self.name == 'mobile'
+    #: Axis-label size, or None for "whatever the chart declares".
+    #:
+    #: Same None-means-defer rule as `legend_fontsize`, and it exists for the
+    #: same reason: `UserProjectAreaChart` labels at 13pt where everything
+    #: else leaves it to rcParams, and desktop must reproduce both.
+    axis_label_fontsize: int | None = None
 
+    #: Tick-label size, or None for "the chart's own, else `base_fontsize`".
+    tick_fontsize: int | None = None
+
+
+#: One size for every text role on a phone. The four `*_fontsize` fields are
+#: separate because *desktop* needs them separate — a family may label at 13pt
+#: and tick at 12pt — but at 4in wide there is no room for a hierarchy.
+_MOBILE_FONT = 9
 
 #: Applied to every family's mobile profile unless it overrides them.
 #:
 #: `figsize` is deliberately absent: there is no defensible default for it.
 #: See the module docstring on why aspect preservation is the wrong rule.
 MOBILE_DEFAULTS = dict(
-    base_fontsize=9,
-    legend_fontsize=9,
+    base_fontsize=_MOBILE_FONT,
+    legend_fontsize=_MOBILE_FONT,
+    axis_label_fontsize=_MOBILE_FONT,
+    tick_fontsize=_MOBILE_FONT,
     legend_placement='below',
     max_legend_entries=6,
     max_ticks=5,

--- a/src/webapp/dashboards/charts/layout.py
+++ b/src/webapp/dashboards/charts/layout.py
@@ -24,6 +24,29 @@ underneath, the plot itself is under an inch tall. **Mobile figures are
 declared explicitly per family**, sized so the tight-bbox intrinsic width
 lands near 350pt — roughly 1:1 with a phone viewport once card padding is off,
 which is what puts a 9pt label on screen at ~9px instead of ~2px.
+
+## The tablet profile
+
+The mobile pass gave phones a figure and left tablets in the desktop band,
+where an 18in figure is squeezed into ~640px. Measured on the running app,
+that put the status dashboard's smallest label at **6.0px at a 768 viewport**
+— worse than the same chart on a phone, which is the defect this profile
+exists to close.
+
+The band is Bootstrap `md` to just under `xl`: **768px to 1199.98px**. The
+lower edge is forced (it is where `mobile` ends). The upper edge was measured
+rather than chosen: on these pages the chart's container is the viewport less
+144px, so desktop's smallest label lands at 8.1px at 1024, 9.7px at 1200 and
+10.4px at 1280. Desktop stops being the problem somewhere around 1110-1200,
+and 1200 is the breakpoint there. Extending the band to `xxl` instead would
+hand every 1280 laptop a figure sized for a 640px card.
+
+A tablet layout is **desktop with a smaller figure**, not a large phone —
+see `TABLET_DEFAULTS`. The figures are sized so the tight bbox lands near
+730pt, which is what keeps a 9-11pt label at ~9px on the narrow edge of the
+band. It grows to ~15px at the wide edge, because the band spans a 1.7x range
+of container widths and the chart fills whatever it is given; the phone band
+spans 2.2x and ships with the same property.
 """
 
 from dataclasses import dataclass, fields, replace
@@ -107,26 +130,46 @@ MOBILE_DEFAULTS = dict(
 )
 
 
-def profile(figsize, mobile_figsize, *, base_fontsize=11,
+#: Applied to every family's tablet profile unless it overrides them.
+#:
+#: Deliberately tiny, and deliberately says nothing about fonts. A tablet is
+#: a small desktop, not a large phone: `legend_placement`, `label_rotation`
+#: and every `*_fontsize` are left absent so they inherit *desktop's* values,
+#: which keeps the per-family type hierarchy (13pt labels over 12pt ticks on
+#: the user/project area chart) that the phone had to flatten.
+#:
+#: Only two things genuinely do not survive the smaller figure: twelve date
+#: ticks, and an uncapped legend — 20 pace-chart rows are taller than a 3in
+#: plot at any width.
+TABLET_DEFAULTS = dict(
+    max_legend_entries=10,
+    max_ticks=8,
+)
+
+
+def profile(figsize, mobile_figsize, tablet_figsize, *, base_fontsize=11,
             legend_placement='right', max_legend_entries=None, max_ticks=12,
-            label_rotation=0, mobile=None):
-    """Build one family's ``{'desktop': ..., 'mobile': ...}`` pair.
+            label_rotation=0, mobile=None, tablet=None):
+    """Build one family's ``{'desktop': ..., 'mobile': ..., 'tablet': ...}``.
 
     The keyword arguments configure **desktop**, and must reproduce today's
     rendering exactly — they are read straight off the existing
     `plt.subplots(figsize=...)` call and the tick/rotation constants around
-    it. Mobile overrides go in the `mobile` dict, never as bare keywords: an
-    earlier version collected them with `**kwargs`, which meant a name that
-    happened to match a desktop parameter was silently applied to desktop
-    instead. `legend_placement='right'` on the pies read as a mobile override
-    and configured desktop, where it was already the default, so it did
-    nothing at all and looked like it worked.
+    it. Non-desktop overrides go in the `mobile` / `tablet` dicts, never as
+    bare keywords: an earlier version collected them with `**kwargs`, which
+    meant a name that happened to match a desktop parameter was silently
+    applied to desktop instead. `legend_placement='right'` on the pies read as
+    a mobile override and configured desktop, where it was already the
+    default, so it did nothing at all and looked like it worked.
 
-    `mobile_figsize` is **required and positional**. It used to default to the
-    desktop aspect ratio at 4.5in wide, which sounds reasonable and is not:
-    18:5 becomes a 4.5 x 1.25in strip, and a strip with its legend moved
-    underneath has well under an inch of plot left. Every family now states
-    its own, sized so the tight bbox lands near 350pt wide.
+    Both non-desktop figsizes are **required and positional**. `mobile_figsize`
+    used to default to the desktop aspect ratio at 4.5in wide, which sounds
+    reasonable and is not: 18:5 becomes a 4.5 x 1.25in strip, and a strip with
+    its legend moved underneath has well under an inch of plot left.
+    `tablet_figsize` is positional for the same reason — the tight bbox is a
+    function of the legend contents, so it can only be measured, never derived
+    — and because a family that genuinely wants desktop's figure (the pies do)
+    should have to say so.
     """
     desktop = Layout(
         name='desktop',
@@ -139,14 +182,19 @@ def profile(figsize, mobile_figsize, *, base_fontsize=11,
         legend_fontsize=None,
     )
 
-    overrides = {**MOBILE_DEFAULTS, **(mobile or {})}
-    unknown = set(overrides) - {f.name for f in fields(Layout)}
-    if unknown:
-        raise TypeError(f'unknown Layout field(s) in mobile override: '
-                        f'{sorted(unknown)}')
-    return {'desktop': desktop,
-            'mobile': replace(desktop, name='mobile',
-                              figsize=tuple(mobile_figsize), **overrides)}
+    def _derive(name, figsize_, defaults, given):
+        overrides = {**defaults, **(given or {})}
+        unknown = set(overrides) - {f.name for f in fields(Layout)}
+        if unknown:
+            raise TypeError(f'unknown Layout field(s) in {name} override: '
+                            f'{sorted(unknown)}')
+        return replace(desktop, name=name, figsize=tuple(figsize_), **overrides)
+
+    return {
+        'desktop': desktop,
+        'mobile': _derive('mobile', mobile_figsize, MOBILE_DEFAULTS, mobile),
+        'tablet': _derive('tablet', tablet_figsize, TABLET_DEFAULTS, tablet),
+    }
 
 
 def resolve_layout(layouts, layout) -> Layout:

--- a/src/webapp/dashboards/charts/pace.py
+++ b/src/webapp/dashboards/charts/pace.py
@@ -132,7 +132,12 @@ class PaceChart(BaseChart):
     #: facility-scope fanout — well under 10 MB of cached SVG per process.
     cache_maxsize = 192
     empty_message = 'No allocations available'
-    LAYOUTS = profile((10, 4), (4.0, 3.0))
+    #: Tablet: the narrowest desktop figure of the wide families, and still
+    #: the worst reader — 6.3px at a 624px card, because its smallest text is
+    #: 6pt where the others' is 8.25pt. 6.5in lands the tight bbox at ~590pt.
+    #: The `TABLET_DEFAULTS` legend cap does real work here: 20 project rows
+    #: set the figure height on their own, whatever `figsize` says.
+    LAYOUTS = profile((10, 4), (4.0, 3.0), (6.5, 3.2))
     #: Normalized to the 0.3 every other chart uses (was 0.2, undocumented).
     grid = {'alpha': 0.3}
 

--- a/src/webapp/dashboards/charts/pie.py
+++ b/src/webapp/dashboards/charts/pie.py
@@ -81,7 +81,19 @@ class PieChart(BaseChart):
     #: a pie is square, so a legend beside it uses width the plot cannot,
     #: whereas the wide families have no width to spare. The `max_legend_entries`
     #: cap keeps that column from growing taller than the pie.
-    LAYOUTS = profile((7, 4), (3.6, 2.9), mobile={'legend_placement': 'right'})
+    #:
+    #: **Tablet is desktop, deliberately.** A pie's tight bbox is only ~360pt
+    #: — a pie trims to its own square, where the wide families trim to nearly
+    #: their declared inches — so every surface that renders one already gives
+    #: it as much width as it can use. Measured at a 768 viewport the three
+    #: pie surfaces read 13.8px, 10.7px and 16.6px; shrinking the figure would
+    #: make the jobs pie smaller on screen and the allocations pie's labels
+    #: larger, and neither is an improvement. The `max_legend_entries` cap is
+    #: dropped with it, because on this family the cap removes *slices*, and a
+    #: tablet has room for all of them.
+    LAYOUTS = profile((7, 4), (3.6, 2.9), (7, 4),
+                      mobile={'legend_placement': 'right'},
+                      tablet={'max_legend_entries': None})
     grid = None                       # pies have no grid
 
     start_angle = _PIE_START_ANGLE

--- a/src/webapp/dashboards/charts/pie.py
+++ b/src/webapp/dashboards/charts/pie.py
@@ -218,9 +218,11 @@ class FacilityPie(_FixedCapPie):
 
     cache_name = 'facility_pie_chart'
     #: One entry per resource filter combination; few distinct views. Raised
-    #: from 32 with the mobile layout: a second live profile splits every
-    #: chart's key space, and this was the tightest budget in the package.
-    cache_maxsize = 48
+    #: 32 -> 48 with the mobile layout and 48 -> 72 with the tablet one: each
+    #: live profile splits every chart's key space, and this was the tightest
+    #: budget in the package. The split is real here even though a tablet pie
+    #: renders the desktop figure — same bytes, different key.
+    cache_maxsize = 72
     empty_message = 'No facility data available'
     fields = ('facility', 'annualized_rate')
 

--- a/src/webapp/dashboards/charts/stacked.py
+++ b/src/webapp/dashboards/charts/stacked.py
@@ -46,7 +46,11 @@ class StackedSeriesChart(BaseChart):
     #: smart date axis shortens labels enough to leave them horizontal. It
     #: survives for `JobsTimeseriesChart`, whose categorical axis falls back
     #: to rotation when its period labels are a grain we cannot compact.
-    LAYOUTS = profile((18, 5), (4.0, 2.8), label_rotation=30)
+    #: Tablet: 11in lands the tight bbox at ~756pt, which reads 10.0px in the
+    #: 686px card these charts sit in at a 768 viewport. Proportionally taller
+    #: than desktop — 18:5 at 11in is a 3in strip, and the band count does not
+    #: shrink with the figure.
+    LAYOUTS = profile((18, 5), (4.0, 2.8), (11, 3.6), label_rotation=30)
 
     #: 'bar' — discrete bars per x position; 'area' — filled stackplot.
     stack_mode = 'bar'

--- a/src/webapp/dashboards/charts/stacked.py
+++ b/src/webapp/dashboards/charts/stacked.py
@@ -46,11 +46,14 @@ class StackedSeriesChart(BaseChart):
     #: smart date axis shortens labels enough to leave them horizontal. It
     #: survives for `JobsTimeseriesChart`, whose categorical axis falls back
     #: to rotation when its period labels are a grain we cannot compact.
-    #: Tablet: 11in lands the tight bbox at ~756pt, which reads 10.0px in the
-    #: 686px card these charts sit in at a 768 viewport. Proportionally taller
-    #: than desktop — 18:5 at 11in is a 3in strip, and the band count does not
-    #: shrink with the figure.
-    LAYOUTS = profile((18, 5), (4.0, 2.8), (11, 3.6), label_rotation=30)
+    #: Tablet: 10in. This family has the widest legend labels in the package
+    #: — the status page's "WYOM0247 (33,408)" is a name *and* a value — so
+    #: its tight bbox runs ~130pt past what a sample payload predicts, and 11in
+    #: measured 8.4px in the narrowest card any chart sits in (625px, the
+    #: status page nests two card bodies). Proportionally taller than desktop:
+    #: 18:5 at 10in is a 2.8in strip, and the band count does not shrink with
+    #: the figure.
+    LAYOUTS = profile((18, 5), (4.0, 2.8), (10, 3.4), label_rotation=30)
 
     #: 'bar' — discrete bars per x position; 'area' — filled stackplot.
     stack_mode = 'bar'

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -1875,6 +1875,7 @@ def _panel_histogram(ctx, fragment_url, *, mode, scope_for, log_label,
         target_id=_target_id(ctx, dim),
         account_projcodes=ctx['account_projcodes'],
         username=ctx['username'],
+        layout=layout,
     )
 
 

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -1815,13 +1815,14 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     height: auto;
 }
 
-/* Chart gutters on phones.
+/* Chart gutters below desktop.
    ------------------------------------------------------------------
-   The server now renders a phone-sized figure (see charts/layout.py), which
-   only pays off if the figure gets the width. Measured at a 375px viewport on
-   /status/derecho, it does not: the chart sits in a card inside a card, and
-   each `.card-body` takes 16px a side, so a 375px viewport hands the chart
-   287px. The figure is then scaled DOWN to fit, undoing part of the point.
+   The server renders a phone- or tablet-sized figure (see charts/layout.py),
+   which only pays off if the figure gets the width. Measured at a 375px
+   viewport on /status/derecho, it does not: the chart sits in a card inside a
+   card, and each `.card-body` takes 16px a side, so a 375px viewport hands the
+   chart 287px. The figure is then scaled DOWN to fit, undoing part of the
+   point.
 
    Cards nest on several surfaces and un-nesting them is not a chart change,
    so instead the chart bleeds back over its immediate card padding. 16px a
@@ -1830,10 +1831,22 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
    self-contained rectangles with their own internal margins; unlike text they
    do not need the gutter to read.
 
-   `width: 100%` (not just `max-width`) so a figure narrower than the card
-   fills it rather than leaving a gutter. Desktop keeps `max-width` alone —
-   upscaling an 18in figure on a wide screen would just blur it. */
-@media (max-width: 767.98px) {
+   The two halves have different bands, which is measurement, not oversight:
+
+   - the **gutter** runs the whole non-desktop range. The nested card bodies
+     cost the same 32px at 768 as at 375, and it buys a real 5%: measured on
+     /status/derecho at a 768 viewport the chart's box goes 625 -> 657px and
+     its smallest label 9.0 -> 9.4px. Verified symmetric and non-overflowing at
+     both edges of the tablet band, and on /status/partition-history, which
+     nests one card body rather than two.
+   - `width: 100%` stays on phones only. It exists to *upscale* a figure
+     narrower than its card, and no tablet figure is: every one measured
+     renders at 100% of its card across the whole band under `max-width`
+     alone. Extending it would only reach the pies, whose tablet profile is
+     deliberately the desktop figure — it would blow them up, not fix them.
+     Desktop keeps `max-width` alone for the original reason: upscaling an
+     18in figure on a wide screen would just blur it. */
+@media (max-width: 1199.98px) {
     .chart-container,
     .jobs-histogram-chart,
     .jobs-timeline-chart,
@@ -1842,7 +1855,9 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
         margin-left: -1rem;
         margin-right: -1rem;
     }
+}
 
+@media (max-width: 767.98px) {
     .chart-container svg,
     .jobs-histogram-chart svg,
     .jobs-timeline-chart svg,

--- a/src/webapp/static/js/layout-axis.js
+++ b/src/webapp/static/js/layout-axis.js
@@ -23,8 +23,8 @@
  * Together they cover both: fragments are correct on the very first paint
  * because `hx-trigger="load"` fires after this listener registers, and full
  * pages are correct from the second navigation onward. A first-ever visit on
- * a phone sees desktop-sized charts on one page. They still fit — nothing
- * overflows at 390px — they are merely small, which is the status quo.
+ * a phone or tablet sees desktop-sized charts on one page. They still fit —
+ * nothing overflows at 390px — they are merely small, which is the status quo.
  *
  * PR 3 (app-wide dark mode) wants the same carrier for `theme`, with the
  * added constraint that a theme flash is visible where a chart size is not.
@@ -45,12 +45,24 @@
     /* Bootstrap's `md` breakpoint, matching dashboard-init.js's
      * collapseFilterPanels. One definition of "phone" across the app. */
     var MOBILE_QUERY = '(max-width: 767.98px)';
+
+    /* Bootstrap's `xl`. The upper edge of the tablet band was measured, not
+     * picked: on these pages the chart's card is the viewport less ~144px, so
+     * the desktop figure's smallest label lands at 6.0px at 768, 8.1px at
+     * 1024, 9.7px at 1200 and 10.4px at 1280. Desktop stops being the problem
+     * around 1110-1200, and `xl` is the breakpoint there. Going up to `xxl`
+     * instead would hand every 1280 laptop a figure sized for a 640px card. */
+    var TABLET_QUERY = '(max-width: 1199.98px)';
+
     var COOKIE = 'sam_layout';
     var PARAM = 'layout';
 
+    /* Narrowest match wins — below 768 both queries are true. */
     function currentLayout() {
-        return window.matchMedia && window.matchMedia(MOBILE_QUERY).matches
-            ? 'mobile' : 'desktop';
+        if (!window.matchMedia) { return 'desktop'; }
+        if (window.matchMedia(MOBILE_QUERY).matches) { return 'mobile'; }
+        if (window.matchMedia(TABLET_QUERY).matches) { return 'tablet'; }
+        return 'desktop';
     }
 
     /* Session cookie (no Max-Age): the viewport is a property of this visit,

--- a/src/webapp/utils/htmx.py
+++ b/src/webapp/utils/htmx.py
@@ -6,14 +6,16 @@ from sam.manage import management_transaction
 
 
 #: The chart layouts a request may ask for. Anything else means "no override".
-_LAYOUTS = frozenset({'desktop', 'mobile'})
+#: Must match the names ``charts/layout.profile()`` builds — the string is
+#: passed straight through to the chart layer and into its cache key.
+_LAYOUTS = frozenset({'desktop', 'tablet', 'mobile'})
 
 #: Written by ``static/js/layout-axis.js`` from ``matchMedia``.
 LAYOUT_COOKIE = 'sam_layout'
 
 
 def read_layout(default: str = 'desktop') -> str:
-    """Which chart layout this request wants: ``'desktop'`` or ``'mobile'``.
+    """Which chart layout this request wants — see ``_LAYOUTS``.
 
     Two sources, in precedence order — the query string, then the cookie —
     because charts reach the browser two different ways and neither channel
@@ -27,11 +29,11 @@ def read_layout(default: str = 'desktop') -> str:
     These are htmx fragments, and a stale or hand-typed value must not break a
     card. Passing an unknown name through would be equally safe — the chart
     layer falls back too — but normalizing here keeps the value that reaches
-    the *cache key* to two spellings instead of arbitrarily many, and the key
-    is shared across workers and pods.
+    the *cache key* to the declared spellings instead of arbitrarily many, and
+    the key is shared across workers and pods.
 
     Returns:
-        ``'desktop'`` or ``'mobile'`` — never anything else.
+        A member of ``_LAYOUTS`` — never anything else.
     """
     raw = (request.args.get('layout')
            or request.cookies.get(LAYOUT_COOKIE)

--- a/tests/unit/snapshots/chart_fingerprints.json
+++ b/tests/unit/snapshots/chart_fingerprints.json
@@ -357,8 +357,8 @@
       "Others"
     ],
     "size": [
-      749.1,
-      254.0
+      692.8,
+      242.9
     ]
   },
   "disk_area.empty": {
@@ -511,8 +511,8 @@
       "Others"
     ],
     "size": [
-      771.2,
-      256.7
+      714.9,
+      245.8
     ]
   },
   "disk_entity_pie.empty": {
@@ -1286,8 +1286,8 @@
       "Data (GiB)"
     ],
     "size": [
-      730.7,
-      312.1
+      674.9,
+      289.9
     ]
   },
   "distribution.empty": {
@@ -1503,8 +1503,8 @@
       "Files"
     ],
     "size": [
-      746.7,
-      312.1
+      690.9,
+      289.9
     ]
   },
   "distribution.log_y": {
@@ -1626,8 +1626,8 @@
       "Data (GiB)"
     ],
     "size": [
-      742.4,
-      312.1
+      686.5,
+      289.9
     ]
   },
   "facility_pie.empty": {
@@ -1957,8 +1957,8 @@
       "Charges"
     ],
     "size": [
-      731.2,
-      309.7
+      675.4,
+      288.0
     ]
   },
   "jobs_hist.empty": {
@@ -2081,8 +2081,8 @@
       "Jobs"
     ],
     "size": [
-      730.7,
-      309.7
+      674.9,
+      288.0
     ]
   },
   "jobs_hist.jobs_owners": {
@@ -2303,8 +2303,8 @@
       "Jobs"
     ],
     "size": [
-      730.7,
-      309.7
+      674.9,
+      288.0
     ]
   },
   "jobs_hist.log_y": {
@@ -2432,8 +2432,8 @@
       "Jobs"
     ],
     "size": [
-      741.9,
-      308.9
+      686.1,
+      286.8
     ]
   },
   "jobs_ts.empty": {
@@ -2689,8 +2689,8 @@
       "Others"
     ],
     "size": [
-      762.3,
-      254.0
+      706.0,
+      242.9
     ]
   },
   "jobs_ts.user_linked": {
@@ -2963,8 +2963,8 @@
       "Others"
     ],
     "size": [
-      756.0,
-      254.0
+      699.7,
+      242.9
     ]
   },
   "jobs_usage_pie.by_project": {
@@ -5392,8 +5392,8 @@
       "Others"
     ],
     "size": [
-      756.1,
-      254.0
+      699.7,
+      242.9
     ]
   },
   "usage_stacked.empty": {
@@ -5501,8 +5501,8 @@
       "Charges"
     ],
     "size": [
-      684.0,
-      254.0
+      628.2,
+      242.9
     ]
   },
   "usage_timeseries.empty": {
@@ -5637,8 +5637,8 @@
       "Job Count"
     ],
     "size": [
-      684.0,
-      254.0
+      628.2,
+      242.9
     ]
   },
   "user_proj_area.empty": {
@@ -5794,8 +5794,8 @@
       "Others (4)"
     ],
     "size": [
-      824.1,
-      257.0
+      767.7,
+      245.9
     ]
   },
   "user_proj_area.project_current": {
@@ -5968,8 +5968,8 @@
       "Others (2)"
     ],
     "size": [
-      824.0,
-      257.0
+      767.7,
+      245.9
     ]
   },
   "user_usage_pie.charges": {

--- a/tests/unit/snapshots/chart_fingerprints.json
+++ b/tests/unit/snapshots/chart_fingerprints.json
@@ -136,6 +136,81 @@
       175.2
     ]
   },
+  "alloc_type_pie.trimmed@tablet": {
+    "counts": {
+      "a": 0,
+      "g": 48,
+      "path": 23,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#0057c2",
+      "#00357a",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#011837",
+      "#97999b",
+      "#0057c2",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#0057c2",
+      "#011837",
+      "#00357a",
+      "#011837",
+      "#ff1f1f",
+      "#011837",
+      "#fdd509",
+      "#011837",
+      "#faa119",
+      "#011837",
+      "#00818f",
+      "#011837",
+      "#42c0ff",
+      "#011837",
+      "#00a2b4",
+      "#011837",
+      "#97999b",
+      "#011837",
+      "#0057c2",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "Type01 (120K)",
+      "Type02 (110K)",
+      "Type03 (100,000)",
+      "Type04 (90,000)",
+      "Type05 (80,000)",
+      "Type06 (70,000)",
+      "Type07 (60,000)",
+      "Type08 (50,000)",
+      "Type09 (40,000)",
+      "Type10 (30,000)",
+      "Others (2) (30,000)"
+    ],
+    "size": [
+      361.0,
+      236.2
+    ]
+  },
   "disk_area.bytes_linked": {
     "counts": {
       "a": 4,
@@ -235,6 +310,55 @@
     "size": [
       266.9,
       245.2
+    ]
+  },
+  "disk_area.bytes_linked@tablet": {
+    "counts": {
+      "a": 4,
+      "g": 59,
+      "path": 22,
+      "text": 15,
+      "use": 10
+    },
+    "drill_hrefs": [
+      "/admin/user/bob",
+      "/admin/user/bob",
+      "/admin/user/alice",
+      "/admin/user/alice"
+    ],
+    "fills": [
+      "#bbbcbc",
+      "#fdd509",
+      "#fbe174",
+      "#011837",
+      "#fbe174",
+      "#011837",
+      "#fdd509",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 3",
+      "Mar 5",
+      "Mar 7",
+      "Mar 9",
+      "0",
+      "1",
+      "2",
+      "3",
+      "4",
+      "Disk usage (TiB)",
+      "bob",
+      "alice",
+      "Others"
+    ],
+    "size": [
+      749.1,
+      254.0
     ]
   },
   "disk_area.empty": {
@@ -340,6 +464,55 @@
     "size": [
       285.0,
       247.5
+    ]
+  },
+  "disk_area.files@tablet": {
+    "counts": {
+      "a": 0,
+      "g": 79,
+      "path": 27,
+      "text": 20,
+      "use": 15
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#bbbcbc",
+      "#fdd509",
+      "#fbe174",
+      "#011837",
+      "#fbe174",
+      "#011837",
+      "#fdd509",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 3",
+      "Mar 5",
+      "Mar 7",
+      "Mar 9",
+      "0",
+      "600B",
+      "1.20T",
+      "1.80T",
+      "2.40T",
+      "3.00T",
+      "3.60T",
+      "4.20T",
+      "4.80T",
+      "5.40T",
+      "Number of files",
+      "bob",
+      "alice",
+      "Others"
+    ],
+    "size": [
+      771.2,
+      256.7
     ]
   },
   "disk_entity_pie.empty": {
@@ -524,6 +697,107 @@
       175.2
     ]
   },
+  "disk_entity_pie.group@tablet": {
+    "counts": {
+      "a": 27,
+      "g": 46,
+      "path": 21,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-group-gid/1000",
+      "#sam/row/data-group-gid/1001",
+      "#sam/row/data-group-gid/1002",
+      "#sam/row/data-group-gid/1003",
+      "#sam/row/data-group-gid/1004",
+      "#sam/row/data-group-gid/1005",
+      "#sam/row/data-group-gid/1006",
+      "#sam/row/data-group-gid/1007",
+      "#sam/row/data-group-gid/1008",
+      "#sam/row/data-group-gid/1000",
+      "#sam/row/data-group-gid/1000",
+      "#sam/row/data-group-gid/1001",
+      "#sam/row/data-group-gid/1001",
+      "#sam/row/data-group-gid/1002",
+      "#sam/row/data-group-gid/1002",
+      "#sam/row/data-group-gid/1003",
+      "#sam/row/data-group-gid/1003",
+      "#sam/row/data-group-gid/1004",
+      "#sam/row/data-group-gid/1004",
+      "#sam/row/data-group-gid/1005",
+      "#sam/row/data-group-gid/1005",
+      "#sam/row/data-group-gid/1006",
+      "#sam/row/data-group-gid/1006",
+      "#sam/row/data-group-gid/1007",
+      "#sam/row/data-group-gid/1007",
+      "#sam/row/data-group-gid/1008",
+      "#sam/row/data-group-gid/1008"
+    ],
+    "fills": [
+      "#0057c2",
+      "#00357a",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#011837",
+      "#bbbcbc",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#0057c2",
+      "#011837",
+      "#00357a",
+      "#011837",
+      "#ff1f1f",
+      "#011837",
+      "#fdd509",
+      "#011837",
+      "#faa119",
+      "#011837",
+      "#00818f",
+      "#011837",
+      "#42c0ff",
+      "#011837",
+      "#00a2b4",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "7.7%",
+      "gid 1000 (114 MiB)",
+      "user1 (105 MiB)",
+      "user2 (95.4 MiB)",
+      "gid 1003 (85.8 MiB)",
+      "user4 (76.3 MiB)",
+      "user5 (66.8 MiB)",
+      "gid 1006 (57.2 MiB)",
+      "user7 (47.7 MiB)",
+      "user8 (38.1 MiB)",
+      "Other (3) (57.2 MiB)"
+    ],
+    "size": [
+      362.3,
+      236.2
+    ]
+  },
   "disk_entity_pie.owner": {
     "counts": {
       "a": 27,
@@ -702,6 +976,107 @@
       175.2
     ]
   },
+  "disk_entity_pie.owner@tablet": {
+    "counts": {
+      "a": 27,
+      "g": 46,
+      "path": 21,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-owner-uid/1000",
+      "#sam/row/data-owner-uid/1001",
+      "#sam/row/data-owner-uid/1002",
+      "#sam/row/data-owner-uid/1003",
+      "#sam/row/data-owner-uid/1004",
+      "#sam/row/data-owner-uid/1005",
+      "#sam/row/data-owner-uid/1006",
+      "#sam/row/data-owner-uid/1007",
+      "#sam/row/data-owner-uid/1008",
+      "#sam/row/data-owner-uid/1000",
+      "#sam/row/data-owner-uid/1000",
+      "#sam/row/data-owner-uid/1001",
+      "#sam/row/data-owner-uid/1001",
+      "#sam/row/data-owner-uid/1002",
+      "#sam/row/data-owner-uid/1002",
+      "#sam/row/data-owner-uid/1003",
+      "#sam/row/data-owner-uid/1003",
+      "#sam/row/data-owner-uid/1004",
+      "#sam/row/data-owner-uid/1004",
+      "#sam/row/data-owner-uid/1005",
+      "#sam/row/data-owner-uid/1005",
+      "#sam/row/data-owner-uid/1006",
+      "#sam/row/data-owner-uid/1006",
+      "#sam/row/data-owner-uid/1007",
+      "#sam/row/data-owner-uid/1007",
+      "#sam/row/data-owner-uid/1008",
+      "#sam/row/data-owner-uid/1008"
+    ],
+    "fills": [
+      "#0057c2",
+      "#00357a",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#011837",
+      "#bbbcbc",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#0057c2",
+      "#011837",
+      "#00357a",
+      "#011837",
+      "#ff1f1f",
+      "#011837",
+      "#fdd509",
+      "#011837",
+      "#faa119",
+      "#011837",
+      "#00818f",
+      "#011837",
+      "#42c0ff",
+      "#011837",
+      "#00a2b4",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "7.7%",
+      "uid 1000 (114 MiB)",
+      "user1 (105 MiB)",
+      "user2 (95.4 MiB)",
+      "uid 1003 (85.8 MiB)",
+      "user4 (76.3 MiB)",
+      "user5 (66.8 MiB)",
+      "uid 1006 (57.2 MiB)",
+      "user7 (47.7 MiB)",
+      "user8 (38.1 MiB)",
+      "Other (3) (57.2 MiB)"
+    ],
+    "size": [
+      362.3,
+      236.2
+    ]
+  },
   "distribution.data": {
     "counts": {
       "a": 18,
@@ -842,6 +1217,77 @@
     "size": [
       280.6,
       200.3
+    ]
+  },
+  "distribution.data@tablet": {
+    "counts": {
+      "a": 18,
+      "g": 72,
+      "path": 33,
+      "text": 13,
+      "use": 12
+    },
+    "drill_hrefs": [
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3"
+    ],
+    "fills": [
+      "#fef1ab",
+      "#fee35a",
+      "#fdd509",
+      "#fef5d0",
+      "#fdf3c7",
+      "#fdf1bd",
+      "#fdefb4",
+      "#fdedab",
+      "#fceba2",
+      "#fce999",
+      "#fce790",
+      "#fce586",
+      "#fbe37d",
+      "#fbe174",
+      "#faa119",
+      "#fde9cf",
+      "#fcdbb0",
+      "#fbcc91",
+      "#fabe72",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "&lt; 30d",
+      "30-90d",
+      "90-180d",
+      "&gt; 180d",
+      "0",
+      "50",
+      "100",
+      "150",
+      "200",
+      "250",
+      "300",
+      "350",
+      "Data (GiB)"
+    ],
+    "size": [
+      730.7,
+      312.1
     ]
   },
   "distribution.empty": {
@@ -990,6 +1436,77 @@
       200.3
     ]
   },
+  "distribution.files@tablet": {
+    "counts": {
+      "a": 18,
+      "g": 72,
+      "path": 33,
+      "text": 13,
+      "use": 12
+    },
+    "drill_hrefs": [
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3"
+    ],
+    "fills": [
+      "#fef1ab",
+      "#fee35a",
+      "#fdd509",
+      "#fef5d0",
+      "#fdf3c7",
+      "#fdf1bd",
+      "#fdefb4",
+      "#fdedab",
+      "#fceba2",
+      "#fce999",
+      "#fce790",
+      "#fce586",
+      "#fbe37d",
+      "#fbe174",
+      "#faa119",
+      "#fde9cf",
+      "#fcdbb0",
+      "#fbcc91",
+      "#fabe72",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "&lt; 30d",
+      "30-90d",
+      "90-180d",
+      "&gt; 180d",
+      "0",
+      "5,000",
+      "10,000",
+      "15,000",
+      "20,000",
+      "25,000",
+      "30,000",
+      "35,000",
+      "Files"
+    ],
+    "size": [
+      746.7,
+      312.1
+    ]
+  },
   "distribution.log_y": {
     "counts": {
       "a": 3,
@@ -1072,6 +1589,47 @@
       200.3
     ]
   },
+  "distribution.log_y@tablet": {
+    "counts": {
+      "a": 3,
+      "g": 66,
+      "path": 12,
+      "text": 5,
+      "use": 16
+    },
+    "drill_hrefs": [
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/3"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "&lt; 30d",
+      "30-90d",
+      "90-180d",
+      "&gt; 180d",
+      "1 0 2",
+      "2 \u00d7 1 0 1",
+      "3 \u00d7 1 0 1",
+      "4 \u00d7 1 0 1",
+      "6 \u00d7 1 0 1",
+      "2 \u00d7 1 0 2",
+      "3 \u00d7 1 0 2",
+      "4 \u00d7 1 0 2",
+      "Data (GiB)"
+    ],
+    "size": [
+      742.4,
+      312.1
+    ]
+  },
   "facility_pie.empty": {
     "html": "<div class=\"text-center text-muted\">No facility data available</div>",
     "kind": "placeholder"
@@ -1144,6 +1702,41 @@
     "size": [
       272.4,
       175.2
+    ]
+  },
+  "facility_pie.normal@tablet": {
+    "counts": {
+      "a": 0,
+      "g": 18,
+      "path": 7,
+      "text": 6,
+      "use": 0
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#0057c2",
+      "#00357a",
+      "#ff1f1f",
+      "#ffffff",
+      "#0057c2",
+      "#011837",
+      "#00357a",
+      "#011837",
+      "#ff1f1f",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "57.1%",
+      "28.6%",
+      "14.3%",
+      "UNIV (5.00M)",
+      "WNA (2.50M)",
+      "NCAR (1.25M)"
+    ],
+    "size": [
+      334.0,
+      236.2
     ]
   },
   "jobs_hist.charges": {
@@ -1294,6 +1887,80 @@
       198.6
     ]
   },
+  "jobs_hist.charges@tablet": {
+    "counts": {
+      "a": 19,
+      "g": 76,
+      "path": 34,
+      "text": 14,
+      "use": 13
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4"
+    ],
+    "fills": [
+      "#fef1ab",
+      "#feea83",
+      "#fee35a",
+      "#fddc32",
+      "#fdd509",
+      "#fef5d0",
+      "#fdf0b9",
+      "#fceba2",
+      "#fce68b",
+      "#fbe174",
+      "#fddfb1",
+      "#fcd08b",
+      "#fcc065",
+      "#fbb13f",
+      "#faa119",
+      "#fabe72",
+      "#ffb3b3",
+      "#ff8282",
+      "#ff5050",
+      "#ff1f1f",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0-1m",
+      "1-10m",
+      "10m-1h",
+      "1-6h",
+      "&gt; 6h",
+      "0",
+      "100",
+      "200",
+      "300",
+      "400",
+      "500",
+      "600",
+      "700",
+      "Charges"
+    ],
+    "size": [
+      731.2,
+      309.7
+    ]
+  },
   "jobs_hist.empty": {
     "html": "<div class=\"text-center text-muted\">No jobs in this range</div>",
     "kind": "placeholder"
@@ -1376,6 +2043,46 @@
     "size": [
       280.6,
       198.6
+    ]
+  },
+  "jobs_hist.flat_no_owners@tablet": {
+    "counts": {
+      "a": 4,
+      "g": 61,
+      "path": 19,
+      "text": 14,
+      "use": 13
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/4"
+    ],
+    "fills": [
+      "#0057c2",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0-1m",
+      "1-10m",
+      "10m-1h",
+      "1-6h",
+      "&gt; 6h",
+      "0",
+      "50",
+      "100",
+      "150",
+      "200",
+      "250",
+      "300",
+      "350",
+      "Jobs"
+    ],
+    "size": [
+      730.7,
+      309.7
     ]
   },
   "jobs_hist.jobs_owners": {
@@ -1526,6 +2233,80 @@
       198.6
     ]
   },
+  "jobs_hist.jobs_owners@tablet": {
+    "counts": {
+      "a": 19,
+      "g": 76,
+      "path": 34,
+      "text": 14,
+      "use": 13
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4"
+    ],
+    "fills": [
+      "#fef1ab",
+      "#feea83",
+      "#fee35a",
+      "#fddc32",
+      "#fdd509",
+      "#fef5d0",
+      "#fdf0b9",
+      "#fceba2",
+      "#fce68b",
+      "#fbe174",
+      "#fddfb1",
+      "#fcd08b",
+      "#fcc065",
+      "#fbb13f",
+      "#faa119",
+      "#fabe72",
+      "#ffb3b3",
+      "#ff8282",
+      "#ff5050",
+      "#ff1f1f",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0-1m",
+      "1-10m",
+      "10m-1h",
+      "1-6h",
+      "&gt; 6h",
+      "0",
+      "50",
+      "100",
+      "150",
+      "200",
+      "250",
+      "300",
+      "350",
+      "Jobs"
+    ],
+    "size": [
+      730.7,
+      309.7
+    ]
+  },
   "jobs_hist.log_y": {
     "counts": {
       "a": 4,
@@ -1610,6 +2391,49 @@
     "size": [
       295.5,
       196.7
+    ]
+  },
+  "jobs_hist.log_y@tablet": {
+    "counts": {
+      "a": 4,
+      "g": 65,
+      "path": 13,
+      "text": 7,
+      "use": 16
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/4"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#ff1f1f",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0-1m",
+      "1-10m",
+      "10m-1h",
+      "1-6h",
+      "&gt; 6h",
+      "100",
+      "2 \u00d7 1 0 1",
+      "3 \u00d7 1 0 1",
+      "4 \u00d7 1 0 1",
+      "6 \u00d7 1 0 1",
+      "2 \u00d7 1 0 2",
+      "3 \u00d7 1 0 2",
+      "Jobs"
+    ],
+    "size": [
+      741.9,
+      308.9
     ]
   },
   "jobs_ts.empty": {
@@ -1781,6 +2605,92 @@
     "size": [
       277.7,
       247.0
+    ]
+  },
+  "jobs_ts.project_unlinked@tablet": {
+    "counts": {
+      "a": 32,
+      "g": 108,
+      "path": 55,
+      "text": 21,
+      "use": 15
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9"
+    ],
+    "fills": [
+      "#bbbcbc",
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#011837",
+      "#faa119",
+      "#011837",
+      "#fbe174",
+      "#011837",
+      "#fdd509",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 2",
+      "Mar 3",
+      "Mar 4",
+      "Mar 5",
+      "Mar 6",
+      "Mar 7",
+      "Mar 8",
+      "Mar 9",
+      "Mar 10",
+      "0",
+      "50",
+      "100",
+      "150",
+      "200",
+      "CPU-hours",
+      "alice",
+      "bob",
+      "carol",
+      "Others"
+    ],
+    "size": [
+      762.3,
+      254.0
     ]
   },
   "jobs_ts.user_linked": {
@@ -1964,6 +2874,99 @@
       247.0
     ]
   },
+  "jobs_ts.user_linked@tablet": {
+    "counts": {
+      "a": 38,
+      "g": 112,
+      "path": 56,
+      "text": 22,
+      "use": 16
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "/admin/user/alice",
+      "/admin/user/alice",
+      "/admin/user/bob",
+      "/admin/user/bob",
+      "/admin/user/carol",
+      "/admin/user/carol"
+    ],
+    "fills": [
+      "#bbbcbc",
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#011837",
+      "#faa119",
+      "#011837",
+      "#fbe174",
+      "#011837",
+      "#fdd509",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 2",
+      "Mar 3",
+      "Mar 4",
+      "Mar 5",
+      "Mar 6",
+      "Mar 7",
+      "Mar 8",
+      "Mar 9",
+      "Mar 10",
+      "0",
+      "10",
+      "20",
+      "30",
+      "40",
+      "50",
+      "Jobs",
+      "alice",
+      "bob",
+      "carol",
+      "Others"
+    ],
+    "size": [
+      756.0,
+      254.0
+    ]
+  },
   "jobs_usage_pie.by_project": {
     "counts": {
       "a": 27,
@@ -2137,6 +3140,102 @@
       175.2
     ]
   },
+  "jobs_usage_pie.by_project@tablet": {
+    "counts": {
+      "a": 27,
+      "g": 43,
+      "path": 21,
+      "text": 17,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-job-project/user0",
+      "#sam/row/data-job-project/user1",
+      "#sam/row/data-job-project/user2",
+      "#sam/row/data-job-project/user3",
+      "#sam/row/data-job-project/user4",
+      "#sam/row/data-job-project/user5",
+      "#sam/row/data-job-project/user6",
+      "#sam/row/data-job-project/user7",
+      "#sam/row/data-job-project/user8",
+      "#sam/row/data-job-project/user0",
+      "#sam/row/data-job-project/user0",
+      "#sam/row/data-job-project/user1",
+      "#sam/row/data-job-project/user1",
+      "#sam/row/data-job-project/user2",
+      "#sam/row/data-job-project/user2",
+      "#sam/row/data-job-project/user3",
+      "#sam/row/data-job-project/user3",
+      "#sam/row/data-job-project/user4",
+      "#sam/row/data-job-project/user4",
+      "#sam/row/data-job-project/user5",
+      "#sam/row/data-job-project/user5",
+      "#sam/row/data-job-project/user6",
+      "#sam/row/data-job-project/user6",
+      "#sam/row/data-job-project/user7",
+      "#sam/row/data-job-project/user7",
+      "#sam/row/data-job-project/user8",
+      "#sam/row/data-job-project/user8"
+    ],
+    "fills": [
+      "#0057c2",
+      "#00357a",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#011837",
+      "#bbbcbc",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#0057c2",
+      "#011837",
+      "#00357a",
+      "#011837",
+      "#ff1f1f",
+      "#011837",
+      "#fdd509",
+      "#011837",
+      "#faa119",
+      "#011837",
+      "#00818f",
+      "#011837",
+      "#42c0ff",
+      "#011837",
+      "#00a2b4",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "6.7%",
+      "6.3%",
+      "6.0%",
+      "5.7%",
+      "5.3%",
+      "5.0%",
+      "52.0%",
+      "user0 (100)",
+      "user1 (95)",
+      "user2 (90)",
+      "user3 (85)",
+      "user4 (80)",
+      "user5 (75)",
+      "user6 (70)",
+      "user7 (65)",
+      "user8 (60)",
+      "Other (780)"
+    ],
+    "size": [
+      327.1,
+      236.2
+    ]
+  },
   "jobs_usage_pie.by_user": {
     "counts": {
       "a": 24,
@@ -2296,6 +3395,96 @@
     "size": [
       294.9,
       175.2
+    ]
+  },
+  "jobs_usage_pie.by_user@tablet": {
+    "counts": {
+      "a": 24,
+      "g": 42,
+      "path": 21,
+      "text": 16,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user8",
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user8",
+      "#sam/row/data-job-user/user8"
+    ],
+    "fills": [
+      "#0057c2",
+      "#00357a",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#011837",
+      "#bbbcbc",
+      "#ffffff",
+      "#011837",
+      "#0057c2",
+      "#011837",
+      "#00357a",
+      "#011837",
+      "#ff1f1f",
+      "#011837",
+      "#fdd509",
+      "#011837",
+      "#faa119",
+      "#011837",
+      "#00818f",
+      "#011837",
+      "#42c0ff",
+      "#011837",
+      "#00a2b4",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "6.7%",
+      "6.3%",
+      "5.9%",
+      "5.5%",
+      "5.1%",
+      "54.4%",
+      "(unknown) (1,000)",
+      "user1 (940)",
+      "user2 (880)",
+      "user3 (820)",
+      "user4 (760)",
+      "user5 (700)",
+      "user6 (640)",
+      "user7 (580)",
+      "user8 (520)",
+      "Other (8,160)"
+    ],
+    "size": [
+      356.5,
+      236.2
     ]
   },
   "jobs_usage_pie.empty": {
@@ -2463,6 +3652,96 @@
       175.2
     ]
   },
+  "jobs_user_pie.delegated@tablet": {
+    "counts": {
+      "a": 24,
+      "g": 42,
+      "path": 21,
+      "text": 16,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user8",
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user8",
+      "#sam/row/data-job-user/user8"
+    ],
+    "fills": [
+      "#0057c2",
+      "#00357a",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#011837",
+      "#bbbcbc",
+      "#ffffff",
+      "#011837",
+      "#0057c2",
+      "#011837",
+      "#00357a",
+      "#011837",
+      "#ff1f1f",
+      "#011837",
+      "#fdd509",
+      "#011837",
+      "#faa119",
+      "#011837",
+      "#00818f",
+      "#011837",
+      "#42c0ff",
+      "#011837",
+      "#00a2b4",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "6.7%",
+      "6.3%",
+      "5.9%",
+      "5.5%",
+      "5.1%",
+      "54.4%",
+      "(unknown) (1,000)",
+      "user1 (940)",
+      "user2 (880)",
+      "user3 (820)",
+      "user4 (760)",
+      "user5 (700)",
+      "user6 (640)",
+      "user7 (580)",
+      "user8 (520)",
+      "Other (8,160)"
+    ],
+    "size": [
+      356.5,
+      236.2
+    ]
+  },
   "nodetype.empty": {
     "html": "<div class=\"text-center text-muted\">No history data available for this node type</div>",
     "kind": "placeholder"
@@ -2581,6 +3860,66 @@
     "size": [
       292.8,
       370.2
+    ]
+  },
+  "nodetype.normal@tablet": {
+    "counts": {
+      "a": 0,
+      "g": 123,
+      "path": 44,
+      "text": 28,
+      "use": 23
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#ff1f1f",
+      "#0057c2",
+      "#42c0ff",
+      "#011837",
+      "#ffffff",
+      "#ff1f1f",
+      "#011837",
+      "#0057c2",
+      "#011837",
+      "#42c0ff",
+      "#011837",
+      "#ffffff",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0",
+      "20",
+      "40",
+      "60",
+      "80",
+      "100",
+      "120",
+      "Number of Nodes",
+      "Down",
+      "Fully Allocated",
+      "Resources Available",
+      "18:00",
+      "Feb 28",
+      "20:00",
+      "22:00",
+      "00:00",
+      "Mar 1",
+      "02:00",
+      "Time (MDT)",
+      "0%",
+      "20%",
+      "40%",
+      "60%",
+      "80%",
+      "100%",
+      "Utilization",
+      "CPU/GPU Utilization",
+      "Memory Utilization"
+    ],
+    "size": [
+      736.1,
+      473.0
     ]
   },
   "pace.empty": {
@@ -2837,6 +4176,107 @@
       292.9
     ]
   },
+  "pace.future@tablet": {
+    "counts": {
+      "a": 20,
+      "g": 89,
+      "path": 40,
+      "text": 26,
+      "use": 11
+    },
+    "drill_hrefs": [
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0006",
+      "/user/project-details-modal/PROJ0006",
+      "/user/project-details-modal/PROJ0008",
+      "/user/project-details-modal/PROJ0008",
+      "/user/project-details-modal/PROJ0010",
+      "/user/project-details-modal/PROJ0010",
+      "/user/project-details-modal/PROJ0012",
+      "/user/project-details-modal/PROJ0012",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0014",
+      "/user/project-details-modal/PROJ0014"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#ff1f1f",
+      "#00818f",
+      "#00a2b4",
+      "#42c0ff",
+      "#0057c2",
+      "#5a77a6",
+      "#bbbcbc",
+      "#011837",
+      "#00357a",
+      "#fdd509",
+      "#011837",
+      "#fbe174",
+      "#011837",
+      "#faa119",
+      "#011837",
+      "#fabe72",
+      "#011837",
+      "#ff1f1f",
+      "#011837",
+      "#00818f",
+      "#011837",
+      "#00a2b4",
+      "#011837",
+      "#42c0ff",
+      "#011837",
+      "#0057c2",
+      "#011837",
+      "#5a77a6",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Nov",
+      "2025",
+      "Jan",
+      "2026",
+      "Mar",
+      "May",
+      "Jul",
+      "Sep",
+      "0",
+      "5.00M",
+      "10.0M",
+      "15.0M",
+      "20.0M",
+      "Rate (per year)",
+      "today",
+      "PROJ0000 (5.17M/yr)",
+      "PROJ0002 (4.75M/yr)",
+      "PROJ0004 (4.34M/yr)",
+      "PROJ0006 (3.93M/yr)",
+      "PROJ0008 (3.51M/yr)",
+      "PROJ0010 (3.10M/yr)",
+      "PROJ0012 (2.69M/yr)",
+      "PROJ0001 (2.65M/yr)",
+      "PROJ0003 (2.43M/yr)",
+      "PROJ0014 (2.27M/yr)",
+      "Other (15 projects) (17.3M/yr)"
+    ],
+    "size": [
+      605.6,
+      238.5
+    ]
+  },
   "pace.size": {
     "counts": {
       "a": 40,
@@ -3087,6 +4527,107 @@
       292.9
     ]
   },
+  "pace.size@tablet": {
+    "counts": {
+      "a": 20,
+      "g": 89,
+      "path": 40,
+      "text": 26,
+      "use": 11
+    },
+    "drill_hrefs": [
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0005",
+      "/user/project-details-modal/PROJ0005",
+      "/user/project-details-modal/PROJ0006",
+      "/user/project-details-modal/PROJ0006",
+      "/user/project-details-modal/PROJ0007",
+      "/user/project-details-modal/PROJ0007",
+      "/user/project-details-modal/PROJ0008",
+      "/user/project-details-modal/PROJ0008",
+      "/user/project-details-modal/PROJ0009",
+      "/user/project-details-modal/PROJ0009"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#ff1f1f",
+      "#00818f",
+      "#00a2b4",
+      "#42c0ff",
+      "#0057c2",
+      "#5a77a6",
+      "#bbbcbc",
+      "#011837",
+      "#00357a",
+      "#fdd509",
+      "#011837",
+      "#fbe174",
+      "#011837",
+      "#faa119",
+      "#011837",
+      "#fabe72",
+      "#011837",
+      "#ff1f1f",
+      "#011837",
+      "#00818f",
+      "#011837",
+      "#00a2b4",
+      "#011837",
+      "#42c0ff",
+      "#011837",
+      "#0057c2",
+      "#011837",
+      "#5a77a6",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Nov",
+      "2025",
+      "Jan",
+      "2026",
+      "Mar",
+      "May",
+      "Jul",
+      "Sep",
+      "0",
+      "5.00M",
+      "10.0M",
+      "15.0M",
+      "20.0M",
+      "Rate (per year)",
+      "today",
+      "PROJ0000 (2.50M)",
+      "PROJ0001 (2.40M)",
+      "PROJ0002 (2.30M)",
+      "PROJ0003 (2.20M)",
+      "PROJ0004 (2.10M)",
+      "PROJ0005 (2.00M)",
+      "PROJ0006 (1.90M)",
+      "PROJ0007 (1.80M)",
+      "PROJ0008 (1.70M)",
+      "PROJ0009 (1.60M)",
+      "Other (15 projects) (12.0M)"
+    ],
+    "size": [
+      593.5,
+      238.5
+    ]
+  },
   "pace.small_top_n": {
     "counts": {
       "a": 12,
@@ -3241,6 +4782,81 @@
       275.8
     ]
   },
+  "pace.small_top_n@tablet": {
+    "counts": {
+      "a": 12,
+      "g": 82,
+      "path": 32,
+      "text": 23,
+      "use": 13
+    },
+    "drill_hrefs": [
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0005",
+      "/user/project-details-modal/PROJ0005"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#ff1f1f",
+      "#00818f",
+      "#011837",
+      "#00357a",
+      "#fdd509",
+      "#011837",
+      "#fbe174",
+      "#011837",
+      "#faa119",
+      "#011837",
+      "#fabe72",
+      "#011837",
+      "#ff1f1f",
+      "#011837",
+      "#00818f",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Nov",
+      "2025",
+      "Jan",
+      "2026",
+      "Mar",
+      "May",
+      "Jul",
+      "Sep",
+      "0",
+      "200K",
+      "400K",
+      "600K",
+      "800K",
+      "1.00M",
+      "1.20M",
+      "Rate (per year)",
+      "today",
+      "PROJ0000 (600K)",
+      "PROJ0001 (500K)",
+      "PROJ0002 (400K)",
+      "PROJ0003 (300K)",
+      "PROJ0004 (200K)",
+      "PROJ0005 (100,000)"
+    ],
+    "size": [
+      561.8,
+      231.8
+    ]
+  },
   "queue.cores": {
     "counts": {
       "a": 0,
@@ -3341,6 +4957,60 @@
     "size": [
       282.8,
       342.1
+    ]
+  },
+  "queue.cores@tablet": {
+    "counts": {
+      "a": 0,
+      "g": 130,
+      "path": 47,
+      "text": 30,
+      "use": 24
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0",
+      "2",
+      "5",
+      "8",
+      "10",
+      "12",
+      "15",
+      "18",
+      "Count",
+      "Running",
+      "Pending",
+      "Held",
+      "Active Users",
+      "18:00",
+      "Feb 28",
+      "20:00",
+      "22:00",
+      "00:00",
+      "Mar 1",
+      "02:00",
+      "Time (MDT)",
+      "0",
+      "200",
+      "400",
+      "600",
+      "800",
+      "1,000",
+      "Resources",
+      "Cores Running",
+      "Cores Pending"
+    ],
+    "size": [
+      736.8,
+      473.0
     ]
   },
   "queue.empty": {
@@ -3445,6 +5115,60 @@
     "size": [
       272.5,
       342.1
+    ]
+  },
+  "queue.gpus@tablet": {
+    "counts": {
+      "a": 0,
+      "g": 130,
+      "path": 47,
+      "text": 30,
+      "use": 24
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0",
+      "2",
+      "5",
+      "8",
+      "10",
+      "12",
+      "15",
+      "18",
+      "Count",
+      "Running",
+      "Pending",
+      "Held",
+      "Active Users",
+      "18:00",
+      "Feb 28",
+      "20:00",
+      "22:00",
+      "00:00",
+      "Mar 1",
+      "02:00",
+      "Time (MDT)",
+      "0",
+      "10",
+      "20",
+      "30",
+      "40",
+      "50",
+      "Resources",
+      "GPUs Running",
+      "GPUs Pending"
+    ],
+    "size": [
+      724.2,
+      473.0
     ]
   },
   "usage_stacked.core_hours": {
@@ -3598,6 +5322,80 @@
       247.0
     ]
   },
+  "usage_stacked.core_hours@tablet": {
+    "counts": {
+      "a": 28,
+      "g": 90,
+      "path": 50,
+      "text": 16,
+      "use": 11
+    },
+    "drill_hrefs": [
+      "#sam/day/2026-03-01",
+      "#sam/day/2026-03-03",
+      "#sam/day/2026-03-04",
+      "#sam/day/2026-03-05",
+      "#sam/day/2026-03-07",
+      "#sam/day/2026-03-08",
+      "#sam/day/2026-03-09",
+      "#sam/day/2026-03-10",
+      "#sam/day/2026-03-01",
+      "#sam/day/2026-03-03",
+      "#sam/day/2026-03-04",
+      "#sam/day/2026-03-05",
+      "#sam/day/2026-03-07",
+      "#sam/day/2026-03-08",
+      "#sam/day/2026-03-09",
+      "#sam/day/2026-03-10",
+      "#sam/day/2026-03-01",
+      "#sam/day/2026-03-03",
+      "#sam/day/2026-03-04",
+      "#sam/day/2026-03-05",
+      "#sam/day/2026-03-07",
+      "#sam/day/2026-03-08",
+      "#sam/day/2026-03-09",
+      "#sam/day/2026-03-10",
+      "#sam/user/bob",
+      "#sam/user/bob",
+      "#sam/user/alice",
+      "#sam/user/alice"
+    ],
+    "fills": [
+      "#bbbcbc",
+      "#fdd509",
+      "#fbe174",
+      "#011837",
+      "#fbe174",
+      "#011837",
+      "#fdd509",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 3",
+      "Mar 5",
+      "Mar 7",
+      "Mar 9",
+      "Mar 11",
+      "0",
+      "20",
+      "40",
+      "60",
+      "80",
+      "Core-Hours",
+      "bob",
+      "alice",
+      "Others"
+    ],
+    "size": [
+      756.1,
+      254.0
+    ]
+  },
   "usage_stacked.empty": {
     "html": "<div class=\"text-center text-muted\">No usage data recorded for this period</div>",
     "kind": "placeholder"
@@ -3671,6 +5469,40 @@
     "size": [
       272.6,
       203.6
+    ]
+  },
+  "usage_timeseries.charges@tablet": {
+    "counts": {
+      "a": 0,
+      "g": 63,
+      "path": 27,
+      "text": 13,
+      "use": 11
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#0057c2",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 3",
+      "Mar 5",
+      "Mar 7",
+      "Mar 9",
+      "Mar 11",
+      "0",
+      "20",
+      "40",
+      "60",
+      "80",
+      "Charges"
+    ],
+    "size": [
+      684.0,
+      254.0
     ]
   },
   "usage_timeseries.empty": {
@@ -3764,6 +5596,49 @@
     "size": [
       272.6,
       203.6
+    ]
+  },
+  "usage_timeseries.linked_jobs@tablet": {
+    "counts": {
+      "a": 8,
+      "g": 63,
+      "path": 27,
+      "text": 13,
+      "use": 11
+    },
+    "drill_hrefs": [
+      "#sam/day/2026-03-01",
+      "#sam/day/2026-03-03",
+      "#sam/day/2026-03-04",
+      "#sam/day/2026-03-05",
+      "#sam/day/2026-03-07",
+      "#sam/day/2026-03-08",
+      "#sam/day/2026-03-09",
+      "#sam/day/2026-03-10"
+    ],
+    "fills": [
+      "#0057c2",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 3",
+      "Mar 5",
+      "Mar 7",
+      "Mar 9",
+      "Mar 11",
+      "0",
+      "20",
+      "40",
+      "60",
+      "80",
+      "Job Count"
+    ],
+    "size": [
+      684.0,
+      254.0
     ]
   },
   "user_proj_area.empty": {
@@ -3871,6 +5746,56 @@
     "size": [
       272.5,
       284.8
+    ]
+  },
+  "user_proj_area.peak_unlinked@tablet": {
+    "counts": {
+      "a": 0,
+      "g": 66,
+      "path": 25,
+      "text": 18,
+      "use": 11
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#bbbcbc",
+      "#f8ebb7",
+      "#fbe174",
+      "#fdd509",
+      "#011837",
+      "#fdd509",
+      "#011837",
+      "#fbe174",
+      "#011837",
+      "#f8ebb7",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "18:00",
+      "Feb 28",
+      "20:00",
+      "22:00",
+      "00:00",
+      "Mar 1",
+      "02:00",
+      "0",
+      "10",
+      "20",
+      "30",
+      "40",
+      "50",
+      "Jobs",
+      "PROJ0001 (28)",
+      "PROJ0002 (14)",
+      "PROJ0003 (9)",
+      "Others (4)"
+    ],
+    "size": [
+      824.1,
+      257.0
     ]
   },
   "user_proj_area.project_current": {
@@ -3988,6 +5913,63 @@
     "size": [
       272.5,
       284.8
+    ]
+  },
+  "user_proj_area.project_current@tablet": {
+    "counts": {
+      "a": 6,
+      "g": 66,
+      "path": 25,
+      "text": 18,
+      "use": 11
+    },
+    "drill_hrefs": [
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0003"
+    ],
+    "fills": [
+      "#bbbcbc",
+      "#f8ebb7",
+      "#fbe174",
+      "#fdd509",
+      "#011837",
+      "#fdd509",
+      "#011837",
+      "#fbe174",
+      "#011837",
+      "#f8ebb7",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "18:00",
+      "Feb 28",
+      "20:00",
+      "22:00",
+      "00:00",
+      "Mar 1",
+      "02:00",
+      "0",
+      "10",
+      "20",
+      "30",
+      "40",
+      "50",
+      "Jobs",
+      "PROJ0001 (20)",
+      "PROJ0002 (10)",
+      "PROJ0003 (5)",
+      "Others (2)"
+    ],
+    "size": [
+      824.0,
+      257.0
     ]
   },
   "user_usage_pie.charges": {
@@ -4168,6 +6150,107 @@
       175.2
     ]
   },
+  "user_usage_pie.charges@tablet": {
+    "counts": {
+      "a": 27,
+      "g": 46,
+      "path": 21,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user0",
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user8"
+    ],
+    "fills": [
+      "#0057c2",
+      "#00357a",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#011837",
+      "#bbbcbc",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#0057c2",
+      "#011837",
+      "#00357a",
+      "#011837",
+      "#ff1f1f",
+      "#011837",
+      "#fdd509",
+      "#011837",
+      "#faa119",
+      "#011837",
+      "#00818f",
+      "#011837",
+      "#42c0ff",
+      "#011837",
+      "#00a2b4",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "7.7%",
+      "user0 (12,000)",
+      "user1 (11,000)",
+      "user2 (10,000)",
+      "user3 (9,000)",
+      "user4 (8,000)",
+      "user5 (7,000)",
+      "user6 (6,000)",
+      "user7 (5,000)",
+      "user8 (4,000)",
+      "Other (3) (6,000)"
+    ],
+    "size": [
+      351.2,
+      236.2
+    ]
+  },
   "user_usage_pie.default_metric": {
     "counts": {
       "a": 27,
@@ -4344,6 +6427,107 @@
     "size": [
       292.4,
       175.2
+    ]
+  },
+  "user_usage_pie.default_metric@tablet": {
+    "counts": {
+      "a": 27,
+      "g": 46,
+      "path": 21,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user0",
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user8"
+    ],
+    "fills": [
+      "#0057c2",
+      "#00357a",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#011837",
+      "#bbbcbc",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#0057c2",
+      "#011837",
+      "#00357a",
+      "#011837",
+      "#ff1f1f",
+      "#011837",
+      "#fdd509",
+      "#011837",
+      "#faa119",
+      "#011837",
+      "#00818f",
+      "#011837",
+      "#42c0ff",
+      "#011837",
+      "#00a2b4",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "7.7%",
+      "user0 (12,000)",
+      "user1 (11,000)",
+      "user2 (10,000)",
+      "user3 (9,000)",
+      "user4 (8,000)",
+      "user5 (7,000)",
+      "user6 (6,000)",
+      "user7 (5,000)",
+      "user8 (4,000)",
+      "Other (3) (6,000)"
+    ],
+    "size": [
+      351.2,
+      236.2
     ]
   },
   "user_usage_pie.empty": {
@@ -4526,6 +6710,107 @@
     "size": [
       287.2,
       175.2
+    ]
+  },
+  "user_usage_pie.jobs@tablet": {
+    "counts": {
+      "a": 27,
+      "g": 46,
+      "path": 21,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user0",
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user8"
+    ],
+    "fills": [
+      "#0057c2",
+      "#00357a",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#011837",
+      "#bbbcbc",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#0057c2",
+      "#011837",
+      "#00357a",
+      "#011837",
+      "#ff1f1f",
+      "#011837",
+      "#fdd509",
+      "#011837",
+      "#faa119",
+      "#011837",
+      "#00818f",
+      "#011837",
+      "#42c0ff",
+      "#011837",
+      "#00a2b4",
+      "#011837",
+      "#bbbcbc",
+      "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "7.7%",
+      "user0 (600)",
+      "user1 (550)",
+      "user2 (500)",
+      "user3 (450)",
+      "user4 (400)",
+      "user5 (350)",
+      "user6 (300)",
+      "user7 (250)",
+      "user8 (200)",
+      "Other (3) (300)"
+    ],
+    "size": [
+      343.4,
+      236.2
     ]
   }
 }

--- a/tests/unit/test_chart_cache_key_signatures.py
+++ b/tests/unit/test_chart_cache_key_signatures.py
@@ -211,7 +211,7 @@ def test_migrated_charts_declare_cache_config():
     for name, cls in _migrated().items():
         assert cls.cache_name, f'{cls.__name__} has no cache_name'
         assert cls.cache_maxsize, f'{cls.__name__} has no cache_maxsize'
-        assert cls.LAYOUTS and 'desktop' in cls.LAYOUTS and 'mobile' in cls.LAYOUTS
+        assert cls.LAYOUTS and {'desktop', 'mobile', 'tablet'} <= set(cls.LAYOUTS)
 
 
 def _cases_by_chart():
@@ -251,16 +251,21 @@ class TestRenderAxesAreKeyed:
     def test_layout_changes_the_key(self):
         from webapp.dashboards.charts.dualpanel import NodetypeHistoryChart as C
         assert self._keys(C) != self._keys(C, layout='mobile')
+        assert self._keys(C) != self._keys(C, layout='tablet')
 
     def test_theme_changes_the_key(self):
         from webapp.dashboards.charts.dualpanel import NodetypeHistoryChart as C
         assert self._keys(C) != self._keys(C, theme='dark')
 
+    LAYOUTS = ('desktop', 'mobile', 'tablet')
+    THEMES = ('light', 'dark')
+
     def test_axes_are_independent(self):
         from webapp.dashboards.charts.dualpanel import NodetypeHistoryChart as C
         seen = {self._keys(C, layout=l, theme=t)
-                for l in ('desktop', 'mobile') for t in ('light', 'dark')}
-        assert len(seen) == 4, 'the two axes are not independent in the key'
+                for l in self.LAYOUTS for t in self.THEMES}
+        assert len(seen) == len(self.LAYOUTS) * len(self.THEMES), (
+            'the two axes are not independent in the key')
 
     def test_every_migrated_chart_renders_under_every_combination(self, app):
         """Both axes must actually render, not merely be accepted.
@@ -271,8 +276,8 @@ class TestRenderAxesAreKeyed:
         cases = _cases_by_chart()
         assert cases, 'no migrated chart has a sample case'
         for fn, (args, kwargs) in cases.items():
-            for lay in ('desktop', 'mobile'):
-                for thm in ('light', 'dark'):
+            for lay in self.LAYOUTS:
+                for thm in self.THEMES:
                     with app.test_request_context('/'):
                         out = fn(*args, **kwargs, layout=lay, theme=thm)
                     assert '<svg' in out, (

--- a/tests/unit/test_chart_fingerprints.py
+++ b/tests/unit/test_chart_fingerprints.py
@@ -14,18 +14,20 @@ Regenerate after an intentional change, then review the diff in that commit:
 
     CHART_FINGERPRINT_REGEN=1 pytest tests/unit/test_chart_fingerprints.py
 
-## Both layouts are pinned
+## Every layout is pinned
 
-Every non-empty case is rendered twice, at ``layout='desktop'`` and at
-``layout='mobile'``, under snapshot keys ``<case>`` and ``<case>@mobile``.
+Every non-empty case is rendered once per declared layout: desktop keeps the
+bare case id, and each other profile adds a suffix — ``<case>@mobile``,
+``<case>@tablet``. The list is read off the chart classes, so a fourth profile
+pins itself.
 
-The mobile half exists because the mobile pass is *tuning* work: figure
+The non-desktop halves exist because these passes are *tuning* work: figure
 sizes, legend placement and font sizes get moved until they look right, and
 without a pinned baseline "I nudged the pace chart" and "I broke the pace
 chart" produce the same diff — none. It also makes the desktop invariant
-enforceable in the same run: a mobile-tuning commit that moves a desktop
-fingerprint has leaked, and that is the single most likely way this pass
-regresses the 1,000+ desktop users it is not for.
+enforceable in the same run: a mobile- or tablet-tuning commit that moves a
+desktop fingerprint has leaked, and that is the single most likely way these
+passes regress the 1,000+ desktop users they are not for.
 
 Empty cases are layout-invariant by construction — ``is_empty()`` short-circuits
 before ``make_figure()`` — so they are pinned once, and
@@ -44,19 +46,33 @@ from chart_samples import CASES
 
 SNAPSHOT = Path(__file__).parent / 'snapshots' / 'chart_fingerprints.json'
 
-#: Suffix appended to a case id for its mobile rendering. Desktop keeps the
-#: bare id so the existing snapshot keys — and every diff anyone has already
-#: reviewed — stay stable.
-MOBILE_SUFFIX = '@mobile'
+
+def extra_layouts():
+    """Every declared layout except desktop, which keeps the bare case id.
+
+    Read off the chart classes rather than listed here, so adding a profile to
+    ``layout.profile()`` pins it in this gate without touching this file. The
+    bare-id convention for desktop is what keeps the existing snapshot keys —
+    and every diff anyone has already reviewed — stable.
+    """
+    from webapp.dashboards import charts
+
+    names = set()
+    for fn in vars(charts).values():
+        cls = getattr(fn, 'chart_class', None)
+        if cls is not None and cls.LAYOUTS:
+            names |= set(cls.LAYOUTS)
+    return tuple(sorted(names - {'desktop'}))
 
 
 def _render_all(app):
-    """Render every case inside one app context, at both layouts.
+    """Render every case inside one app context, at every layout.
 
     Several charts resolve modal routes through ``url_for``, so an application
     context is required even though nothing here touches the database.
     """
     out = {}
+    layouts = extra_layouts()
     with app.test_request_context('/'):
         for case_id, fn, args, kwargs in CASES:
             out[case_id] = svg_fingerprint(fn(*args, **kwargs))
@@ -64,8 +80,9 @@ def _render_all(app):
                 # Layout-invariant by construction; pinned once. The claim is
                 # tested directly by test_empty_state_is_layout_invariant.
                 continue
-            out[case_id + MOBILE_SUFFIX] = svg_fingerprint(
-                fn(*args, **kwargs, layout='mobile'))
+            for name in layouts:
+                out[f'{case_id}@{name}'] = svg_fingerprint(
+                    fn(*args, **kwargs, layout=name))
     return out
 
 
@@ -156,8 +173,18 @@ def test_empty_state_is_layout_invariant(app):
     with app.test_request_context('/'):
         for case_id, fn, args, kwargs in empties:
             desktop = fn(*args, **kwargs)
-            mobile = fn(*args, **kwargs, layout='mobile')
-            assert desktop == mobile, f'{case_id} placeholder differs by layout'
+            for name in extra_layouts():
+                other = fn(*args, **kwargs, layout=name)
+                assert desktop == other, (
+                    f'{case_id} placeholder differs at layout={name}')
+
+
+def _pairs(rendered, name):
+    suffix = '@' + name
+    out = [(cid, cid + suffix) for cid in rendered
+           if '@' not in cid and cid + suffix in rendered]
+    assert out, f'no desktop/{name} pairs rendered'
+    return sorted(out)
 
 
 def test_mobile_renders_smaller_than_desktop(rendered):
@@ -168,15 +195,29 @@ def test_mobile_renders_smaller_than_desktop(rendered):
     labels rendered at roughly their nominal size, and it is the one claim
     that must hold for all fifteen charts no matter how the tuning moves.
     """
-    pairs = [(cid, cid + MOBILE_SUFFIX) for cid in rendered
-             if not cid.endswith(MOBILE_SUFFIX)
-             and cid + MOBILE_SUFFIX in rendered]
-    assert pairs, 'no desktop/mobile pairs rendered'
-
     wider = []
-    for desktop_id, mobile_id in sorted(pairs):
+    for desktop_id, mobile_id in _pairs(rendered, 'mobile'):
         dw = rendered[desktop_id]['size'][0]
         mw = rendered[mobile_id]['size'][0]
         if mw >= dw:
             wider.append(f'{desktop_id}: desktop {dw}pt -> mobile {mw}pt')
     assert not wider, 'mobile figure is not narrower:\n  ' + '\n  '.join(wider)
+
+
+def test_tablet_falls_between_mobile_and_desktop(rendered):
+    """The band is between the other two, so the figure must be as well.
+
+    Non-strict at the desktop end on purpose: the pie family declares tablet
+    *as* its desktop figure (see `PieChart.LAYOUTS`), because a pie's tight
+    bbox is already narrower than every card that renders one. Strict at the
+    mobile end, where no family has a reason to tie.
+    """
+    bad = []
+    for desktop_id, tablet_id in _pairs(rendered, 'tablet'):
+        dw = rendered[desktop_id]['size'][0]
+        tw = rendered[tablet_id]['size'][0]
+        mw = rendered[desktop_id + '@mobile']['size'][0]
+        if not mw < tw <= dw:
+            bad.append(f'{desktop_id}: mobile {mw}pt, tablet {tw}pt, '
+                       f'desktop {dw}pt')
+    assert not bad, 'tablet figure is out of order:\n  ' + '\n  '.join(bad)

--- a/tests/unit/test_chart_layout_axis.py
+++ b/tests/unit/test_chart_layout_axis.py
@@ -23,7 +23,7 @@ from webapp.dashboards import charts
 from webapp.dashboards.charts import dualpanel, histogram, pace, pie, stacked
 from webapp.dashboards.charts.base import BaseChart
 from webapp.dashboards.charts.layout import (
-    MOBILE_DEFAULTS, Layout, profile, resolve_layout,
+    MOBILE_DEFAULTS, TABLET_DEFAULTS, Layout, profile, resolve_layout,
 )
 
 #: Every class in the package that declares its own profile.
@@ -48,38 +48,67 @@ def _chart_classes():
 
 class TestProfile:
 
-    def test_mobile_figsize_is_required(self):
-        """It used to default to the desktop aspect ratio at 4.5in wide, which
-        turns 18:5 into a strip with no room for a plot once the legend moves
-        underneath. Making it positional means a new family cannot inherit
-        that mistake by omission."""
+    def test_non_desktop_figsizes_are_required(self):
+        """`mobile_figsize` used to default to the desktop aspect ratio at
+        4.5in wide, which turns 18:5 into a strip with no room for a plot once
+        the legend moves underneath. Making both positional means a new family
+        cannot inherit that mistake by omission — and a family that genuinely
+        wants desktop's figure at tablet size has to say so."""
         with pytest.raises(TypeError):
             profile((18, 5))
+        with pytest.raises(TypeError):
+            profile((18, 5), (4.6, 3.2))
 
-    def test_keywords_configure_desktop_not_mobile(self):
+    @pytest.mark.parametrize('name', ['mobile', 'tablet'])
+    def test_keywords_configure_desktop_not_the_others(self, name):
         """The bug this signature was changed to prevent.
 
         `label_rotation=30` reads like a mobile override and is not one. When
-        mobile overrides were collected with `**kwargs`, any name colliding
-        with a desktop parameter was silently applied to desktop instead —
-        the override looked accepted and did nothing.
+        overrides were collected with `**kwargs`, any name colliding with a
+        desktop parameter was silently applied to desktop instead — the
+        override looked accepted and did nothing.
+
+        Tablet inherits desktop's rotation because `TABLET_DEFAULTS` says
+        nothing about it; mobile flattens it to 45. Either way the assertion
+        is that the *keyword* landed on desktop.
         """
-        p = profile((18, 5), (4.6, 3.2), label_rotation=30)
+        p = profile((18, 5), (4.6, 3.2), (11, 3.6), label_rotation=30)
         assert p['desktop'].label_rotation == 30
-        assert p['mobile'].label_rotation == MOBILE_DEFAULTS['label_rotation']
+        expected = {'mobile': MOBILE_DEFAULTS, 'tablet': TABLET_DEFAULTS}[name]
+        assert p[name].label_rotation == expected.get('label_rotation', 30)
 
     def test_mobile_dict_overrides_the_defaults(self):
-        p = profile((7, 4), (4.0, 3.2), mobile={'legend_placement': 'right'})
+        p = profile((7, 4), (4.0, 3.2), (7, 4),
+                    mobile={'legend_placement': 'right'})
         assert p['mobile'].legend_placement == 'right'
         assert p['desktop'].legend_placement == 'right'
         # Untouched keys still come from MOBILE_DEFAULTS.
         assert p['mobile'].max_legend_entries == MOBILE_DEFAULTS['max_legend_entries']
 
-    def test_unknown_mobile_override_is_rejected(self):
+    def test_tablet_dict_overrides_the_defaults(self):
+        p = profile((7, 4), (4.0, 3.2), (7, 4),
+                    tablet={'max_legend_entries': None})
+        assert p['tablet'].max_legend_entries is None
+        assert p['tablet'].max_ticks == TABLET_DEFAULTS['max_ticks']
+
+    def test_tablet_inherits_desktop_where_it_says_nothing(self):
+        """A tablet is a small desktop, not a large phone. `TABLET_DEFAULTS`
+        names two fields; everything else — placement, rotation, and all four
+        font sizes — must come through from desktop rather than from the
+        phone's flattened one-size-fits-all."""
+        p = profile((18, 5), (4.0, 2.8), (11, 3.6), label_rotation=30)
+        d, t = p['desktop'], p['tablet']
+        for field in ('legend_placement', 'label_rotation', 'base_fontsize',
+                      'legend_fontsize', 'axis_label_fontsize',
+                      'tick_fontsize'):
+            assert getattr(t, field) == getattr(d, field), field
+
+    @pytest.mark.parametrize('name', ['mobile', 'tablet'])
+    def test_unknown_override_is_rejected(self, name):
         """A typo'd field name would otherwise be dropped in silence, which is
         exactly how `legend_placement` came to look wired when it wasn't."""
         with pytest.raises(TypeError, match='unknown Layout field'):
-            profile((7, 4), (4.0, 3.2), mobile={'legend_size': 9})
+            profile((7, 4), (4.0, 3.2), (7, 4), **{name: {'legend_size': 9}})
 
     def test_desktop_legend_fontsize_is_none(self):
         """None means "defer to the chart", which is what keeps desktop
@@ -117,15 +146,39 @@ class TestProfiles:
         assert 3.5 <= mobile[0] <= 5.0, f'{cls.__name__} mobile width {mobile[0]}'
 
     @pytest.mark.parametrize('cls', LAYOUT_OWNERS, ids=lambda c: c.__name__)
-    def test_mobile_is_not_the_desktop_aspect_ratio(self, cls):
-        """Preserving the ratio is what produced a 4.5 x 1.25in strip."""
-        d, m = cls.LAYOUTS['desktop'].figsize, cls.LAYOUTS['mobile'].figsize
-        assert abs(m[1] / m[0] - d[1] / d[0]) > 0.01, cls.__name__
+    def test_tablet_figure_sits_between_the_two(self, cls):
+        """The band is between the other two, so the figure must be as well.
+
+        Non-strict at the desktop end: `PieChart` declares tablet *as* its
+        desktop figure, because a pie's tight bbox is already narrower than
+        every card that renders one. See its `LAYOUTS` comment.
+        """
+        d = cls.LAYOUTS['desktop'].figsize
+        m = cls.LAYOUTS['mobile'].figsize
+        t = cls.LAYOUTS['tablet'].figsize
+        assert m[0] < t[0] <= d[0], (
+            f'{cls.__name__}: mobile {m[0]}in, tablet {t[0]}in, '
+            f'desktop {d[0]}in')
+
+    @pytest.mark.parametrize('cls', LAYOUT_OWNERS, ids=lambda c: c.__name__)
+    @pytest.mark.parametrize('name', ['mobile', 'tablet'])
+    def test_smaller_figures_are_not_the_desktop_aspect_ratio(self, cls, name):
+        """Preserving the ratio is what produced a 4.5 x 1.25in strip.
+
+        A family whose figure is *unchanged* is exempt — it is not a scaled
+        copy, it is the same figure, and the hazard this guards against is
+        scaling one dimension by the other's factor.
+        """
+        d = cls.LAYOUTS['desktop'].figsize
+        s = cls.LAYOUTS[name].figsize
+        if tuple(s) == tuple(d):
+            pytest.skip(f'{cls.__name__} {name} is the desktop figure')
+        assert abs(s[1] / s[0] - d[1] / d[0]) > 0.01, cls.__name__
 
     def test_every_bound_chart_reaches_a_profile(self):
         for name, cls in _chart_classes().items():
             assert cls.LAYOUTS, f'{name} ({cls.__name__}) has no LAYOUTS'
-            assert set(cls.LAYOUTS) == {'desktop', 'mobile'}, name
+            assert set(cls.LAYOUTS) == {'desktop', 'mobile', 'tablet'}, name
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/test_layout_transport.py
+++ b/tests/unit/test_layout_transport.py
@@ -18,6 +18,8 @@ render. Together they leave only that one first page, on which charts are
 merely small rather than broken.
 """
 
+import importlib
+import inspect
 import re
 from pathlib import Path
 
@@ -87,6 +89,72 @@ class TestReadLayout:
         from webapp.utils.htmx import _LAYOUTS
 
         assert _LAYOUTS == set(pie.PieChart.LAYOUTS)
+
+
+# --------------------------------------------------------------------------
+# The last hop: renderer to renderer
+# --------------------------------------------------------------------------
+
+#: The modules whose fragment renderers take a ``layout`` argument.
+#: ``utils/fragments.py:_register_one`` resolves it once for all 27
+#: jobs/disk-scans routes and hands it to every panel, so the axis reaches
+#: these two files and then has to be *carried* the rest of the way by hand.
+_RENDERER_MODULES = ('webapp.jobs.routes', 'webapp.disk_scans.routes')
+
+
+def _layout_takers(module):
+    """``{name: fn}`` for everything in the module's namespace that accepts a
+    ``layout`` argument — its own renderers *and* the imported chart callables,
+    which advertise it through ``chart_view``'s explicit ``__signature__``."""
+    out = {}
+    for name, fn in vars(module).items():
+        # Plain functions only. The module namespace also holds Flask
+        # `LocalProxy` objects (`current_app`, `request`), and merely asking
+        # one for a signature dereferences it — outside an app context that
+        # raises rather than returning something uninteresting.
+        if not inspect.isfunction(fn):
+            continue
+        try:
+            sig = inspect.signature(fn)
+        except (TypeError, ValueError):
+            continue
+        if 'layout' in sig.parameters:
+            out[name] = fn
+    return out
+
+
+@pytest.mark.parametrize('mod_name', _RENDERER_MODULES)
+def test_renderers_forward_the_layout_they_are_given(mod_name):
+    """A renderer that delegates to something layout-aware must pass it on.
+
+    This is the one hop nothing else can check. The registrar resolves
+    ``read_layout()`` once and the chart layer honours whatever it is given,
+    so a renderer that accepts ``layout`` and then calls its delegate without
+    it fails *silently* — the fragment renders, at desktop, forever. That is
+    exactly what happened to the three jobs histogram panels (Wait Times, Job
+    Sizes, Durations): ``_panel_histogram`` took the argument and dropped it,
+    and all three served an 18in figure to phones and tablets alike.
+
+    Renderers that draw no chart are exempt by construction rather than by
+    allowlist: they call nothing that takes a ``layout``, so there is nothing
+    to forward. ``utils/fragments.py`` states that contract — "panels that draw
+    no chart accept and ignore it".
+    """
+    module = importlib.import_module(mod_name)
+    takers = _layout_takers(module)
+    assert takers, f'{mod_name} has no layout-aware callables — test is stale'
+
+    dropped = []
+    for name, fn in takers.items():
+        if getattr(fn, '__module__', None) != mod_name:
+            continue                       # imported chart view, not a renderer
+        src = inspect.getsource(fn)
+        delegates = [d for d in takers
+                     if d != name and re.search(rf'\b{re.escape(d)}\s*\(', src)]
+        if delegates and 'layout=layout' not in src:
+            dropped.append(f'{name} calls {sorted(delegates)} without layout=')
+    assert not dropped, (
+        'layout dropped on the way to a chart:\n  ' + '\n  '.join(dropped))
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/test_layout_transport.py
+++ b/tests/unit/test_layout_transport.py
@@ -42,15 +42,17 @@ class TestReadLayout:
         with app.test_request_context('/'):
             assert read_layout() == 'desktop'
 
-    @pytest.mark.parametrize('value', ['mobile', 'MOBILE', ' mobile '])
-    def test_query_string_selects_mobile(self, app, value):
+    @pytest.mark.parametrize('value', ['mobile', 'MOBILE', ' mobile ',
+                                       'tablet', 'TABLET', ' tablet '])
+    def test_query_string_selects_a_declared_layout(self, app, value):
         with app.test_request_context('/', query_string={'layout': value}):
-            assert read_layout() == 'mobile'
+            assert read_layout() == value.strip().lower()
 
-    def test_cookie_selects_mobile(self, app):
+    @pytest.mark.parametrize('value', ['mobile', 'tablet'])
+    def test_cookie_selects_a_declared_layout(self, app, value):
         with app.test_request_context(
-                '/', headers={'Cookie': f'{LAYOUT_COOKIE}=mobile'}):
-            assert read_layout() == 'mobile'
+                '/', headers={'Cookie': f'{LAYOUT_COOKIE}={value}'}):
+            assert read_layout() == value
 
     def test_query_string_outranks_the_cookie(self, app):
         """The fragment reflects the viewport *now*; the cookie reflects
@@ -72,10 +74,19 @@ class TestReadLayout:
     def test_normalizes_rather_than_passing_through(self, app):
         """The chart layer is lenient too, so passing an unknown value along
         would render correctly — but it would reach the *cache key*, and that
-        key is shared across workers and pods. Two spellings, not arbitrarily
-        many."""
+        key is shared across workers and pods. The declared spellings, not
+        arbitrarily many."""
         with app.test_request_context('/', query_string={'layout': 'bogus'}):
-            assert read_layout() in ('desktop', 'mobile')
+            assert read_layout() in ('desktop', 'tablet', 'mobile')
+
+    def test_every_name_reaches_a_chart_profile(self, app):
+        """A vocabulary the transport accepts but the charts cannot draw would
+        cache an exception path. The two lists are declared in different files;
+        this is what keeps them one list."""
+        from webapp.dashboards.charts import pie
+        from webapp.utils.htmx import _LAYOUTS
+
+        assert _LAYOUTS == set(pie.PieChart.LAYOUTS)
 
 
 # --------------------------------------------------------------------------
@@ -106,9 +117,10 @@ class TestCacheKeyPartitionsByLayout:
             return user_aware_cache_key()
 
     def test_layout_is_in_the_key(self, app):
-        desktop = self._key(app)
-        mobile = self._key(app, headers={'Cookie': f'{LAYOUT_COOKIE}=mobile'})
-        assert desktop != mobile
+        keys = {self._key(app)}
+        for name in ('mobile', 'tablet'):
+            keys.add(self._key(app, headers={'Cookie': f'{LAYOUT_COOKIE}={name}'}))
+        assert len(keys) == 3, 'two layouts share a cached-HTML slot'
 
     def test_same_layout_shares_a_slot(self, app):
         a = self._key(app, headers={'Cookie': f'{LAYOUT_COOKIE}=mobile'})
@@ -135,20 +147,42 @@ class TestLayoutAxisJs:
     def js(self):
         return JS.read_text()
 
+    #: Bootstrap's `max-width` breakpoints (each 0.02px under the `min-width`
+    #: one). A layout boundary that is not one of these is a number somebody
+    #: invented, and it will drift away from the CSS that has to agree with it.
+    BOOTSTRAP_MAX_WIDTHS = {'575.98', '767.98', '991.98', '1199.98', '1399.98'}
+
     def test_uses_the_app_wide_breakpoint(self, js):
         """Bootstrap's `md`, matching ``dashboard-init.js``'s
         ``collapseFilterPanels``. Two definitions of "phone" would put the
-        filter panels and the charts on different sides of the same window."""
+        filter panels and the charts on different sides of the same window.
+
+        This used to assert the two files' query *sets* were equal, which was
+        right while "phone or not" was the only question. The tablet band adds
+        a second boundary that ``dashboard-init.js`` has no opinion on, so the
+        claim narrows to: every breakpoint that file uses is one this file also
+        uses, and anything extra here is a real Bootstrap breakpoint.
+        """
         assert '(max-width: 767.98px)' in js
 
         other = (JS.parent / 'dashboard-init.js').read_text()
         # Both files may hold the query in a constant, so match the literal
         # rather than the matchMedia call site.
-        query = r"\(max-width: [\d.]+px\)"
+        query = r"\(max-width: ([\d.]+)px\)"
         mine = set(re.findall(query, js))
         theirs = set(re.findall(query, other))
-        assert mine and mine == theirs, (
-            f'breakpoint drift: layout-axis {mine} vs dashboard-init {theirs}')
+        assert theirs and theirs <= mine, (
+            f'breakpoint drift: dashboard-init uses {theirs - mine} which '
+            f'layout-axis does not')
+        assert mine <= self.BOOTSTRAP_MAX_WIDTHS, (
+            f'layout-axis invented a breakpoint: '
+            f'{sorted(mine - self.BOOTSTRAP_MAX_WIDTHS)}')
+
+    def test_selects_the_narrowest_matching_band(self, js):
+        """Below 768 both queries match, so the order of the tests is the
+        whole behaviour: mobile must be asked first or a phone gets the tablet
+        figure. Asserted positionally because there is no JS test runner."""
+        assert js.index('MOBILE_QUERY).matches') < js.index('TABLET_QUERY).matches')
 
     def test_cookie_name_matches_the_server(self, js):
         assert f"'{LAYOUT_COOKIE}'" in js or f'"{LAYOUT_COOKIE}"' in js


### PR DESCRIPTION
## Summary

A third chart layout profile, `tablet`, between `mobile` and `desktop`. Stacked
on #416 — **retarget to `staging` once that merges** (and note the child-PR
hazard: merging a parent closes the child).

Implements `docs/plans/TABLET_CHARTS.md`, written at the end of the mobile pass.
The gap it names is real and was measured, not assumed: **a phone rendered
these charts better than an iPad did.** Anything ≥768px fell in the `desktop`
band, so an 18in figure was squeezed into a ~640px card and its smallest label
landed at **6.0px** at a 768 viewport, against the phone's 9.8px.

Bands are Bootstrap breakpoints: **mobile ≤767.98 · tablet 768–1199.98 ·
desktop ≥1200**.

### Measured, at a 768 viewport — smallest on-screen label

| surface | before | after |
|---|---|---|
| `/status/derecho` stacked (625px card — the narrowest in the app) | 6.0px | **9.4px** |
| `/status/partition-history` dual panel | 6.4px | **10.7px** |
| `/status/queue-history` dual panel | 8.1px | **10.5px** |
| jobs explorer timeline | 6.5px | **10.4px** |
| jobs explorer histograms | 8.8px *(stuck at desktop — see below)* | **11.0px** |
| `/status/filesystem-scans` distribution | — | **10.7px** |
| `/allocations` pace | 5.9px | **9.2–10.6px** |
| pies (unchanged by design) | 10.7–16.6px | 10.7–16.6px |

Across the band the same chart reads 9.4px at 768 and 15.4px at 1199, filling
its card at both ends. At a 1215px window the cookie flips to `desktop` and the
18in figure returns at 9.8px; at 390px `mobile` still measures 9.8px.

---

## The commits

| | |
|---|---|
| **T1** | Retire `Layout.is_mobile` — a boolean asked of a three-value vocabulary. Its two call sites become the None-means-defer rule `legend_fontsize` already used. Pure refactor: **zero fingerprint movement.** |
| **T2** | `profile()` takes a third required positional + `tablet={...}`; `TABLET_DEFAULTS`; six declarations. Fingerprint gate reads the layout list off the chart classes. **79 → 111 keys, all 32 additions `@tablet`.** |
| **T3** | Two media queries, narrowest asked first; `tablet` in `_LAYOUTS`. |
| **T4** | Browser tuning against the running app. Two figures moved from their sample-data estimates, and one real bug surfaced. |
| **T5** | CSS gutter, cache budget, docs. |

---

## Three decisions worth reviewing

**1. The upper boundary is 1200, and it was measured.** On these pages the
chart's card is the viewport less 144px and the desktop figure's smallest text
is 12 user-units, so:

| clientWidth | card | smallest label |
|---|---|---|
| 785 | 641 | 6.0px |
| 1009 | 865 | 8.1px |
| 1185 | 1041 | 9.7px |
| 1265 | 1121 | 10.4px |

Desktop clears 9px at ~1110 and 10px at ~1217. The plan said "if it lands at
1280, use `xxl` (1400)". It lands between the two, and `xl` still wins: `xxl`
would hand every 1280 laptop a figure sized for a 640px card, which is a worse
defect than 9.7px labels.

**2. A tablet is a small desktop, not a large phone.** `TABLET_DEFAULTS` names
exactly two fields — `max_legend_entries=10`, `max_ticks=8`. Placement,
rotation and all four font sizes are absent, so they inherit *desktop's*. The
per-family type hierarchy the phone had to flatten (13pt labels over 12pt ticks
on the user/project area chart) survives. `legend_placement='right'` was
checked at tablet width and reads fine, so it is not overridden.

**3. `PieChart`'s tablet figure IS its desktop figure.** A pie trims to its own
square, so its tight bbox is ~360pt where the wide families' is near their
declared inches — every surface that renders a pie already gives it more width
than it can use (13.8px, 10.7px and 16.6px at a 768 viewport). Shrinking it
would make the jobs pie smaller on screen and the allocations pie's labels
larger, and neither is an improvement. Consequences, all deliberate:

- the ordering assertions are `mobile < tablet <= desktop`, non-strict at the
  desktop end;
- the aspect-ratio test skips a figure that is *unchanged* rather than scaled;
- the five pies pay for a duplicate cache entry holding byte-identical SVG
  (~5% of the chart working set). The alternative — a special case in
  `chart_view._key` — buys nothing measurable.

---

## A pre-existing bug this surfaced

**`_panel_histogram` dropped the `layout` it was given.** Wait Times, Job Sizes
and Durations accepted the argument and never passed it to `_render_histogram`,
so all three rendered the 18in desktop figure at *every* viewport. This is a
mobile-pass bug, not a tablet one: **phones have been getting a desktop figure
on those three tabs since #416.** It was found only because shrinking the
tablet figure changed nothing on screen.

`test_renderers_forward_the_layout_they_are_given` closes it: a renderer that
accepts `layout` and calls another layout-aware callable must forward it.
Renderers that draw no chart are exempt *by construction* rather than by
allowlist — they call nothing that takes a layout, which is the contract
`utils/fragments.py` already states. Verified by mutation: reverting the
one-line fix fails the test naming the exact function.

---

## Sizing method

Font size and figure size turn out to be **one knob, not two**: the chart always
fills its card, so on-screen label px = `fontsize × card / bbox`. The tablet
profile therefore changes geometry only, and each family's figure was sized
against the narrowest card it actually renders into (viewport − 144px on the
status pages, − 82px on the jobs cards) and measured — the tight bbox is a
function of the legend contents, so it cannot be derived from `figsize`. The
plan's "~9.3in" arithmetic was replaced accordingly; `StackedSeriesChart` in
particular runs ~130pt past what a sample payload predicts, because the status
page's legend labels are a name *and* a value.

## CSS

The chart gutter's two halves get different bands, from measurement:

- the **negative margin** extends to the whole non-desktop range. The nested
  `.card-body` levels cost the same 32px at 768 as at 375, and it buys a real
  5%: 625 → 657px, 9.0 → 9.4px. Symmetric and non-overflowing at both edges of
  the band, and on a page that nests one card body rather than two.
- **`width: 100%` stays on phones only.** It exists to *upscale* a figure
  narrower than its card, and no tablet figure is — every one measured already
  fills its card under `max-width` alone. Extending it would reach only the
  pies and blow them up.

## Cache

Measured across the 32 sample cases: desktop 562 KB, tablet 483 KB (0.86×),
mobile 417 KB (0.74×). Three layouts are **2.60×** desktop alone; six
combinations with the theme axis land near **5.2×**, up from the 3.1× that
`helm/values.yaml` budgeted for four — still comfortably inside 192 MB against
a base that dropped 58% with `svg.fonttype: none`. The three tightest
`cache_maxsize` budgets are raised again: `facility_pie_chart` 48 → 72,
`nodetype_history` and `queue_history` 96 → 144.

---

### Test Results

Full suite: **4260 passed, 36 skipped, 1 xfailed** in 99s.

Fingerprints: the discipline that made the mobile pass reviewable is kept —
the new layout was pinned in the gate *before* any tuning, so every tuning
commit has a baseline. **Every delta in this branch is a `@tablet` key.** A
desktop or mobile delta in a tablet-tuning commit would be a leak into the
users this pass is not for, and there are none.

New coverage: tablet cases through `read_layout`, `_LAYOUTS` ≡ the chart
profiles, the narrowest-match ordering in the sender, `TABLET_DEFAULTS`
inheritance from desktop, and the renderer-forwarding gate above.

`test_uses_the_app_wide_breakpoint` compared the two JS files' media-query
*sets* for equality, which was right while "phone or not" was the only
question. It now asserts the weaker true claim: every breakpoint
`dashboard-init.js` uses is one `layout-axis.js` uses, and anything extra there
is a real Bootstrap breakpoint rather than an invented number.

### Browser verification

Playwright against `webdev`, Redis flushed between measurements (chart keys
hash input data, not rendering code). Walked 390 / 768 / 785 / 1024 / 1199 /
1215 across `/status/derecho` (6h and 168h), `/status/partition-history`,
`/status/queue-history`, `/status/filesystem-scans`, `/allocations/projects`
and the jobs explorer's five tabs. Zero chart overflow at every width; drill
anchors intact (18 modal routes on the status chart, 66 on a histogram, 777 on
the timeline).

**Known, and not caused by this PR:** `/status/derecho` overflows 65px at a
1009px viewport — a nav `.btn-group` of period pills. Isolated by zeroing every
margin this PR adds, which leaves the overflow unchanged. Same family as the
jobs explorer's pre-existing 20px overflow at 375px.

### Deploy

`sam-admin cache --refresh --category chart` after deploying — chart keys hash
input data, not rendering code, so warm Redis entries serve old-code SVGs for
up to 600s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
