### PR TITLE
Dark-mode charts (PR 4 of the chart render-axis series)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -623,6 +623,25 @@ same vocabulary, and unparsable grains come back unchanged.
 Design + measurements: `docs/plans/MOBILE_CHARTS.md`,
 `docs/plans/TABLET_CHARTS.md`.
 
+### The `theme` axis (light / dark)
+
+The second render axis, and the reason dark mode needs a *server-side* carrier
+at all: charts are matplotlib SVGs with colours baked into the bytes, so no
+stylesheet can retheme them. Transport mirrors `layout` — `read_theme()` in
+`utils/htmx.py`, composed into both `chart_view`'s key and
+`user_aware_cache_key` — but uses **one channel, the cookie**: a viewport is
+discovered client-side after the server answers, a theme is declared by a click
+that reloads, so cookie and browser can never disagree.
+
+| | |
+|---|---|
+| **Chrome** | `Theme` carries text/spine/grid/edges/legend-face/accent. `BaseChart.apply_chrome()` applies them after `finish()`. It must **not** touch `ax.texts` — those artists set their own colour for a reason (pie autopct reads the *wedge*, the pace marker reads `theme.accent`). |
+| **Data** | The `UNITY_*` palettes are invariant in **hue** only. `Theme.data_color()` tints a fill toward white until it clears `min_data_contrast` (3:1) against `Theme.surface`; `Theme.LIGHT` sets it `None` and returns the identical object, which is what makes light byte-identical. |
+| **Roles** | `Theme.muted_data` is the inert "Others" band and must **bypass** the lift — its job is to recede, and lifting it undoes that. `Theme.area_alpha` is 0.85 light / 1.0 dark because figures are transparent and composite against the card. |
+| **Surface** | `Theme.DARK.surface` == `--surface-card` == `#1b2733`, pinned by `test_dark_card_matches_chart_blend_target`. |
+
+Design + rationale: `docs/plans/DARK_MODE.md` § *PR 4 as built*.
+
 ### Adding a chart
 
 1. Subclass the closest family; set `cache_name`, `cache_maxsize`,
@@ -632,9 +651,11 @@ Design + measurements: `docs/plans/MOBILE_CHARTS.md`,
    cache hit must never construct the chart or run `prepare()`.
 3. Bind with `chart_view(...)` in `__init__.py`, add to `__all__`.
 4. Add a case to `tests/unit/chart_samples.py` (a gate requires one). It is
-   fingerprinted at **every** layout automatically.
-5. Pass `layout=read_layout()` at the call site. Fragments registered through
-   `utils/fragments.py` get it for free.
+   fingerprinted at **every** layout × theme automatically.
+5. Pass `layout=read_layout(), theme=read_theme()` at the call site. Fragments
+   registered through `utils/fragments.py` get both for free — but a renderer
+   that *relays* them to a delegate must forward them by hand
+   (`test_renderers_forward_the_axis_they_are_given` is the gate).
 
 ### Drill-downs
 
@@ -676,16 +697,20 @@ a row drill — row drills resolve within the clicked chart's pane.
    zips bands against patches by position, and a capped legend is no longer
    `reversed(bands)`. The fingerprint proves href *strings*, not the artists
    carrying them, so a misaligned drill looks green.
+❌ **DON'T** put a theme-dependent colour in `ax.text()` without setting it
+   explicitly — `apply_chrome` skips `ax.texts` by design, so it will render in
+   whatever the light rcParams baked in.
 ✅ **DO** regenerate the fingerprint snapshot in the *same commit* as an
    intentional visual change:
    `CHART_FINGERPRINT_REGEN=1 pytest tests/unit/test_chart_fingerprints.py`.
    A fingerprint delta in a commit that didn't declare one is a bug. **A
-   desktop delta in a mobile-tuning commit always is.**
+   desktop-light delta in a mobile- or dark-tuning commit always is.**
 ✅ **DO** run `sam-admin cache --refresh --category chart` after deploying a
    visible change — keys hash *input data*, not rendering code, so warm Redis
    entries serve old-code SVGs for up to 600 s.
 
 Design + rationale: `docs/plans/CHART_ARCHITECTURE.md` (the hierarchy),
+`docs/plans/DARK_MODE.md` (the theme axis),
 `docs/plans/MOBILE_CHARTS.md` + `docs/plans/TABLET_CHARTS.md` (the layout
 axis).
 

--- a/docs/plans/CHART_ARCHITECTURE.md
+++ b/docs/plans/CHART_ARCHITECTURE.md
@@ -22,8 +22,8 @@ noted, because several of these numbers are commit-completion gates.
 |---|---|---|---|
 | **1** | **Chart architecture refactor** ← *this document* | — | The OO hierarchy, the structured drill scheme, `Layout`/`Theme` as inert parameters, plus cosmetic normalization (C12) and `svg.fonttype` (C2a). Visual change is permitted but confined to declared commits. |
 | 2 | Mobile-friendly charts — **SHIPPED**, see `MOBILE_CHARTS.md` | 1 | Wires the `mobile` layout: cookie + htmx transport, `read_layout()`, per-family mobile profiles, the two `Layout` fields nothing read, mobile chart gutters. |
-| 3 | App-wide dark mode | — (parallel to 2) | `data-bs-theme`, cookie carrier, `variables.css` dark block, the 83 hardcoded-white sites. **Separate planning session.** |
-| 4 | Dark-mode charts | 1 **and** 3 | Wires the `dark` theme through the axis PR 1 built. |
+| 3 | App-wide dark mode — **SHIPPED**, see `DARK_MODE.md` | — (parallel to 2) | `data-bs-theme`, cookie carrier, `variables.css` dark block, the 83 hardcoded-white sites. |
+| 4 | Dark-mode charts — **SHIPPED**, see `DARK_MODE.md` § *PR 4 as built* | 1 **and** 3 | Wires the `dark` theme through the axis PR 1 built: `apply_chrome`, `Theme.data_color`, `theme=read_theme()` at the call sites. |
 
 **What PR 2 leaves PR 3/4.** The cookie rail exists and is worth reusing:
 `static/js/layout-axis.js` writes `sam_layout` from `matchMedia` and
@@ -1076,11 +1076,14 @@ Every colour below is **chrome** and must move onto `Theme`. Data/series colours
 colour from the *wedge* luminance, not the page, so it is already correct for both
 themes. (It does return a bare `'#fff'` at `:205` — a literal, but a correct one.)
 
-**Needs a design decision, not a mechanical swap:** `UNITY_PALETTE_10[8]` is
-`#011837` (space blue) used as a **pie wedge fill** (`:118`) — on a dark page it
-vanishes into the background while still carrying a white percentage label. And
-the `alpha=0.85` stackplots (`:482`, `:595`) plus `_PACE_OTHER_COLOR` composite
-against the *page*, so every stacked band desaturates on dark.
+**Needed a design decision, not a mechanical swap** — all three were answered
+in PR 4, and the third had not been anticipated here:
+
+| Flagged | Answer |
+|---|---|
+| `UNITY_PALETTE_10[8]` `#011837` as a **pie wedge fill** (`:118`) — 1.17:1 on the dark card | `Theme.min_data_contrast` + `lift_for_contrast`: tint toward white to a 3:1 floor. Touches 3 of 10 pie colours; hue and separability both survive (tinting desaturates as it lightens, where an HSL lift collapsed all three blues onto one). |
+| `alpha=0.85` stackplots (`:482`, `:595`) compositing against the page | `Theme.area_alpha` — 0.85 light, **1.0** dark. The softening a white page wants is what makes a dark one muddy. |
+| **Not flagged, and the one that actually looked worst:** `_PACE_OTHER_COLOR` / `others_color` — `--ncar-gray-light` | `Theme.muted_data`. This is not a contrast problem, it is an *inverted* one: the inert "Others" band is 1.90:1 on white (recessive, correct) and 7.97:1 on the dark card, making the band that means least the brightest thing on the chart. It must bypass the lift, or `min_data_contrast` drags it back up. |
 
 ## Appendix C — corrections applied on re-verification (2026-07-31)
 

--- a/docs/plans/DARK_MODE.md
+++ b/docs/plans/DARK_MODE.md
@@ -1,6 +1,8 @@
 # Application-wide dark mode
 
-**Status: IMPLEMENTED (2026-08-01) on `dark_mode_sans_charts`, D0–D8 landed.**
+**Status: IMPLEMENTED (2026-08-01). PR 3 on `dark_mode_sans_charts` (D0–D9);
+PR 4, dark charts, on `dark_charts` — see § *PR 4 as built*, which supersedes
+§ *Handoff to PR 4* below.**
 Deviations from this plan are recorded in **Appendix E** — read that before
 treating any section below as a description of the shipped code.
 This is **PR 3** of the four-PR roadmap declared in
