### PR TITLE
Dark mode: the stragglers

### DIFF
--- a/docs/plans/DARK_MODE_STRAGGLERS.md
+++ b/docs/plans/DARK_MODE_STRAGGLERS.md
@@ -1,0 +1,215 @@
+# Dark mode: the stragglers
+
+**Branch**: `dark_mode_stragglers` (off `staging` @ 186c311). PR base `staging`.
+Follow-up to PR #419 (app-wide dark mode) and its § *PR 4 as built*.
+
+## Context
+
+PR #419 retired SAM's own hardcoded surfaces onto tier-2 role tokens and the
+app reads well in dark mode. What it did not reach is a specific class of
+surface: **the ones Bootstrap owns and does not retheme**, plus a handful of
+inline literals in templates that no stylesheet can reach. Four were reported
+from real use within a day of the merge:
+
+| Reported | Measured, in the browser, dark theme |
+|---|---|
+| resource-details month table has an invisible chevron | `.table-primary` row paints `#cfe2ff`; the chevron is `.text-muted` = `rgba(222,226,230,.75)` → **1.01:1** |
+| project tree's outermost node is too bright | `<li style="background: #fff3cd">` under `--text-primary` (#e9ecef) → light-on-light |
+| the 3 tabs on `/admin/project/<code>/edit` are bright | `.tab-content.bg-white` = `#fff` with `color: rgb(233,236,239)` → **white on white** |
+| `/admin/resources` innermost rows are bright | `.table-secondary` cells paint `#e2e3e5`; `.text-muted` cells on them → ~1.1:1. Nested `table.bg-white` → white on white |
+| `/allocations/projects` "Total" row shows up black | `<tfoot class="table-secondary">` forces `--bs-table-color: #000` over a `--surface-secondary` (#2a3745) cell → **black on slate** |
+
+They are five symptoms of **three** mechanisms, all of them systemic:
+
+1. **Bootstrap contextual `.table-*` classes.** `.table-primary` /
+   `.table-secondary` / `.table-info` / `.table-warning` hardcode
+   `--bs-table-bg` to a light tint *and* `--bs-table-color: #000`, and
+   Bootstrap's `[data-bs-theme=dark]` block redefines none of them. This is the
+   same defect `.table-subtle` was created for (dashboard.css:958) — that fix
+   covered `.table-light` only, and the other five variants were left. **24
+   occurrences in 11 templates.** Note both halves bite independently: where a
+   SAM rule already supplies a dark background, the `#000` *colour* half
+   survives on its own, which is the `/allocations/projects` Total row.
+2. **Theme-blind utilities**: `bg-white` (**4 sites**). `.bg-light` and
+   `.bg-dark` are already absent; `bg-body-*` is themed and fine.
+3. **Inline `style=` literals in templates** — unreachable by any stylesheet.
+   **20 literals across 8 templates**, of which the tree highlight (`#fff3cd`,
+   5 sites) and the rolling-rate bar (6 literals) are the ones that actually
+   render wrong.
+
+Plus one straggler in CSS: `.date-group-header td { background-color: #f1f3f5 }`
+(dashboard.css:1017) — a light row background with no dark counterpart.
+
+**Out of scope, deliberately.** The 35 `text-dark` / 13 `text-white` hits the
+inventory turned up are *not* defects: they sit on saturated brand fills
+(`badge bg-warning text-dark`, `modal-header bg-primary text-white`), which is
+the `--text-on-brand` invariant PR 3 established. Spot-measured on
+`/user/resource-details`: the gold badge renders `rgb(255,218,106)` on
+`rgb(51,39,1)` in dark — already correct. Also out: Flask-Admin (documented out
+of scope in DARK_MODE.md), and the `rgba(0,0,0,…)` box-shadows, which the
+ratchet's own comment already judged theme-neutral.
+
+## The work
+
+### 1. Contextual table variants — one dark block, no template churn
+
+In `dashboard.css`, immediately after `.table-subtle`, add a dark-only override
+for the five remaining variants, mapping each onto Bootstrap's `-bg-subtle`
+palette (which *does* retheme — the same lever `status.css:17-44` already uses
+for the status badges), with the text colour on `--text-primary` exactly as
+`.table-subtle` chose:
+
+```css
+:root[data-bs-theme="dark"] .table-primary   { --bs-table-bg: var(--bs-primary-bg-subtle);   … }
+:root[data-bs-theme="dark"] .table-secondary { --bs-table-bg: var(--bs-secondary-bg-subtle); … }
+/* success / info / warning / danger likewise */
+```
+
+Each block mirrors `.table-subtle`'s full variable set — `--bs-table-color`,
+`--bs-table-border-color`, and the `striped` / `active` / `hover` pairs — because
+those all carry `#000` in the stock class and each will surface somewhere
+eventually.
+
+**Why override rather than migrate 24 templates to a SAM class**, which is what
+`.table-subtle` did: the tint is load-bearing here in a way it was not for
+`.table-light` on a `<thead>` — `project_directories_card.html` uses
+`table-warning` to mark an orphaned directory row *inside* a `table-secondary`
+table. Preserving the semantic name at the call site keeps that readable, and a
+dark-only rule leaves light mode byte-identical by construction. Deviation from
+the `.table-subtle` precedent, so it gets a comment saying this.
+
+### 2. `bg-white` → `bg-body` (4 sites)
+
+`--bs-body-bg` is bridged to `--surface-card`, which is `#ffffff` in light — so
+this is byte-identical in light mode and follows the card surface in dark.
+Sites: `admin/edit_project.html:80`, `admin/fragments/facility_card.html:95`,
+`admin/fragments/resources_card.html:135`,
+`user/partials/_resource_details_macros.html:97`.
+
+### 3. Tree "current node" highlight (5 inline sites)
+
+Replace the inline `background:#fff3cd; border-left-color:#ffc107;` with one
+class defined in `dashboard.css`:
+
+```css
+.tree-node-current    { background: var(--bs-warning-bg-subtle);
+                        border-left-color: var(--bs-warning); font-weight: 700; }
+tr.tree-node-current  { --bs-table-bg: var(--bs-warning-bg-subtle);
+                        --bs-table-color: var(--text-primary); }
+```
+
+`--bs-warning-bg-subtle` is `#fff3cd` in light (byte-identical) and `#332701` in
+dark. The `<tr>` variant sets `--bs-table-bg` rather than `background`, because
+Bootstrap paints each `<td>` opaquely over any row-level background — the trap
+already documented at `components.css:14`.
+
+Sites: `user/resource_details.html:376`, `user/resource_details_disk.html:19`
+and `:217`, `shared/project_tree.html:62` and `:198`.
+
+### 4. Rolling-rate bar + the small inline literals
+
+`user/fragments/rolling_rate_htmx.html`: track `#e9ecef` →
+`var(--surface-secondary)` (**exactly** `#e9ecef` in light); steady-state marker
+`#343a40` → `var(--text-primary)`; threshold label chip
+`rgba(255,255,255,0.82)` → `rgba(var(--surface-card-rgb), 0.82)`; axis labels
+`#6c757d` → `var(--text-secondary)`. The `#dc3545` threshold line stays — danger
+is meaning-bearing and invariant by the tier-1 rule.
+
+Then the remainder of the inline set: `#ccc` status dots (institutions_table,
+organization_card) → `var(--text-tertiary)`; `#dee2e6` / `#ced4da` row rules in
+`project_allocation_tree_htmx.html` → `var(--border-default)`; the
+`rgba(33,37,41,0.55)` "now" marker on the two progress bars →
+`rgba(var(--text-primary-rgb), 0.55)`.
+
+### 5. `.date-group-header` (dashboard.css:1017)
+
+`#f1f3f5` → `var(--surface-tertiary)` (`#f8f9fa` light — a declared 4-unit
+shift, the same kind `auth.css:105` documents).
+
+**This one moves a test gate**: `tests/unit/test_css_tokens.py`'s `ALLOWED`
+ratchet is an *equality* check, not a ceiling — removing a literal from
+`dashboard.css` without lowering `'dashboard.css': 19` to `18` fails the suite
+with "Fewer raw colours than the ratchet allows — good. Lower these in ALLOWED."
+
+## Regression coverage
+
+`e2e/test_dark_mode.py` samples 8 hand-picked selectors on 3 pages. Every defect
+above sat outside that sample — the lesson of Appendix E, again, at one more
+remove. Add a dark-only **leaf-text contrast sweep**: for each visible element
+that carries its own text, composite the ancestor backgrounds (the existing
+`_EFFECTIVE_COLOURS_JS` walk does exactly this) and fail below `MIN_CONTRAST`.
+
+- Dark only. Light mode is the identity here and a sweep over it just doubles
+  runtime.
+- Page list seeded with the surfaces above: `/admin/resources`,
+  `/allocations/projects`, plus the existing `PAGES`. Static routes only — the
+  `<projcode>` edit page can't be reached without assuming a projcode survives
+  the obfuscated snapshot.
+- Collapsed content has zero size and is skipped, so the sweep clicks the
+  page's `[data-bs-toggle="collapse"]` triggers first (bounded, and only those
+  whose target is a `.collapse` in the document) — the nested `/admin/resources`
+  tables are exactly the case that only exists after expansion.
+- Any legitimate exception gets a named allowlist entry with a reason, on the
+  `ALLOWED_CONSOLE` model — which is deliberately empty, and should stay that
+  way here too.
+
+## Verification
+
+1. `docker compose up webdev --watch`, then walk the five reported surfaces in
+   both themes at <http://127.0.0.1:5050>: `/user/resource-details/NCIS0001?resource=Casper`
+   (month table + tree), `/admin/project/NCIS0001/edit` (3 tabs),
+   `/admin/resources` (expand a Resource, a Contract, a Facility),
+   `/allocations/projects` (Total row).
+2. Measure, don't eyeball — re-run the same computed-contrast probe used to
+   produce the table at the top of this doc; every sampled label ≥ 3:1.
+3. `make e2e` (needs `make docker-up`) — the new sweep must come up clean with
+   an empty allowlist.
+4. `pytest tests/unit/test_css_tokens.py tests/unit/test_template_csp_lint.py`
+   — the ratchet at 18, CSP lint untouched (it permits `style=` attributes; only
+   `<style>` blocks, `on*=` and `hx-on:` are violations).
+5. Full suite. No chart fingerprint delta is expected: nothing here touches
+   `--surface-card` or `charts/theme.py`, and a delta would mean one of them
+   moved.
+
+## As built
+
+Everything above shipped as planned. What the plan did not predict is what the
+sweep found once it existed — it went red on **nine** surfaces the five reports
+had not mentioned, on the first run:
+
+| Found | Was | Now |
+|---|---|---|
+| `/status/derecho` outage banner, 4 elements | `.alert-warning` set `color: var(--text-heading)` — space-blue in light, **near-white on `--ncar-orange` (1.77:1) in dark** | a new invariant token, `--text-on-brand-dark` |
+| the same banner's `.text-muted` line | `rgba(222,226,230,.75)` on orange = **1.39:1** | `.alert .text-muted { color: inherit !important }` — Bootstrap's colour utilities carry `!important`, so the first pass at this silently did nothing |
+| `/user/info`, `/user/accounts` badges | `.text-secondary` — Bootstrap does NOT retheme `--bs-secondary-rgb`, unlike `.text-body-secondary` | swapped at 9 sites |
+| progress-bar `%` labels, 4 | white on `--success-color` **2.54:1**, on `--warning-color` **2.15:1** | `--text-on-brand-dark`. Theme-invariant — equally unreadable in light, so this one is a **declared legibility change in both themes**, not a dark repair |
+
+`--text-on-brand-dark` is the plan's one architectural addition: `--text-on-brand`
+is white, for saturated brand fills, and there was no name for the opposite
+case — dark ink on a brand fill that is itself light (gold, orange). It is
+invariant for the same reason its sibling is, valued at `--ncar-space-blue`,
+which is what `--text-heading` already resolved to in light, so every surface
+adopting it is byte-identical there. `INVARIANT_TOKENS` in
+`tests/unit/test_css_tokens.py` now names the set once, because two tests
+needed the same list and a token in one but not the other is exactly the
+half-wired state they exist to catch.
+
+The `.tree-node-current` rule also needed a second selector: `.tree-list li`
+(0,1,1) outranks a bare class, so the first draft rendered the current node
+identical to every other node — caught by measuring, not by looking.
+
+## Light mode must not move
+
+Every substitution above is either byte-identical in light (`--surface-card`
+`#ffffff`, `--surface-secondary` `#e9ecef`, `--bs-warning-bg-subtle` `#fff3cd`)
+or a declared small shift, listed here: `#f1f3f5`→`#f8f9fa`, `#ccc`→`#97999b`,
+`#dee2e6`/`#ced4da`→`#E2E8F0`, `#343a40`→`#323133`, `#6c757d`→`#718096`,
+`.text-secondary`→`.text-body-secondary` (#6c757d → rgba(50,49,51,.75) over
+white). Verified after the fact by reading the computed values back in the
+browser: the month row is still `rgb(207,226,255)`, the `table-info` row
+`rgb(207,244,252)`, the tree node `rgb(255,243,205)` with a `rgb(255,193,7)`
+left border at weight 700 — all byte-identical to before.
+
+The **one** intended visible change in light mode is the progress-bar `%`
+label, white → space-blue on the green and amber fills. It is in the As-built
+table above and nowhere else.