@@ -12,8 +14,8 @@ cut from `staging` at `bee0f4d`, PR targets `staging`.
 |---|---|---|---|
 | 1 | Chart architecture refactor (layout **and theme** render axes) | — | **merged** — `bee0f4d` (#414) |
 | 2 | Mobile-friendly charts | 1 | landed with #414 |
-| **3** | **App-wide dark mode** ← *this document* | 1 | this branch |
-| 4 | Dark-mode charts | 1 **and** 3 | not started |
+| **3** | **App-wide dark mode** ← *this document* | 1 | merged to this series — PR #419 |
+| **4** | **Dark-mode charts** | 1 **and** 3 | `dark_charts`, stacked on #419 |
 
 All line references are against `staging` at `bee0f4d` and were re-verified
 while revising; where this document contradicts a count in
@@ -854,6 +856,11 @@ Recorded per that document's own convention.
 
 ## Handoff to PR 4 — dark charts
 
+> **Superseded by § *PR 4 as built*, at the end of this document.** Kept
+> because the scoping below was accurate and the *starting state* it records is
+> what the next reader needs to understand the diff.
+
+
 **Decision (Ben, 2026-08-01): PR 3 ships without chart theming.** The known
 gap is that chart SVGs carry baked colours, so in dark mode their legend text
 is `#011837` on the `#1b2733` card (~1.3:1) and `UNITY_PALETTE_10[8]` space
@@ -974,3 +981,90 @@ except where noted.
 | 8 | (not stated) | `utils/csp.py`'s docstring says "Four routes cache fully-rendered HTML"; there are **five** | Pre-existing drift, fixed in D0 |
 | 9 | (not stated) | Bootstrap's dark block already sets `color-scheme:dark`, so native controls/scrollbars need no work | One less thing |
 | 10 | (not stated) | The navbar utility menu is `is_authenticated`-gated; the login page is a separate shell | Toggle must sit outside the conditional and be duplicated into `login.html` |
+
+---
+
+## PR 4 as built — dark charts (2026-08-01, `dark_charts`)
+
+Supersedes § *Handoff to PR 4*. The handoff's scoping held: the plumbing was
+already merged, and the work was "pass the argument, then decide the colours".
+What it did **not** predict is that passing the argument was the smaller half.
+
+### The defect was bigger than "tune `Theme.DARK`"
+
+`Theme.DARK` had been live and reachable since PR 1, and **nothing applied
+`Theme.text` or `Theme.spine`.** Those two fields had zero readers in the whole
+package — every title, axis label, tick, spine and legend label took its colour
+from the module-level rcParams block, which bakes the *light* chrome in at
+import because it runs once per process, before any request has a theme. So a
+chart asked for in dark rendered the light bytes, which is exactly the 1.3:1
+figure the handoff measured.
+
+The fix is `BaseChart.apply_chrome`, called after `finish()` so the legend
+exists by then. It deliberately does **not** touch `ax.texts`: those are
+artists a chart placed itself, and each already carries a colour chosen for a
+reason no theme should overrule — the pie's percentage labels take theirs from
+the *wedge* luminance, the pace chart's "today" marker from `theme.accent`.
+
+`test_theme_changes_colour_but_never_geometry` is the gate for the class of bug
+this was. It asserts both directions, and the second one is the point: a theme
+that changes no fill is indistinguishable from a theme that is not plumbed in,
+and that is the state the package shipped in for a full release.
+
+### The three data-colour decisions
+
+`CHART_ARCHITECTURE.md` Appendix B flagged two. There were three.
+
+| | Answer | Field |
+|---|---|---|
+| Brand darks as fills — `#011837` at **1.17:1** on the card, `#00357a` at 1.29:1 | Tint toward white to a 3:1 floor (WCAG 1.4.11, non-text) | `min_data_contrast` + `lift_for_contrast` |
+| `alpha=0.85` stackplots compositing against the card | 1.0 on dark | `area_alpha` |
+| **Unflagged** — "Others" at 7.97:1 on the card | A muted role at 1.77:1, mirroring the 1.90:1 it has on white | `muted_data` |
+
+**Why tint rather than raise HSL lightness.** Both restore contrast; only one
+keeps the palette usable. The three failing pie colours are all blues, and
+lifting each to exactly 3:1 by lightness converges them on `#0469f0` /
+`#0068ef` / `#0069eb` — three names for one blue, in a palette whose whole job
+is telling ten things apart. Tinting desaturates as it lightens and lands them
+on `#627083` / `#4c72a2` / `#246fcb`. Measured: every palette's minimum
+pairwise channel distance is unchanged or better, so nothing became harder to
+tell apart than it already was.
+
+**The third one is the interesting one**, and it is the same shape as Appendix
+E's methodological lesson one level up. It is not a contrast failure — 7.97:1
+passes any threshold you care to set. It is an *inverted* one: `others_color`
+is named for a value and used for a role, and the role is "recede". A value
+that recedes on white shouts on near-black. No contrast assertion would ever
+have caught it; it was found by looking at the rendered chart. Note it must
+also **bypass** `data_color`, or `min_data_contrast` lifts it straight back up.
+
+### Light mode is byte-identical, and that is proven rather than asserted
+
+`Theme.LIGHT.min_data_contrast` is `None`, and `data_colors` returns the *same
+object* in that case rather than an equal one. Every value `apply_chrome`
+assigns is the literal the rcParams block already installed. The evidence: of
+the 111 pre-existing fingerprint keys, **0 changed**; the 96 new keys are all
+`@dark`. (The line-level diff on the snapshot looks alarming — sorted-key
+insertion reflows the file — so check keys, not lines.)
+
+### Deviations from the handoff
+
+| # | Handoff said | Actually |
+|---|---|---|
+| 1 | "22 places that already pass `layout=`" | 22 exactly — but they are not 22 call sites. **18** are real chart calls (allocations 5, user 4, status 4, jobs 3, disk-scans 2), **1** is the `utils/fragments.py` registrar covering 27 routes, and **3** are the hand-carry hops inside `jobs/routes.py` where the axis is merely relayed. That last group is the one that silently failed for `layout`, so it is the one worth counting separately. |
+| 2 | "give `test_renderers_forward_the_layout_they_are_given` a `theme` sibling" | Better as one test parameterized over `_AXES` — the two axes are transported identically and fail identically. Added `test_the_registrar_resolves_both_axes` beside it, because the per-renderer test only checks that whatever *arrived* got forwarded; it passes fine if the registrar stops resolving an axis at all. |
+| 3 | "regenerate the fingerprint snapshot at every layout × theme" | Done — 111 → 207 keys. Desktop+light keeps the bare case id, so every previously reviewed diff stays stable. |
+| 4 | "extend `SAMPLES` to chart `<text>`" | A separate test instead. `SAMPLES` walks *ancestors* for the backdrop, which is wrong for a pie: the percentage label sits on a sibling `<path>`, not an ancestor. `test_chart_text_is_legible` hit-tests with `elementsFromPoint`, so a label on a wedge is measured against the wedge. |
+| 5 | (not stated) | `test_resource_details_disk_chart_route.py`'s chart double has a deliberately explicit signature, and it failed loudly on the new kwarg — exactly as its docstring says it should. Extended rather than loosened. |
+
+**Verification.** Full Python suite 4331 passed / 36 skipped. Browser tier 62
+passed against a live stack in both themes. The new browser gate was checked
+for vacuity by disabling `apply_chrome` and confirming it goes red with the
+documented signature — `1.17:1 fg=rgb(1,24,55) bg=rgb(27,39,51)` — while light
+stayed green.
+
+**On deploy**: chart cache keys hash *input data*, not rendering code, so warm
+Redis entries serve pre-PR-4 SVGs for up to 600 s. Run
+`sam-admin cache --refresh --category chart`. Dark mode also doubles the chart
+cache working set; the `maxmemory` rationale still deserves real numbers rather
+than the assumption inherited from PR 1.

--- a/e2e/test_dark_mode.py
+++ b/e2e/test_dark_mode.py
@@ -48,6 +48,12 @@ SAMPLES = [
 #: Pages chosen for coverage of the sampled families, not for breadth.
 PAGES = ['/user/info', '/allocations/transactions', '/status/derecho']
 
+#: Pages that render a chart inline in a full-page GET — the two families that
+#: cover the interesting cases: pies (text sits *on* a wedge) and stacked areas
+#: (text sits on the card). The jobs and disk-scans surfaces draw charts too but
+#: are plugin-gated, and CI runs without those plugins.
+CHART_PAGES = ['/allocations/projects', '/status/derecho']
+
 
 # --------------------------------------------------------------------------
 # WCAG relative luminance / contrast ratio
@@ -145,6 +151,120 @@ def test_sampled_surfaces_are_legible(page, base_url, page_url, theme):
     assert not failures, (
         f'{page_url} ({theme}) has text below {MIN_CONTRAST}:1:\n'
         + '\n'.join(failures))
+
+
+#: Every ``<text>`` in every chart on the page, each measured against whatever
+#: is *actually* behind that glyph.
+#:
+#: The ancestor-background walk the chrome sampler uses is wrong here, and
+#: wrong in the direction that hides the defect: a pie's percentage label sits
+#: on a **wedge**, which is a sibling ``<path>``, not an ancestor. Walking
+#: parents would measure white-on-card for a label that is really white-on-gold
+#: and report a failure that is not real — or, worse, pass a label that is
+#: genuinely unreadable on its wedge.
+#:
+#: So this hit-tests the point instead: ``elementsFromPoint`` returns the paint
+#: order front-to-back, and the first thing under the glyph is the truth.
+#: Shape tags are checked explicitly because ``<g>`` and ``<svg>`` inherit a
+#: ``fill`` and would otherwise answer for a backdrop they do not paint.
+_CHART_TEXT_COLOURS_JS = """
+() => {
+  const SHAPES = new Set(['path', 'rect', 'circle', 'ellipse', 'polygon']);
+  const parse = (s) => {
+    const m = (s || '').match(/rgba?\\(([^)]+)\\)/);
+    if (!m) return null;
+    const p = m[1].split(',').map(x => parseFloat(x.trim()));
+    return { r: p[0], g: p[1], b: p[2], a: p.length > 3 ? p[3] : 1 };
+  };
+  const over = (top, bottom) => ({
+    r: top.r * top.a + bottom.r * (1 - top.a),
+    g: top.g * top.a + bottom.g * (1 - top.a),
+    b: top.b * top.a + bottom.b * (1 - top.a),
+    a: 1,
+  });
+
+  const out = [];
+  const charts = [...document.querySelectorAll('svg')]
+      .filter(s => s.querySelector('text'));
+
+  for (const svg of charts) {
+    // elementsFromPoint is viewport-relative, so the chart has to be on
+    // screen before any of its glyphs can be hit-tested.
+    svg.scrollIntoView({ behavior: 'instant', block: 'center' });
+
+    for (const el of svg.querySelectorAll('text')) {
+      const label = (el.textContent || '').trim();
+      if (!label) continue;
+      const box = el.getBoundingClientRect();
+      if (!box.width || !box.height) continue;
+      const cx = box.x + box.width / 2, cy = box.y + box.height / 2;
+      if (cx < 0 || cy < 0 || cx > innerWidth || cy > innerHeight) continue;
+
+      const fg = parse(getComputedStyle(el).fill);
+      if (!fg) continue;
+
+      const stack = [];
+      for (const node of document.elementsFromPoint(cx, cy)) {
+        if (node === el || el.contains(node)) continue;
+        const style = getComputedStyle(node);
+        const tag = node.tagName.toLowerCase();
+        const paint = SHAPES.has(tag) ? parse(style.fill)
+                                      : parse(style.backgroundColor);
+        if (!paint || !paint.a) continue;
+        stack.push(paint);
+        if (paint.a === 1) break;
+      }
+
+      let bg = { r: 255, g: 255, b: 255, a: 1 };   // the canvas, last resort
+      for (let i = stack.length - 1; i >= 0; i--) bg = over(stack[i], bg);
+      out.push({ fg: [fg.r, fg.g, fg.b], bg: [bg.r, bg.g, bg.b], text: label });
+    }
+  }
+  return out;
+}
+"""
+
+
+@pytest.mark.parametrize('theme', THEMES)
+@pytest.mark.parametrize('page_url', CHART_PAGES)
+def test_chart_text_is_legible(page, base_url, page_url, theme):
+    """Chart ink, which is the one surface CSS cannot reach.
+
+    Charts are matplotlib SVGs with colours baked in at render time, so no
+    stylesheet can retheme them — the server has to know the theme, which is
+    the whole reason `sam_theme` is a cookie rather than `localStorage`. Before
+    the chart layer applied `Theme`, every label on every chart carried
+    `fill="rgb(1,24,55)"` against the `#1b2733` card: **1.3:1**, on pages that
+    had already been eyeballed and called fine.
+
+    That is the third time in this migration the same defect — brand colour
+    used as foreground — was found by measurement after screenshots missed it
+    (see DARK_MODE.md Appendix E), which is why it is asserted rather than
+    reviewed.
+    """
+    set_theme(page, base_url, theme)
+    visit(page, page_url)
+    assert_theme_applied(page, theme)
+
+    samples = page.evaluate(_CHART_TEXT_COLOURS_JS)
+    assert samples, (
+        f'{page_url} ({theme}) rendered no chart text at all. Either the page '
+        f'stopped drawing charts or `svg.fonttype` left "none" and every glyph '
+        f'is a path again — in which case this test is silently vacuous.')
+
+    failures = []
+    for found in samples:
+        ratio = contrast_ratio(found['fg'], found['bg'])
+        if ratio < MIN_CONTRAST:
+            failures.append(
+                f'  {ratio:.2f}:1 '
+                f'fg=rgb{tuple(round(v) for v in found["fg"])} '
+                f'bg=rgb{tuple(round(v) for v in found["bg"])} '
+                f'text={found["text"]!r}')
+
+    assert not failures, (
+        f'{page_url} ({theme}): {len(failures)} of {len(samples)} chart labels '
+        f'are below {MIN_CONTRAST}:1:\n' + '\n'.join(failures))
 
 
 def test_clicking_the_toggle_persists_the_choice(page, base_url):

--- a/src/webapp/dashboards/allocations/blueprint.py
+++ b/src/webapp/dashboards/allocations/blueprint.py
@@ -12,7 +12,7 @@ from typing import List, Dict
 
 from webapp.extensions import db, cache, user_aware_cache_key
 from webapp.utils.htmx import (
-    handle_htmx_form_post, read_layout, register_typeahead,
+    handle_htmx_form_post, read_layout, read_theme, register_typeahead,
 )
 from sam.queries.allocations import (
     ALLOCATION_TRANSACTION_SORT_COLUMNS,
@@ -336,8 +336,10 @@ def projects():
     # sites with no htmx request behind them — the layout arrives on the
     # cookie. `user_aware_cache_key` partitions the cached HTML by it; without
     # that, the first visitor to warm this page would decide whether everyone
-    # else got phone-sized or desktop-sized pies.
-    layout = read_layout()
+    # else got phone-sized or desktop-sized pies. The theme rides the same
+    # cookie mechanism and the same cache-key partition, and its failure is the
+    # louder one — a light pie on a dark page.
+    layout, theme = read_layout(), read_theme()
 
     # Facility scope resolution.
     # ``allowed_facility_names`` is the user's universe — every facility
@@ -425,8 +427,8 @@ def projects():
         overview_data = all_overviews.get(rn, [])
         resource_overviews[rn] = {
             'table_data': overview_data,
-            'chart': generate_facility_pie_chart_matplotlib(overview_data,
-                                                            layout=layout),
+            'chart': generate_facility_pie_chart_matplotlib(
+                overview_data, layout=layout, theme=theme),
         }
 
     # Generate allocation type pie chart SVGs per resource/facility
@@ -437,7 +439,7 @@ def projects():
             if len(types) > 1:
                 allocation_type_charts[resource_name][facility_name] = \
                     generate_allocation_type_pie_chart_matplotlib(
-                        types, layout=layout)
+                        types, layout=layout, theme=theme)
             else:
                 allocation_type_charts[resource_name][facility_name] = None
 
@@ -490,7 +492,7 @@ def projects():
             if len(chartable) > 1:
                 allocation_type_usage_charts[resource_name][facility_name] = \
                     generate_allocation_type_pie_chart_matplotlib(
-                        chartable, layout=layout)
+                        chartable, layout=layout, theme=theme)
             else:
                 allocation_type_usage_charts[resource_name][facility_name] = None
 
@@ -506,8 +508,8 @@ def projects():
         chartable = [d for d in usage_overview_data if d.get('total_used', 0.0) > 0]
         resource_usage_overviews[rn] = {
             'table_data': usage_overview_data,
-            'chart': generate_facility_pie_chart_matplotlib(chartable,
-                                                            layout=layout)
+            'chart': generate_facility_pie_chart_matplotlib(
+                chartable, layout=layout, theme=theme)
                      if chartable else '<div class="text-center text-muted small py-3">No usage data yet</div>',
         }
 
@@ -591,7 +593,7 @@ def htmx_pace_chart(resource_name):
 
     chart_svg = generate_pace_chart_matplotlib(
         per_project_usage, active_at, resource_name=resource_name,
-        sort_by=sort_by, layout=read_layout(),
+        sort_by=sort_by, layout=read_layout(), theme=read_theme(),
     )
 
     # Sanitize resource_name into a stable HTML id — matches the

--- a/src/webapp/dashboards/charts/base.py
+++ b/src/webapp/dashboards/charts/base.py
@@ -20,6 +20,7 @@ instead — `links.py` and `series.py` import no matplotlib, enforced by test.
         decorate(axes, ...)       labels, ticks, grid, scale, theme chrome
         add_legend(axes, ...)     placement from layout, colours from theme
         finish(fig, axes, ...)    autofmt_xdate, xlim, annotations
+        apply_chrome(...)         theme.text/spine onto every chrome artist
         to_svg(fig)               the single savefig/close chokepoint
 
 Hooks default to no-ops, so a leaf implements only what differs. State goes on
@@ -261,6 +262,54 @@ class BaseChart:
         # default beside 9pt ticks.
         ax.xaxis.get_offset_text().set_fontsize(layout.base_fontsize)
 
+    def apply_chrome(self, fig, axes, theme):
+        """Recolour every chrome artist from *theme*, after the chart is drawn.
+
+        The rcParams block in `theme.py` bakes the **light** chrome in at
+        import — it runs once per process, before any request has a theme —
+        so every title, axis label, tick, spine and legend label starts life
+        `#011837`. That is the whole of the dark-chart defect: figures already
+        render on a transparent background, so there was never a white box to
+        remove, only ink that could not be read. Verified in-browser at
+        **1.3:1** on `/allocations/projects` before this existed.
+
+        Applied centrally, after `finish()`, rather than left to each family,
+        for the reason `apply_tick_fontsize` gives: a chart that forgets is
+        invisible until someone looks at it in the other theme, and there are
+        sixteen of them.
+
+        **What it deliberately does not touch: `ax.texts`.** Those are the
+        artists a chart placed itself, and every one of them already carries a
+        colour chosen for a reason no theme should overrule — the pie's
+        percentage labels take theirs from the *wedge* luminance
+        (`autopct_color_for`), and the pace chart's "today" marker takes
+        theirs from `theme.accent`. Blanket-setting them would paint white
+        text onto a gold wedge.
+
+        A no-op in light mode by construction: every value assigned here is
+        the literal the rcParams block already installed, which
+        `test_chart_theme.py::TestThemeLight` is what keeps true.
+        """
+        for ax in (axes if isinstance(axes, (tuple, list)) else (axes,)):
+            ax.title.set_color(theme.text)
+            ax.xaxis.label.set_color(theme.text)
+            ax.yaxis.label.set_color(theme.text)
+            # `colors` covers the tick marks and their labels together, which
+            # is what rcParams `xtick.color` + `labelcolor: inherit` does.
+            ax.tick_params(axis='both', colors=theme.text)
+            for spine in ax.spines.values():
+                spine.set_color(theme.spine)
+            # A separate Text artist that `tick_params` does not reach — the
+            # same one `apply_date_axis` has to size by hand.
+            for axis in (ax.xaxis, ax.yaxis):
+                axis.get_offset_text().set_color(theme.text)
+
+            legend = ax.get_legend()
+            if legend is not None:
+                for text in legend.get_texts():
+                    text.set_color(theme.text)
+                legend.get_title().set_color(theme.text)
+
     def apply_tick_fontsize(self, axes, layout):
         """Size tick labels from the layout.
 
@@ -301,6 +350,9 @@ class BaseChart:
         self.decorate(axes, lay, thm)
         self.add_legend(axes, lay, thm)
         self.finish(fig, axes, lay, thm)
+        # Last, so it reaches artists the hooks above created — the legend in
+        # particular does not exist until `add_legend` has run.
+        self.apply_chrome(fig, axes, thm)
         return fig_to_svg(fig)
 
     # --- caching ----------------------------------------------------------

--- a/src/webapp/dashboards/charts/dualpanel.py
+++ b/src/webapp/dashboards/charts/dualpanel.py
@@ -125,13 +125,19 @@ class NodetypeHistoryChart(DualPanelTimeSeriesChart):
 
     def draw(self, axes, layout, theme):
         ax1, ax2 = axes
+        # Series colours through the theme: only ncar-blue actually moves (it
+        # is 2.27:1 on the dark card), but resolving all of them one way keeps
+        # the next colour added here from being the exception.
+        vermilion, blue, sky, teal = theme.data_colors(
+            [UNITY_NCAR_VERMILION, UNITY_NCAR_BLUE, UNITY_NCAR_SKY,
+             UNITY_NCAR_TEAL])
         ax1.stackplot(
             self.timestamps,
             self.column('nodes_down'),
             self.column('nodes_allocated'),
             self.column('nodes_available'),
             labels=['Down', 'Fully Allocated', 'Resources Available'],
-            colors=[UNITY_NCAR_VERMILION, UNITY_NCAR_BLUE, UNITY_NCAR_SKY])
+            colors=[vermilion, blue, sky])
 
         utilization = [d.get('utilization_percent') for d in self.history_data]
         memory = [d.get('memory_utilization_percent') for d in self.history_data]
@@ -139,12 +145,12 @@ class NodetypeHistoryChart(DualPanelTimeSeriesChart):
         if any(u is not None for u in utilization):
             times = [self.timestamps[i] for i, u in enumerate(utilization) if u is not None]
             ax2.plot(times, [u for u in utilization if u is not None],
-                     color=UNITY_NCAR_BLUE, linewidth=3, label='CPU/GPU Utilization')
+                     color=blue, linewidth=3, label='CPU/GPU Utilization')
 
         if any(m is not None for m in memory):
             times = [self.timestamps[i] for i, m in enumerate(memory) if m is not None]
             ax2.plot(times, [m for m in memory if m is not None],
-                     color=UNITY_NCAR_TEAL, linewidth=3, label='Memory Utilization')
+                     color=teal, linewidth=3, label='Memory Utilization')
 
     def decorate(self, axes, layout, theme):
         ax1, ax2 = axes
@@ -189,26 +195,29 @@ class QueueHistoryChart(DualPanelTimeSeriesChart):
     def draw(self, axes, layout, theme):
         ax1, ax2 = axes
         ts = self.timestamps
-        ax1.plot(ts, self.column('running_jobs'), color=UNITY_NCAR_TEAL,
+        teal, orange, vermilion, blue = theme.data_colors(
+            [UNITY_NCAR_TEAL, UNITY_NCAR_ORANGE, UNITY_NCAR_VERMILION,
+             UNITY_NCAR_BLUE])
+        ax1.plot(ts, self.column('running_jobs'), color=teal,
                  linewidth=3, label='Running')
-        ax1.plot(ts, self.column('pending_jobs'), color=UNITY_NCAR_ORANGE,
+        ax1.plot(ts, self.column('pending_jobs'), color=orange,
                  linewidth=3, label='Pending')
-        ax1.plot(ts, self.column('held_jobs'), color=UNITY_NCAR_VERMILION,
+        ax1.plot(ts, self.column('held_jobs'), color=vermilion,
                  linewidth=3, label='Held')
-        ax1.plot(ts, self.column('active_users'), color=UNITY_NCAR_BLUE,
+        ax1.plot(ts, self.column('active_users'), color=blue,
                  linestyle='--', linewidth=2, label='Active Users')
 
         gpus_alloc = self.column('gpus_allocated')
         gpus_pend = self.column('gpus_pending')
         if any(gpus_alloc) or any(gpus_pend):
-            ax2.plot(ts, gpus_alloc, color=UNITY_NCAR_BLUE, linewidth=3,
+            ax2.plot(ts, gpus_alloc, color=blue, linewidth=3,
                      label='GPUs Running')
-            ax2.plot(ts, gpus_pend, color=UNITY_NCAR_TEAL, linewidth=3,
+            ax2.plot(ts, gpus_pend, color=teal, linewidth=3,
                      label='GPUs Pending')
         else:
-            ax2.plot(ts, self.column('cores_allocated'), color=UNITY_NCAR_BLUE,
+            ax2.plot(ts, self.column('cores_allocated'), color=blue,
                      linewidth=3, label='Cores Running')
-            ax2.plot(ts, self.column('cores_pending'), color=UNITY_NCAR_TEAL,
+            ax2.plot(ts, self.column('cores_pending'), color=teal,
                      linewidth=3, label='Cores Pending')
 
     def decorate(self, axes, layout, theme):

--- a/src/webapp/dashboards/charts/histogram.py
+++ b/src/webapp/dashboards/charts/histogram.py
@@ -105,8 +105,9 @@ class CategoricalStackChart(BaseChart):
         self._buckets = list(self.buckets())
         self.labels = [self.bucket_label(b) for b in self._buckets]
         self.values = [self.bucket_total(b) for b in self._buckets]
-        self.band_colors = [UNITY_STACK_10[i % len(UNITY_STACK_10)]
-                            for i in range(len(self.labels))]
+        self.band_colors = self.theme.data_colors(
+            [UNITY_STACK_10[i % len(UNITY_STACK_10)]
+             for i in range(len(self.labels))])
 
     def is_empty(self) -> bool:
         # Defined explicitly per family — see BaseChart.is_empty on why the
@@ -313,7 +314,11 @@ class JobsHistogram(CategoricalStackChart):
         # (UNITY_PALETTE_10[0], the historical flat chart's colour — NOT the
         # stack palette's first entry, which is gold); with owners it keeps
         # the per-band palette its stack would have used.
-        return self.band_colors[i] if self._has_owners else UNITY_PALETTE_10[0]
+        # `band_colors` is already lifted for the theme; the bare fallback is
+        # not, so it needs the same treatment — ncar-blue is 2.27:1 on the
+        # dark card, and this branch paints the entire chart with it.
+        return (self.band_colors[i] if self._has_owners
+                else self.theme.data_color(UNITY_PALETTE_10[0]))
 
     def prepare(self):
         self._has_owners = any(b.get('owners')

--- a/src/webapp/dashboards/charts/pace.py
+++ b/src/webapp/dashboards/charts/pace.py
@@ -33,14 +33,24 @@ from webapp.dashboards.charts import links
 from webapp.dashboards.charts.base import BaseChart
 from webapp.dashboards.charts.layout import profile
 from webapp.dashboards.charts.theme import (
-    UNITY_NCAR_GRAY_LIGHT, UNITY_NCAR_NAVY, UNITY_STACK_10, UNITY_STACK_20,
+    UNITY_NCAR_NAVY, UNITY_STACK_10, UNITY_STACK_20,
 )
 
-_PACE_OTHER_COLOR = matplotlib.colors.to_rgba(UNITY_NCAR_GRAY_LIGHT, 0.85)
 _PACE_TODAY_LINE_COLOR = matplotlib.colors.to_rgba(UNITY_NCAR_NAVY, 0.7)
 _PACE_RATE_SCALE = 365  # internal per-day rates → per-year axis
 
 OTHER_KEY = '__other__'
+
+
+def _pace_other_color(theme):
+    """The inert "Other (N projects)" band.
+
+    Translucent so the ranked bands above it stay dominant, and derived from
+    the theme rather than fixed: `--ncar-gray-light` recedes on a white card
+    and is the *brightest* thing on a dark one, which is exactly backwards for
+    the band that means the least. See `Theme.muted_data`.
+    """
+    return matplotlib.colors.to_rgba(theme.muted_data, 0.85)
 
 
 def pace_bands(allocations: List[Dict], active_at: datetime,
@@ -222,7 +232,8 @@ class PaceChart(BaseChart):
             self.rank_metric.items(), key=lambda kv: kv[1], reverse=True
         )[:top_n]]
         palette = UNITY_STACK_10 if len(self.top_projs) <= 10 else UNITY_STACK_20
-        self.color_map = {pc: palette[i] for i, pc in enumerate(self.top_projs)}
+        self.color_map = {pc: self.theme.data_color(palette[i])
+                          for i, pc in enumerate(self.top_projs)}
 
         self.n_other_projs = len(self.rank_metric) - len(self.top_projs)
         plural = 's' if self.n_other_projs != 1 else ''
@@ -295,8 +306,8 @@ class PaceChart(BaseChart):
         self.days = [self.days[i] for i in keep_idx]
         self.rates_matrix = [band_rates_full[bi, keep_idx] * _PACE_RATE_SCALE
                              for bi in range(band_rates_full.shape[0])]
-        self.colors = [self.color_map.get(k, _PACE_OTHER_COLOR)
-                       for k, _ in ordered]
+        other = _pace_other_color(self.theme)
+        self.colors = [self.color_map.get(k, other) for k, _ in ordered]
 
     def is_empty(self) -> bool:
         # Explicit, not inherited: `self._bands` holds ndarrays, so any
@@ -343,7 +354,7 @@ class PaceChart(BaseChart):
                    for pc in self.top_projs]
         if self.n_other_projs > 0:
             handles.append(mpatches.Patch(
-                color=_PACE_OTHER_COLOR,
+                color=_pace_other_color(theme),
                 label=f'{self.other_label} '
                       f'({_fmt(self.group_sort_totals[OTHER_KEY])})'))
         legend = ax.legend(handles=handles, frameon=False,

--- a/src/webapp/dashboards/charts/pie.py
+++ b/src/webapp/dashboards/charts/pie.py
@@ -28,7 +28,7 @@ from webapp.dashboards.charts.base import BaseChart
 from webapp.dashboards.charts.jobs_metrics import jobs_metric_value
 from webapp.dashboards.charts.layout import profile
 from webapp.dashboards.charts.theme import (
-    UNITY_NCAR_GRAY_LIGHT, UNITY_PALETTE_10, autopct_color_for,
+    UNITY_PALETTE_10, autopct_color_for,
 )
 
 _PIE_START_ANGLE = 60
@@ -208,7 +208,8 @@ class _FixedCapPie(PieChart):
         names, values = trim_fixed_cap([d[name_key] for d in self.data],
                                        [d[value_key] for d in self.data],
                                        cap=self.slice_cap(_PIE_MAX_ENTITIES))
-        colors = list(UNITY_PALETTE_10[:len(names)])
+        colors = self.theme.data_colors(
+            list(UNITY_PALETTE_10[:len(names)]))
         return names, values, colors, [None] * len(names)
 
 
@@ -289,13 +290,13 @@ class DiskEntityPie(_CumulativePie):
         keys = [d['id'] for d in data[:keep]]
         labels = [d['name'] or f'{numeric_label}{d["id"]}' for d in data[:keep]]
         values = list(values_desc[:keep])
-        colors = list(UNITY_PALETTE_10[:keep])
+        colors = self.theme.data_colors(list(UNITY_PALETTE_10[:keep]))
 
         if n_others > 0:
             keys.append(None)                  # inert slice
             labels.append(f'Other ({n_others})')
             values.append(sum(values_desc[keep:]))
-            colors.append(UNITY_NCAR_GRAY_LIGHT)
+            colors.append(self.theme.muted_data)
 
         return labels, values, colors, keys
 
@@ -340,13 +341,13 @@ class UserUsagePie(_CumulativePie):
         keys = [d['username'] for d in data[:keep]]
         labels = list(keys)
         values = list(values_desc[:keep])
-        colors = list(UNITY_PALETTE_10[:keep])
+        colors = self.theme.data_colors(list(UNITY_PALETTE_10[:keep]))
 
         if n_others > 0:
             keys.append(None)                  # inert slice
             labels.append(f'Other ({n_others})')
             values.append(sum(values_desc[keep:]))
-            colors.append(UNITY_NCAR_GRAY_LIGHT)
+            colors.append(self.theme.muted_data)
 
         return labels, values, colors, keys
 
@@ -411,13 +412,13 @@ class JobsUsagePie(_CumulativePie):
         keys = [r.get('value') for r in data[:keep]]
         labels = [k if k is not None else self.unknown_label for k in keys]
         values = list(values_desc[:keep])
-        colors = list(UNITY_PALETTE_10[:keep])
+        colors = self.theme.data_colors(list(UNITY_PALETTE_10[:keep]))
 
         remainder = total - sum(values)
         if remainder > 1e-9:
             keys.append(None)                  # inert slice
             labels.append('Other')
             values.append(remainder)
-            colors.append(UNITY_NCAR_GRAY_LIGHT)
+            colors.append(self.theme.muted_data)
 
         return labels, values, colors, keys

--- a/src/webapp/dashboards/charts/stacked.py
+++ b/src/webapp/dashboards/charts/stacked.py
@@ -28,8 +28,7 @@ from webapp.dashboards.charts.jobs_metrics import (
 )
 from webapp.dashboards.charts.layout import profile
 from webapp.dashboards.charts.theme import (
-    UNITY_NCAR_BLUE, UNITY_NCAR_GRAY_LIGHT, UNITY_STACK_10, UNITY_STACK_20,
-    scale_bytes,
+    UNITY_NCAR_BLUE, UNITY_STACK_10, UNITY_STACK_20, scale_bytes,
 )
 
 _USAGE_METRIC_YLABELS = {
@@ -60,12 +59,10 @@ class StackedSeriesChart(BaseChart):
 
     bar_width = 1
     bar_linewidth = 0.3
-    area_alpha = 0.85
 
     #: Palette for named bands, and whether to walk it backwards.
     palette = UNITY_STACK_10
     palette_reverse = False
-    others_color = UNITY_NCAR_GRAY_LIGHT
 
     show_legend = True
     legend_fontsize = 11
@@ -104,9 +101,12 @@ class StackedSeriesChart(BaseChart):
 
     def prepare(self):
         self.bands = self.build_bands()
+        # The *palette* is lifted for the theme; the inert "Others" band is
+        # not — it takes the theme's muted role, whose whole job is to stay
+        # recessive. Lifting it would defeat that. See `Theme.muted_data`.
         self.colors = series_mod.assign_colors(
-            self.bands, self.palette, self.others_color,
-            reverse=self.palette_reverse)
+            self.bands, self.theme.data_colors(self.palette),
+            self.theme.muted_data, reverse=self.palette_reverse)
         self.x = self.x_values()
 
     def is_empty(self) -> bool:
@@ -139,7 +139,11 @@ class StackedSeriesChart(BaseChart):
 
     def _draw_area(self, ax, theme):
         matrix = [list(self.band_values(b)) for b in self.bands]
-        ax.stackplot(self.x, *matrix, colors=self.colors, alpha=self.area_alpha)
+        # Alpha comes from the theme, not this class: the figure is
+        # transparent, so it composites against the card. See
+        # `Theme.area_alpha`.
+        ax.stackplot(self.x, *matrix, colors=self.colors,
+                     alpha=theme.area_alpha)
 
     def decorate(self, ax, layout, theme):
         ax.set_ylabel(self.ylabel(), **self.label_kw(layout))
@@ -233,7 +237,7 @@ class UsageTrendChart(StackedSeriesChart):
         self._dates = dates
         # A single unnamed band: no legend, so the label never renders.
         self.bands = [series_mod.Series('', vals, None)] if dates else []
-        self.colors = [UNITY_NCAR_BLUE]
+        self.colors = self.theme.data_colors([UNITY_NCAR_BLUE])
         self.x = dates
 
     def x_values(self):

--- a/src/webapp/dashboards/charts/theme.py
+++ b/src/webapp/dashboards/charts/theme.py
@@ -6,10 +6,16 @@ matplotlib's font manager, and applying the rcParams that give every chart the
 editorial flat look. Nothing else in the package may rely on import order.
 
 **Data colours vs chrome colours.** The ``UNITY_*`` palettes below encode data
-— a wedge, a stack band, a bar — and are theme-invariant: a project keeps its
-colour whether the page is light or dark. Everything a `Theme` carries is
-*chrome*: text, spines, grid, edges, the shading blend target. That split is
-what lets a dark theme be a mechanical swap rather than a redesign.
+— a wedge, a stack band, a bar — and are theme-invariant in *hue*: a project
+keeps its colour whether the page is light or dark. Everything a `Theme`
+carries is *chrome*: text, spines, grid, edges, the shading blend target. That
+split is what lets a dark theme be a mechanical swap rather than a redesign.
+
+The one place the split leaks is `Theme.data_color`, and it is a leak the
+chart-architecture plan predicted (Appendix B, "needs a design decision, not a
+mechanical swap"): three of the ten pie colours are brand *darks*, and a dark
+fill on a dark card is not a colour choice, it is an invisible wedge. See
+`lift_for_contrast` for what is done about it and why hue survives.
 """
 
 from dataclasses import dataclass
@@ -238,9 +244,62 @@ class Theme:
     shade_toward: str    # `shade_family` blend target
     accent: str          # the pace chart's "today" marker
 
+    #: The colour actually behind the figure. Every chart is saved with
+    #: ``transparent=True``, so the "background" of a chart is whichever card
+    #: the SVG is inlined into — `--surface-card` in `static/css/variables.css`.
+    #: Distinct from `shade_toward` despite sharing a value in both themes:
+    #: that one is a *blend target* a family may point elsewhere, this one is a
+    #: statement of fact about the page.
+    surface: str
+
+    #: Minimum contrast a data fill must reach against `surface`, or None to
+    #: leave data colours exactly as the palette declares them. See
+    #: `lift_for_contrast`.
+    min_data_contrast: float | None
+
+    #: Fill for the inert aggregate band — the "Others" / "Other (N projects)"
+    #: remainder every family collapses its tail into.
+    #:
+    #: A *role*, not a colour, and the reason it needs one is that its job is
+    #: to **recede**. `--ncar-gray-light` recedes against a white card (1.90:1)
+    #: and shouts against a dark one (7.97:1), where it is routinely the
+    #: largest band on the chart — so on dark it became the loudest thing in
+    #: the picture while meaning the least. The dark value is picked to sit at
+    #: 1.77:1, i.e. to be as recessive as the light one is, and it must NOT go
+    #: through `data_color`: `min_data_contrast` would lift it straight back
+    #: up to 3:1 and undo exactly what it is for. Lift the palette, then place
+    #: this beside it.
+    muted_data: str
+
+    #: Alpha for stacked *areas*. A property of the theme rather than the
+    #: chart, because the figure is transparent and the alpha therefore
+    #: composites against `surface`: 0.85 over white is the light page's
+    #: deliberate softening, and the same 0.85 over `#1b2733` drags every band
+    #: back down toward the card and undoes `min_data_contrast`.
+    area_alpha: float
+
     @property
     def is_dark(self) -> bool:
         return self.name == 'dark'
+
+    # --- data colours ------------------------------------------------------
+
+    def data_color(self, color):
+        """One palette colour, made legible against this theme's `surface`.
+
+        Identity — the *same object* — whenever `min_data_contrast` is None,
+        which is how `Theme.LIGHT` guarantees byte-identical output rather
+        than merely equivalent output.
+        """
+        if self.min_data_contrast is None:
+            return color
+        return lift_for_contrast(color, self.surface, self.min_data_contrast)
+
+    def data_colors(self, colors):
+        """`data_color` over a sequence, preserving order and length."""
+        if self.min_data_contrast is None:
+            return colors
+        return [self.data_color(c) for c in colors]
 
 
 #: Today's rendering, exactly. Every value here is the literal the charts
@@ -255,14 +314,26 @@ Theme.LIGHT = Theme(
     legend_face='white',
     shade_toward='#ffffff',
     accent=UNITY_NCAR_NAVY,
+    surface='#ffffff',
+    # **None, not 3.0.** Four of the palette's warm colours (gold at 1.43:1,
+    # yellow-33 at 1.30:1, orange and sky at 2.06:1) have never cleared 3:1
+    # against a white card and are not defects — a gold wedge outlined by its
+    # neighbours reads fine, and "fixing" them would darken the brand palette
+    # on every existing page. The floor exists for the dark surface, where
+    # the failing colours are *text-dark navies* rather than brand yellows.
+    min_data_contrast=None,
+    area_alpha=0.85,
+    muted_data=UNITY_NCAR_GRAY_LIGHT,
 )
 
-#: Defined so the axis is real and testable, not so it is shippable. The
-#: values are a starting point for the dark-mode pass, which also has to
-#: decide two things a mechanical swap cannot (see the plan, Appendix B):
-#: `UNITY_PALETTE_10[8]` is space blue used as a *wedge fill* and vanishes
-#: into a dark page, and the alpha=0.85 stackplots composite against the page
-#: so every band desaturates.
+# The dark rendering. Chrome values were chosen in PR 1; the two data-colour
+# decisions PR 1 deferred are answered by `min_data_contrast` and
+# `area_alpha` above.
+#:
+# `surface` is `--surface-card` from `static/css/variables.css`, and
+# `test_dark_card_matches_chart_blend_target` fails if the two drift — a
+# chart blending toward a card colour the card no longer has produces a halo
+# that no test other than that one would see.
 Theme.DARK = Theme(
     name='dark',
     text='#e9ecef',
@@ -273,6 +344,18 @@ Theme.DARK = Theme(
     legend_face='#1b2733',
     shade_toward='#1b2733',
     accent='#adc2e6',
+    surface='#1b2733',
+    # WCAG 2.1 SC 1.4.11 (Non-text Contrast) — 3:1 for a graphical object you
+    # need to see to understand the content, which is what a pie wedge is.
+    min_data_contrast=3.0,
+    # 1.0, not 0.85 — see the field docstring. The softening the light page
+    # wants is the thing that makes a dark page muddy.
+    area_alpha=1.0,
+    # 1.77:1 against `surface`, mirroring the 1.90:1 `--ncar-gray-light` has
+    # against a white card. Deliberately not `grid` (2.00:1) despite the
+    # family resemblance — a data band the exact colour of the gridlines
+    # reads as a rendering fault.
+    muted_data='#434d59',
 )
 
 THEMES = {'light': Theme.LIGHT, 'dark': Theme.DARK}
@@ -294,7 +377,63 @@ def resolve_theme(theme) -> Theme:
 # Colour helpers
 # ---------------------------------------------------------------------------
 
-def autopct_color_for(bg_hex: str) -> str:
+def relative_luminance(color) -> float:
+    """WCAG 2.1 relative luminance of any matplotlib colour.
+
+    The same formula `e2e/test_dark_mode.py` runs in the browser, so a colour
+    this module lifts and a colour Playwright measures are judged identically.
+    """
+    def channel(c):
+        return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+    r, g, b = matplotlib.colors.to_rgb(color)
+    return (0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b))
+
+
+def contrast_ratio(a, b) -> float:
+    """WCAG 2.1 contrast ratio between two colours, ignoring alpha."""
+    la, lb = relative_luminance(a), relative_luminance(b)
+    return (max(la, lb) + 0.05) / (min(la, lb) + 0.05)
+
+
+def lift_for_contrast(color, surface, min_ratio: float):
+    """*color*, tinted toward white just far enough to clear *min_ratio*.
+
+    Returned unchanged (identity) when it already clears, which is the common
+    case: on the dark card this touches 3 of the 10 pie colours, 1 of the 10
+    stack colours and 3 of the 20 — the brand *darks*, `#011837` at 1.17:1 and
+    `#00357a` at 1.29:1, which are text colours pressed into service as fills.
+
+    **Why tint toward white rather than raise HSL lightness.** Both restore
+    contrast; only one keeps the palette usable. The three failing pie colours
+    are all blues, and lifting each to exactly 3:1 by lightness converges them
+    on `#0469f0` / `#0068ef` / `#0069eb` — three names for one blue, in a
+    palette whose entire job is telling ten things apart. Tinting lands them
+    on `#627083` / `#4c72a2` / `#246fcb`, which desaturates as it lightens and
+    therefore keeps them separable. Measured: this leaves every palette's
+    minimum pairwise channel distance at or above what it already was, so
+    nothing becomes harder to tell apart than it is today.
+
+    Alpha is carried through untouched — the ratio is a property of the fill,
+    and the one translucent constant in the package (the pace chart's
+    "Other" band) clears the floor anyway.
+    """
+    if contrast_ratio(color, surface) >= min_ratio:
+        return color
+
+    r, g, b, a = matplotlib.colors.to_rgba(color)
+    # Walk in 8-bit steps: the SVG is 8-bit per channel regardless, so a finer
+    # search would return values that render identically, and integer steps
+    # make the result reproducible across platforms and matplotlib versions.
+    for step in range(1, 256):
+        f = step / 255
+        lifted = tuple(round(255 * (c + (1 - c) * f)) / 255 for c in (r, g, b))
+        if contrast_ratio(lifted, surface) >= min_ratio:
+            return lifted + (a,)
+    return (1.0, 1.0, 1.0, a)
+
+
+def autopct_color_for(color) -> str:
     """Pick a readable text color for percent labels on a colored pie wedge.
 
     Returns space-blue on light wedges (gold, sky) and white on dark wedges
@@ -302,9 +441,14 @@ def autopct_color_for(bg_hex: str) -> str:
     against UNITY_PALETTE_10.
 
     Theme-invariant on purpose: the choice is driven by the *wedge* luminance,
-    not the page, so it is already correct in both themes.
+    not the page, so it is already correct in both themes — and it stays
+    correct for free once `Theme.data_color` lifts a wedge, because a lifted
+    wedge is a lighter wedge and this flips to space-blue on its own.
+
+    Accepts any matplotlib colour rather than only a hex string, because a
+    lifted wedge arrives as an RGBA tuple.
     """
-    r, g, b = (int(bg_hex[i:i+2], 16) / 255 for i in (1, 3, 5))
+    r, g, b = matplotlib.colors.to_rgb(color)
     lum = 0.299 * r + 0.587 * g + 0.114 * b
     return UNITY_NCAR_SPACE_BLUE if lum > 0.6 else '#fff'
 

--- a/src/webapp/dashboards/status/blueprint.py
+++ b/src/webapp/dashboards/status/blueprint.py
@@ -4,7 +4,7 @@ System Status dashboard blueprint.
 
 from flask import Blueprint, render_template, request, flash, redirect, url_for, make_response, current_app
 from flask_login import login_required, current_user
-from webapp.utils.htmx import read_layout
+from webapp.utils.htmx import read_layout, read_theme
 from webapp.utils.rbac import require_permission, Permission
 from marshmallow import ValidationError
 from sam.schemas.forms import CreateOutageForm, EditOutageForm
@@ -292,8 +292,8 @@ def nodetype_history(system, node_type):
         return redirect(url_for('status_dashboard.index'))
 
     # Generate chart
-    chart_svg = generate_nodetype_history_matplotlib(history_data,
-                                                     layout=read_layout())
+    chart_svg = generate_nodetype_history_matplotlib(
+        history_data, layout=read_layout(), theme=read_theme())
 
     return render_template(
         'dashboards/status/nodetype_history.html',
@@ -360,8 +360,8 @@ def partition_history(system, partition):
     partition_display = f"{partition.upper()} Partition"
 
     # Generate chart
-    chart_svg = generate_nodetype_history_matplotlib(history_data,
-                                                     layout=read_layout())
+    chart_svg = generate_nodetype_history_matplotlib(
+        history_data, layout=read_layout(), theme=read_theme())
 
     return render_template(
         'dashboards/status/nodetype_history.html',
@@ -411,8 +411,8 @@ def queue_history(system, queue_name):
     )
 
     # Generate chart
-    chart_svg = generate_queue_history_matplotlib(history_data,
-                                                  layout=read_layout())
+    chart_svg = generate_queue_history_matplotlib(
+        history_data, layout=read_layout(), theme=read_theme())
 
     # Per-user / per-project rollup table — only fetched and rendered for
     # operators with VIEW_SYSTEM_STATUS_USER_INFO. Skipping the query
@@ -546,7 +546,7 @@ def _render_user_proj_chart(*, system, queue_name, endpoint_name, endpoint_kwarg
         link_kind = None
     chart_svg = generate_user_proj_stacked_area(
         timeseries, link_kind=link_kind, rank_by=rank_by,
-        layout=read_layout(),
+        layout=read_layout(), theme=read_theme(),
     )
 
     # Two of these cards render on the landing page (one per system

--- a/src/webapp/dashboards/user/blueprint.py
+++ b/src/webapp/dashboards/user/blueprint.py
@@ -21,7 +21,7 @@ from sam.schemas.forms.user import (
 from webapp.extensions import db
 from webapp.api.helpers import parse_input_start_date, parse_input_end_date
 from webapp.utils.form_handler import FlattenedFieldErrors, FormError, HtmxFormHandler
-from webapp.utils.htmx import read_active_only, read_layout
+from webapp.utils.htmx import read_active_only, read_layout, read_theme
 from sam.queries.dashboard import get_user_dashboard_data, get_resource_detail_data, get_project_dashboard_data
 from sam.queries.disk_usage import (
     build_disk_subtree,
@@ -935,7 +935,8 @@ def resource_details_usage_chart(project):
 
     if len(named_series) > 1:
         svg = generate_usage_timeseries_stacked_by_user(
-            stacked, metric=ctx.metric, layout=read_layout())
+            stacked, metric=ctx.metric, layout=read_layout(),
+            theme=read_theme())
         has_data = True
         is_stacked = True
     else:
@@ -944,7 +945,7 @@ def resource_details_usage_chart(project):
             series or {'dates': [], 'values': []},
             link_to_day_rows=True,
             metric=ctx.metric,
-            layout=read_layout(),
+            layout=read_layout(), theme=read_theme(),
         )
         has_data = bool(series and series.get('values'))
         is_stacked = False
@@ -980,7 +981,8 @@ def resource_details_user_pie(project):
         ctx.end_date,
     )
     svg = generate_user_usage_pie_chart(user_breakdown, metric=ctx.metric,
-                                        layout=read_layout())
+                                        layout=read_layout(),
+                                        theme=read_theme())
 
     return render_template(
         'dashboards/user/partials/user_pie_chart.html',
@@ -1066,7 +1068,7 @@ def resource_details_disk_usage_chart(project):
     )
     chart_svg = generate_disk_usage_stacked_area(
         timeseries, link_kind=disk_link_kind, metric=metric,
-        layout=read_layout(),
+        layout=read_layout(), theme=read_theme(),
     )
 
     return render_template(

--- a/src/webapp/disk_scans/routes.py
+++ b/src/webapp/disk_scans/routes.py
@@ -395,7 +395,7 @@ def _scope_for(mode, ctx):
 
 def _render_directories_fragment(ctx, fragment_url, *, mode, scope_for,
                                  log_label, browse=False, forced_owner_uid=None,
-                                 layout='desktop'):
+                                 layout='desktop', theme='light'):
     """Shared body for the project + resource directory fragments.
 
     Both render the *same* ``disk_scans_directories.html`` partial; they differ
@@ -505,7 +505,8 @@ def directories_resource_page(resource):
 
 def _render_entities(ctx, fragment_url, *, mode, scope_for, log_label,
                      dir_fragment_url,
-                     forced_owner_uid=None, layout='desktop'):
+                     forced_owner_uid=None, layout='desktop',
+                     theme='light'):
     """Shared body for the project + resource entity (owner|group) fragments.
 
     Both render the *same* ``disk_scans_entities.html`` partial; they differ
@@ -551,7 +552,8 @@ def _render_entities(ctx, fragment_url, *, mode, scope_for, log_label,
         ]
         if entity_data:
             pie_chart = generate_disk_entity_pie_chart(entity_data, kind,
-                                                       layout=layout)
+                                                       layout=layout,
+                                                       theme=theme)
 
     return render_template(
         'dashboards/user/partials/disk_scans_entities.html',
@@ -569,7 +571,8 @@ _METRIC_WHITELIST = {'data', 'files'}
 def _render_distribution(ctx, fragment_url, *, mode, scope_for, kind,
                          bucket_header, log_label, dir_fragment_url,
                          metric_toggle=False, log_toggle=False,
-                         forced_owner_uid=None, layout='desktop'):
+                         forced_owner_uid=None, layout='desktop',
+                         theme='light'):
     """Shared body for the two distribution histogram fragments (both modes).
 
     The Access-history and File-size tabs are identical end to end — same
@@ -614,7 +617,8 @@ def _render_distribution(ctx, fragment_url, *, mode, scope_for, kind,
             scope_for(ctx['fileset']), kind, owner_uid=owner_uid)
         if hist:
             chart_svg = generate_distribution_histogram(
-                hist, log_y=log_on, metric=metric, layout=layout)
+                hist, log_y=log_on, metric=metric, layout=layout,
+                theme=theme)
     except Exception as exc:
         current_app.logger.exception(
             'disk_scans.%s: scan failed for %s resource=%s',

--- a/src/webapp/jobs/routes.py
+++ b/src/webapp/jobs/routes.py
@@ -914,7 +914,7 @@ def _usage_affordance_permission(entity_key: str, mode: str) -> bool:
 def _render_usage_panel(*, entity_key, mode, machine, fragment_url,
                         jobs_fragment_url, target_id,
                         username=None, account_projcodes=None,
-                        layout='desktop'):
+                        layout='desktop', theme='light'):
     """Shared renderer for the By User / By Project tabs (all modes).
 
     Scoping is the scope object's job; what differs here is only the entity
@@ -949,7 +949,7 @@ def _render_usage_panel(*, entity_key, mode, machine, fragment_url,
 
     pie_svg = generate_jobs_usage_pie_chart(
         usage, metric=metric, row_attr=entity['sentinel_attr'],
-        layout=layout) if usage else None
+        layout=layout, theme=theme) if usage else None
     other = _usage_other(usage) if usage else None
 
     return render_template(
@@ -1082,7 +1082,7 @@ def _band_drill_url(jobs_fragment_url, band, roundtrip):
 def _render_timeline(*, mode, machine, fragment_url, target_id,
                      jobs_fragment_url=None,
                      account_projcodes=None, username=None,
-                     layout='desktop'):
+                     layout='desktop', theme='light'):
     """Renderer for the Jobs tab's activity timeline.
 
     The one panel with a time axis. Upstream cost swings ~500x on whether
@@ -1168,7 +1168,7 @@ def _render_timeline(*, mode, machine, fragment_url, target_id,
         ts, metric=metric, period=period,
         entity_kind=group_by,
         link_entities=link_entities,
-        layout=layout) if has_bands else None)
+        layout=layout, theme=theme) if has_bands else None)
 
     params = _roundtrip_params(machine, target_id)
     band_drills = None
@@ -1202,7 +1202,7 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
                       fragment_url, target_id,
                       jobs_fragment_url=None,
                       account_projcodes=None, username=None,
-                      layout='desktop'):
+                      layout='desktop', theme='light'):
     """Shared renderer for the Wait Times / Job Sizes / Durations tabs."""
     template = 'dashboards/user/partials/jobs_histogram.html'
     if not is_enabled():
@@ -1274,7 +1274,7 @@ def _render_histogram(*, mode, machine, dimension, dimension_toggle,
     has_bands = bool((hist or {}).get('buckets'))
 
     chart_svg = (generate_jobs_histogram(hist, metric=metric, log_y=log_on,
-                                        layout=layout)
+                                        layout=layout, theme=theme)
                  if has_bands else None)
     params = _roundtrip_params(machine, target_id)
 
@@ -1842,7 +1842,8 @@ def _panel_jobs_table(ctx, fragment_url, *, mode, scope_for, log_label, **_kw):
 
 
 def _panel_usage(ctx, fragment_url, *, mode, scope_for, log_label,
-                 entity_key, jobs_fragment_url=None, layout='desktop', **_kw):
+                 entity_key, jobs_fragment_url=None, layout='desktop',
+                 theme='light', **_kw):
     """HTMX fragment: a per-entity usage pie + drillable rows."""
     entity = _USAGE_ENTITIES[entity_key]
     if ctx['machine'] is None:
@@ -1855,13 +1856,14 @@ def _panel_usage(ctx, fragment_url, *, mode, scope_for, log_label,
         target_id=_target_id(ctx, entity['target_stem']),
         username=ctx['username'],
         account_projcodes=ctx['account_projcodes'],
-        layout=layout,
+        layout=layout, theme=theme,
     )
 
 
 def _panel_histogram(ctx, fragment_url, *, mode, scope_for, log_label,
                      dimension, dimension_toggle=False,
-                     jobs_fragment_url=None, layout='desktop', **_kw):
+                     jobs_fragment_url=None, layout='desktop',
+                     theme='light', **_kw):
     """HTMX fragment: one of the three distribution histograms."""
     dim = _panel_dimension(dimension, dimension_toggle)
     if ctx['machine'] is None:
@@ -1875,12 +1877,13 @@ def _panel_histogram(ctx, fragment_url, *, mode, scope_for, log_label,
         target_id=_target_id(ctx, dim),
         account_projcodes=ctx['account_projcodes'],
         username=ctx['username'],
-        layout=layout,
+        layout=layout, theme=theme,
     )
 
 
 def _panel_timeline(ctx, fragment_url, *, mode, scope_for, log_label,
-                    jobs_fragment_url=None, layout='desktop', **_kw):
+                    jobs_fragment_url=None, layout='desktop',
+                    theme='light', **_kw):
     """HTMX fragment: the Jobs tab's activity timeline."""
     if ctx['machine'] is None:
         return _render_timeline(mode=mode, machine=None,
@@ -1891,7 +1894,7 @@ def _panel_timeline(ctx, fragment_url, *, mode, scope_for, log_label,
         target_id=_target_id(ctx, 'timeline'),
         account_projcodes=ctx['account_projcodes'],
         username=ctx['username'],
-        layout=layout,
+        layout=layout, theme=theme,
     )
 
 

--- a/src/webapp/utils/fragments.py
+++ b/src/webapp/utils/fragments.py
@@ -33,7 +33,7 @@ from typing import Any, Callable, Dict, Mapping, Sequence, Tuple
 
 from flask import url_for
 
-from webapp.utils.htmx import read_layout
+from webapp.utils.htmx import read_layout, read_theme
 
 
 @dataclass(frozen=True)
@@ -151,11 +151,17 @@ def _register_one(bp, panel: PanelSpec, mode: ModeSpec) -> None:
             mode=mode.mode,
             scope_for=mode.scope_for(ctx),
             log_label=mode.log_label(ctx),
-            # Every panel that draws a chart needs the render layout, and this
+            # Every panel that draws a chart needs both render axes, and this
             # is the one place all 27 jobs/disk-scans fragment routes pass
-            # through — so it is resolved once here rather than in each
-            # renderer. Panels that draw no chart accept and ignore it.
+            # through — so they are resolved once here rather than in each
+            # renderer. Panels that draw no chart accept and ignore them.
+            #
+            # Resolving them here is only half the job: each renderer then has
+            # to *carry* them to its delegate by hand, which is the hop that
+            # silently failed for `layout` in the three jobs histogram panels.
+            # `test_layout_transport.py` gates both.
             layout=read_layout(),
+            theme=read_theme(),
             **panel.kwargs, **extras,
         )
 

--- a/tests/unit/snapshots/chart_fingerprints.json
+++ b/tests/unit/snapshots/chart_fingerprints.json
@@ -78,6 +78,83 @@
       236.2
     ]
   },
+  "alloc_type_pie.trimmed@dark": {
+    "counts": {
+      "a": 0,
+      "g": 48,
+      "path": 23,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#97999b",
+      "#236eca",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#97999b",
+      "#e9ecef",
+      "#236eca",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "Type01 (120K)",
+      "Type02 (110K)",
+      "Type03 (100,000)",
+      "Type04 (90,000)",
+      "Type05 (80,000)",
+      "Type06 (70,000)",
+      "Type07 (60,000)",
+      "Type08 (50,000)",
+      "Type09 (40,000)",
+      "Type10 (30,000)",
+      "Others (2) (30,000)"
+    ],
+    "size": [
+      361.0,
+      236.2
+    ]
+  },
   "alloc_type_pie.trimmed@mobile": {
     "counts": {
       "a": 0,
@@ -113,6 +190,64 @@
       "#011837",
       "#42c0ff",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "26.9%",
+      "Type01 (120K)",
+      "Type02 (110K)",
+      "Type03 (100,000)",
+      "Type04 (90,000)",
+      "Type05 (80,000)",
+      "Type06 (70,000)",
+      "Others (6) (210K)"
+    ],
+    "size": [
+      289.7,
+      175.2
+    ]
+  },
+  "alloc_type_pie.trimmed@mobile@dark": {
+    "counts": {
+      "a": 0,
+      "g": 34,
+      "path": 15,
+      "text": 14,
+      "use": 0
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -211,6 +346,83 @@
       236.2
     ]
   },
+  "alloc_type_pie.trimmed@tablet@dark": {
+    "counts": {
+      "a": 0,
+      "g": 48,
+      "path": 23,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#97999b",
+      "#236eca",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#97999b",
+      "#e9ecef",
+      "#236eca",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "Type01 (120K)",
+      "Type02 (110K)",
+      "Type03 (100,000)",
+      "Type04 (90,000)",
+      "Type05 (80,000)",
+      "Type06 (70,000)",
+      "Type07 (60,000)",
+      "Type08 (50,000)",
+      "Type09 (40,000)",
+      "Type10 (30,000)",
+      "Others (2) (30,000)"
+    ],
+    "size": [
+      361.0,
+      236.2
+    ]
+  },
   "disk_area.bytes_linked": {
     "counts": {
       "a": 4,
@@ -236,6 +448,60 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 2",
+      "Mar 3",
+      "Mar 4",
+      "Mar 5",
+      "Mar 6",
+      "Mar 7",
+      "Mar 8",
+      "Mar 9",
+      "Mar 10",
+      "0",
+      "1",
+      "2",
+      "3",
+      "4",
+      "Disk usage (TiB)",
+      "bob",
+      "alice",
+      "Others"
+    ],
+    "size": [
+      1143.6,
+      331.6
+    ]
+  },
+  "disk_area.bytes_linked@dark": {
+    "counts": {
+      "a": 4,
+      "g": 79,
+      "path": 27,
+      "text": 20,
+      "use": 15
+    },
+    "drill_hrefs": [
+      "/admin/user/bob",
+      "/admin/user/bob",
+      "/admin/user/alice",
+      "/admin/user/alice"
+    ],
+    "fills": [
+      "#434d59",
+      "#fdd509",
+      "#fbe174",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -312,6 +578,53 @@
       245.2
     ]
   },
+  "disk_area.bytes_linked@mobile@dark": {
+    "counts": {
+      "a": 4,
+      "g": 51,
+      "path": 20,
+      "text": 13,
+      "use": 8
+    },
+    "drill_hrefs": [
+      "/admin/user/bob",
+      "/admin/user/bob",
+      "/admin/user/alice",
+      "/admin/user/alice"
+    ],
+    "fills": [
+      "#434d59",
+      "#fdd509",
+      "#fbe174",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 5",
+      "Mar 9",
+      "0",
+      "1",
+      "2",
+      "3",
+      "4",
+      "Disk usage (TiB)",
+      "bob",
+      "alice",
+      "Others"
+    ],
+    "size": [
+      266.9,
+      245.2
+    ]
+  },
   "disk_area.bytes_linked@tablet": {
     "counts": {
       "a": 4,
@@ -337,6 +650,55 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 3",
+      "Mar 5",
+      "Mar 7",
+      "Mar 9",
+      "0",
+      "1",
+      "2",
+      "3",
+      "4",
+      "Disk usage (TiB)",
+      "bob",
+      "alice",
+      "Others"
+    ],
+    "size": [
+      692.8,
+      242.9
+    ]
+  },
+  "disk_area.bytes_linked@tablet@dark": {
+    "counts": {
+      "a": 4,
+      "g": 59,
+      "path": 22,
+      "text": 15,
+      "use": 10
+    },
+    "drill_hrefs": [
+      "/admin/user/bob",
+      "/admin/user/bob",
+      "/admin/user/alice",
+      "/admin/user/alice"
+    ],
+    "fills": [
+      "#434d59",
+      "#fdd509",
+      "#fbe174",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -419,6 +781,60 @@
       333.1
     ]
   },
+  "disk_area.files@dark": {
+    "counts": {
+      "a": 0,
+      "g": 99,
+      "path": 32,
+      "text": 25,
+      "use": 20
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#434d59",
+      "#fdd509",
+      "#fbe174",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 2",
+      "Mar 3",
+      "Mar 4",
+      "Mar 5",
+      "Mar 6",
+      "Mar 7",
+      "Mar 8",
+      "Mar 9",
+      "Mar 10",
+      "0",
+      "600B",
+      "1.20T",
+      "1.80T",
+      "2.40T",
+      "3.00T",
+      "3.60T",
+      "4.20T",
+      "4.80T",
+      "5.40T",
+      "Number of files",
+      "bob",
+      "alice",
+      "Others"
+    ],
+    "size": [
+      1165.7,
+      333.1
+    ]
+  },
   "disk_area.files@mobile": {
     "counts": {
       "a": 0,
@@ -466,6 +882,53 @@
       247.5
     ]
   },
+  "disk_area.files@mobile@dark": {
+    "counts": {
+      "a": 0,
+      "g": 71,
+      "path": 25,
+      "text": 18,
+      "use": 13
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#434d59",
+      "#fdd509",
+      "#fbe174",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 5",
+      "Mar 9",
+      "0",
+      "600B",
+      "1.20T",
+      "1.80T",
+      "2.40T",
+      "3.00T",
+      "3.60T",
+      "4.20T",
+      "4.80T",
+      "5.40T",
+      "Number of files",
+      "bob",
+      "alice",
+      "Others"
+    ],
+    "size": [
+      285.0,
+      247.5
+    ]
+  },
   "disk_area.files@tablet": {
     "counts": {
       "a": 0,
@@ -486,6 +949,55 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 3",
+      "Mar 5",
+      "Mar 7",
+      "Mar 9",
+      "0",
+      "600B",
+      "1.20T",
+      "1.80T",
+      "2.40T",
+      "3.00T",
+      "3.60T",
+      "4.20T",
+      "4.80T",
+      "5.40T",
+      "Number of files",
+      "bob",
+      "alice",
+      "Others"
+    ],
+    "size": [
+      714.9,
+      245.8
+    ]
+  },
+  "disk_area.files@tablet@dark": {
+    "counts": {
+      "a": 0,
+      "g": 79,
+      "path": 27,
+      "text": 20,
+      "use": 15
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#434d59",
+      "#fdd509",
+      "#fbe174",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -620,6 +1132,108 @@
       236.2
     ]
   },