--- a/e2e/test_dark_mode.py
+++ b/e2e/test_dark_mode.py
@@ -301,6 +301,165 @@ def test_chart_text_is_legible(page, base_url, page_url, theme):
         f'are below {MIN_CONTRAST}:1:\n' + '\n'.join(failures))
 
 
+#: The dark-only sweep: every element that carries its own text, measured
+#: against the surface actually behind it. `SAMPLES` above is eight hand-picked
+#: selectors, and every defect this sweep was written for sat outside all eight
+#: — a `.table-primary` month row, `.table-secondary` group headers three
+#: tables deep, a `bg-white` tab panel, an inline `#fff3cd` on a tree node.
+#: Picking selectors only finds what you already suspect.
+#:
+#: Leaf text only (no element child carrying text of its own), so a card is
+#: measured at its labels rather than reported once per ancestor for the same
+#: glyphs. Backgrounds composite up the ancestor chain exactly as
+#: `_EFFECTIVE_COLOURS_JS` does — an element with `background: transparent`
+#: inside a card is read against the card.
+#:
+#: Ancestor `opacity` is deliberately NOT folded in: a faded row is a design
+#: choice, and applying it would make every `.opacity-50` inactive row a
+#: failure. This measures the colours, not the fade.
+_DARK_SWEEP_JS = """
+() => {
+  const parse = (s) => {
+    const m = (s || '').match(/rgba?\\(([^)]+)\\)/);
+    if (!m) return null;
+    const p = m[1].split(',').map(x => parseFloat(x.trim()));
+    return { r: p[0], g: p[1], b: p[2], a: p.length > 3 ? p[3] : 1 };
+  };
+  const over = (top, bottom) => ({
+    r: top.r * top.a + bottom.r * (1 - top.a),
+    g: top.g * top.a + bottom.g * (1 - top.a),
+    b: top.b * top.a + bottom.b * (1 - top.a),
+    a: 1,
+  });
+  const bgOf = (el) => {
+    const stack = [];
+    for (let n = el; n; n = n.parentElement) {
+      const c = parse(getComputedStyle(n).backgroundColor);
+      if (c && c.a > 0) { stack.push(c); if (c.a === 1) break; }
+    }
+    let bg = { r: 255, g: 255, b: 255, a: 1 };      // the canvas
+    for (let i = stack.length - 1; i >= 0; i--) bg = over(stack[i], bg);
+    return bg;
+  };
+  const ownText = (el) => {
+    let s = '';
+    for (const node of el.childNodes) {
+      if (node.nodeType === 3) s += node.textContent;
+    }
+    return s.trim();
+  };
+
+  const out = [];
+  for (const el of document.querySelectorAll('body *')) {
+    const text = ownText(el);
+    if (!text) continue;
+    const box = el.getBoundingClientRect();
+    if (!box.width || !box.height) continue;          // collapsed / hidden
+    const cs = getComputedStyle(el);
+    if (cs.visibility === 'hidden' || parseFloat(cs.opacity) === 0) continue;
+    const fg = parse(cs.color);
+    if (!fg) continue;
+    const bg = bgOf(el);
+    out.push({
+      fg: [over(fg, bg).r, over(fg, bg).g, over(fg, bg).b],
+      bg: [bg.r, bg.g, bg.b],
+      text: text.slice(0, 40),
+      where: el.tagName.toLowerCase() +
+             (el.className && typeof el.className === 'string'
+                ? '.' + el.className.trim().split(/\\s+/).slice(0, 3).join('.')
+                : ''),
+    });
+  }
+  return out;
+}
+"""
+
+#: Everything on the page that opens without navigating. The nested
+#: `/admin/resources` tables — three of the five reported defects — do not
+#: exist in the DOM until their row is expanded, so a sweep that only measured
+#: what loads would have called that page clean. Restricted to targets that
+#: resolve to a `.collapse` in this document, so the nav accordions and any
+#: htmx-driven toggle are left alone.
+_EXPAND_ALL_JS = """
+() => {
+  let opened = 0;
+  for (const el of document.querySelectorAll('[data-bs-toggle="collapse"]')) {
+    const sel = el.getAttribute('data-bs-target') ||
+                el.getAttribute('href') || '';
+    if (!sel.startsWith('#')) continue;
+    const target = document.querySelector(sel);
+    if (!target || !target.classList.contains('collapse')) continue;
+    if (target.classList.contains('show')) continue;
+    if (/mobileNav/.test(sel)) continue;
+    el.click();
+    opened += 1;
+  }
+  return opened;
+}
+"""
+
+#: Pages for the sweep. `PAGES` covers the sampled-surface families; these add
+#: the three that carried reported defects — the nested admin tables, the
+#: allocations facility table with its `<tfoot>` total, and the resource
+#: details page with its month table and project tree. Static routes only: a
+#: `<projcode>` URL would have to assume a project survives the obfuscated
+#: snapshot.
+SWEEP_PAGES = PAGES + [
+    '/admin/resources',
+    '/allocations/projects',
+    '/user/accounts',
+]
+
+
+def test_no_unreadable_text_in_dark_mode(page, base_url):
+    """Sweep every text-bearing element on a page, not a list of selectors.
+
+    Dark only. Light is the theme every one of these surfaces was designed in
+    and the one the token layer leaves byte-identical; sweeping it doubles the
+    runtime to re-assert the status quo.
+
+    The failure mode this catches is the one that keeps recurring: a surface
+    Bootstrap owns and does not retheme (`.table-*` contextual classes,
+    `.bg-white`), or a colour literal inlined into a template where no
+    stylesheet can reach it. Both render light-on-light and both are invisible
+    in a diff.
+
+    There is no allowlist on purpose. An exception here would mean a surface
+    that is unreadable and approved, which is not a thing — the same reasoning
+    that keeps `ALLOWED_CONSOLE` in conftest.py empty.
+    """
+    set_theme(page, base_url, 'dark')
+
+    failures = []
+    for page_url in SWEEP_PAGES:
+        visit(page, page_url)
+        assert_theme_applied(page, 'dark')
+        page.evaluate(_EXPAND_ALL_JS)
+        page.wait_for_timeout(400)          # Bootstrap's collapse transition
+
+        found = page.evaluate(_DARK_SWEEP_JS)
+        assert found, f'{page_url} rendered no measurable text at all'
+
+        seen = set()
+        for item in found:
+            ratio = contrast_ratio(item['fg'], item['bg'])
+            if ratio >= MIN_CONTRAST:
+                continue
+            key = (item['where'], tuple(round(v) for v in item['bg']))
+            if key in seen:                 # one row of a table stands for all
+                continue
+            seen.add(key)
+            failures.append(
+                f'  {page_url}  {ratio:.2f}:1  {item["where"]}\n'
+                f'      fg=rgb{tuple(round(v) for v in item["fg"])} '
+                f'bg=rgb{tuple(round(v) for v in item["bg"])} '
+                f'text={item["text"]!r}')
+
+    assert not failures, (
+        f'{len(failures)} surface(s) below {MIN_CONTRAST}:1 in dark mode:\n'
+        + '\n'.join(failures))
+
+
 def test_clicking_the_toggle_persists_the_choice(page, base_url):
     """The real control, end to end: click -> cookie -> reload -> next page.
 

--- a/src/webapp/static/css/dashboard.css
+++ b/src/webapp/static/css/dashboard.css
@@ -877,6 +877,17 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     transition: width var(--transition-base);
 }
 
+/* The percentage label sits ON the fill, and two of the four fills are light:
+ * white on --success-color measured 2.54:1 and on --warning-color 2.15:1.
+ * Theme-invariant (the fills are), so this was equally unreadable in light and
+ * is a declared legibility fix in both rather than a dark-mode repair — the
+ * browser sweep does not distinguish, and neither does a reader. Scoped to
+ * `.progress-bar` so the same utility classes keep white ink on badges. */
+.progress-bar.bg-success,
+.progress-bar.bg-warning {
+    color: var(--text-on-brand-dark);
+}
+
 /* Progress bar color variants */
 .bg-success {
     background-color: var(--success-color) !important;
@@ -983,6 +994,91 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     border-color: var(--bs-table-border-color);
 }
 
+/* The OTHER five contextual table variants, in dark mode only.
+ *
+ * `.table-subtle` above replaced `.table-light` and stopped there; the same
+ * defect applies verbatim to `.table-primary` / `-secondary` / `-info` /
+ * `-warning` / `-danger` / `-success`, which are used on 24 rows across 11
+ * templates. Both halves of the stock class bite, and they bite independently:
+ *
+ *   --bs-table-bg    a light tint. The `/admin/resources` nested rows
+ *                    (#e2e3e5) and the resource-details month row (#cfe2ff),
+ *                    which put a `.text-muted` chevron at 1.01:1.
+ *   --bs-table-color #000. Survives on its own wherever a SAM rule already
+ *                    supplies a dark background — that is the black "Total"
+ *                    row in the `/allocations/projects` facility table, whose
+ *                    <th> cells were already painting --surface-secondary.
+ *
+ * Deviation from the `.table-subtle` precedent, which migrated its call sites
+ * onto a SAM class: these keep the stock class name at the call site because
+ * the tint is load-bearing there in a way `.table-light` on a <thead> never
+ * was — project_directories_card.html marks an orphaned row `table-warning`
+ * *inside* a `table-secondary` table, and that reads at a glance. Overriding
+ * in a dark-only block also leaves light mode byte-identical by construction.
+ *
+ * `-secondary` is the group-header / subtotal row, so it takes SAM's recess
+ * (--surface-secondary, LIGHTER than the card — the dark ladder inverts)
+ * rather than Bootstrap's --bs-secondary-bg-subtle, which is #161719 and would
+ * make a header darker than the surface it sits on. The five that carry a hue
+ * take Bootstrap's `-bg-subtle` palette, which does retheme itself — the same
+ * lever status.css:17 uses for the status badges — because for those the hue
+ * IS the message. All six take --text-primary rather than the stock #000 or
+ * the `-text-emphasis` tint, matching .table-subtle and the app's body copy. */
+:root[data-bs-theme="dark"] .table-secondary {
+    --bs-table-bg: var(--surface-secondary);
+    --bs-table-striped-bg: var(--surface-raised);
+    --bs-table-active-bg: var(--surface-raised);
+    --bs-table-hover-bg: var(--surface-raised);
+}
+
+:root[data-bs-theme="dark"] .table-primary {
+    --bs-table-bg: var(--bs-primary-bg-subtle);
+    --bs-table-striped-bg: var(--bs-primary-bg-subtle);
+    --bs-table-active-bg: var(--bs-primary-border-subtle);
+    --bs-table-hover-bg: var(--bs-primary-border-subtle);
+}
+
+:root[data-bs-theme="dark"] .table-info {
+    --bs-table-bg: var(--bs-info-bg-subtle);
+    --bs-table-striped-bg: var(--bs-info-bg-subtle);
+    --bs-table-active-bg: var(--bs-info-border-subtle);
+    --bs-table-hover-bg: var(--bs-info-border-subtle);
+}
+
+:root[data-bs-theme="dark"] .table-warning {
+    --bs-table-bg: var(--bs-warning-bg-subtle);
+    --bs-table-striped-bg: var(--bs-warning-bg-subtle);
+    --bs-table-active-bg: var(--bs-warning-border-subtle);
+    --bs-table-hover-bg: var(--bs-warning-border-subtle);
+}
+
+:root[data-bs-theme="dark"] .table-success {
+    --bs-table-bg: var(--bs-success-bg-subtle);
+    --bs-table-striped-bg: var(--bs-success-bg-subtle);
+    --bs-table-active-bg: var(--bs-success-border-subtle);
+    --bs-table-hover-bg: var(--bs-success-border-subtle);
+}
+
+:root[data-bs-theme="dark"] .table-danger {
+    --bs-table-bg: var(--bs-danger-bg-subtle);
+    --bs-table-striped-bg: var(--bs-danger-bg-subtle);
+    --bs-table-active-bg: var(--bs-danger-border-subtle);
+    --bs-table-hover-bg: var(--bs-danger-border-subtle);
+}
+
+/* The colour half, shared. Separate from the per-variant blocks above so the
+ * one thing every variant gets wrong the same way is stated once. */
+:root[data-bs-theme="dark"] :is(.table-primary, .table-secondary, .table-success,
+                                .table-info, .table-warning, .table-danger) {
+    --bs-table-color: var(--text-primary);
+    --bs-table-striped-color: var(--text-primary);
+    --bs-table-active-color: var(--text-primary);
+    --bs-table-hover-color: var(--text-primary);
+    --bs-table-border-color: var(--border-default);
+    color: var(--bs-table-color);
+    border-color: var(--bs-table-border-color);
+}
+
 .table-hover tbody tr:hover {
     background-color: rgba(var(--ncar-teal-rgb), 0.05);
 }
@@ -1014,7 +1110,7 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
 
 /* Date-bounds group header row in resources table */
 .date-group-header td {
-    background-color: #f1f3f5;
+    background-color: var(--surface-tertiary);
     border-top: 2px solid var(--border-default) !important;
 }
 
@@ -1057,9 +1153,34 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
     color: var(--text-on-brand);
 }
 
+/* The one alert whose fill is LIGHT, so it is the one that cannot take
+ * `--text-on-brand`. It used `--text-heading`, which is space-blue in light and
+ * near-white in dark — 1.77:1 on orange, found by the browser sweep on the
+ * /status outage banner. `--text-on-brand-dark` IS that space-blue, pinned
+ * invariant: light mode does not move, dark stops inheriting a flipped token
+ * onto a fill that never flips. */
 .alert-warning {
     background-color: var(--ncar-orange);
-    color: var(--text-heading);
+    color: var(--text-on-brand-dark);
+}
+
+.alert-warning a,
+.alert-warning button {
+    color: var(--text-on-brand-dark);
+}
+
+/* Descendants that set their own colour have the same problem one level down:
+ * `.text-muted` inside the outage banner resolved to rgba(222,226,230,.75),
+ * i.e. 1.39:1 on orange. Inheriting the alert's ink and de-emphasising with
+ * opacity keeps the "muted" intent without reintroducing a theme-dependent
+ * colour on an invariant fill.
+ *
+ * `!important` because Bootstrap's colour utilities carry it — a plain
+ * declaration here loses to `.text-muted` regardless of specificity, which is
+ * how the first pass at this silently did nothing. */
+.alert .text-muted {
+    color: inherit !important;
+    opacity: 0.8;
 }
 
 .alert-danger {
@@ -1715,6 +1836,51 @@ h6, .h6 { font-size: 0.875rem; line-height: 1.35;     font-weight: var(--font-we
 .tree-list li strong {
     color: var(--text-title);
     font-weight: 700;
+}
+
+/* "You are here" in a project tree — the node whose projcode is the current
+ * scope, and the row form of the same thing in the disk fileset table.
+ *
+ * Was five copies of an inline `background: #fff3cd; border-left-color:
+ * #ffc107` across resource_details.html, resource_details_disk.html (twice)
+ * and shared/project_tree.html (twice). An inline literal is the one surface
+ * a stylesheet cannot reach, so in dark mode the outermost node stayed a
+ * bright pastel with --text-primary (#e9ecef) written on it.
+ *
+ * --bs-warning-bg-subtle IS #fff3cd in light — byte-identical to what the
+ * inline style painted — and #332701 in dark. It is one of the few Bootstrap
+ * families that rethemes itself (see status.css:17). The left border keeps
+ * --bs-warning, which is #ffc107 in both themes: it is the same gold as the
+ * `text-warning` arrow icon the templates put next to it, and a marker on a
+ * tinted ground is meant to stay put.
+ *
+ * The <tr> form sets --bs-table-bg rather than `background`, because
+ * Bootstrap paints every <td> opaquely over any row-level background —
+ * the trap already documented at components.css:14. */
+/* `.tree-list li` (0,1,1) sets the node background, so the bare class would
+ * lose to it on specificity and the current node would be indistinguishable —
+ * which is exactly what the first draft of this shipped. The second selector
+ * carries the tree case; the first carries anything outside a `.tree-list`. */
+.tree-node-current,
+.tree-list li.tree-node-current {
+    background: var(--bs-warning-bg-subtle);
+    border-left-color: var(--bs-warning);
+    font-weight: 700;
+}
+
+tr.tree-node-current {
+    --bs-table-bg: var(--bs-warning-bg-subtle);
+    --bs-table-color: var(--text-primary);
+    color: var(--bs-table-color);
+}
+
+/* The other half of the same inline block: a node whose project is inactive.
+ * `#6c757d` -> --text-secondary (#718096 light) is a declared shift; the 0.6
+ * opacity is carried over exactly rather than rounded to Bootstrap's
+ * `.opacity-50`, which would have moved light mode for no reason. */
+.tree-node-inactive {
+    color: var(--text-secondary);
+    opacity: 0.6;
 }
 
 /* ============================================================================

--- a/src/webapp/static/css/variables.css
+++ b/src/webapp/static/css/variables.css
@@ -168,6 +168,17 @@
        "fixed" into a flipping token and breaking every button in light mode. */
     --text-on-brand:  #ffffff;
 
+    /* The same idea for the brand fills that are themselves LIGHT — gold,
+       orange, sky. `--text-on-brand` is white and white on `--ncar-orange` is
+       1.77:1, so those surfaces need the opposite ink, and it is invariant for
+       exactly the same reason: the fill does not move between themes, so the
+       ink must not either. Value is `--ncar-space-blue`, which is what
+       `--text-heading` already resolved to in light — so the surfaces adopting
+       this are byte-identical in light mode and only stop being near-white on
+       orange in dark. Found by the browser sweep on the /status outage
+       banner. */
+    --text-on-brand-dark: #011837;
+
     /* The surface equivalent, and invariant for the same reason: a white chip
        sitting ON a brand fill, not on a page. The one case today is the
        counter badge inside an inactive (NCAR-blue) nav-pill — the pill stays

--- a/src/webapp/templates/dashboards/admin/edit_project.html
+++ b/src/webapp/templates/dashboards/admin/edit_project.html
@@ -77,7 +77,7 @@
 </ul>
 
 <!-- Tab content -->
-<div class="tab-content border border-top-0 rounded-bottom p-3 bg-white" id="editProjectTabsContent">
+<div class="tab-content border border-top-0 rounded-bottom p-3 bg-body" id="editProjectTabsContent">
 
   <!-- ── Tab 1: Details ─────────────────────────────────────────────── -->
   <div class="tab-pane fade show active" id="tab-details" role="tabpanel">

--- a/src/webapp/templates/dashboards/admin/fragments/facility_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/facility_card.html
@@ -92,7 +92,7 @@
                 <tr class="table-secondary">
                     <td colspan="5" class="ps-5 pt-0 pb-2">
                         {% if visible_ats %}
-                        <table class="table table-sm table-bordered mb-0 bg-white" style="font-size: 0.875em;">
+                        <table class="table table-sm table-bordered mb-0 bg-body" style="font-size: 0.875em;">
                             <thead class="table-subtle">
                                 <tr>
                                     <th>Allocation Type</th>

--- a/src/webapp/templates/dashboards/admin/fragments/institutions_table.html
+++ b/src/webapp/templates/dashboards/admin/fragments/institutions_table.html
@@ -100,7 +100,7 @@
                     <i class="fas fa-chevron-right small text-muted me-1 inst-expand-icon"
                        style="transition: transform 0.2s;"></i>
                     {% else %}
-                    <i class="fas fa-circle small me-1" style="font-size:0.35em; color:#ccc; vertical-align:middle;"></i>
+                    <i class="fas fa-circle small me-1" style="font-size:0.35em; color:var(--text-tertiary); vertical-align:middle;"></i>
                     {% endif %}
                     {{ inst.name }}
                     {% if inst.acronym %}

--- a/src/webapp/templates/dashboards/admin/fragments/organization_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/organization_card.html
@@ -70,7 +70,7 @@
                                    data-action="org-toggle-children"
                                    data-org-id="{{ org.organization_id }}"></i>
                                 {% else %}
-                                <i class="fas fa-circle small me-1" style="font-size:0.35em; color:#ccc; vertical-align:middle;"></i>
+                                <i class="fas fa-circle small me-1" style="font-size:0.35em; color:var(--text-tertiary); vertical-align:middle;"></i>
                                 {% endif %}
                                 <span class="badge bg-body-tertiary text-body-emphasis border">{{ org.acronym }}</span>
                                 <span class="ms-1">{{ org.name }}</span>

--- a/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_allocation_tree_htmx.html
@@ -124,7 +124,7 @@
       {% if is_standalone %}
       {# ── Flat row — one per resource (no accordion, edit pencil at rest) ── #}
       <tbody>
-        <tr style="border-top: 1px solid #dee2e6;">
+        <tr style="border-top: 1px solid var(--border-default);">
 
           {# Col 1: resource name #}
           <td class="fw-semibold py-2" style="vertical-align:middle;">
@@ -182,7 +182,7 @@
       {# ── Resource header row ──────────────────────────────────────── #}
       <tbody>
         <tr class="table-secondary alloc-resource-header"
-            style="cursor:pointer; border-top: 2px solid #ced4da;"
+            style="cursor:pointer; border-top: 2px solid var(--border-default);"
             data-bs-toggle="collapse"
             data-bs-target="#{{ body_id }}"
             aria-expanded="false"

--- a/src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_linked_elements_htmx.html
@@ -223,7 +223,7 @@
   <div class="card">
     <div class="card-header d-flex justify-content-between align-items-center py-2">
       <span class="fw-semibold">
-        <i class="fas fa-folder me-1 text-secondary"></i> Directories
+        <i class="fas fa-folder me-1 text-body-secondary"></i> Directories
       </span>
       {% if can_edit_governance %}
       <button class="btn  btn-primary"

--- a/src/webapp/templates/dashboards/admin/fragments/resources_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/resources_card.html
@@ -132,7 +132,7 @@
                                             Fair-share by facility for {{ r.resource_name }}
                                             <span class="fst-italic">(overrides the facility default; unset to restore it)</span>
                                         </div>
-                                        <table class="table table-sm table-bordered mb-0 bg-white" style="font-size: 0.875em;">
+                                        <table class="table table-sm table-bordered mb-0 bg-body" style="font-size: 0.875em;">
                                             <thead class="table-subtle">
                                                 <tr>
                                                     <th>Facility</th>

--- a/src/webapp/templates/dashboards/allocations/partials/project_table.html
+++ b/src/webapp/templates/dashboards/allocations/partials/project_table.html
@@ -105,7 +105,7 @@
                                             show_label=True) }}
                         {% if bar_state == 'active' %}
                         <div class="position-absolute"
-                             style="left: {{ elapsed_pct }}%; top: -2px; bottom: -2px; width: 2px; background: rgba(33,37,41,0.55); z-index: 2; pointer-events: none;"
+                             style="left: {{ elapsed_pct }}%; top: -2px; bottom: -2px; width: 2px; background: rgba(var(--text-primary-rgb),0.55); z-index: 2; pointer-events: none;"
                              title="{{ elapsed_pct | fmt_pct }} of allocation period elapsed"></div>
                         {% endif %}
                     </div>

--- a/src/webapp/templates/dashboards/fragments/glossary.html
+++ b/src/webapp/templates/dashboards/fragments/glossary.html
@@ -202,7 +202,7 @@ an expired grant is still the project's funding provenance.
 <br>&bull; <span class="badge bg-secondary">expired</span> &mdash; the contract's
 <strong>end date has passed</strong>. Note this is also how a contract is
 deactivated: unlinking the last project sets its end date to that moment.
-<br>&bull; <span class="badge bg-body-tertiary text-secondary border">starts</span> &mdash;
+<br>&bull; <span class="badge bg-body-tertiary text-body-secondary border">starts</span> &mdash;
 the contract is <strong>future-dated</strong> and not yet in effect.
 {%- endmacro %}
 
@@ -211,7 +211,7 @@ the contract is <strong>future-dated</strong> and not yet in effect.
 Projects this user is linked to but that no longer count as active:
 <br>&bull; <span class="badge bg-secondary">solid</span> — the <strong>project
 itself is inactive</strong> (deactivated)
-<br>&bull; <span class="badge bg-body-tertiary text-secondary border">outline</span> —
+<br>&bull; <span class="badge bg-body-tertiary text-body-secondary border">outline</span> —
 the project is still active, but this user's
 <strong>membership has ended</strong>.
 {%- endmacro %}

--- a/src/webapp/templates/dashboards/shared/project_tree.html
+++ b/src/webapp/templates/dashboards/shared/project_tree.html
@@ -58,9 +58,9 @@
 {%- set is_active = node.active if node.active is defined else true -%}
 {%- if not active_only or is_active -%}
 {%- set is_current = (node.projcode == current_projcode) -%}
-<li style="
-    {%- if is_current %}background:#fff3cd;font-weight:bold;border-left-color:#ffc107;{% endif %}
-    {%- if not is_active %}color:#6c757d;opacity:0.6;{% endif %}
+<li class="
+    {%- if is_current %}tree-node-current {% endif %}
+    {%- if not is_active %}tree-node-inactive{% endif %}
 ">
   {#
     Single flex row: [name col, grows] | [allocation col, fixed width]
@@ -194,14 +194,14 @@
 {%- set is_current = (node.projcode == current_projcode) -%}
 {%- set res = alloc_by_projcode.get(node.projcode) if alloc_by_projcode is not none else none -%}
 
-<tr style="
-  {%- if is_current %}background:#fff3cd;font-weight:bold;{% endif %}
-  {%- if not is_active %}opacity:0.6;{% endif %}
+<tr class="
+  {%- if is_current %}tree-node-current {% endif %}
+  {%- if not is_active %}tree-node-inactive{% endif %}
 ">
   {# ── Col 1: identity (carries all indentation) ────────────────────── #}
   <td style="
       padding-left: calc({{ depth }} * 1.25rem + 0.5rem);
-      {%- if depth > 0 %} border-left: 2px solid #dee2e6;{% endif %}
+      {%- if depth > 0 %} border-left: 2px solid var(--border-default);{% endif %}
       white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
       vertical-align:middle;">
     {%- if is_current %}<i class="fas fa-arrow-right text-warning me-1"></i>{% endif -%}

--- a/src/webapp/templates/dashboards/user/fragments/rolling_rate_htmx.html
+++ b/src/webapp/templates/dashboards/user/fragments/rolling_rate_htmx.html
@@ -107,14 +107,14 @@
         <span class="fw-semibold text-nowrap" style="font-size:0.82rem;">{{ label }}</span>
 
         {# col 2: thermometer bar #}
-        <div class="position-relative" style="height:18px; background:#e9ecef; border-radius:4px; overflow:visible;">
+        <div class="position-relative" style="height:18px; background:var(--surface-secondary); border-radius:4px; overflow:visible;">
             <div style="position:absolute; left:0; top:0; height:100%; width:{{ center_pos }}%; background:rgba(13,202,240,0.08); border-radius:4px 0 0 4px;"></div>
             <div style="position:absolute; left:{{ center_pos }}%; top:0; height:100%; width:{{ center_pos }}%; background:rgba(253,126,20,0.08); border-radius:0 4px 4px 0;"></div>
             <div style="position:absolute; left:{{ fill_start }}%; top:0; height:100%; width:{{ fill_width_pct }}%; background:{{ fill_color }}; border-radius:4px; opacity:0.85;"></div>
-            <div style="position:absolute; left:{{ center_pos }}%; top:-2px; bottom:-2px; width:2px; background:#343a40; opacity:0.75;" title="100% = steady-state"></div>
+            <div style="position:absolute; left:{{ center_pos }}%; top:-2px; bottom:-2px; width:2px; background:var(--text-primary); opacity:0.75;" title="100% = steady-state"></div>
             {% if win.threshold_pct is not none and thresh_pos > center_pos %}
-            <div style="position:absolute; left:{{ thresh_pos }}%; top:-2px; bottom:-2px; width:0; border-left:2px dashed #dc3545; opacity:0.85;" title="{{ win.threshold_pct }}% limit"></div>
-            <span style="position:absolute; left:{{ thresh_pos }}%; top:50%; transform:translate(-50%,-50%); font-size:0.6rem; font-weight:600; color:#dc3545; background:rgba(255,255,255,0.82); padding:0 3px; border-radius:2px; white-space:nowrap; pointer-events:none; z-index:1;">{{ win.threshold_pct }}%</span>
+            <div style="position:absolute; left:{{ thresh_pos }}%; top:-2px; bottom:-2px; width:0; border-left:2px dashed var(--bs-danger); opacity:0.85;" title="{{ win.threshold_pct }}% limit"></div>
+            <span style="position:absolute; left:{{ thresh_pos }}%; top:50%; transform:translate(-50%,-50%); font-size:0.6rem; font-weight:600; color:var(--bs-danger); background:rgba(var(--surface-card-rgb),0.82); padding:0 3px; border-radius:2px; white-space:nowrap; pointer-events:none; z-index:1;">{{ win.threshold_pct }}%</span>
             {% endif %}
         </div>
 
@@ -168,7 +168,7 @@
 
         {# Scale row — col1: empty spacer, col2: tick labels, col3+col4: nothing #}
         <span></span>
-        <div class="position-relative" style="height:1.1rem; font-size:0.65rem; color:#6c757d; margin-top:1px;">
+        <div class="position-relative" style="height:1.1rem; font-size:0.65rem; color:var(--text-secondary); margin-top:1px;">
             <span style="position:absolute; left:0;">0%</span>
             <span style="position:absolute; left:{{ center_pos }}%; transform:translateX(-50%);">&#9650; 100%</span>
             <span style="position:absolute; right:0;">200%</span>

--- a/src/webapp/templates/dashboards/user/partials/_resource_details_macros.html
+++ b/src/webapp/templates/dashboards/user/partials/_resource_details_macros.html
@@ -94,7 +94,7 @@
              hx-target="#{{ jid }}-content"
              hx-trigger="shown.bs.collapse once"
              hx-swap="innerHTML">
-            <div class="p-2 bg-white border-start border-3" id="{{ jid }}-content">
+            <div class="p-2 bg-body border-start border-3" id="{{ jid }}-content">
                 <span class="text-muted small">
                     <i class="fas fa-spinner fa-spin me-1"></i> Loading jobs…
                 </span>

--- a/src/webapp/templates/dashboards/user/partials/project_card.html
+++ b/src/webapp/templates/dashboards/user/partials/project_card.html
@@ -58,7 +58,7 @@
       <div class="stat-value text-body-emphasis text-detail">
         {% for po in project.organizations_current_first() %}
             <div class="mb-1">
-                <span class="badge bg-body-tertiary {{ 'text-secondary' if not po.is_active else 'text-body-emphasis' }} border">{{ po.organization.acronym }}</span>
+                <span class="badge bg-body-tertiary {{ 'text-body-secondary' if not po.is_active else 'text-body-emphasis' }} border">{{ po.organization.acronym }}</span>
                 <span class="text-muted">{{ po.organization.name }}</span>
                 {%- if not po.is_active and po.end_date %}
                 <span class="text-muted small">— until {{ po.end_date | fmt_date }}</span>
@@ -107,7 +107,7 @@
                 <span class="text-muted">- {{ pc.contract.title }}</span>
                 {%- if not pc.contract.is_active %}
                   {%- if pc.contract.is_future %}
-                  <span class="badge bg-body-tertiary text-secondary border fw-normal ms-1">starts {{ pc.contract.start_date | fmt_date }}</span>
+                  <span class="badge bg-body-tertiary text-body-secondary border fw-normal ms-1">starts {{ pc.contract.start_date | fmt_date }}</span>
                   {%- else %}
                   <span class="badge bg-secondary fw-normal ms-1">expired {{ pc.contract.end_date | fmt_date }}</span>
                   {%- endif %}
@@ -216,7 +216,7 @@
                                                         show_label=True) }}
                                     {% if first.bar_state == 'active' and resource.resource_type in ['HPC', 'DAV'] %}
                                     <div class="position-absolute"
-                                         style="left: {{ first.elapsed_pct }}%; top: -2px; bottom: -2px; width: 2px; background: rgba(33,37,41,0.55); z-index: 2; pointer-events: none;"
+                                         style="left: {{ first.elapsed_pct }}%; top: -2px; bottom: -2px; width: 2px; background: rgba(var(--text-primary-rgb),0.55); z-index: 2; pointer-events: none;"
                                          title="{{ first.elapsed_pct | fmt_pct }} of allocation period elapsed"></div>
                                     {% endif %}
                                 </div>

--- a/src/webapp/templates/dashboards/user/partials/user_card.html
+++ b/src/webapp/templates/dashboards/user/partials/user_card.html
@@ -131,7 +131,7 @@
                 <div class="stat-value text-body-emphasis text-detail">
                     {% for ui in former_insts %}
                     <div class="mb-1">
-                        <span class="badge bg-body-tertiary text-secondary border">{{ ui.institution.acronym or '—' }}</span>
+                        <span class="badge bg-body-tertiary text-body-secondary border">{{ ui.institution.acronym or '—' }}</span>
                         <span class="text-muted">{{ ui.institution.name }}</span>
                         <span class="text-muted small">
                             {%- if ui.is_future %} — starts {{ ui.start_date | fmt_date }}
@@ -172,7 +172,7 @@
                 <div class="stat-value text-body-emphasis text-detail">
                     {% for uo in former_orgs %}
                     <div class="mb-1">
-                        <span class="badge bg-body-tertiary text-secondary border">{{ uo.organization.acronym }}</span>
+                        <span class="badge bg-body-tertiary text-body-secondary border">{{ uo.organization.acronym }}</span>
                         <span class="text-muted">{{ uo.organization.name }}</span>
                         <span class="text-muted small">
                             {%- if uo.is_future %} — starts {{ uo.start_date | fmt_date }}
@@ -246,7 +246,7 @@
                     {% endfor %}
                     {% for project in former.ended %}
                     <a href="{{ url_for('admin_dashboard.projects', projcode=project.projcode) }}"
-                       class="badge bg-body-tertiary text-secondary border text-decoration-none me-1 mb-1">
+                       class="badge bg-body-tertiary text-body-secondary border text-decoration-none me-1 mb-1">
                         {{ project.projcode }}
                     </a>
                     {% endfor %}

--- a/src/webapp/templates/dashboards/user/resource_details.html
+++ b/src/webapp/templates/dashboards/user/resource_details.html
@@ -373,7 +373,7 @@
                            scope=node.projcode,
                            start_date=start_date, end_date=end_date,
                            usage_tab=usage_tab) %}
-<li style="{{ 'background: #fff3cd; border-left-color: #ffc107; font-weight: bold;' if is_selected else '' }}">
+<li{% if is_selected %} class="tree-node-current"{% endif %}>
     {% if is_clickable %}
     <a href="{{ node_url }}" data-tab-param-link
        class="d-flex align-items-center gap-2 text-decoration-none text-body">

--- a/src/webapp/templates/dashboards/user/resource_details_disk.html
+++ b/src/webapp/templates/dashboards/user/resource_details_disk.html
@@ -16,7 +16,7 @@
                            projcode=projcode, resource=resource_name,
                            scope=node.projcode,
                            start_date=start_date, end_date=end_date) %}
-<li style="{{ 'background: #fff3cd; border-left-color: #ffc107; font-weight: bold;' if is_selected else '' }}">
+<li{% if is_selected %} class="tree-node-current"{% endif %}>
     {% if is_clickable %}
     <a href="{{ node_url }}" class="d-flex align-items-center gap-2 text-decoration-none text-body">
     {% else %}
@@ -214,7 +214,7 @@
                                                   projcode=projcode, resource=resource_name,
                                                   scope=scope, fileset=d.name,
                                                   start_date=start_date, end_date=end_date) %}
-                        <tr style="cursor: pointer;{% if is_active %} background: #fff3cd;{% endif %}"
+                        <tr class="cursor-pointer{% if is_active %} tree-node-current{% endif %}"
                             data-action="navigate" data-href="{{ row_url }}">
                             {% if _multi_proj %}
                             <td><strong>{{ d.projcode }}</strong></td>

--- a/tests/unit/test_css_tokens.py
+++ b/tests/unit/test_css_tokens.py
@@ -93,13 +93,24 @@ NAMED_RE = re.compile(
 # panel's own `--bs-dropdown-*` values — all of which are either theme-neutral
 # or deliberately pinned to a brand surface. They are left as ordinary
 # pre-existing debt for a later pass rather than forced into tokens here.
+#: Tier-2 tokens that are deliberately theme-INVARIANT: they name the one case
+#: where the surface underneath does not move between themes, so the ink on it
+#: must not either. Named in one place because two tests need the same set —
+#: one asserts they are absent from the dark block, the other exempts them from
+#: the "every role token has a dark value" rule, and a token added to one but
+#: not the other is the half-wired state both exist to catch.
+INVARIANT_TOKENS = {'--text-on-brand', '--surface-on-brand',
+                    '--text-on-brand-dark'}
+
 ALLOWED = {
     # D2: -2 (--bs-card-bg, --bs-card-cap-bg)
     # D4: -49 (10 surfaces + 39 foregrounds -> --text-on-brand)
     # D6: -3  (greys and borders -> role tokens)
     # D8: -3  (the white pill fills in the .btn-group selector rows, found by
     #          the browser contrast assertions)
-    'dashboard.css':   19,
+    # stragglers: -1 (.date-group-header's #f1f3f5 -> --surface-tertiary; the
+    #          one light row background the dark theme could not reach)
+    'dashboard.css':   18,
 }
 
 
@@ -290,12 +301,17 @@ def test_dark_block_redeclares_the_bootstrap_bridge():
 
 
 def test_invariant_tokens_are_not_flipped():
-    """`--text-on-brand` / `--surface-on-brand` must NOT appear in the dark
-    block. White on a saturated NCAR-blue button is correct in both themes;
-    "fixing" either into a theme-dependent value breaks every button and every
-    pill badge in one of the two."""
+    """The `-on-brand` tokens must NOT appear in the dark block.
+
+    White on a saturated NCAR-blue button is correct in both themes; "fixing"
+    either into a theme-dependent value breaks every button and every pill
+    badge in one of the two. `--text-on-brand-dark` is the same contract read
+    the other way — space-blue on a LIGHT brand fill (gold, orange) is correct
+    in both themes, and it exists because `--text-heading` was being used
+    there, which does flip and put near-white on orange at 1.77:1.
+    """
     dark = _dark_tokens()
-    flipped = sorted({'--text-on-brand', '--surface-on-brand'} & set(dark))
+    flipped = sorted(INVARIANT_TOKENS & set(dark))
     assert not flipped, (
         f'{flipped} redefined in the dark block, but they are invariant by '
         f'design — see their definitions in variables.css')
@@ -307,7 +323,7 @@ def test_every_role_token_has_a_dark_value():
     that catches a token added later and half-wired."""
     light = {n for n in _css_tokens()
              if n.startswith(('--surface-', '--text-', '--border-'))}