+  "disk_entity_pie.group@dark": {
+    "counts": {
+      "a": 27,
+      "g": 46,
+      "path": 21,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-group-gid/1000",
+      "#sam/row/data-group-gid/1001",
+      "#sam/row/data-group-gid/1002",
+      "#sam/row/data-group-gid/1003",
+      "#sam/row/data-group-gid/1004",
+      "#sam/row/data-group-gid/1005",
+      "#sam/row/data-group-gid/1006",
+      "#sam/row/data-group-gid/1007",
+      "#sam/row/data-group-gid/1008",
+      "#sam/row/data-group-gid/1000",
+      "#sam/row/data-group-gid/1000",
+      "#sam/row/data-group-gid/1001",
+      "#sam/row/data-group-gid/1001",
+      "#sam/row/data-group-gid/1002",
+      "#sam/row/data-group-gid/1002",
+      "#sam/row/data-group-gid/1003",
+      "#sam/row/data-group-gid/1003",
+      "#sam/row/data-group-gid/1004",
+      "#sam/row/data-group-gid/1004",
+      "#sam/row/data-group-gid/1005",
+      "#sam/row/data-group-gid/1005",
+      "#sam/row/data-group-gid/1006",
+      "#sam/row/data-group-gid/1006",
+      "#sam/row/data-group-gid/1007",
+      "#sam/row/data-group-gid/1007",
+      "#sam/row/data-group-gid/1008",
+      "#sam/row/data-group-gid/1008"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "7.7%",
+      "gid 1000 (114 MiB)",
+      "user1 (105 MiB)",
+      "user2 (95.4 MiB)",
+      "gid 1003 (85.8 MiB)",
+      "user4 (76.3 MiB)",
+      "user5 (66.8 MiB)",
+      "gid 1006 (57.2 MiB)",
+      "user7 (47.7 MiB)",
+      "user8 (38.1 MiB)",
+      "Other (3) (57.2 MiB)"
+    ],
+    "size": [
+      362.3,
+      236.2
+    ]
+  },
   "disk_entity_pie.group@mobile": {
     "counts": {
       "a": 18,
@@ -674,6 +1288,82 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "26.9%",
+      "gid 1000 (114 MiB)",
+      "user1 (105 MiB)",
+      "user2 (95.4 MiB)",
+      "gid 1003 (85.8 MiB)",
+      "user4 (76.3 MiB)",
+      "user5 (66.8 MiB)",
+      "Other (6) (200 MiB)"
+    ],
+    "size": [
+      300.0,
+      175.2
+    ]
+  },
+  "disk_entity_pie.group@mobile@dark": {
+    "counts": {
+      "a": 18,
+      "g": 34,
+      "path": 15,
+      "text": 14,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-group-gid/1000",
+      "#sam/row/data-group-gid/1001",
+      "#sam/row/data-group-gid/1002",
+      "#sam/row/data-group-gid/1003",
+      "#sam/row/data-group-gid/1004",
+      "#sam/row/data-group-gid/1005",
+      "#sam/row/data-group-gid/1000",
+      "#sam/row/data-group-gid/1000",
+      "#sam/row/data-group-gid/1001",
+      "#sam/row/data-group-gid/1001",
+      "#sam/row/data-group-gid/1002",
+      "#sam/row/data-group-gid/1002",
+      "#sam/row/data-group-gid/1003",
+      "#sam/row/data-group-gid/1003",
+      "#sam/row/data-group-gid/1004",
+      "#sam/row/data-group-gid/1004",
+      "#sam/row/data-group-gid/1005",
+      "#sam/row/data-group-gid/1005"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -769,6 +1459,108 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "7.7%",
+      "gid 1000 (114 MiB)",
+      "user1 (105 MiB)",
+      "user2 (95.4 MiB)",
+      "gid 1003 (85.8 MiB)",
+      "user4 (76.3 MiB)",
+      "user5 (66.8 MiB)",
+      "gid 1006 (57.2 MiB)",
+      "user7 (47.7 MiB)",
+      "user8 (38.1 MiB)",
+      "Other (3) (57.2 MiB)"
+    ],
+    "size": [
+      362.3,
+      236.2
+    ]
+  },
+  "disk_entity_pie.group@tablet@dark": {
+    "counts": {
+      "a": 27,
+      "g": 46,
+      "path": 21,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-group-gid/1000",
+      "#sam/row/data-group-gid/1001",
+      "#sam/row/data-group-gid/1002",
+      "#sam/row/data-group-gid/1003",
+      "#sam/row/data-group-gid/1004",
+      "#sam/row/data-group-gid/1005",
+      "#sam/row/data-group-gid/1006",
+      "#sam/row/data-group-gid/1007",
+      "#sam/row/data-group-gid/1008",
+      "#sam/row/data-group-gid/1000",
+      "#sam/row/data-group-gid/1000",
+      "#sam/row/data-group-gid/1001",
+      "#sam/row/data-group-gid/1001",
+      "#sam/row/data-group-gid/1002",
+      "#sam/row/data-group-gid/1002",
+      "#sam/row/data-group-gid/1003",
+      "#sam/row/data-group-gid/1003",
+      "#sam/row/data-group-gid/1004",
+      "#sam/row/data-group-gid/1004",
+      "#sam/row/data-group-gid/1005",
+      "#sam/row/data-group-gid/1005",
+      "#sam/row/data-group-gid/1006",
+      "#sam/row/data-group-gid/1006",
+      "#sam/row/data-group-gid/1007",
+      "#sam/row/data-group-gid/1007",
+      "#sam/row/data-group-gid/1008",
+      "#sam/row/data-group-gid/1008"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -899,6 +1691,108 @@
       236.2
     ]
   },
+  "disk_entity_pie.owner@dark": {
+    "counts": {
+      "a": 27,
+      "g": 46,
+      "path": 21,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-owner-uid/1000",
+      "#sam/row/data-owner-uid/1001",
+      "#sam/row/data-owner-uid/1002",
+      "#sam/row/data-owner-uid/1003",
+      "#sam/row/data-owner-uid/1004",
+      "#sam/row/data-owner-uid/1005",
+      "#sam/row/data-owner-uid/1006",
+      "#sam/row/data-owner-uid/1007",
+      "#sam/row/data-owner-uid/1008",
+      "#sam/row/data-owner-uid/1000",
+      "#sam/row/data-owner-uid/1000",
+      "#sam/row/data-owner-uid/1001",
+      "#sam/row/data-owner-uid/1001",
+      "#sam/row/data-owner-uid/1002",
+      "#sam/row/data-owner-uid/1002",
+      "#sam/row/data-owner-uid/1003",
+      "#sam/row/data-owner-uid/1003",
+      "#sam/row/data-owner-uid/1004",
+      "#sam/row/data-owner-uid/1004",
+      "#sam/row/data-owner-uid/1005",
+      "#sam/row/data-owner-uid/1005",
+      "#sam/row/data-owner-uid/1006",
+      "#sam/row/data-owner-uid/1006",
+      "#sam/row/data-owner-uid/1007",
+      "#sam/row/data-owner-uid/1007",
+      "#sam/row/data-owner-uid/1008",
+      "#sam/row/data-owner-uid/1008"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "7.7%",
+      "uid 1000 (114 MiB)",
+      "user1 (105 MiB)",
+      "user2 (95.4 MiB)",
+      "uid 1003 (85.8 MiB)",
+      "user4 (76.3 MiB)",
+      "user5 (66.8 MiB)",
+      "uid 1006 (57.2 MiB)",
+      "user7 (47.7 MiB)",
+      "user8 (38.1 MiB)",
+      "Other (3) (57.2 MiB)"
+    ],
+    "size": [
+      362.3,
+      236.2
+    ]
+  },
   "disk_entity_pie.owner@mobile": {
     "counts": {
       "a": 18,
@@ -953,6 +1847,82 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "26.9%",
+      "uid 1000 (114 MiB)",
+      "user1 (105 MiB)",
+      "user2 (95.4 MiB)",
+      "uid 1003 (85.8 MiB)",
+      "user4 (76.3 MiB)",
+      "user5 (66.8 MiB)",
+      "Other (6) (200 MiB)"
+    ],
+    "size": [
+      300.0,
+      175.2
+    ]
+  },
+  "disk_entity_pie.owner@mobile@dark": {
+    "counts": {
+      "a": 18,
+      "g": 34,
+      "path": 15,
+      "text": 14,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-owner-uid/1000",
+      "#sam/row/data-owner-uid/1001",
+      "#sam/row/data-owner-uid/1002",
+      "#sam/row/data-owner-uid/1003",
+      "#sam/row/data-owner-uid/1004",
+      "#sam/row/data-owner-uid/1005",
+      "#sam/row/data-owner-uid/1000",
+      "#sam/row/data-owner-uid/1000",
+      "#sam/row/data-owner-uid/1001",
+      "#sam/row/data-owner-uid/1001",
+      "#sam/row/data-owner-uid/1002",
+      "#sam/row/data-owner-uid/1002",
+      "#sam/row/data-owner-uid/1003",
+      "#sam/row/data-owner-uid/1003",
+      "#sam/row/data-owner-uid/1004",
+      "#sam/row/data-owner-uid/1004",
+      "#sam/row/data-owner-uid/1005",
+      "#sam/row/data-owner-uid/1005"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -1077,6 +2047,108 @@
       236.2
     ]
   },
+  "disk_entity_pie.owner@tablet@dark": {
+    "counts": {
+      "a": 27,
+      "g": 46,
+      "path": 21,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-owner-uid/1000",
+      "#sam/row/data-owner-uid/1001",
+      "#sam/row/data-owner-uid/1002",
+      "#sam/row/data-owner-uid/1003",
+      "#sam/row/data-owner-uid/1004",
+      "#sam/row/data-owner-uid/1005",
+      "#sam/row/data-owner-uid/1006",
+      "#sam/row/data-owner-uid/1007",
+      "#sam/row/data-owner-uid/1008",
+      "#sam/row/data-owner-uid/1000",
+      "#sam/row/data-owner-uid/1000",
+      "#sam/row/data-owner-uid/1001",
+      "#sam/row/data-owner-uid/1001",
+      "#sam/row/data-owner-uid/1002",
+      "#sam/row/data-owner-uid/1002",
+      "#sam/row/data-owner-uid/1003",
+      "#sam/row/data-owner-uid/1003",
+      "#sam/row/data-owner-uid/1004",
+      "#sam/row/data-owner-uid/1004",
+      "#sam/row/data-owner-uid/1005",
+      "#sam/row/data-owner-uid/1005",
+      "#sam/row/data-owner-uid/1006",
+      "#sam/row/data-owner-uid/1006",
+      "#sam/row/data-owner-uid/1007",
+      "#sam/row/data-owner-uid/1007",
+      "#sam/row/data-owner-uid/1008",
+      "#sam/row/data-owner-uid/1008"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "7.7%",
+      "uid 1000 (114 MiB)",
+      "user1 (105 MiB)",
+      "user2 (95.4 MiB)",
+      "uid 1003 (85.8 MiB)",
+      "user4 (76.3 MiB)",
+      "user5 (66.8 MiB)",
+      "uid 1006 (57.2 MiB)",
+      "user7 (47.7 MiB)",
+      "user8 (38.1 MiB)",
+      "Other (3) (57.2 MiB)"
+    ],
+    "size": [
+      362.3,
+      236.2
+    ]
+  },
   "distribution.data": {
     "counts": {
       "a": 18,
@@ -1126,6 +2198,77 @@
       "#fbcc91",
       "#fabe72",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "&lt; 30d",
+      "30-90d",
+      "90-180d",
+      "&gt; 180d",
+      "0",
+      "50",
+      "100",
+      "150",
+      "200",
+      "250",
+      "300",
+      "350",
+      "Data (GiB)"
+    ],
+    "size": [
+      842.3,
+      334.3
+    ]
+  },
+  "distribution.data@dark": {
+    "counts": {
+      "a": 18,
+      "g": 72,
+      "path": 33,
+      "text": 13,
+      "use": 12
+    },
+    "drill_hrefs": [
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3"
+    ],
+    "fills": [
+      "#686225",
+      "#b29c17",
+      "#fdd509",
+      "#676649",
+      "#76734d",
+      "#857f52",
+      "#948b56",
+      "#a2975a",
+      "#b1a45f",
+      "#c0b063",
+      "#cfbc67",
+      "#ddc86b",
+      "#ecd570",
+      "#fbe174",
+      "#faa119",
+      "#675a48",
+      "#987c56",
+      "#c99d64",
+      "#fabe72",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -1219,6 +2362,77 @@
       200.3
     ]
   },
+  "distribution.data@mobile@dark": {
+    "counts": {
+      "a": 18,
+      "g": 72,
+      "path": 33,
+      "text": 13,
+      "use": 12
+    },
+    "drill_hrefs": [
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3"
+    ],
+    "fills": [
+      "#686225",
+      "#b29c17",
+      "#fdd509",
+      "#676649",
+      "#76734d",
+      "#857f52",
+      "#948b56",
+      "#a2975a",
+      "#b1a45f",
+      "#c0b063",
+      "#cfbc67",
+      "#ddc86b",
+      "#ecd570",
+      "#fbe174",
+      "#faa119",
+      "#675a48",
+      "#987c56",
+      "#c99d64",
+      "#fabe72",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "&lt; 30d",
+      "30-90d",
+      "90-180d",
+      "&gt; 180d",
+      "0",
+      "50",
+      "100",
+      "150",
+      "200",
+      "250",
+      "300",
+      "350",
+      "Data (GiB)"
+    ],
+    "size": [
+      280.6,
+      200.3
+    ]
+  },
   "distribution.data@tablet": {
     "counts": {
       "a": 18,
@@ -1268,6 +2482,77 @@
       "#fbcc91",
       "#fabe72",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "&lt; 30d",
+      "30-90d",
+      "90-180d",
+      "&gt; 180d",
+      "0",
+      "50",
+      "100",
+      "150",
+      "200",
+      "250",
+      "300",
+      "350",
+      "Data (GiB)"
+    ],
+    "size": [
+      674.9,
+      289.9
+    ]
+  },
+  "distribution.data@tablet@dark": {
+    "counts": {
+      "a": 18,
+      "g": 72,
+      "path": 33,
+      "text": 13,
+      "use": 12
+    },
+    "drill_hrefs": [
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3"
+    ],
+    "fills": [
+      "#686225",
+      "#b29c17",
+      "#fdd509",
+      "#676649",
+      "#76734d",
+      "#857f52",
+      "#948b56",
+      "#a2975a",
+      "#b1a45f",
+      "#c0b063",
+      "#cfbc67",
+      "#ddc86b",
+      "#ecd570",
+      "#fbe174",
+      "#faa119",
+      "#675a48",
+      "#987c56",
+      "#c99d64",
+      "#fabe72",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -1365,6 +2650,77 @@
       334.3
     ]
   },
+  "distribution.files@dark": {
+    "counts": {
+      "a": 18,
+      "g": 72,
+      "path": 33,
+      "text": 13,
+      "use": 12
+    },
+    "drill_hrefs": [
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3"
+    ],
+    "fills": [
+      "#686225",
+      "#b29c17",
+      "#fdd509",
+      "#676649",
+      "#76734d",
+      "#857f52",
+      "#948b56",
+      "#a2975a",
+      "#b1a45f",
+      "#c0b063",
+      "#cfbc67",
+      "#ddc86b",
+      "#ecd570",
+      "#fbe174",
+      "#faa119",
+      "#675a48",
+      "#987c56",
+      "#c99d64",
+      "#fabe72",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "&lt; 30d",
+      "30-90d",
+      "90-180d",
+      "&gt; 180d",
+      "0",
+      "5,000",
+      "10,000",
+      "15,000",
+      "20,000",
+      "25,000",
+      "30,000",
+      "35,000",
+      "Files"
+    ],
+    "size": [
+      858.3,
+      334.3
+    ]
+  },
   "distribution.files@mobile": {
     "counts": {
       "a": 18,
@@ -1414,6 +2770,77 @@
       "#fbcc91",
       "#fabe72",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "&lt; 30d",
+      "30-90d",
+      "90-180d",
+      "&gt; 180d",
+      "0",
+      "5,000",
+      "10,000",
+      "15,000",
+      "20,000",
+      "25,000",
+      "30,000",
+      "35,000",
+      "Files"
+    ],
+    "size": [
+      293.7,
+      200.3
+    ]
+  },
+  "distribution.files@mobile@dark": {
+    "counts": {
+      "a": 18,
+      "g": 72,
+      "path": 33,
+      "text": 13,
+      "use": 12
+    },
+    "drill_hrefs": [
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3"
+    ],
+    "fills": [
+      "#686225",
+      "#b29c17",
+      "#fdd509",
+      "#676649",
+      "#76734d",
+      "#857f52",
+      "#948b56",
+      "#a2975a",
+      "#b1a45f",
+      "#c0b063",
+      "#cfbc67",
+      "#ddc86b",
+      "#ecd570",
+      "#fbe174",
+      "#faa119",
+      "#675a48",
+      "#987c56",
+      "#c99d64",
+      "#fabe72",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -1507,6 +2934,77 @@
       289.9
     ]
   },
+  "distribution.files@tablet@dark": {
+    "counts": {
+      "a": 18,
+      "g": 72,
+      "path": 33,
+      "text": 13,
+      "use": 12
+    },
+    "drill_hrefs": [
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3",
+      "#sam/row/data-ah-bucket/3"
+    ],
+    "fills": [
+      "#686225",
+      "#b29c17",
+      "#fdd509",
+      "#676649",
+      "#76734d",
+      "#857f52",
+      "#948b56",
+      "#a2975a",
+      "#b1a45f",
+      "#c0b063",
+      "#cfbc67",
+      "#ddc86b",
+      "#ecd570",
+      "#fbe174",
+      "#faa119",
+      "#675a48",
+      "#987c56",
+      "#c99d64",
+      "#fabe72",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "&lt; 30d",
+      "30-90d",
+      "90-180d",
+      "&gt; 180d",
+      "0",
+      "5,000",
+      "10,000",
+      "15,000",
+      "20,000",
+      "25,000",
+      "30,000",
+      "35,000",
+      "Files"
+    ],
+    "size": [
+      690.9,
+      289.9
+    ]
+  },
   "distribution.log_y": {
     "counts": {
       "a": 3,
@@ -1526,6 +3024,49 @@
       "#faa119",
       "#fabe72",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "&lt; 30d",
+      "30-90d",
+      "90-180d",
+      "&gt; 180d",
+      "1 0 2",
+      "2 \u00d7 1 0 1",
+      "3 \u00d7 1 0 1",
+      "4 \u00d7 1 0 1",
+      "6 \u00d7 1 0 1",
+      "2 \u00d7 1 0 2",
+      "3 \u00d7 1 0 2",
+      "4 \u00d7 1 0 2",
+      "Data (GiB)"
+    ],
+    "size": [
+      854.0,
+      334.3
+    ]
+  },
+  "distribution.log_y@dark": {
+    "counts": {
+      "a": 3,
+      "g": 66,
+      "path": 12,
+      "text": 5,
+      "use": 16
+    },
+    "drill_hrefs": [
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/3"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#e9ecef",
+      "#011837",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -1589,6 +3130,49 @@
       200.3
     ]
   },
+  "distribution.log_y@mobile@dark": {
+    "counts": {
+      "a": 3,
+      "g": 66,
+      "path": 12,
+      "text": 5,
+      "use": 16
+    },
+    "drill_hrefs": [
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/3"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#e9ecef",
+      "#011837",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "&lt; 30d",
+      "30-90d",
+      "90-180d",
+      "&gt; 180d",
+      "1 0 2",
+      "2 \u00d7 1 0 1",
+      "3 \u00d7 1 0 1",
+      "4 \u00d7 1 0 1",
+      "6 \u00d7 1 0 1",
+      "2 \u00d7 1 0 2",
+      "3 \u00d7 1 0 2",
+      "4 \u00d7 1 0 2",
+      "Data (GiB)"
+    ],
+    "size": [
+      295.9,
+      200.3
+    ]
+  },
   "distribution.log_y@tablet": {
     "counts": {
       "a": 3,
@@ -1608,6 +3192,49 @@
       "#faa119",
       "#fabe72",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "&lt; 30d",
+      "30-90d",
+      "90-180d",
+      "&gt; 180d",
+      "1 0 2",
+      "2 \u00d7 1 0 1",
+      "3 \u00d7 1 0 1",
+      "4 \u00d7 1 0 1",
+      "6 \u00d7 1 0 1",
+      "2 \u00d7 1 0 2",
+      "3 \u00d7 1 0 2",
+      "4 \u00d7 1 0 2",
+      "Data (GiB)"
+    ],
+    "size": [
+      686.5,
+      289.9
+    ]
+  },
+  "distribution.log_y@tablet@dark": {
+    "counts": {
+      "a": 3,
+      "g": 66,
+      "path": 12,
+      "text": 5,
+      "use": 16
+    },
+    "drill_hrefs": [
+      "#sam/row/data-ah-bucket/0",
+      "#sam/row/data-ah-bucket/1",
+      "#sam/row/data-ah-bucket/3"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#e9ecef",
+      "#011837",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -1669,6 +3296,41 @@
       236.2
     ]
   },
+  "facility_pie.normal@dark": {
+    "counts": {
+      "a": 0,
+      "g": 18,
+      "path": 7,
+      "text": 6,
+      "use": 0
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "57.1%",
+      "28.6%",
+      "14.3%",
+      "UNIV (5.00M)",
+      "WNA (2.50M)",
+      "NCAR (1.25M)"
+    ],
+    "size": [
+      334.0,
+      236.2
+    ]
+  },
   "facility_pie.normal@mobile": {
     "counts": {
       "a": 0,
@@ -1704,6 +3366,41 @@
       175.2
     ]
   },
+  "facility_pie.normal@mobile@dark": {
+    "counts": {
+      "a": 0,
+      "g": 18,
+      "path": 7,
+      "text": 6,
+      "use": 0
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "57.1%",
+      "28.6%",
+      "14.3%",
+      "UNIV (5.00M)",
+      "WNA (2.50M)",
+      "NCAR (1.25M)"
+    ],
+    "size": [
+      272.4,
+      175.2
+    ]
+  },
   "facility_pie.normal@tablet": {
     "counts": {
       "a": 0,
@@ -1724,6 +3421,41 @@
       "#011837",
       "#ff1f1f",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "57.1%",
+      "28.6%",
+      "14.3%",
+      "UNIV (5.00M)",
+      "WNA (2.50M)",
+      "NCAR (1.25M)"
+    ],
+    "size": [
+      334.0,
+      236.2
+    ]
+  },
+  "facility_pie.normal@tablet@dark": {
+    "counts": {
+      "a": 0,
+      "g": 18,
+      "path": 7,
+      "text": 6,
+      "use": 0
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -1790,6 +3522,80 @@
       "#ff5050",
       "#ff1f1f",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0-1m",
+      "1-10m",
+      "10m-1h",
+      "1-6h",
+      "&gt; 6h",
+      "0",
+      "100",
+      "200",
+      "300",
+      "400",
+      "500",
+      "600",
+      "700",
+      "Charges"
+    ],
+    "size": [
+      842.8,
+      331.5
+    ]
+  },
+  "jobs_hist.charges@dark": {
+    "counts": {
+      "a": 19,
+      "g": 76,
+      "path": 34,
+      "text": 14,
+      "use": 13
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4"
+    ],
+    "fills": [
+      "#686225",
+      "#8d7f1e",
+      "#b29c17",
+      "#d8b810",
+      "#fdd509",
+      "#676649",
+      "#8c8554",
+      "#b1a45f",
+      "#d6c269",
+      "#fbe174",
+      "#67502a",
+      "#8c6526",
+      "#b07922",
+      "#d58d1d",
+      "#faa119",
+      "#fabe72",
+      "#69242c",
+      "#9b2328",
+      "#cd2123",
+      "#ff1f1f",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -1887,6 +3693,80 @@
       198.6
     ]
   },
+  "jobs_hist.charges@mobile@dark": {
+    "counts": {
+      "a": 19,
+      "g": 76,
+      "path": 34,
+      "text": 14,
+      "use": 13
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4"
+    ],
+    "fills": [
+      "#686225",
+      "#8d7f1e",
+      "#b29c17",
+      "#d8b810",
+      "#fdd509",
+      "#676649",
+      "#8c8554",
+      "#b1a45f",
+      "#d6c269",
+      "#fbe174",
+      "#67502a",
+      "#8c6526",
+      "#b07922",
+      "#d58d1d",
+      "#faa119",
+      "#fabe72",
+      "#69242c",
+      "#9b2328",
+      "#cd2123",
+      "#ff1f1f",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0-1m",
+      "1-10m",
+      "10m-1h",
+      "1-6h",
+      "&gt; 6h",
+      "0",
+      "100",
+      "200",
+      "300",
+      "400",
+      "500",
+      "600",
+      "700",
+      "Charges"
+    ],
+    "size": [
+      281.0,
+      198.6
+    ]
+  },
   "jobs_hist.charges@tablet": {
     "counts": {
       "a": 19,
@@ -1961,6 +3841,80 @@
       288.0
     ]
   },