-    invariant = {'--text-on-brand', '--surface-on-brand'}
+    invariant = INVARIANT_TOKENS
     # `-rgb` companions are covered by their parents being covered.
     expected = {n for n in light if not n.endswith('-rgb')} - invariant
     dark = set(_dark_tokens())


### PR DESCRIPTION
Follow-up to #419. Five light-in-dark surfaces were reported from real use within a day of the merge; they turned out to be three systemic mechanisms, and a sweep written to catch them found nine more.

Every number below was measured in the browser, not eyeballed.

## What was reported, and what it actually was

| Reported | Measured (dark) | Mechanism |
|---|---|---|
| resource-details month table has an invisible chevron | `.table-primary` paints `#cfe2ff`; `.text-muted` chevron on it = **1.01:1** | contextual `.table-*` |
| project tree's outermost node is too bright | inline `background:#fff3cd` under `--text-primary` | inline literal |
| the 3 tabs on `/admin/project/<code>/edit` are bright | `.tab-content.bg-white` → **white on white** | theme-blind utility |
| `/admin/resources` innermost rows are bright | `.table-secondary` cells `#e2e3e5`; nested `table.bg-white` | both |
| `/allocations/projects` "Total" row shows up black | `<tfoot class="table-secondary">` forces `--bs-table-color:#000` over a `#2a3745` cell | contextual `.table-*` |

Bootstrap's contextual `.table-*` classes hardcode *both* a light `--bs-table-bg` and `--bs-table-color:#000`, and Bootstrap's dark block redefines neither — the same defect `.table-subtle` was created for, which covered `.table-light` and stopped there. Note the two halves bite independently: the black Total row is the *colour* half surviving on its own, on a row whose background a SAM rule had already darkened.

## What the sweep found that nobody reported

| Found | Now |
|---|---|
| `/status` outage banner, 5 elements — `.alert-warning` set `color: var(--text-heading)`, near-white on `--ncar-orange` at **1.77:1**, and its `.text-muted` line at **1.39:1** | a new invariant token, `--text-on-brand-dark` |
| 9 `.text-secondary` badges at **2.98:1** — Bootstrap rethemes `--bs-secondary-color` but not `--bs-secondary-rgb`, so the utility that looks themed is the one that isn't | `.text-body-secondary` |
| progress-bar `%` labels — white on `--success-color` **2.54:1**, `--warning-color` **2.15:1** | same token. Those fills are invariant, so this is a **declared legibility change in both themes** |

`--text-on-brand-dark` is the one architectural addition: `--text-on-brand` is white, for saturated brand fills, and there was no name for the opposite case — dark ink on a brand fill that is itself light. Valued at `--ncar-space-blue`, which is what `--text-heading` already resolved to in light, so light mode does not move.