+  "jobs_hist.charges@tablet@dark": {
+    "counts": {
+      "a": 19,
+      "g": 76,
+      "path": 34,
+      "text": 14,
+      "use": 13
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4"
+    ],
+    "fills": [
+      "#686225",
+      "#8d7f1e",
+      "#b29c17",
+      "#d8b810",
+      "#fdd509",
+      "#676649",
+      "#8c8554",
+      "#b1a45f",
+      "#d6c269",
+      "#fbe174",
+      "#67502a",
+      "#8c6526",
+      "#b07922",
+      "#d58d1d",
+      "#faa119",
+      "#fabe72",
+      "#69242c",
+      "#9b2328",
+      "#cd2123",
+      "#ff1f1f",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0-1m",
+      "1-10m",
+      "10m-1h",
+      "1-6h",
+      "&gt; 6h",
+      "0",
+      "100",
+      "200",
+      "300",
+      "400",
+      "500",
+      "600",
+      "700",
+      "Charges"
+    ],
+    "size": [
+      675.4,
+      288.0
+    ]
+  },
   "jobs_hist.empty": {
     "html": "<div class=\"text-center text-muted\">No jobs in this range</div>",
     "kind": "placeholder"
@@ -1982,6 +3936,46 @@
     "fills": [
       "#0057c2",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0-1m",
+      "1-10m",
+      "10m-1h",
+      "1-6h",
+      "&gt; 6h",
+      "0",
+      "50",
+      "100",
+      "150",
+      "200",
+      "250",
+      "300",
+      "350",
+      "Jobs"
+    ],
+    "size": [
+      842.3,
+      331.5
+    ]
+  },
+  "jobs_hist.flat_no_owners@dark": {
+    "counts": {
+      "a": 4,
+      "g": 61,
+      "path": 19,
+      "text": 14,
+      "use": 13
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/4"
+    ],
+    "fills": [
+      "#236eca",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -2045,6 +4039,46 @@
       198.6
     ]
   },
+  "jobs_hist.flat_no_owners@mobile@dark": {
+    "counts": {
+      "a": 4,
+      "g": 61,
+      "path": 19,
+      "text": 14,
+      "use": 13
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/4"
+    ],
+    "fills": [
+      "#236eca",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0-1m",
+      "1-10m",
+      "10m-1h",
+      "1-6h",
+      "&gt; 6h",
+      "0",
+      "50",
+      "100",
+      "150",
+      "200",
+      "250",
+      "300",
+      "350",
+      "Jobs"
+    ],
+    "size": [
+      280.6,
+      198.6
+    ]
+  },
   "jobs_hist.flat_no_owners@tablet": {
     "counts": {
       "a": 4,
@@ -2062,6 +4096,46 @@
     "fills": [
       "#0057c2",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0-1m",
+      "1-10m",
+      "10m-1h",
+      "1-6h",
+      "&gt; 6h",
+      "0",
+      "50",
+      "100",
+      "150",
+      "200",
+      "250",
+      "300",
+      "350",
+      "Jobs"
+    ],
+    "size": [
+      674.9,
+      288.0
+    ]
+  },
+  "jobs_hist.flat_no_owners@tablet@dark": {
+    "counts": {
+      "a": 4,
+      "g": 61,
+      "path": 19,
+      "text": 14,
+      "use": 13
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/4"
+    ],
+    "fills": [
+      "#236eca",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -2159,6 +4233,80 @@
       331.5
     ]
   },
+  "jobs_hist.jobs_owners@dark": {
+    "counts": {
+      "a": 19,
+      "g": 76,
+      "path": 34,
+      "text": 14,
+      "use": 13
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4"
+    ],
+    "fills": [
+      "#686225",
+      "#8d7f1e",
+      "#b29c17",
+      "#d8b810",
+      "#fdd509",
+      "#676649",
+      "#8c8554",
+      "#b1a45f",
+      "#d6c269",
+      "#fbe174",
+      "#67502a",
+      "#8c6526",
+      "#b07922",
+      "#d58d1d",
+      "#faa119",
+      "#fabe72",
+      "#69242c",
+      "#9b2328",
+      "#cd2123",
+      "#ff1f1f",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0-1m",
+      "1-10m",
+      "10m-1h",
+      "1-6h",
+      "&gt; 6h",
+      "0",
+      "50",
+      "100",
+      "150",
+      "200",
+      "250",
+      "300",
+      "350",
+      "Jobs"
+    ],
+    "size": [
+      842.3,
+      331.5
+    ]
+  },
   "jobs_hist.jobs_owners@mobile": {
     "counts": {
       "a": 19,
@@ -2210,6 +4358,80 @@
       "#ff5050",
       "#ff1f1f",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0-1m",
+      "1-10m",
+      "10m-1h",
+      "1-6h",
+      "&gt; 6h",
+      "0",
+      "50",
+      "100",
+      "150",
+      "200",
+      "250",
+      "300",
+      "350",
+      "Jobs"
+    ],
+    "size": [
+      280.6,
+      198.6
+    ]
+  },
+  "jobs_hist.jobs_owners@mobile@dark": {
+    "counts": {
+      "a": 19,
+      "g": 76,
+      "path": 34,
+      "text": 14,
+      "use": 13
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4"
+    ],
+    "fills": [
+      "#686225",
+      "#8d7f1e",
+      "#b29c17",
+      "#d8b810",
+      "#fdd509",
+      "#676649",
+      "#8c8554",
+      "#b1a45f",
+      "#d6c269",
+      "#fbe174",
+      "#67502a",
+      "#8c6526",
+      "#b07922",
+      "#d58d1d",
+      "#faa119",
+      "#fabe72",
+      "#69242c",
+      "#9b2328",
+      "#cd2123",
+      "#ff1f1f",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -2307,6 +4529,80 @@
       288.0
     ]
   },
+  "jobs_hist.jobs_owners@tablet@dark": {
+    "counts": {
+      "a": 19,
+      "g": 76,
+      "path": 34,
+      "text": 14,
+      "use": 13
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4",
+      "#sam/row/data-jh-bucket/4"
+    ],
+    "fills": [
+      "#686225",
+      "#8d7f1e",
+      "#b29c17",
+      "#d8b810",
+      "#fdd509",
+      "#676649",
+      "#8c8554",
+      "#b1a45f",
+      "#d6c269",
+      "#fbe174",
+      "#67502a",
+      "#8c6526",
+      "#b07922",
+      "#d58d1d",
+      "#faa119",
+      "#fabe72",
+      "#69242c",
+      "#9b2328",
+      "#cd2123",
+      "#ff1f1f",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0-1m",
+      "1-10m",
+      "10m-1h",
+      "1-6h",
+      "&gt; 6h",
+      "0",
+      "50",
+      "100",
+      "150",
+      "200",
+      "250",
+      "300",
+      "350",
+      "Jobs"
+    ],
+    "size": [
+      674.9,
+      288.0
+    ]
+  },
   "jobs_hist.log_y": {
     "counts": {
       "a": 4,
@@ -2328,6 +4624,51 @@
       "#fabe72",
       "#ff1f1f",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0-1m",
+      "1-10m",
+      "10m-1h",
+      "1-6h",
+      "&gt; 6h",
+      "100",
+      "2 \u00d7 1 0 1",
+      "3 \u00d7 1 0 1",
+      "4 \u00d7 1 0 1",
+      "6 \u00d7 1 0 1",
+      "2 \u00d7 1 0 2",
+      "3 \u00d7 1 0 2",
+      "Jobs"
+    ],
+    "size": [
+      853.5,
+      331.1
+    ]
+  },
+  "jobs_hist.log_y@dark": {
+    "counts": {
+      "a": 4,
+      "g": 65,
+      "path": 13,
+      "text": 7,
+      "use": 16
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/4"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#ff1f1f",
+      "#e9ecef",
+      "#011837",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -2393,6 +4734,51 @@
       196.7
     ]
   },
+  "jobs_hist.log_y@mobile@dark": {
+    "counts": {
+      "a": 4,
+      "g": 65,
+      "path": 13,
+      "text": 7,
+      "use": 16
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/4"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#ff1f1f",
+      "#e9ecef",
+      "#011837",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0-1m",
+      "1-10m",
+      "10m-1h",
+      "1-6h",
+      "&gt; 6h",
+      "100",
+      "2 \u00d7 1 0 1",
+      "3 \u00d7 1 0 1",
+      "4 \u00d7 1 0 1",
+      "6 \u00d7 1 0 1",
+      "2 \u00d7 1 0 2",
+      "3 \u00d7 1 0 2",
+      "Jobs"
+    ],
+    "size": [
+      295.5,
+      196.7
+    ]
+  },
   "jobs_hist.log_y@tablet": {
     "counts": {
       "a": 4,
@@ -2414,6 +4800,51 @@
       "#fabe72",
       "#ff1f1f",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0-1m",
+      "1-10m",
+      "10m-1h",
+      "1-6h",
+      "&gt; 6h",
+      "100",
+      "2 \u00d7 1 0 1",
+      "3 \u00d7 1 0 1",
+      "4 \u00d7 1 0 1",
+      "6 \u00d7 1 0 1",
+      "2 \u00d7 1 0 2",
+      "3 \u00d7 1 0 2",
+      "Jobs"
+    ],
+    "size": [
+      686.1,
+      286.8
+    ]
+  },
+  "jobs_hist.log_y@tablet@dark": {
+    "counts": {
+      "a": 4,
+      "g": 65,
+      "path": 13,
+      "text": 7,
+      "use": 16
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jh-bucket/0",
+      "#sam/row/data-jh-bucket/1",
+      "#sam/row/data-jh-bucket/2",
+      "#sam/row/data-jh-bucket/4"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#ff1f1f",
+      "#e9ecef",
+      "#011837",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -2526,6 +4957,92 @@
       331.6
     ]
   },
+  "jobs_ts.project_unlinked@dark": {
+    "counts": {
+      "a": 32,
+      "g": 108,
+      "path": 55,
+      "text": 21,
+      "use": 15
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9"
+    ],
+    "fills": [
+      "#434d59",
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 2",
+      "Mar 3",
+      "Mar 4",
+      "Mar 5",
+      "Mar 6",
+      "Mar 7",
+      "Mar 8",
+      "Mar 9",
+      "Mar 10",
+      "0",
+      "50",
+      "100",
+      "150",
+      "200",
+      "CPU-hours",
+      "alice",
+      "bob",
+      "carol",
+      "Others"
+    ],
+    "size": [
+      1156.8,
+      331.6
+    ]
+  },
   "jobs_ts.project_unlinked@mobile": {
     "counts": {
       "a": 32,
@@ -2607,6 +5124,87 @@
       247.0
     ]
   },
+  "jobs_ts.project_unlinked@mobile@dark": {
+    "counts": {
+      "a": 32,
+      "g": 93,
+      "path": 55,
+      "text": 16,
+      "use": 10
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9"
+    ],
+    "fills": [
+      "#434d59",
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 3",
+      "Mar 5",
+      "Mar 7",
+      "Mar 9",
+      "0",
+      "50",
+      "100",
+      "150",
+      "200",
+      "CPU-hours",
+      "alice",
+      "bob",
+      "carol",
+      "Others"
+    ],
+    "size": [
+      277.7,
+      247.0
+    ]
+  },
   "jobs_ts.project_unlinked@tablet": {
     "counts": {
       "a": 32,
@@ -2663,6 +5261,92 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 2",
+      "Mar 3",
+      "Mar 4",
+      "Mar 5",
+      "Mar 6",
+      "Mar 7",
+      "Mar 8",
+      "Mar 9",
+      "Mar 10",
+      "0",
+      "50",
+      "100",
+      "150",
+      "200",
+      "CPU-hours",
+      "alice",
+      "bob",
+      "carol",
+      "Others"
+    ],
+    "size": [
+      706.0,
+      242.9
+    ]
+  },
+  "jobs_ts.project_unlinked@tablet@dark": {
+    "counts": {
+      "a": 32,
+      "g": 108,
+      "path": 55,
+      "text": 21,
+      "use": 15
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9"
+    ],
+    "fills": [
+      "#434d59",
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -2786,6 +5470,99 @@
       331.6
     ]
   },
+  "jobs_ts.user_linked@dark": {
+    "counts": {
+      "a": 38,
+      "g": 112,
+      "path": 56,
+      "text": 22,
+      "use": 16
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "/admin/user/alice",
+      "/admin/user/alice",
+      "/admin/user/bob",
+      "/admin/user/bob",
+      "/admin/user/carol",
+      "/admin/user/carol"
+    ],
+    "fills": [
+      "#434d59",
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 2",
+      "Mar 3",
+      "Mar 4",
+      "Mar 5",
+      "Mar 6",
+      "Mar 7",
+      "Mar 8",
+      "Mar 9",
+      "Mar 10",
+      "0",
+      "10",
+      "20",
+      "30",
+      "40",
+      "50",
+      "Jobs",
+      "alice",
+      "bob",
+      "carol",
+      "Others"
+    ],
+    "size": [
+      1150.5,
+      331.6
+    ]
+  },
   "jobs_ts.user_linked@mobile": {
     "counts": {
       "a": 38,
@@ -2874,6 +5651,94 @@
       247.0
     ]
   },
+  "jobs_ts.user_linked@mobile@dark": {
+    "counts": {
+      "a": 38,
+      "g": 97,
+      "path": 56,
+      "text": 17,
+      "use": 11
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "/admin/user/alice",
+      "/admin/user/alice",
+      "/admin/user/bob",
+      "/admin/user/bob",
+      "/admin/user/carol",
+      "/admin/user/carol"
+    ],
+    "fills": [
+      "#434d59",
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 3",
+      "Mar 5",
+      "Mar 7",
+      "Mar 9",
+      "0",
+      "10",
+      "20",
+      "30",
+      "40",
+      "50",
+      "Jobs",
+      "alice",
+      "bob",
+      "carol",
+      "Others"
+    ],
+    "size": [
+      272.5,
+      247.0
+    ]
+  },
   "jobs_ts.user_linked@tablet": {
     "counts": {
       "a": 38,
@@ -2936,6 +5801,99 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 2",
+      "Mar 3",
+      "Mar 4",
+      "Mar 5",
+      "Mar 6",
+      "Mar 7",
+      "Mar 8",
+      "Mar 9",
+      "Mar 10",
+      "0",
+      "10",
+      "20",
+      "30",
+      "40",
+      "50",
+      "Jobs",
+      "alice",
+      "bob",
+      "carol",
+      "Others"
+    ],
+    "size": [
+      699.7,
+      242.9
+    ]
+  },
+  "jobs_ts.user_linked@tablet@dark": {
+    "counts": {
+      "a": 38,
+      "g": 112,
+      "path": 56,
+      "text": 22,
+      "use": 16
+    },
+    "drill_hrefs": [
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "#sam/row/data-jt-period/0",
+      "#sam/row/data-jt-period/2",
+      "#sam/row/data-jt-period/3",
+      "#sam/row/data-jt-period/4",
+      "#sam/row/data-jt-period/6",
+      "#sam/row/data-jt-period/7",
+      "#sam/row/data-jt-period/8",
+      "#sam/row/data-jt-period/9",
+      "/admin/user/alice",
+      "/admin/user/alice",
+      "/admin/user/bob",
+      "/admin/user/bob",
+      "/admin/user/carol",
+      "/admin/user/carol"
+    ],
+    "fills": [
+      "#434d59",
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -3063,6 +6021,103 @@
       236.2
     ]
   },
+  "jobs_usage_pie.by_project@dark": {
+    "counts": {
+      "a": 27,
+      "g": 43,
+      "path": 21,
+      "text": 17,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-job-project/user0",
+      "#sam/row/data-job-project/user1",
+      "#sam/row/data-job-project/user2",
+      "#sam/row/data-job-project/user3",
+      "#sam/row/data-job-project/user4",
+      "#sam/row/data-job-project/user5",
+      "#sam/row/data-job-project/user6",
+      "#sam/row/data-job-project/user7",
+      "#sam/row/data-job-project/user8",
+      "#sam/row/data-job-project/user0",
+      "#sam/row/data-job-project/user0",
+      "#sam/row/data-job-project/user1",
+      "#sam/row/data-job-project/user1",
+      "#sam/row/data-job-project/user2",
+      "#sam/row/data-job-project/user2",
+      "#sam/row/data-job-project/user3",
+      "#sam/row/data-job-project/user3",
+      "#sam/row/data-job-project/user4",
+      "#sam/row/data-job-project/user4",
+      "#sam/row/data-job-project/user5",
+      "#sam/row/data-job-project/user5",
+      "#sam/row/data-job-project/user6",
+      "#sam/row/data-job-project/user6",
+      "#sam/row/data-job-project/user7",
+      "#sam/row/data-job-project/user7",
+      "#sam/row/data-job-project/user8",
+      "#sam/row/data-job-project/user8"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "6.7%",
+      "6.3%",
+      "6.0%",
+      "5.7%",
+      "5.3%",
+      "5.0%",
+      "52.0%",
+      "user0 (100)",
+      "user1 (95)",
+      "user2 (90)",
+      "user3 (85)",
+      "user4 (80)",
+      "user5 (75)",
+      "user6 (70)",
+      "user7 (65)",
+      "user8 (60)",
+      "Other (780)"
+    ],
+    "size": [
+      327.1,
+      236.2
+    ]
+  },
   "jobs_usage_pie.by_project@mobile": {
     "counts": {
       "a": 18,
@@ -3117,6 +6172,82 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "6.7%",
+      "6.3%",
+      "6.0%",
+      "5.7%",
+      "5.3%",
+      "5.0%",
+      "65.0%",
+      "user0 (100)",
+      "user1 (95)",
+      "user2 (90)",
+      "user3 (85)",
+      "user4 (80)",
+      "user5 (75)",
+      "Other (975)"
+    ],
+    "size": [
+      265.5,
+      175.2
+    ]
+  },
+  "jobs_usage_pie.by_project@mobile@dark": {
+    "counts": {
+      "a": 18,
+      "g": 34,
+      "path": 15,
+      "text": 14,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-job-project/user0",
+      "#sam/row/data-job-project/user1",
+      "#sam/row/data-job-project/user2",
+      "#sam/row/data-job-project/user3",
+      "#sam/row/data-job-project/user4",
+      "#sam/row/data-job-project/user5",
+      "#sam/row/data-job-project/user0",
+      "#sam/row/data-job-project/user0",
+      "#sam/row/data-job-project/user1",
+      "#sam/row/data-job-project/user1",
+      "#sam/row/data-job-project/user2",
+      "#sam/row/data-job-project/user2",
+      "#sam/row/data-job-project/user3",
+      "#sam/row/data-job-project/user3",
+      "#sam/row/data-job-project/user4",
+      "#sam/row/data-job-project/user4",
+      "#sam/row/data-job-project/user5",
+      "#sam/row/data-job-project/user5"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -3236,6 +6367,103 @@
       236.2
     ]
   },
+  "jobs_usage_pie.by_project@tablet@dark": {
+    "counts": {
+      "a": 27,
+      "g": 43,
+      "path": 21,
+      "text": 17,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-job-project/user0",
+      "#sam/row/data-job-project/user1",
+      "#sam/row/data-job-project/user2",
+      "#sam/row/data-job-project/user3",
+      "#sam/row/data-job-project/user4",
+      "#sam/row/data-job-project/user5",
+      "#sam/row/data-job-project/user6",
+      "#sam/row/data-job-project/user7",
+      "#sam/row/data-job-project/user8",
+      "#sam/row/data-job-project/user0",
+      "#sam/row/data-job-project/user0",
+      "#sam/row/data-job-project/user1",
+      "#sam/row/data-job-project/user1",
+      "#sam/row/data-job-project/user2",
+      "#sam/row/data-job-project/user2",
+      "#sam/row/data-job-project/user3",
+      "#sam/row/data-job-project/user3",
+      "#sam/row/data-job-project/user4",
+      "#sam/row/data-job-project/user4",
+      "#sam/row/data-job-project/user5",
+      "#sam/row/data-job-project/user5",
+      "#sam/row/data-job-project/user6",
+      "#sam/row/data-job-project/user6",
+      "#sam/row/data-job-project/user7",
+      "#sam/row/data-job-project/user7",
+      "#sam/row/data-job-project/user8",
+      "#sam/row/data-job-project/user8"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "6.7%",
+      "6.3%",
+      "6.0%",
+      "5.7%",
+      "5.3%",
+      "5.0%",
+      "52.0%",
+      "user0 (100)",
+      "user1 (95)",
+      "user2 (90)",
+      "user3 (85)",
+      "user4 (80)",
+      "user5 (75)",
+      "user6 (70)",
+      "user7 (65)",
+      "user8 (60)",
+      "Other (780)"
+    ],
+    "size": [
+      327.1,
+      236.2
+    ]
+  },
   "jobs_usage_pie.by_user": {
     "counts": {
       "a": 24,
@@ -3301,6 +6529,99 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "6.7%",
+      "6.3%",
+      "5.9%",
+      "5.5%",
+      "5.1%",
+      "54.4%",
+      "(unknown) (1,000)",
+      "user1 (940)",
+      "user2 (880)",
+      "user3 (820)",
+      "user4 (760)",
+      "user5 (700)",
+      "user6 (640)",
+      "user7 (580)",
+      "user8 (520)",
+      "Other (8,160)"
+    ],
+    "size": [
+      356.5,
+      236.2
+    ]
+  },
+  "jobs_usage_pie.by_user@dark": {
+    "counts": {
+      "a": 24,
+      "g": 42,
+      "path": 21,
+      "text": 16,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user8",
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user8",
+      "#sam/row/data-job-user/user8"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -3397,6 +6718,78 @@
       175.2
     ]
   },
+  "jobs_usage_pie.by_user@mobile@dark": {
+    "counts": {
+      "a": 15,
+      "g": 33,
+      "path": 15,
+      "text": 13,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user5"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "6.7%",
+      "6.3%",
+      "5.9%",
+      "5.5%",
+      "5.1%",
+      "66.0%",
+      "(unknown) (1,000)",
+      "user1 (940)",
+      "user2 (880)",
+      "user3 (820)",
+      "user4 (760)",
+      "user5 (700)",
+      "Other (9,900)"
+    ],
+    "size": [
+      294.9,
+      175.2
+    ]
+  },
   "jobs_usage_pie.by_user@tablet": {
     "counts": {
       "a": 24,
@@ -3462,6 +6855,99 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "6.7%",
+      "6.3%",
+      "5.9%",
+      "5.5%",
+      "5.1%",
+      "54.4%",
+      "(unknown) (1,000)",
+      "user1 (940)",
+      "user2 (880)",
+      "user3 (820)",
+      "user4 (760)",
+      "user5 (700)",
+      "user6 (640)",
+      "user7 (580)",
+      "user8 (520)",
+      "Other (8,160)"
+    ],
+    "size": [
+      356.5,
+      236.2
+    ]
+  },
+  "jobs_usage_pie.by_user@tablet@dark": {
+    "counts": {
+      "a": 24,
+      "g": 42,
+      "path": 21,
+      "text": 16,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user8",
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user8",
+      "#sam/row/data-job-user/user8"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -3581,6 +7067,99 @@
       236.2
     ]
   },
+  "jobs_user_pie.delegated@dark": {
+    "counts": {
+      "a": 24,
+      "g": 42,
+      "path": 21,
+      "text": 16,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user8",
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user8",
+      "#sam/row/data-job-user/user8"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "6.7%",
+      "6.3%",
+      "5.9%",
+      "5.5%",
+      "5.1%",
+      "54.4%",
+      "(unknown) (1,000)",
+      "user1 (940)",
+      "user2 (880)",
+      "user3 (820)",
+      "user4 (760)",
+      "user5 (700)",
+      "user6 (640)",
+      "user7 (580)",
+      "user8 (520)",
+      "Other (8,160)"
+    ],
+    "size": [
+      356.5,
+      236.2
+    ]
+  },
   "jobs_user_pie.delegated@mobile": {
     "counts": {
       "a": 15,
@@ -3630,6 +7209,78 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "6.7%",
+      "6.3%",
+      "5.9%",
+      "5.5%",
+      "5.1%",
+      "66.0%",
+      "(unknown) (1,000)",
+      "user1 (940)",
+      "user2 (880)",
+      "user3 (820)",
+      "user4 (760)",
+      "user5 (700)",
+      "Other (9,900)"
+    ],
+    "size": [
+      294.9,
+      175.2
+    ]
+  },
+  "jobs_user_pie.delegated@mobile@dark": {
+    "counts": {
+      "a": 15,
+      "g": 33,
+      "path": 15,
+      "text": 13,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user5"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -3742,6 +7393,99 @@
       236.2
     ]
   },
+  "jobs_user_pie.delegated@tablet@dark": {
+    "counts": {
+      "a": 24,
+      "g": 42,
+      "path": 21,
+      "text": 16,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user8",
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user1",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user2",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user3",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user4",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user5",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user6",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user7",
+      "#sam/row/data-job-user/user8",
+      "#sam/row/data-job-user/user8"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "6.7%",
+      "6.3%",
+      "5.9%",
+      "5.5%",
+      "5.1%",
+      "54.4%",
+      "(unknown) (1,000)",
+      "user1 (940)",
+      "user2 (880)",
+      "user3 (820)",
+      "user4 (760)",
+      "user5 (700)",
+      "user6 (640)",
+      "user7 (580)",
+      "user8 (520)",
+      "Other (8,160)"
+    ],
+    "size": [
+      356.5,
+      236.2
+    ]
+  },
   "nodetype.empty": {
     "html": "<div class=\"text-center text-muted\">No history data available for this node type</div>",
     "kind": "placeholder"
@@ -3769,6 +7513,71 @@
       "#011837",
       "#ffffff",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0",
+      "20",
+      "40",
+      "60",
+      "80",
+      "100",
+      "120",
+      "Number of Nodes",
+      "Down",
+      "Fully Allocated",
+      "Resources Available",
+      "17:00",
+      "Feb 28",
+      "18:00",
+      "19:00",
+      "20:00",
+      "21:00",
+      "22:00",
+      "23:00",
+      "00:00",
+      "Mar 1",
+      "01:00",
+      "02:00",
+      "Time (MDT)",
+      "0%",
+      "20%",
+      "40%",
+      "60%",
+      "80%",
+      "100%",
+      "Utilization",
+      "CPU/GPU Utilization",
+      "Memory Utilization"
+    ],
+    "size": [
+      1070.9,
+      628.2
+    ]
+  },
+  "nodetype.normal@dark": {
+    "counts": {
+      "a": 0,
+      "g": 158,
+      "path": 54,
+      "text": 33,
+      "use": 33
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#ff1f1f",
+      "#236eca",
+      "#42c0ff",
+      "#e9ecef",
+      "#1b2733",
+      "#ff1f1f",
+      "#e9ecef",
+      "#236eca",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#1b2733",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -3862,6 +7671,57 @@
       370.2
     ]
   },
+  "nodetype.normal@mobile@dark": {
+    "counts": {
+      "a": 0,
+      "g": 91,
+      "path": 34,
+      "text": 22,
+      "use": 15
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#ff1f1f",
+      "#236eca",
+      "#42c0ff",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#236eca",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0",
+      "50",
+      "100",
+      "Number of Nodes",
+      "Down",
+      "Fully Allocated",
+      "Resources Available",
+      "18:00",
+      "Feb 28",
+      "21:00",
+      "00:00",
+      "Mar 1",
+      "Time (MDT)",
+      "0%",
+      "20%",
+      "40%",
+      "60%",
+      "80%",
+      "100%",
+      "Utilization",
+      "CPU/GPU Utilization",
+      "Memory Utilization"
+    ],
+    "size": [
+      292.8,
+      370.2
+    ]
+  },
   "nodetype.normal@tablet": {
     "counts": {
       "a": 0,
@@ -3885,6 +7745,66 @@
       "#011837",
       "#ffffff",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0",
+      "20",
+      "40",
+      "60",
+      "80",
+      "100",
+      "120",
+      "Number of Nodes",
+      "Down",
+      "Fully Allocated",
+      "Resources Available",
+      "18:00",
+      "Feb 28",
+      "20:00",
+      "22:00",
+      "00:00",
+      "Mar 1",
+      "02:00",
+      "Time (MDT)",
+      "0%",
+      "20%",
+      "40%",
+      "60%",
+      "80%",
+      "100%",
+      "Utilization",
+      "CPU/GPU Utilization",
+      "Memory Utilization"
+    ],
+    "size": [
+      736.1,
+      473.0
+    ]
+  },
+  "nodetype.normal@tablet@dark": {
+    "counts": {
+      "a": 0,
+      "g": 123,
+      "path": 44,
+      "text": 28,
+      "use": 23
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#ff1f1f",
+      "#236eca",
+      "#42c0ff",
+      "#e9ecef",
+      "#1b2733",
+      "#ff1f1f",
+      "#e9ecef",
+      "#236eca",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#1b2733",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -4097,6 +8017,177 @@
       376.2
     ]
   },
+  "pace.future@dark": {
+    "counts": {
+      "a": 40,
+      "g": 159,
+      "path": 70,
+      "text": 46,
+      "use": 21
+    },
+    "drill_hrefs": [
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0006",
+      "/user/project-details-modal/PROJ0006",
+      "/user/project-details-modal/PROJ0008",
+      "/user/project-details-modal/PROJ0008",
+      "/user/project-details-modal/PROJ0010",
+      "/user/project-details-modal/PROJ0010",
+      "/user/project-details-modal/PROJ0012",
+      "/user/project-details-modal/PROJ0012",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0014",
+      "/user/project-details-modal/PROJ0014",
+      "/user/project-details-modal/PROJ0005",
+      "/user/project-details-modal/PROJ0005",
+      "/user/project-details-modal/PROJ0007",
+      "/user/project-details-modal/PROJ0007",
+      "/user/project-details-modal/PROJ0016",
+      "/user/project-details-modal/PROJ0016",
+      "/user/project-details-modal/PROJ0009",
+      "/user/project-details-modal/PROJ0009",
+      "/user/project-details-modal/PROJ0011",
+      "/user/project-details-modal/PROJ0011",
+      "/user/project-details-modal/PROJ0018",
+      "/user/project-details-modal/PROJ0018",
+      "/user/project-details-modal/PROJ0013",
+      "/user/project-details-modal/PROJ0013",
+      "/user/project-details-modal/PROJ0015",
+      "/user/project-details-modal/PROJ0015",
+      "/user/project-details-modal/PROJ0020",
+      "/user/project-details-modal/PROJ0020",
+      "/user/project-details-modal/PROJ0017",
+      "/user/project-details-modal/PROJ0017"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#f8ebb7",
+      "#faa119",
+      "#fabe72",
+      "#f8dbb5",
+      "#ff1f1f",
+      "#00818f",
+      "#00a2b4",
+      "#71c0cb",
+      "#42c0ff",
+      "#86d3fc",
+      "#34e1f4",
+      "#86e8f5",
+      "#236eca",
+      "#5a77a6",
+      "#a8b7ce",
+      "#adc2e6",
+      "#4c71a2",
+      "#637084",
+      "#434d59",
+      "#e9ecef",
+      "#adc2e6",
+      "#fdd509",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#f8ebb7",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#fabe72",
+      "#e9ecef",
+      "#f8dbb5",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#71c0cb",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#86d3fc",
+      "#e9ecef",
+      "#34e1f4",
+      "#e9ecef",
+      "#86e8f5",
+      "#e9ecef",
+      "#236eca",
+      "#e9ecef",
+      "#5a77a6",
+      "#e9ecef",
+      "#a8b7ce",
+      "#e9ecef",
+      "#adc2e6",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#637084",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Oct",
+      "2025",
+      "Nov",
+      "Dec",
+      "Jan",
+      "2026",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "0",
+      "2.50M",
+      "5.00M",
+      "7.50M",
+      "10.0M",
+      "12.5M",
+      "15.0M",
+      "17.5M",
+      "20.0M",
+      "Rate (per year)",
+      "today",
+      "PROJ0000 (5.17M/yr)",
+      "PROJ0002 (4.75M/yr)",
+      "PROJ0004 (4.34M/yr)",
+      "PROJ0006 (3.93M/yr)",
+      "PROJ0008 (3.51M/yr)",
+      "PROJ0010 (3.10M/yr)",
+      "PROJ0012 (2.69M/yr)",
+      "PROJ0001 (2.65M/yr)",
+      "PROJ0003 (2.43M/yr)",
+      "PROJ0014 (2.27M/yr)",
+      "PROJ0005 (2.21M/yr)",
+      "PROJ0007 (1.99M/yr)",
+      "PROJ0016 (1.86M/yr)",
+      "PROJ0009 (1.77M/yr)",
+      "PROJ0011 (1.55M/yr)",
+      "PROJ0018 (1.45M/yr)",
+      "PROJ0013 (1.33M/yr)",
+      "PROJ0015 (1.11M/yr)",
+      "PROJ0020 (1.03M/yr)",
+      "PROJ0017 (885K/yr)",
+      "Other (5 projects) (2.15M/yr)"
+    ],
+    "size": [
+      800.5,
+      376.2
+    ]
+  },
   "pace.future@mobile": {
     "counts": {
       "a": 12,
@@ -4143,6 +8234,85 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Oct",
+      "2025",
+      "Jan",
+      "2026",
+      "Apr",
+      "Jul",
+      "0",
+      "2.50M",
+      "5.00M",
+      "7.50M",
+      "10.0M",
+      "12.5M",
+      "15.0M",
+      "17.5M",
+      "20.0M",
+      "Rate (per year)",
+      "today",
+      "PROJ0000 (5.17M/yr)",
+      "PROJ0002 (4.75M/yr)",
+      "PROJ0004 (4.34M/yr)",
+      "PROJ0006 (3.93M/yr)",
+      "PROJ0008 (3.51M/yr)",
+      "PROJ0010 (3.10M/yr)",
+      "Other (19 projects) (27.4M/yr)"
+    ],
+    "size": [
+      327.2,
+      292.9
+    ]
+  },
+  "pace.future@mobile@dark": {
+    "counts": {
+      "a": 12,
+      "g": 85,
+      "path": 34,
+      "text": 24,
+      "use": 13
+    },
+    "drill_hrefs": [
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0006",
+      "/user/project-details-modal/PROJ0006",
+      "/user/project-details-modal/PROJ0008",
+      "/user/project-details-modal/PROJ0008",
+      "/user/project-details-modal/PROJ0010",
+      "/user/project-details-modal/PROJ0010"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#ff1f1f",
+      "#00818f",
+      "#434d59",
+      "#e9ecef",
+      "#adc2e6",
+      "#fdd509",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#fabe72",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -4242,6 +8412,107 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Nov",
+      "2025",
+      "Jan",
+      "2026",
+      "Mar",
+      "May",
+      "Jul",
+      "Sep",
+      "0",
+      "5.00M",
+      "10.0M",
+      "15.0M",
+      "20.0M",
+      "Rate (per year)",
+      "today",
+      "PROJ0000 (5.17M/yr)",
+      "PROJ0002 (4.75M/yr)",
+      "PROJ0004 (4.34M/yr)",
+      "PROJ0006 (3.93M/yr)",
+      "PROJ0008 (3.51M/yr)",
+      "PROJ0010 (3.10M/yr)",
+      "PROJ0012 (2.69M/yr)",
+      "PROJ0001 (2.65M/yr)",
+      "PROJ0003 (2.43M/yr)",
+      "PROJ0014 (2.27M/yr)",
+      "Other (15 projects) (17.3M/yr)"
+    ],
+    "size": [
+      605.6,
+      238.5
+    ]
+  },
+  "pace.future@tablet@dark": {
+    "counts": {
+      "a": 20,
+      "g": 89,
+      "path": 40,
+      "text": 26,
+      "use": 11
+    },
+    "drill_hrefs": [
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0006",
+      "/user/project-details-modal/PROJ0006",
+      "/user/project-details-modal/PROJ0008",
+      "/user/project-details-modal/PROJ0008",
+      "/user/project-details-modal/PROJ0010",
+      "/user/project-details-modal/PROJ0010",
+      "/user/project-details-modal/PROJ0012",
+      "/user/project-details-modal/PROJ0012",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0014",
+      "/user/project-details-modal/PROJ0014"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#ff1f1f",
+      "#00818f",
+      "#00a2b4",
+      "#42c0ff",
+      "#236eca",
+      "#5a77a6",
+      "#434d59",
+      "#e9ecef",
+      "#adc2e6",
+      "#fdd509",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#fabe72",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#236eca",
+      "#e9ecef",
+      "#5a77a6",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -4448,6 +8719,177 @@
       376.2
     ]
   },
+  "pace.size@dark": {
+    "counts": {
+      "a": 40,
+      "g": 159,
+      "path": 70,
+      "text": 46,
+      "use": 21
+    },
+    "drill_hrefs": [
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0005",
+      "/user/project-details-modal/PROJ0005",
+      "/user/project-details-modal/PROJ0006",
+      "/user/project-details-modal/PROJ0006",
+      "/user/project-details-modal/PROJ0007",
+      "/user/project-details-modal/PROJ0007",
+      "/user/project-details-modal/PROJ0008",
+      "/user/project-details-modal/PROJ0008",
+      "/user/project-details-modal/PROJ0009",
+      "/user/project-details-modal/PROJ0009",
+      "/user/project-details-modal/PROJ0010",
+      "/user/project-details-modal/PROJ0010",
+      "/user/project-details-modal/PROJ0011",
+      "/user/project-details-modal/PROJ0011",
+      "/user/project-details-modal/PROJ0012",
+      "/user/project-details-modal/PROJ0012",
+      "/user/project-details-modal/PROJ0013",
+      "/user/project-details-modal/PROJ0013",
+      "/user/project-details-modal/PROJ0014",
+      "/user/project-details-modal/PROJ0014",
+      "/user/project-details-modal/PROJ0015",
+      "/user/project-details-modal/PROJ0015",
+      "/user/project-details-modal/PROJ0016",
+      "/user/project-details-modal/PROJ0016",
+      "/user/project-details-modal/PROJ0017",
+      "/user/project-details-modal/PROJ0017",
+      "/user/project-details-modal/PROJ0018",
+      "/user/project-details-modal/PROJ0018",
+      "/user/project-details-modal/PROJ0019",
+      "/user/project-details-modal/PROJ0019"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#f8ebb7",
+      "#faa119",
+      "#fabe72",
+      "#f8dbb5",
+      "#ff1f1f",
+      "#00818f",
+      "#00a2b4",
+      "#71c0cb",
+      "#42c0ff",
+      "#86d3fc",
+      "#34e1f4",
+      "#86e8f5",
+      "#236eca",
+      "#5a77a6",
+      "#a8b7ce",
+      "#adc2e6",
+      "#4c71a2",
+      "#637084",
+      "#434d59",
+      "#e9ecef",
+      "#adc2e6",
+      "#fdd509",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#f8ebb7",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#fabe72",
+      "#e9ecef",
+      "#f8dbb5",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#71c0cb",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#86d3fc",
+      "#e9ecef",
+      "#34e1f4",
+      "#e9ecef",
+      "#86e8f5",
+      "#e9ecef",
+      "#236eca",
+      "#e9ecef",
+      "#5a77a6",
+      "#e9ecef",
+      "#a8b7ce",
+      "#e9ecef",
+      "#adc2e6",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#637084",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Oct",
+      "2025",
+      "Nov",
+      "Dec",
+      "Jan",
+      "2026",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "0",
+      "2.50M",
+      "5.00M",
+      "7.50M",
+      "10.0M",
+      "12.5M",
+      "15.0M",
+      "17.5M",
+      "20.0M",
+      "Rate (per year)",
+      "today",
+      "PROJ0000 (2.50M)",
+      "PROJ0001 (2.40M)",
+      "PROJ0002 (2.30M)",
+      "PROJ0003 (2.20M)",
+      "PROJ0004 (2.10M)",
+      "PROJ0005 (2.00M)",
+      "PROJ0006 (1.90M)",
+      "PROJ0007 (1.80M)",
+      "PROJ0008 (1.70M)",
+      "PROJ0009 (1.60M)",
+      "PROJ0010 (1.50M)",
+      "PROJ0011 (1.40M)",
+      "PROJ0012 (1.30M)",
+      "PROJ0013 (1.20M)",
+      "PROJ0014 (1.10M)",
+      "PROJ0015 (1.00M)",
+      "PROJ0016 (900K)",
+      "PROJ0017 (800K)",
+      "PROJ0018 (700K)",
+      "PROJ0019 (600K)",
+      "Other (5 projects) (1.50M)"
+    ],
+    "size": [
+      788.3,
+      376.2
+    ]
+  },
   "pace.size@mobile": {
     "counts": {
       "a": 12,
@@ -4494,6 +8936,85 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Oct",
+      "2025",
+      "Jan",
+      "2026",
+      "Apr",
+      "Jul",
+      "0",
+      "2.50M",
+      "5.00M",
+      "7.50M",
+      "10.0M",
+      "12.5M",
+      "15.0M",
+      "17.5M",
+      "20.0M",
+      "Rate (per year)",
+      "today",
+      "PROJ0000 (2.50M)",
+      "PROJ0001 (2.40M)",
+      "PROJ0002 (2.30M)",
+      "PROJ0003 (2.20M)",
+      "PROJ0004 (2.10M)",
+      "PROJ0005 (2.00M)",
+      "Other (19 projects) (19.0M)"
+    ],
+    "size": [
+      313.6,
+      292.9
+    ]
+  },
+  "pace.size@mobile@dark": {
+    "counts": {
+      "a": 12,
+      "g": 85,
+      "path": 34,
+      "text": 24,
+      "use": 13
+    },
+    "drill_hrefs": [
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0005",
+      "/user/project-details-modal/PROJ0005"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#ff1f1f",
+      "#00818f",
+      "#434d59",
+      "#e9ecef",
+      "#adc2e6",
+      "#fdd509",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#fabe72",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -4628,6 +9149,107 @@
       238.5
     ]
   },
+  "pace.size@tablet@dark": {
+    "counts": {
+      "a": 20,
+      "g": 89,
+      "path": 40,
+      "text": 26,
+      "use": 11
+    },
+    "drill_hrefs": [
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0005",
+      "/user/project-details-modal/PROJ0005",
+      "/user/project-details-modal/PROJ0006",
+      "/user/project-details-modal/PROJ0006",
+      "/user/project-details-modal/PROJ0007",
+      "/user/project-details-modal/PROJ0007",
+      "/user/project-details-modal/PROJ0008",
+      "/user/project-details-modal/PROJ0008",
+      "/user/project-details-modal/PROJ0009",
+      "/user/project-details-modal/PROJ0009"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#ff1f1f",
+      "#00818f",
+      "#00a2b4",
+      "#42c0ff",
+      "#236eca",
+      "#5a77a6",
+      "#434d59",
+      "#e9ecef",
+      "#adc2e6",
+      "#fdd509",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#fabe72",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#236eca",
+      "#e9ecef",
+      "#5a77a6",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Nov",
+      "2025",
+      "Jan",
+      "2026",
+      "Mar",
+      "May",
+      "Jul",
+      "Sep",
+      "0",
+      "5.00M",
+      "10.0M",
+      "15.0M",
+      "20.0M",
+      "Rate (per year)",
+      "today",
+      "PROJ0000 (2.50M)",
+      "PROJ0001 (2.40M)",
+      "PROJ0002 (2.30M)",
+      "PROJ0003 (2.20M)",
+      "PROJ0004 (2.10M)",
+      "PROJ0005 (2.00M)",
+      "PROJ0006 (1.90M)",
+      "PROJ0007 (1.80M)",
+      "PROJ0008 (1.70M)",
+      "PROJ0009 (1.60M)",
+      "Other (15 projects) (12.0M)"
+    ],
+    "size": [
+      593.5,
+      238.5
+    ]
+  },
   "pace.small_top_n": {
     "counts": {
       "a": 12,
@@ -4671,6 +9293,87 @@
       "#011837",
       "#00818f",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Oct",
+      "2025",
+      "Nov",
+      "Dec",
+      "Jan",
+      "2026",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "0",
+      "200K",
+      "400K",
+      "600K",
+      "800K",
+      "1.00M",
+      "1.20M",
+      "Rate (per year)",
+      "today",
+      "PROJ0000 (600K)",
+      "PROJ0001 (500K)",
+      "PROJ0002 (400K)",
+      "PROJ0003 (300K)",
+      "PROJ0004 (200K)",
+      "PROJ0005 (100,000)"
+    ],
+    "size": [
+      759.0,
+      276.2
+    ]
+  },
+  "pace.small_top_n@dark": {
+    "counts": {
+      "a": 12,
+      "g": 106,
+      "path": 38,
+      "text": 29,
+      "use": 19
+    },
+    "drill_hrefs": [
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0005",
+      "/user/project-details-modal/PROJ0005"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#ff1f1f",
+      "#00818f",
+      "#e9ecef",
+      "#adc2e6",
+      "#fdd509",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#fabe72",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -4782,6 +9485,79 @@
       275.8
     ]
   },
+  "pace.small_top_n@mobile@dark": {
+    "counts": {
+      "a": 12,
+      "g": 74,
+      "path": 30,
+      "text": 21,
+      "use": 11
+    },
+    "drill_hrefs": [
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0005",
+      "/user/project-details-modal/PROJ0005"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#ff1f1f",
+      "#00818f",
+      "#e9ecef",
+      "#adc2e6",
+      "#fdd509",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#fabe72",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Oct",
+      "2025",
+      "Jan",
+      "2026",
+      "Apr",
+      "Jul",
+      "0",
+      "200K",
+      "400K",
+      "600K",
+      "800K",
+      "1.00M",
+      "1.20M",
+      "Rate (per year)",
+      "today",
+      "PROJ0000 (600K)",
+      "PROJ0001 (500K)",
+      "PROJ0002 (400K)",
+      "PROJ0003 (300K)",
+      "PROJ0004 (200K)",
+      "PROJ0005 (100,000)"
+    ],
+    "size": [
+      294.6,
+      275.8
+    ]
+  },
   "pace.small_top_n@tablet": {
     "counts": {
       "a": 12,
@@ -4825,6 +9601,81 @@
       "#011837",
       "#00818f",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Nov",
+      "2025",
+      "Jan",
+      "2026",
+      "Mar",
+      "May",
+      "Jul",
+      "Sep",
+      "0",
+      "200K",
+      "400K",
+      "600K",
+      "800K",
+      "1.00M",
+      "1.20M",
+      "Rate (per year)",
+      "today",
+      "PROJ0000 (600K)",
+      "PROJ0001 (500K)",
+      "PROJ0002 (400K)",
+      "PROJ0003 (300K)",
+      "PROJ0004 (200K)",
+      "PROJ0005 (100,000)"
+    ],
+    "size": [
+      561.8,
+      231.8
+    ]
+  },
+  "pace.small_top_n@tablet@dark": {
+    "counts": {
+      "a": 12,
+      "g": 82,
+      "path": 32,
+      "text": 23,
+      "use": 13
+    },
+    "drill_hrefs": [
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0000",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0004",
+      "/user/project-details-modal/PROJ0005",
+      "/user/project-details-modal/PROJ0005"
+    ],
+    "fills": [
+      "#fdd509",
+      "#fbe174",
+      "#faa119",
+      "#fabe72",
+      "#ff1f1f",
+      "#00818f",
+      "#e9ecef",
+      "#adc2e6",
+      "#fdd509",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#fabe72",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -4916,6 +9767,65 @@
       517.3
     ]
   },