## The regression net

`SAMPLES` is eight hand-picked selectors on three pages, and **every defect here sat outside all eight**. The new `test_no_unreadable_text_in_dark_mode` walks every element carrying its own text, composites the ancestor backgrounds, and fails below 3:1. Dark only. Two details decide whether it finds anything:

- it **expands the page's collapsibles first** — three of the five reported defects live in `/admin/resources` nested tables that do not exist in the DOM until their row is opened;
- ancestor `opacity` is deliberately **not** folded in, or every `.opacity-50` inactive row becomes a failure.

No allowlist, on the `ALLOWED_CONSOLE` model.

## Light mode does not move

Fixes are dark-only blocks or byte-identical substitutions (`--surface-card` `#ffffff`, `--surface-secondary` `#e9ecef`, `--bs-warning-bg-subtle` `#fff3cd`). Verified by reading computed values back: month row still `rgb(207,226,255)`, `table-info` `rgb(207,244,252)`, tree node `rgb(255,243,205)` with a `rgb(255,193,7)` border at weight 700. Small declared shifts and the one intended visible change (progress-bar label ink) are listed in `docs/plans/DARK_MODE_STRAGGLERS.md`.

`ALLOWED['dashboard.css']` goes 19 → 18 — that ratchet is an equality check, so an unclaimed improvement fails it exactly like a regression.

## Test Results

- `pytest -c e2e/pytest.ini e2e/test_dark_mode.py` — **14 passed** against a live stack (including the new sweep)
- `pytest tests/unit/test_css_tokens.py tests/unit/test_template_csp_lint.py` — **11 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)