+  "queue.cores@dark": {
+    "counts": {
+      "a": 0,
+      "g": 165,
+      "path": 57,
+      "text": 35,
+      "use": 34
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#e9ecef",
+      "#1b2733",
+      "#e9ecef",
+      "#1b2733",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0",
+      "2",
+      "5",
+      "8",
+      "10",
+      "12",
+      "15",
+      "18",
+      "Count",
+      "Running",
+      "Pending",
+      "Held",
+      "Active Users",
+      "17:00",
+      "Feb 28",
+      "18:00",
+      "19:00",
+      "20:00",
+      "21:00",
+      "22:00",
+      "23:00",
+      "00:00",
+      "Mar 1",
+      "01:00",
+      "02:00",
+      "Time (MDT)",
+      "0",
+      "200",
+      "400",
+      "600",
+      "800",
+      "1,000",
+      "Resources",
+      "Cores Running",
+      "Cores Pending"
+    ],
+    "size": [
+      848.4,
+      517.3
+    ]
+  },
   "queue.cores@mobile": {
     "counts": {
       "a": 0,
@@ -4927,6 +9837,49 @@
     "drill_hrefs": [],
     "fills": [
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0",
+      "5",
+      "10",
+      "15",
+      "Count",
+      "Running",
+      "Pending",
+      "Held",
+      "Active Users",
+      "18:00",
+      "Feb 28",
+      "21:00",
+      "00:00",
+      "Mar 1",
+      "Time (MDT)",
+      "0",
+      "250",
+      "500",
+      "750",
+      "1,000",
+      "Resources",
+      "Cores Running",
+      "Cores Pending"
+    ],
+    "size": [
+      282.8,
+      342.1
+    ]
+  },
+  "queue.cores@mobile@dark": {
+    "counts": {
+      "a": 0,
+      "g": 94,
+      "path": 36,
+      "text": 23,
+      "use": 15
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -4974,6 +9927,60 @@
       "#011837",
       "#ffffff",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0",
+      "2",
+      "5",
+      "8",
+      "10",
+      "12",
+      "15",
+      "18",
+      "Count",
+      "Running",
+      "Pending",
+      "Held",
+      "Active Users",
+      "18:00",
+      "Feb 28",
+      "20:00",
+      "22:00",
+      "00:00",
+      "Mar 1",
+      "02:00",
+      "Time (MDT)",
+      "0",
+      "200",
+      "400",
+      "600",
+      "800",
+      "1,000",
+      "Resources",
+      "Cores Running",
+      "Cores Pending"
+    ],
+    "size": [
+      736.8,
+      473.0
+    ]
+  },
+  "queue.cores@tablet@dark": {
+    "counts": {
+      "a": 0,
+      "g": 130,
+      "path": 47,
+      "text": 30,
+      "use": 24
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#e9ecef",
+      "#1b2733",
+      "#e9ecef",
+      "#1b2733",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -5076,6 +10083,65 @@
       517.3
     ]
   },
+  "queue.gpus@dark": {
+    "counts": {
+      "a": 0,
+      "g": 165,
+      "path": 57,
+      "text": 35,
+      "use": 34
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#e9ecef",
+      "#1b2733",
+      "#e9ecef",
+      "#1b2733",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0",
+      "2",
+      "5",
+      "8",
+      "10",
+      "12",
+      "15",
+      "18",
+      "Count",
+      "Running",
+      "Pending",
+      "Held",
+      "Active Users",
+      "17:00",
+      "Feb 28",
+      "18:00",
+      "19:00",
+      "20:00",
+      "21:00",
+      "22:00",
+      "23:00",
+      "00:00",
+      "Mar 1",
+      "01:00",
+      "02:00",
+      "Time (MDT)",
+      "0",
+      "10",
+      "20",
+      "30",
+      "40",
+      "50",
+      "Resources",
+      "GPUs Running",
+      "GPUs Pending"
+    ],
+    "size": [
+      835.8,
+      517.3
+    ]
+  },
   "queue.gpus@mobile": {
     "counts": {
       "a": 0,
@@ -5087,6 +10153,47 @@
     "drill_hrefs": [],
     "fills": [
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0",
+      "5",
+      "10",
+      "15",
+      "Count",
+      "Running",
+      "Pending",
+      "Held",
+      "Active Users",
+      "18:00",
+      "Feb 28",
+      "21:00",
+      "00:00",
+      "Mar 1",
+      "Time (MDT)",
+      "0",
+      "20",
+      "40",
+      "Resources",
+      "GPUs Running",
+      "GPUs Pending"
+    ],
+    "size": [
+      272.5,
+      342.1
+    ]
+  },
+  "queue.gpus@mobile@dark": {
+    "counts": {
+      "a": 0,
+      "g": 86,
+      "path": 34,
+      "text": 21,
+      "use": 13
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -5132,6 +10239,60 @@
       "#011837",
       "#ffffff",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "0",
+      "2",
+      "5",
+      "8",
+      "10",
+      "12",
+      "15",
+      "18",
+      "Count",
+      "Running",
+      "Pending",
+      "Held",
+      "Active Users",
+      "18:00",
+      "Feb 28",
+      "20:00",
+      "22:00",
+      "00:00",
+      "Mar 1",
+      "02:00",
+      "Time (MDT)",
+      "0",
+      "10",
+      "20",
+      "30",
+      "40",
+      "50",
+      "Resources",
+      "GPUs Running",
+      "GPUs Pending"
+    ],
+    "size": [
+      724.2,
+      473.0
+    ]
+  },
+  "queue.gpus@tablet@dark": {
+    "counts": {
+      "a": 0,
+      "g": 130,
+      "path": 47,
+      "text": 30,
+      "use": 24
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#e9ecef",
+      "#1b2733",
+      "#e9ecef",
+      "#1b2733",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -5251,6 +10412,86 @@
       331.6
     ]
   },
+  "usage_stacked.core_hours@dark": {
+    "counts": {
+      "a": 28,
+      "g": 114,
+      "path": 56,
+      "text": 22,
+      "use": 17
+    },
+    "drill_hrefs": [
+      "#sam/day/2026-03-01",
+      "#sam/day/2026-03-03",
+      "#sam/day/2026-03-04",
+      "#sam/day/2026-03-05",
+      "#sam/day/2026-03-07",
+      "#sam/day/2026-03-08",
+      "#sam/day/2026-03-09",
+      "#sam/day/2026-03-10",
+      "#sam/day/2026-03-01",
+      "#sam/day/2026-03-03",
+      "#sam/day/2026-03-04",
+      "#sam/day/2026-03-05",
+      "#sam/day/2026-03-07",
+      "#sam/day/2026-03-08",
+      "#sam/day/2026-03-09",
+      "#sam/day/2026-03-10",
+      "#sam/day/2026-03-01",
+      "#sam/day/2026-03-03",
+      "#sam/day/2026-03-04",
+      "#sam/day/2026-03-05",
+      "#sam/day/2026-03-07",
+      "#sam/day/2026-03-08",
+      "#sam/day/2026-03-09",
+      "#sam/day/2026-03-10",
+      "#sam/user/bob",
+      "#sam/user/bob",
+      "#sam/user/alice",
+      "#sam/user/alice"
+    ],
+    "fills": [
+      "#434d59",
+      "#fdd509",
+      "#fbe174",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Feb 28",
+      "2026",
+      "Mar 1",
+      "Mar 2",
+      "Mar 3",
+      "Mar 4",
+      "Mar 5",
+      "Mar 6",
+      "Mar 7",
+      "Mar 8",
+      "Mar 9",
+      "Mar 10",
+      "Mar 11",
+      "0",
+      "20",
+      "40",
+      "60",
+      "80",
+      "Core-Hours",
+      "bob",
+      "alice",
+      "Others"
+    ],
+    "size": [
+      1150.6,
+      331.6
+    ]
+  },
   "usage_stacked.core_hours@mobile": {
     "counts": {
       "a": 28,
@@ -5300,6 +10541,77 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 5",
+      "Mar 9",
+      "0",
+      "20",
+      "40",
+      "60",
+      "80",
+      "Core-Hours",
+      "bob",
+      "alice",
+      "Others"
+    ],
+    "size": [
+      272.6,
+      247.0
+    ]
+  },
+  "usage_stacked.core_hours@mobile@dark": {
+    "counts": {
+      "a": 28,
+      "g": 78,
+      "path": 47,
+      "text": 13,
+      "use": 8
+    },
+    "drill_hrefs": [
+      "#sam/day/2026-03-01",
+      "#sam/day/2026-03-03",
+      "#sam/day/2026-03-04",
+      "#sam/day/2026-03-05",
+      "#sam/day/2026-03-07",
+      "#sam/day/2026-03-08",
+      "#sam/day/2026-03-09",
+      "#sam/day/2026-03-10",
+      "#sam/day/2026-03-01",
+      "#sam/day/2026-03-03",
+      "#sam/day/2026-03-04",
+      "#sam/day/2026-03-05",
+      "#sam/day/2026-03-07",
+      "#sam/day/2026-03-08",
+      "#sam/day/2026-03-09",
+      "#sam/day/2026-03-10",
+      "#sam/day/2026-03-01",
+      "#sam/day/2026-03-03",
+      "#sam/day/2026-03-04",
+      "#sam/day/2026-03-05",
+      "#sam/day/2026-03-07",
+      "#sam/day/2026-03-08",
+      "#sam/day/2026-03-09",
+      "#sam/day/2026-03-10",
+      "#sam/user/bob",
+      "#sam/user/bob",
+      "#sam/user/alice",
+      "#sam/user/alice"
+    ],
+    "fills": [
+      "#434d59",
+      "#fdd509",
+      "#fbe174",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -5396,6 +10708,80 @@
       242.9
     ]
   },
+  "usage_stacked.core_hours@tablet@dark": {
+    "counts": {
+      "a": 28,
+      "g": 90,
+      "path": 50,
+      "text": 16,
+      "use": 11
+    },
+    "drill_hrefs": [
+      "#sam/day/2026-03-01",
+      "#sam/day/2026-03-03",
+      "#sam/day/2026-03-04",
+      "#sam/day/2026-03-05",
+      "#sam/day/2026-03-07",
+      "#sam/day/2026-03-08",
+      "#sam/day/2026-03-09",
+      "#sam/day/2026-03-10",
+      "#sam/day/2026-03-01",
+      "#sam/day/2026-03-03",
+      "#sam/day/2026-03-04",
+      "#sam/day/2026-03-05",
+      "#sam/day/2026-03-07",
+      "#sam/day/2026-03-08",
+      "#sam/day/2026-03-09",
+      "#sam/day/2026-03-10",
+      "#sam/day/2026-03-01",
+      "#sam/day/2026-03-03",
+      "#sam/day/2026-03-04",
+      "#sam/day/2026-03-05",
+      "#sam/day/2026-03-07",
+      "#sam/day/2026-03-08",
+      "#sam/day/2026-03-09",
+      "#sam/day/2026-03-10",
+      "#sam/user/bob",
+      "#sam/user/bob",
+      "#sam/user/alice",
+      "#sam/user/alice"
+    ],
+    "fills": [
+      "#434d59",
+      "#fdd509",
+      "#fbe174",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 3",
+      "Mar 5",
+      "Mar 7",
+      "Mar 9",
+      "Mar 11",
+      "0",
+      "20",
+      "40",
+      "60",
+      "80",
+      "Core-Hours",
+      "bob",
+      "alice",
+      "Others"
+    ],
+    "size": [
+      699.7,
+      242.9
+    ]
+  },
   "usage_stacked.empty": {
     "html": "<div class=\"text-center text-muted\">No usage data recorded for this period</div>",
     "kind": "placeholder"
@@ -5412,6 +10798,46 @@
     "fills": [
       "#0057c2",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Feb 28",
+      "2026",
+      "Mar 1",
+      "Mar 2",
+      "Mar 3",
+      "Mar 4",
+      "Mar 5",
+      "Mar 6",
+      "Mar 7",
+      "Mar 8",
+      "Mar 9",
+      "Mar 10",
+      "Mar 11",
+      "0",
+      "20",
+      "40",
+      "60",
+      "80",
+      "Charges"
+    ],
+    "size": [
+      1074.6,
+      331.6
+    ]
+  },
+  "usage_timeseries.charges@dark": {
+    "counts": {
+      "a": 0,
+      "g": 87,
+      "path": 33,
+      "text": 19,
+      "use": 17
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#236eca",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -5471,6 +10897,37 @@
       203.6
     ]
   },
+  "usage_timeseries.charges@mobile@dark": {
+    "counts": {
+      "a": 0,
+      "g": 51,
+      "path": 24,
+      "text": 10,
+      "use": 8
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#236eca",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 5",
+      "Mar 9",
+      "0",
+      "20",
+      "40",
+      "60",
+      "80",
+      "Charges"
+    ],
+    "size": [
+      272.6,
+      203.6
+    ]
+  },
   "usage_timeseries.charges@tablet": {
     "counts": {
       "a": 0,
@@ -5483,6 +10940,40 @@
     "fills": [
       "#0057c2",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 3",
+      "Mar 5",
+      "Mar 7",
+      "Mar 9",
+      "Mar 11",
+      "0",
+      "20",
+      "40",
+      "60",
+      "80",
+      "Charges"
+    ],
+    "size": [
+      628.2,
+      242.9
+    ]
+  },
+  "usage_timeseries.charges@tablet@dark": {
+    "counts": {
+      "a": 0,
+      "g": 63,
+      "path": 27,
+      "text": 13,
+      "use": 11
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#236eca",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -5558,6 +11049,55 @@
       331.6
     ]
   },
+  "usage_timeseries.linked_jobs@dark": {
+    "counts": {
+      "a": 8,
+      "g": 87,
+      "path": 33,
+      "text": 19,
+      "use": 17
+    },
+    "drill_hrefs": [
+      "#sam/day/2026-03-01",
+      "#sam/day/2026-03-03",
+      "#sam/day/2026-03-04",
+      "#sam/day/2026-03-05",
+      "#sam/day/2026-03-07",
+      "#sam/day/2026-03-08",
+      "#sam/day/2026-03-09",
+      "#sam/day/2026-03-10"
+    ],
+    "fills": [
+      "#236eca",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Feb 28",
+      "2026",
+      "Mar 1",
+      "Mar 2",
+      "Mar 3",
+      "Mar 4",
+      "Mar 5",
+      "Mar 6",
+      "Mar 7",
+      "Mar 8",
+      "Mar 9",
+      "Mar 10",
+      "Mar 11",
+      "0",
+      "20",
+      "40",
+      "60",
+      "80",
+      "Job Count"
+    ],
+    "size": [
+      1074.6,
+      331.6
+    ]
+  },
   "usage_timeseries.linked_jobs@mobile": {
     "counts": {
       "a": 8,
@@ -5598,6 +11138,46 @@
       203.6
     ]
   },
+  "usage_timeseries.linked_jobs@mobile@dark": {
+    "counts": {
+      "a": 8,
+      "g": 51,
+      "path": 24,
+      "text": 10,
+      "use": 8
+    },
+    "drill_hrefs": [
+      "#sam/day/2026-03-01",
+      "#sam/day/2026-03-03",
+      "#sam/day/2026-03-04",
+      "#sam/day/2026-03-05",
+      "#sam/day/2026-03-07",
+      "#sam/day/2026-03-08",
+      "#sam/day/2026-03-09",
+      "#sam/day/2026-03-10"
+    ],
+    "fills": [
+      "#236eca",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 5",
+      "Mar 9",
+      "0",
+      "20",
+      "40",
+      "60",
+      "80",
+      "Job Count"
+    ],
+    "size": [
+      272.6,
+      203.6
+    ]
+  },
   "usage_timeseries.linked_jobs@tablet": {
     "counts": {
       "a": 8,
@@ -5619,6 +11199,49 @@
     "fills": [
       "#0057c2",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "Mar 1",
+      "2026",
+      "Mar 3",
+      "Mar 5",
+      "Mar 7",
+      "Mar 9",
+      "Mar 11",
+      "0",
+      "20",
+      "40",
+      "60",
+      "80",
+      "Job Count"
+    ],
+    "size": [
+      628.2,
+      242.9
+    ]
+  },
+  "usage_timeseries.linked_jobs@tablet@dark": {
+    "counts": {
+      "a": 8,
+      "g": 63,
+      "path": 27,
+      "text": 13,
+      "use": 11
+    },
+    "drill_hrefs": [
+      "#sam/day/2026-03-01",
+      "#sam/day/2026-03-03",
+      "#sam/day/2026-03-04",
+      "#sam/day/2026-03-05",
+      "#sam/day/2026-03-07",
+      "#sam/day/2026-03-08",
+      "#sam/day/2026-03-09",
+      "#sam/day/2026-03-10"
+    ],
+    "fills": [
+      "#236eca",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -5700,6 +11323,61 @@
       334.6
     ]
   },
+  "user_proj_area.peak_unlinked@dark": {
+    "counts": {
+      "a": 0,
+      "g": 86,
+      "path": 30,
+      "text": 23,
+      "use": 16
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#434d59",
+      "#f8ebb7",
+      "#fbe174",
+      "#fdd509",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#f8ebb7",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "17:00",
+      "Feb 28",
+      "18:00",
+      "19:00",
+      "20:00",
+      "21:00",
+      "22:00",
+      "23:00",
+      "00:00",
+      "Mar 1",
+      "01:00",
+      "02:00",
+      "0",
+      "10",
+      "20",
+      "30",
+      "40",
+      "50",
+      "Jobs",
+      "PROJ0001 (28)",
+      "PROJ0002 (14)",
+      "PROJ0003 (9)",
+      "Others (4)"
+    ],
+    "size": [
+      1218.6,
+      334.6
+    ]
+  },
   "user_proj_area.peak_unlinked@mobile": {
     "counts": {
       "a": 0,
@@ -5748,6 +11426,54 @@
       284.8
     ]
   },
+  "user_proj_area.peak_unlinked@mobile@dark": {
+    "counts": {
+      "a": 0,
+      "g": 58,
+      "path": 23,
+      "text": 16,
+      "use": 9
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#434d59",
+      "#f8ebb7",
+      "#fbe174",
+      "#fdd509",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#f8ebb7",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "18:00",
+      "Feb 28",
+      "21:00",
+      "00:00",
+      "Mar 1",
+      "0",
+      "10",
+      "20",
+      "30",
+      "40",
+      "50",
+      "Jobs",
+      "PROJ0001 (28)",
+      "PROJ0002 (14)",
+      "PROJ0003 (9)",
+      "Others (4)"
+    ],
+    "size": [
+      272.5,
+      284.8
+    ]
+  },
   "user_proj_area.peak_unlinked@tablet": {
     "counts": {
       "a": 0,
@@ -5771,6 +11497,56 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "18:00",
+      "Feb 28",
+      "20:00",
+      "22:00",
+      "00:00",
+      "Mar 1",
+      "02:00",
+      "0",
+      "10",
+      "20",
+      "30",
+      "40",
+      "50",
+      "Jobs",
+      "PROJ0001 (28)",
+      "PROJ0002 (14)",
+      "PROJ0003 (9)",
+      "Others (4)"
+    ],
+    "size": [
+      767.7,
+      245.9
+    ]
+  },
+  "user_proj_area.peak_unlinked@tablet@dark": {
+    "counts": {
+      "a": 0,
+      "g": 66,
+      "path": 25,
+      "text": 18,
+      "use": 11
+    },
+    "drill_hrefs": [],
+    "fills": [
+      "#434d59",
+      "#f8ebb7",
+      "#fbe174",
+      "#fdd509",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#f8ebb7",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -5860,6 +11636,68 @@
       334.6
     ]
   },
+  "user_proj_area.project_current@dark": {
+    "counts": {
+      "a": 6,
+      "g": 86,
+      "path": 30,
+      "text": 23,
+      "use": 16
+    },
+    "drill_hrefs": [
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0003"
+    ],
+    "fills": [
+      "#434d59",
+      "#f8ebb7",
+      "#fbe174",
+      "#fdd509",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#f8ebb7",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "17:00",
+      "Feb 28",
+      "18:00",
+      "19:00",
+      "20:00",
+      "21:00",
+      "22:00",
+      "23:00",
+      "00:00",
+      "Mar 1",
+      "01:00",
+      "02:00",
+      "0",
+      "10",
+      "20",
+      "30",
+      "40",
+      "50",
+      "Jobs",
+      "PROJ0001 (20)",
+      "PROJ0002 (10)",
+      "PROJ0003 (5)",
+      "Others (2)"
+    ],
+    "size": [
+      1218.5,
+      334.6
+    ]
+  },
   "user_proj_area.project_current@mobile": {
     "counts": {
       "a": 6,
@@ -5915,6 +11753,61 @@
       284.8
     ]
   },
+  "user_proj_area.project_current@mobile@dark": {
+    "counts": {
+      "a": 6,
+      "g": 58,
+      "path": 23,
+      "text": 16,
+      "use": 9
+    },
+    "drill_hrefs": [
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0003"
+    ],
+    "fills": [
+      "#434d59",
+      "#f8ebb7",
+      "#fbe174",
+      "#fdd509",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#f8ebb7",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "18:00",
+      "Feb 28",
+      "21:00",
+      "00:00",
+      "Mar 1",
+      "0",
+      "10",
+      "20",
+      "30",
+      "40",
+      "50",
+      "Jobs",
+      "PROJ0001 (20)",
+      "PROJ0002 (10)",
+      "PROJ0003 (5)",
+      "Others (2)"
+    ],
+    "size": [
+      272.5,
+      284.8
+    ]
+  },
   "user_proj_area.project_current@tablet": {
     "counts": {
       "a": 6,
@@ -5945,6 +11838,63 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "18:00",
+      "Feb 28",
+      "20:00",
+      "22:00",
+      "00:00",
+      "Mar 1",
+      "02:00",
+      "0",
+      "10",
+      "20",
+      "30",
+      "40",
+      "50",
+      "Jobs",
+      "PROJ0001 (20)",
+      "PROJ0002 (10)",
+      "PROJ0003 (5)",
+      "Others (2)"
+    ],
+    "size": [
+      767.7,
+      245.9
+    ]
+  },
+  "user_proj_area.project_current@tablet@dark": {
+    "counts": {
+      "a": 6,
+      "g": 66,
+      "path": 25,
+      "text": 18,
+      "use": 11
+    },
+    "drill_hrefs": [
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0001",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0002",
+      "/user/project-details-modal/PROJ0003",
+      "/user/project-details-modal/PROJ0003"
+    ],
+    "fills": [
+      "#434d59",
+      "#f8ebb7",
+      "#fbe174",
+      "#fdd509",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#fbe174",
+      "#e9ecef",
+      "#f8ebb7",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -6073,6 +12023,108 @@
       236.2
     ]
   },
+  "user_usage_pie.charges@dark": {
+    "counts": {
+      "a": 27,
+      "g": 46,
+      "path": 21,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user0",
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user8"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "7.7%",
+      "user0 (12,000)",
+      "user1 (11,000)",
+      "user2 (10,000)",
+      "user3 (9,000)",
+      "user4 (8,000)",
+      "user5 (7,000)",
+      "user6 (6,000)",
+      "user7 (5,000)",
+      "user8 (4,000)",
+      "Other (3) (6,000)"
+    ],
+    "size": [
+      351.2,
+      236.2
+    ]
+  },
   "user_usage_pie.charges@mobile": {
     "counts": {
       "a": 18,
@@ -6127,6 +12179,82 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "26.9%",
+      "user0 (12,000)",
+      "user1 (11,000)",
+      "user2 (10,000)",
+      "user3 (9,000)",
+      "user4 (8,000)",
+      "user5 (7,000)",
+      "Other (6) (21,000)"
+    ],
+    "size": [
+      292.4,
+      175.2
+    ]
+  },
+  "user_usage_pie.charges@mobile@dark": {
+    "counts": {
+      "a": 18,
+      "g": 34,
+      "path": 15,
+      "text": 14,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user0",
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user5"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -6222,6 +12350,108 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "7.7%",
+      "user0 (12,000)",
+      "user1 (11,000)",
+      "user2 (10,000)",
+      "user3 (9,000)",
+      "user4 (8,000)",
+      "user5 (7,000)",
+      "user6 (6,000)",
+      "user7 (5,000)",
+      "user8 (4,000)",
+      "Other (3) (6,000)"
+    ],
+    "size": [
+      351.2,
+      236.2
+    ]
+  },
+  "user_usage_pie.charges@tablet@dark": {
+    "counts": {
+      "a": 27,
+      "g": 46,
+      "path": 21,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user0",
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user8"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -6352,6 +12582,108 @@
       236.2
     ]
   },
+  "user_usage_pie.default_metric@dark": {
+    "counts": {
+      "a": 27,
+      "g": 46,
+      "path": 21,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user0",
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user8"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "7.7%",
+      "user0 (12,000)",
+      "user1 (11,000)",
+      "user2 (10,000)",
+      "user3 (9,000)",
+      "user4 (8,000)",
+      "user5 (7,000)",
+      "user6 (6,000)",
+      "user7 (5,000)",
+      "user8 (4,000)",
+      "Other (3) (6,000)"
+    ],
+    "size": [
+      351.2,
+      236.2
+    ]
+  },
   "user_usage_pie.default_metric@mobile": {
     "counts": {
       "a": 18,
@@ -6406,6 +12738,82 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "26.9%",
+      "user0 (12,000)",
+      "user1 (11,000)",
+      "user2 (10,000)",
+      "user3 (9,000)",
+      "user4 (8,000)",
+      "user5 (7,000)",
+      "Other (6) (21,000)"
+    ],
+    "size": [
+      292.4,
+      175.2
+    ]
+  },
+  "user_usage_pie.default_metric@mobile@dark": {
+    "counts": {
+      "a": 18,
+      "g": 34,
+      "path": 15,
+      "text": 14,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user0",
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user5"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -6501,6 +12909,108 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "7.7%",
+      "user0 (12,000)",
+      "user1 (11,000)",
+      "user2 (10,000)",
+      "user3 (9,000)",
+      "user4 (8,000)",
+      "user5 (7,000)",
+      "user6 (6,000)",
+      "user7 (5,000)",
+      "user8 (4,000)",
+      "Other (3) (6,000)"
+    ],
+    "size": [
+      351.2,
+      236.2
+    ]
+  },
+  "user_usage_pie.default_metric@tablet@dark": {
+    "counts": {
+      "a": 27,
+      "g": 46,
+      "path": 21,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user0",
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user8"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -6635,6 +13145,108 @@
       236.2
     ]
   },
+  "user_usage_pie.jobs@dark": {
+    "counts": {
+      "a": 27,
+      "g": 46,
+      "path": 21,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user0",
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user8"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "7.7%",
+      "user0 (600)",
+      "user1 (550)",
+      "user2 (500)",
+      "user3 (450)",
+      "user4 (400)",
+      "user5 (350)",
+      "user6 (300)",
+      "user7 (250)",
+      "user8 (200)",
+      "Other (3) (300)"
+    ],
+    "size": [
+      343.4,
+      236.2
+    ]
+  },
   "user_usage_pie.jobs@mobile": {
     "counts": {
       "a": 18,
@@ -6689,6 +13301,82 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "26.9%",
+      "user0 (600)",
+      "user1 (550)",
+      "user2 (500)",
+      "user3 (450)",
+      "user4 (400)",
+      "user5 (350)",
+      "Other (6) (1,050)"
+    ],
+    "size": [
+      287.2,
+      175.2
+    ]
+  },
+  "user_usage_pie.jobs@mobile@dark": {
+    "counts": {
+      "a": 18,
+      "g": 34,
+      "path": 15,
+      "text": 14,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user0",
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user5"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [
@@ -6784,6 +13472,108 @@
       "#011837",
       "#bbbcbc",
       "#011837"
+    ],
+    "kind": "svg",
+    "labels": [
+      "15.4%",
+      "14.1%",
+      "12.8%",
+      "11.5%",
+      "10.3%",
+      "9.0%",
+      "7.7%",
+      "6.4%",
+      "5.1%",
+      "7.7%",
+      "user0 (600)",
+      "user1 (550)",
+      "user2 (500)",
+      "user3 (450)",
+      "user4 (400)",
+      "user5 (350)",
+      "user6 (300)",
+      "user7 (250)",
+      "user8 (200)",
+      "Other (3) (300)"
+    ],
+    "size": [
+      343.4,
+      236.2
+    ]
+  },
+  "user_usage_pie.jobs@tablet@dark": {
+    "counts": {
+      "a": 27,
+      "g": 46,
+      "path": 21,
+      "text": 20,
+      "use": 0
+    },
+    "drill_hrefs": [
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user0",
+      "#sam/user/user0",
+      "#sam/user/user1",
+      "#sam/user/user1",
+      "#sam/user/user2",
+      "#sam/user/user2",
+      "#sam/user/user3",
+      "#sam/user/user3",
+      "#sam/user/user4",
+      "#sam/user/user4",
+      "#sam/user/user5",
+      "#sam/user/user5",
+      "#sam/user/user6",
+      "#sam/user/user6",
+      "#sam/user/user7",
+      "#sam/user/user7",
+      "#sam/user/user8",
+      "#sam/user/user8"
+    ],
+    "fills": [
+      "#236eca",
+      "#4c71a2",
+      "#ff1f1f",
+      "#fdd509",
+      "#faa119",
+      "#00818f",
+      "#42c0ff",
+      "#00a2b4",
+      "#627083",
+      "#434d59",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#011837",
+      "#ffffff",
+      "#236eca",
+      "#e9ecef",
+      "#4c71a2",
+      "#e9ecef",
+      "#ff1f1f",
+      "#e9ecef",
+      "#fdd509",
+      "#e9ecef",
+      "#faa119",
+      "#e9ecef",
+      "#00818f",
+      "#e9ecef",
+      "#42c0ff",
+      "#e9ecef",
+      "#00a2b4",
+      "#e9ecef",
+      "#627083",
+      "#e9ecef",
+      "#434d59",
+      "#e9ecef"
     ],
     "kind": "svg",
     "labels": [

--- a/tests/unit/test_chart_fingerprints.py
+++ b/tests/unit/test_chart_fingerprints.py
@@ -14,24 +14,28 @@ Regenerate after an intentional change, then review the diff in that commit:
 
     CHART_FINGERPRINT_REGEN=1 pytest tests/unit/test_chart_fingerprints.py
 
-## Every layout is pinned
+## Every layout and every theme is pinned
 
-Every non-empty case is rendered once per declared layout: desktop keeps the
-bare case id, and each other profile adds a suffix — ``<case>@mobile``,
-``<case>@tablet``. The list is read off the chart classes, so a fourth profile
-pins itself.
+Every non-empty case is rendered once per (layout, theme) combination. Desktop
+and light are the identity, so they keep the bare case id and every other
+rendering adds suffixes — ``<case>@mobile``, ``<case>@dark``,
+``<case>@mobile@dark``. Both lists are read off the code (the chart classes and
+``charts.theme.THEMES``), so a fourth profile or a third theme pins itself.
 
-The non-desktop halves exist because these passes are *tuning* work: figure
-sizes, legend placement and font sizes get moved until they look right, and
-without a pinned baseline "I nudged the pace chart" and "I broke the pace
-chart" produce the same diff — none. It also makes the desktop invariant
-enforceable in the same run: a mobile- or tablet-tuning commit that moves a
-desktop fingerprint has leaked, and that is the single most likely way these
-passes regress the 1,000+ desktop users they are not for.
+Keeping desktop+light bare is what preserves the existing snapshot keys, and
+with them every diff anyone has already reviewed.
 
-Empty cases are layout-invariant by construction — ``is_empty()`` short-circuits
-before ``make_figure()`` — so they are pinned once, and
-``test_empty_state_is_layout_invariant`` proves the short-circuit really does
+The non-identity halves exist because these passes are *tuning* work: figure
+sizes, legend placement, font sizes and now chrome colours get moved until they
+look right, and without a pinned baseline "I nudged the pace chart" and "I broke
+the pace chart" produce the same diff — none. It also makes the desktop+light
+invariant enforceable in the same run: a mobile-tuning or dark-tuning commit
+that moves a desktop light fingerprint has leaked, and that is the single most
+likely way these passes regress the users they are not for.
+
+Empty cases are invariant on both axes by construction — ``is_empty()``
+short-circuits before ``make_figure()`` — so they are pinned once, and
+``test_empty_state_is_axis_invariant`` proves the short-circuit really does
 precede the geometry.
 """
 
@@ -65,24 +69,57 @@ def extra_layouts():
     return tuple(sorted(names - {'desktop'}))
 
 
+def extra_themes():
+    """Every declared theme except light, which keeps the bare case id.
+
+    Read off ``charts.theme.THEMES`` for the same reason ``extra_layouts``
+    reads the chart classes: the vocabulary lives in one place and this gate
+    follows it.
+    """
+    from webapp.dashboards.charts.theme import THEMES
+
+    return tuple(sorted(set(THEMES) - {'light'}))
+
+
+def _renderings():
+    """``[(suffix, kwargs), ...]`` — every (layout, theme) combination.
+
+    Desktop and light contribute no suffix and no kwarg, so the identity
+    rendering is spelled exactly as it was before either axis existed.
+    """
+    out = []
+    for layout in ('desktop',) + extra_layouts():
+        for theme in ('light',) + extra_themes():
+            suffix = ''
+            kwargs = {}
+            if layout != 'desktop':
+                suffix += f'@{layout}'
+                kwargs['layout'] = layout
+            if theme != 'light':
+                suffix += f'@{theme}'
+                kwargs['theme'] = theme
+            out.append((suffix, kwargs))
+    return out
+
+
 def _render_all(app):
-    """Render every case inside one app context, at every layout.
+    """Render every case inside one app context, at every layout and theme.
 
     Several charts resolve modal routes through ``url_for``, so an application
     context is required even though nothing here touches the database.
     """
     out = {}
-    layouts = extra_layouts()
+    renderings = _renderings()
     with app.test_request_context('/'):
         for case_id, fn, args, kwargs in CASES:
-            out[case_id] = svg_fingerprint(fn(*args, **kwargs))
             if case_id.endswith('.empty'):
-                # Layout-invariant by construction; pinned once. The claim is
-                # tested directly by test_empty_state_is_layout_invariant.
+                # Invariant on both axes by construction; pinned once. The
+                # claim is tested directly by test_empty_state_is_axis_invariant.
+                out[case_id] = svg_fingerprint(fn(*args, **kwargs))
                 continue
-            for name in layouts:
-                out[f'{case_id}@{name}'] = svg_fingerprint(
-                    fn(*args, **kwargs, layout=name))
+            for suffix, axis_kwargs in renderings:
+                out[case_id + suffix] = svg_fingerprint(
+                    fn(*args, **kwargs, **axis_kwargs))
     return out
 
 
@@ -161,22 +198,61 @@ def test_empty_states_are_placeholders(rendered):
             assert 'text-muted' in fp['html']
 
 
-def test_empty_state_is_layout_invariant(app):
+def test_empty_state_is_axis_invariant(app):
     """Pinning empty cases once is only safe if the short-circuit really is
-    layout-independent — i.e. ``is_empty()`` runs before ``make_figure()``.
+    axis-independent — i.e. ``is_empty()`` runs before ``make_figure()``.
 
     Cheap to assert, and it fails loudly if anyone ever moves the empty check
-    below the figure creation to give the placeholder a layout-aware size.
+    below the figure creation to give the placeholder an axis-aware size or a
+    themed colour.
     """
     empties = [c for c in CASES if c[0].endswith('.empty')]
     assert empties, 'no empty cases — the invariant below would be vacuous'
     with app.test_request_context('/'):
         for case_id, fn, args, kwargs in empties:
-            desktop = fn(*args, **kwargs)
-            for name in extra_layouts():
-                other = fn(*args, **kwargs, layout=name)
-                assert desktop == other, (
-                    f'{case_id} placeholder differs at layout={name}')
+            identity = fn(*args, **kwargs)
+            for suffix, axis_kwargs in _renderings():
+                if not suffix:
+                    continue
+                other = fn(*args, **kwargs, **axis_kwargs)
+                assert identity == other, (
+                    f'{case_id} placeholder differs at {suffix.lstrip("@")}')
+
+
+def test_theme_changes_colour_but_never_geometry(rendered):
+    """The theme axis is chrome and palette only — asserted as a property.
+
+    Two claims, and each catches a different real mistake:
+
+    **Geometry must not move.** ``bbox_inches='tight'`` sizes the figure from
+    text extents, which a colour cannot change. If a dark fingerprint's size
+    ever differs, something structural leaked into the theme branch — a legend
+    that only renders in one theme, an extra artist — and the two themes have
+    silently stopped being the same chart.
+
+    **Colour must move.** The failure this guards is the whole reason PR 4
+    exists: ``Theme.DARK`` was defined, live and reachable for a full release
+    while *nothing applied it*, so a chart asked for in dark rendered exactly
+    the light bytes. A theme that changes nothing is indistinguishable from a
+    theme that is not plumbed in, and only this direction of the assertion can
+    tell them apart.
+    """
+    moved, unchanged = [], []
+    for theme in extra_themes():
+        for base_id in [c for c in rendered if '@' not in c]:
+            themed = rendered.get(f'{base_id}@{theme}')
+            if themed is None or themed['kind'] != 'svg':
+                continue               # empty-state cases are pinned once
+            if themed['size'] != rendered[base_id]['size']:
+                moved.append(f'{base_id}@{theme}: {rendered[base_id]["size"]} '
+                             f'-> {themed["size"]}')
+            if themed['fills'] == rendered[base_id]['fills']:
+                unchanged.append(f'{base_id}@{theme}')
+
+    assert not moved, 'theme moved the geometry:\n  ' + '\n  '.join(moved)
+    assert not unchanged, (
+        'theme did not change any fill — is it reaching the artists?\n  '
+        + '\n  '.join(unchanged))
 
 
 def _pairs(rendered, name):

--- a/tests/unit/test_chart_theme.py
+++ b/tests/unit/test_chart_theme.py
@@ -121,9 +121,24 @@ class TestAutopctColor:
 
     def test_is_theme_invariant(self):
         """Driven by the wedge, not the page — so it needs no theme argument
-        and is already correct for dark mode."""
+        and is already correct for dark mode.
+
+        Asserts the *property* (one argument, and it is not a theme) rather
+        than that argument's spelling: it was renamed `bg_hex` -> `color` when
+        wedge colours started arriving as lifted RGBA tuples, and a test that
+        fails on a rename while a real theme argument would slip past it is
+        pinning the wrong thing.
+        """
         import inspect
-        assert list(inspect.signature(T.autopct_color_for).parameters) == ['bg_hex']
+        params = list(inspect.signature(T.autopct_color_for).parameters)
+        assert len(params) == 1 and 'theme' not in params
+
+    def test_accepts_a_lifted_rgba_wedge(self):
+        """`Theme.data_color` hands back RGBA tuples for the colours it lifts,
+        and every one of them is a pie wedge that still needs a label."""
+        lifted = T.Theme.DARK.data_color(T.UNITY_NCAR_SPACE_BLUE)
+        assert not isinstance(lifted, str)          # guard the premise
+        assert T.autopct_color_for(lifted) in (T.UNITY_NCAR_SPACE_BLUE, '#fff')
 
 
 class TestPalettes:

--- a/tests/unit/test_css_tokens.py
+++ b/tests/unit/test_css_tokens.py
@@ -249,13 +249,19 @@ def test_dark_card_matches_chart_blend_target():
 
     Picking the value once, in CSS, is what makes PR 4 (dark charts)
     mechanical. This test is what keeps it picked once.
+
+    `surface` joined the list in PR 4 and is the load-bearing one: it is what
+    `Theme.data_color` measures a wedge's contrast *against*, so a stale value
+    here does not produce a halo, it produces a palette lifted to clear a
+    surface the chart is not sitting on — silently, and in the direction of
+    "looks fine in the fingerprint".
     """
     from webapp.dashboards.charts.theme import Theme
 
     card = _dark_tokens().get('--surface-card')
     assert card, 'the dark block does not define --surface-card'
 
-    for attr in ('shade_toward', 'legend_face', 'segment_edge'):
+    for attr in ('shade_toward', 'legend_face', 'segment_edge', 'surface'):
         value = getattr(Theme.DARK, attr)
         assert value.lower() == card.lower(), (
             f'Theme.DARK.{attr} = {value} but --surface-card = {card}. '

--- a/tests/unit/test_layout_transport.py
+++ b/tests/unit/test_layout_transport.py
@@ -95,16 +95,21 @@ class TestReadLayout:
 # The last hop: renderer to renderer
 # --------------------------------------------------------------------------
 
-#: The modules whose fragment renderers take a ``layout`` argument.
-#: ``utils/fragments.py:_register_one`` resolves it once for all 27
-#: jobs/disk-scans routes and hands it to every panel, so the axis reaches
+#: The modules whose fragment renderers take a render-axis argument.
+#: ``utils/fragments.py:_register_one`` resolves both axes once for all 27
+#: jobs/disk-scans routes and hands them to every panel, so an axis reaches
 #: these two files and then has to be *carried* the rest of the way by hand.
 _RENDERER_MODULES = ('webapp.jobs.routes', 'webapp.disk_scans.routes')
 
+#: Both render axes are transported identically and fail identically, so this
+#: section is generic over the two. ``theme`` is the dark-mode sibling added in
+#: PR 4 — see ``test_theme_transport.py`` for everything else about it.
+_AXES = ('layout', 'theme')
 
-def _layout_takers(module):
-    """``{name: fn}`` for everything in the module's namespace that accepts a
-    ``layout`` argument — its own renderers *and* the imported chart callables,
+
+def _axis_takers(module, axis):
+    """``{name: fn}`` for everything in the module's namespace that accepts an
+    *axis* argument — its own renderers *and* the imported chart callables,
     which advertise it through ``chart_view``'s explicit ``__signature__``."""
     out = {}
     for name, fn in vars(module).items():
@@ -118,31 +123,37 @@ def _layout_takers(module):
             sig = inspect.signature(fn)
         except (TypeError, ValueError):
             continue
-        if 'layout' in sig.parameters:
+        if axis in sig.parameters:
             out[name] = fn
     return out
 
 
+@pytest.mark.parametrize('axis', _AXES)
 @pytest.mark.parametrize('mod_name', _RENDERER_MODULES)
-def test_renderers_forward_the_layout_they_are_given(mod_name):
-    """A renderer that delegates to something layout-aware must pass it on.
+def test_renderers_forward_the_axis_they_are_given(mod_name, axis):
+    """A renderer that delegates to something axis-aware must pass it on.
 
     This is the one hop nothing else can check. The registrar resolves
-    ``read_layout()`` once and the chart layer honours whatever it is given,
-    so a renderer that accepts ``layout`` and then calls its delegate without
-    it fails *silently* — the fragment renders, at desktop, forever. That is
-    exactly what happened to the three jobs histogram panels (Wait Times, Job
-    Sizes, Durations): ``_panel_histogram`` took the argument and dropped it,
-    and all three served an 18in figure to phones and tablets alike.
+    ``read_layout()`` / ``read_theme()`` once and the chart layer honours
+    whatever it is given, so a renderer that accepts the argument and then
+    calls its delegate without it fails *silently* — the fragment renders, at
+    desktop or in light, forever. That is exactly what happened to the three
+    jobs histogram panels (Wait Times, Job Sizes, Durations):
+    ``_panel_histogram`` took ``layout`` and dropped it, and all three served
+    an 18in figure to phones and tablets alike.
+
+    The theme parameterization is not symmetry for its own sake: a dropped
+    theme is the *louder* failure of the two, because a light chart on a dark
+    page is wrong at a glance where a slightly-too-large figure is not.
 
     Renderers that draw no chart are exempt by construction rather than by
-    allowlist: they call nothing that takes a ``layout``, so there is nothing
+    allowlist: they call nothing that takes the argument, so there is nothing
     to forward. ``utils/fragments.py`` states that contract — "panels that draw
-    no chart accept and ignore it".
+    no chart accept and ignore them".
     """
     module = importlib.import_module(mod_name)
-    takers = _layout_takers(module)
-    assert takers, f'{mod_name} has no layout-aware callables — test is stale'
+    takers = _axis_takers(module, axis)
+    assert takers, f'{mod_name} has no {axis}-aware callables — test is stale'
 
     dropped = []
     for name, fn in takers.items():
@@ -151,10 +162,23 @@ def test_renderers_forward_the_layout_they_are_given(mod_name):
         src = inspect.getsource(fn)
         delegates = [d for d in takers
                      if d != name and re.search(rf'\b{re.escape(d)}\s*\(', src)]
-        if delegates and 'layout=layout' not in src:
-            dropped.append(f'{name} calls {sorted(delegates)} without layout=')
+        if delegates and f'{axis}={axis}' not in src:
+            dropped.append(f'{name} calls {sorted(delegates)} without {axis}=')
     assert not dropped, (
-        'layout dropped on the way to a chart:\n  ' + '\n  '.join(dropped))
+        f'{axis} dropped on the way to a chart:\n  ' + '\n  '.join(dropped))
+
+
+def test_the_registrar_resolves_both_axes():
+    """``utils/fragments.py`` is the single hop covering 27 routes. If it
+    stops resolving an axis, every jobs and disk-scans chart silently pins to
+    that axis's default and the per-renderer test above still passes — it only
+    checks that whatever arrived gets forwarded."""
+    from webapp.utils import fragments
+
+    src = inspect.getsource(fragments._register_one)
+    for axis in _AXES:
+        assert f'{axis}=read_{axis}()' in src, (
+            f'the fragment registrar no longer resolves {axis}')
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/test_resource_details_disk_chart_route.py
+++ b/tests/unit/test_resource_details_disk_chart_route.py
@@ -28,13 +28,17 @@ def _sentinel_chart(monkeypatch):
     The double's signature is deliberately explicit rather than ``**kwargs``:
     it is the only thing asserting that this route calls the chart the way the
     chart expects. When the ``layout`` axis was threaded through, this fixture
-    failed loudly — which is the behaviour worth keeping.
+    failed loudly — and again when ``theme`` was, in PR 4. That is the
+    behaviour worth keeping: a ``**kwargs`` double would have swallowed both
+    and left the route free to stop forwarding either.
     """
-    captured = {'metric': None, 'layout': None}
+    captured = {'metric': None, 'layout': None, 'theme': None}
 
-    def _fake(timeseries, link_kind=None, metric='bytes', layout='desktop'):
+    def _fake(timeseries, link_kind=None, metric='bytes', layout='desktop',
+              theme='light'):
         captured['metric'] = metric
         captured['layout'] = layout
+        captured['theme'] = theme
         return '<svg data-test="disk-chart"></svg>'
 
     monkeypatch.setattr(
@@ -65,6 +69,7 @@ class TestDiskUsageChartRoute:
         assert _active_tab_label(html) == 'Data Volume'
         assert _sentinel_chart['metric'] == 'bytes'
         assert _sentinel_chart['layout'] == 'desktop'
+        assert _sentinel_chart['theme'] == 'light'
 
     def test_layout_reaches_the_chart(self, auth_client, active_project,
                                       _sentinel_chart):
@@ -82,6 +87,30 @@ class TestDiskUsageChartRoute:
                                     resource=_DISK_RESOURCE))
         assert resp.status_code == 200
         assert _sentinel_chart['layout'] == 'mobile'
+
+    def test_theme_reaches_the_chart(self, auth_client, active_project,
+                                     _sentinel_chart):
+        """The theme's own half of the same claim.
+
+        Only the cookie is asserted as a *live* channel: unlike ``layout``, no
+        JavaScript ever writes ``?theme=``, so the query string is a
+        hand-debugging affordance rather than transport. See
+        ``webapp/utils/htmx.py:read_theme``.
+        """
+        auth_client.set_cookie('sam_theme', 'dark', domain='localhost')
+        resp = auth_client.get(_url(active_project.projcode,
+                                    resource=_DISK_RESOURCE))
+        assert resp.status_code == 200
+        assert _sentinel_chart['theme'] == 'dark'
+
+    def test_bogus_theme_falls_back_to_light(self, auth_client, active_project,
+                                             _sentinel_chart):
+        """Lenient, never a 400 — same rule as the layout axis below."""
+        auth_client.set_cookie('sam_theme', 'sepia', domain='localhost')
+        resp = auth_client.get(_url(active_project.projcode,
+                                    resource=_DISK_RESOURCE))
+        assert resp.status_code == 200
+        assert _sentinel_chart['theme'] == 'light'
 
     def test_bogus_layout_falls_back_to_desktop(self, auth_client,
                                                 active_project,


### PR DESCRIPTION
## Summary

PR 4 of 4 in the chart render-axis series (`docs/plans/CHART_ARCHITECTURE.md`
§ *Roadmap*). Wires the `dark` theme through the axis PR 1 built.

**Stacked on #419** — base is `dark_mode_sans_charts`, not `staging`. Retarget
to `staging` once #419 merges; merging the parent will otherwise close this one.

As-built writeup: `docs/plans/DARK_MODE.md` § *PR 4 as built*, which supersedes
§ *Handoff to PR 4* in the same file.

## The defect was bigger than "tune `Theme.DARK`"

`Theme.DARK` has been live and reachable since #414, and **nothing applied
`Theme.text` or `Theme.spine`** — both fields had zero readers in the package.
Every title, axis label, tick, spine and legend label took its colour from the
module-level rcParams block, which bakes the *light* chrome in at import
because it runs once per process, before any request has a theme. A chart asked
for in dark rendered the light bytes: `fill="rgb(1,24,55)"` on the `#1b2733`
card, **1.17:1**.

`BaseChart.apply_chrome()` fixes it, run after `finish()` so the legend exists
by then. It deliberately does **not** touch `ax.texts`: those are artists a
chart placed itself, and each already carries a colour chosen for a reason no
theme should overrule — the pie's percentage labels take theirs from the
*wedge* luminance, the pace chart's "today" marker from `theme.accent`.
Blanket-setting them would paint white text onto a gold wedge.

## Three data-colour decisions, not two

`CHART_ARCHITECTURE.md` Appendix B flagged two. There were three.

| Problem | Answer |
|---|---|
| Brand darks as fills — `#011837` at 1.17:1, `#00357a` at 1.29:1 | `min_data_contrast` + `lift_for_contrast`: tint toward white to a 3:1 floor (WCAG 1.4.11, non-text) |
| `alpha=0.85` stackplots compositing against the card | `area_alpha` — 0.85 light, 1.0 dark |
| **Unflagged:** "Others" at 7.97:1 | `muted_data` — a role at 1.77:1, mirroring the 1.90:1 it has on white |

**Tinting rather than raising HSL lightness is load-bearing.** The three failing
pie colours are all blues; lifting each to exactly 3:1 by lightness converges
them on `#0469f0` / `#0068ef` / `#0069eb` — three names for one blue, in a
palette whose whole job is telling ten things apart. Tinting desaturates as it
lightens and lands them on `#627083` / `#4c72a2` / `#246fcb`, leaving every
palette's minimum pairwise channel distance at or above what it already was.

**The third decision is the one worth reviewing.** It is not a contrast failure
— 7.97:1 passes any threshold you care to set. It is an *inverted* one:
`others_color` is named for a value (`--ncar-gray-light`) and used for a role,
and the role is "recede". A value that recedes on white shouts on near-black,
so the band that means least became the brightest thing on the chart. No
contrast assertion would have caught it; it was found by looking at a rendered
chart. It must also **bypass** the lift, or `min_data_contrast` drags it
straight back up.

## Transport

22 places passed `layout=`; all 22 now pass `theme=` beside it. They are not 22
call sites, and the breakdown is the part worth reviewing:

- **18** real chart calls (allocations 5, user 4, status 4, jobs 3, disk-scans 2)
- **1** `utils/fragments.py` registrar, covering 27 jobs/disk-scans fragment routes
- **3** hand-carry hops inside `jobs/routes.py` where the axis is merely relayed

That last group is the one that silently failed for `layout` — the three jobs
histogram panels took the argument and dropped it, serving an 18in figure to
phones for a release.

## Test Results

- **Full suite: 4331 passed**, 36 skipped, 1 xfailed.
- **Browser tier: 62 passed** against a live stack, both themes.

### Light mode is byte-identical, and that is proven rather than asserted

`Theme.LIGHT.min_data_contrast` is `None`, and `data_colors` returns the *same
object* in that case rather than an equal one. Every value `apply_chrome`
assigns is the literal the rcParams block already installed.

The fingerprint gate now pins every case at every layout x theme, 111 -> 207
keys. **Of the 111 pre-existing keys, 0 changed**; the 96 new keys are all
`@dark`. The line-level diff on that snapshot looks alarming — sorted-key
insertion reflows the file — so check keys, not lines.

### The new gates

- `test_theme_changes_colour_but_never_geometry` asserts both directions. The
  second is the point: a theme that changes no fill is indistinguishable from a
  theme that is not plumbed in, which is the state this package shipped in for a
  full release.
- `test_renderers_forward_the_axis_they_are_given` — the existing layout gate,
  now parameterized over both axes rather than given a copy-pasted sibling.
- `test_the_registrar_resolves_both_axes` — because the per-renderer test only
  proves that whatever *arrived* got forwarded. If the registrar stopped
  resolving an axis, all 27 fragments would pin to its default and that test
  would still pass.
- `e2e/test_dark_mode.py::test_chart_text_is_legible` — a separate test rather
  than an extension of `SAMPLES`, because that helper walks *ancestors* for the
  backdrop, which is wrong for a pie: the percentage label sits on a sibling
  `<path>`. This hit-tests with `elementsFromPoint` instead, so a label on a
  wedge is measured against the wedge.

**Checked for vacuity**: disabling `apply_chrome` turns the browser gate red
with exactly the documented signature — `1.17:1 fg=rgb(1,24,55)
bg=rgb(27,39,51)` — on both chart pages in dark, while both light cases stay
green.

## Deploy note

Chart cache keys hash *input data*, not rendering code, so warm Redis entries
serve pre-PR-4 SVGs for up to 600 s. Run
`sam-admin cache --refresh --category chart` after deploying. Dark mode also
doubles the chart cache working set; the `maxmemory` rationale still deserves
real numbers rather than the assumption inherited from #414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
