### PR TITLE
Fix the remaining collapse-trigger rows that toggle on button clicks (#356)

### DIFF
--- a/e2e/test_issue356_collapse_rows.py
+++ b/e2e/test_issue356_collapse_rows.py
@@ -1,0 +1,134 @@
+"""Issue #356: an action button must not toggle its collapse-trigger row.
+
+A group row written as ``<tr data-bs-toggle="collapse">`` that also contains an
+Edit/Delete button toggles the row when the button is clicked. Bootstrap
+registers its data-api handlers via ``EventHandler.on(document, ...)``, which
+passes the delegation flag as ``addEventListener``'s ``useCapture`` argument,
+so they run in the **capture** phase on ``document`` — before any listener on
+the button. Nothing the button does (``data-stop-propagation`` included) can
+prevent it; the fix is to move the toggle onto the non-action ``<td>``s.
+
+``tests/unit/test_collapse_trigger_rows.py`` proves the *markup* no longer puts
+a trigger on a row that holds a button. Only a browser proves the *behaviour*,
+and the issue's acceptance criterion is written as one::
+
+    { rowExpandedAfterEditClick: false, modalShown: true }
+
+Both halves matter, hence two tests per card: the pencil must not expand the
+row, **and** the ordinary cells must still expand it. A fix that killed the
+expander outright would satisfy the first on its own.
+
+Sibling of ``test_pr378_regressions.py`` — a named-issue behavioural module,
+as opposed to the console and legibility sweeps.
+"""
+import pytest
+
+from conftest import visit
+
+
+#: (label, page route, tab button selector or None, readiness selector,
+#:  data-bs-target prefix)
+#:
+#: The prefix is what ties a case to its card: each fragment names its collapse
+#: targets after the entity, so `#aoi-group-` can only match the Areas card.
+#: Resources is included as a non-regression case — it was fixed in #355 and
+#: its wallclock-exemption pencil lost a (dead) stop_propagation flag here.
+#:
+#: The readiness selector is load-bearing, not decoration. Several of these
+#: panes are htmx fragments — #institutions-pane fetches itself on
+#: `shown.bs.tab from:#institutions-tab once` — so clicking the tab and
+#: waiting for networkidle can return before the rows exist. Without an
+#: explicit wait the "no row-level trigger" assertion passes against an empty
+#: pane and the case skips, which is a silent pass on the exact bug this file
+#: is here to catch. Observed for real: the institution-type case skipped
+#: against a container that definitely still had the bug.
+CARDS = [
+    ('facility', '/admin/facilities', None,
+     '#facilities-pane table', '#facility-panels-'),
+    ('institution-type', '/admin/organizations', '#institutions-tab',
+     '#institutions-pane table', '#inst-type-'),
+    ('aoi-group', '/admin/organizations', '#areas-tab',
+     '#areas-pane table', '#aoi-group-'),
+    ('contract-source', '/admin/contracts', None,
+     '#contractsTable', '#contract-source-'),
+    ('resource-type', '/admin/resources', None,
+     '#resources-pane table', '#res-type-'),
+]
+
+CASE_IDS = [case[0] for case in CARDS]
+
+
+def _first_trigger_cell(page, route, tab, ready, prefix):
+    """Open the card (and its tab) and return a visible trigger cell.
+
+    Skips only when the snapshot genuinely has no such row — a dataset gap is
+    not a regression. Failure to *render the pane at all* is a different thing
+    and fails loudly, so a missing fragment can never masquerade as a pass.
+
+    Asserts the trigger is a ``<td>``: if it is still on the ``<tr>`` the bug
+    is present, and saying so here is far clearer than the downstream
+    assertion failing for a reason the message does not explain.
+    """
+    visit(page, route)
+
+    if tab:
+        page.click(tab)
+
+    try:
+        page.wait_for_selector(ready, state='visible', timeout=15_000)
+    except Exception:
+        raise AssertionError(
+            f'{prefix}: {ready!r} never rendered on {route}. The pane did not '
+            f'load, so this case would otherwise skip and report a pass '
+            f'without having tested anything.'
+        ) from None
+    page.wait_for_load_state('networkidle')
+
+    row_level = page.locator(f'tr[data-bs-toggle="collapse"][data-bs-target^="{prefix}"]')
+    assert row_level.count() == 0, (
+        f'{prefix}: the collapse trigger is still on the <tr>, so its action '
+        f'buttons will toggle the row (issue #356). Move it onto the '
+        f'non-action <td>s with the collapse_toggle macro.'
+    )
+
+    cell = page.locator(
+        f'td[data-bs-toggle="collapse"][data-bs-target^="{prefix}"]:visible').first
+    try:
+        cell.wait_for(state='visible', timeout=10_000)
+    except Exception:
+        pytest.skip(f'no {prefix} group row rendered for this user/dataset')
+    return cell
+
+
+@pytest.mark.parametrize('label,route,tab,ready,prefix', CARDS, ids=CASE_IDS)
+def test_action_button_does_not_toggle_the_row(page, label, route, tab, ready, prefix):
+    """The #356 assertion: modal opens, row stays put."""
+    cell = _first_trigger_cell(page, route, tab, ready, prefix)
+    target = cell.get_attribute('data-bs-target')
+
+    assert page.locator(f'{target}.show').count() == 0, (
+        f'{label}: {target} is already expanded before the test acts')
+
+    row = cell.locator('xpath=ancestor::tr[1]')
+    pencil = row.locator('button[data-bs-toggle="modal"]:visible').first
+    if pencil.count() == 0:
+        pytest.skip(f'{label}: no edit button on this row for this user')
+
+    pencil.click()
+    page.wait_for_selector('.modal.show', timeout=10_000)
+
+    assert page.locator(f'{target}.show').count() == 0, (
+        f'{label}: clicking the edit button also expanded {target}. The '
+        f'collapse trigger is reaching the button — see issue #356 and '
+        f'templates/dashboards/fragments/collapse.html.'
+    )
+
+
+@pytest.mark.parametrize('label,route,tab,ready,prefix', CARDS, ids=CASE_IDS)
+def test_the_cell_still_expands_the_row(page, label, route, tab, ready, prefix):
+    """The over-correction guard: the group row must remain expandable."""
+    cell = _first_trigger_cell(page, route, tab, ready, prefix)
+    target = cell.get_attribute('data-bs-target')
+
+    cell.click()
+    page.locator(f'{target}.show').wait_for(state='visible', timeout=10_000)

--- a/src/webapp/templates/dashboards/admin/fragments/contracts_table_htmx.html
+++ b/src/webapp/templates/dashboards/admin/fragments/contracts_table_htmx.html
@@ -1,5 +1,6 @@
 {% from 'dashboards/fragments/action_buttons.html' import edit_modal_button, delete_row_button with context %}
 {% from 'dashboards/fragments/contract_bits.html' import contract_user_link, nsf_program_link with context %}
+{% from 'dashboards/fragments/collapse.html' import collapse_toggle %}
 {#
   htmx: All Contracts table — grouped by funding source.
 
@@ -7,7 +8,7 @@
   subject of this page, and burying their only table inside a tab on a
   different page made it hard to find.
 
-  Two-level table: a source row per contract_source acts as a Bootstrap
+  Two-level table: the spanning cell of a source row acts as a Bootstrap
   collapse trigger, its contracts are a collapsed <tbody> beneath it. The
   grouping is kept from the original — 2,225 contracts across a handful of
   sources reads far better grouped than flat.
@@ -47,15 +48,17 @@
                    Most sources are empty under the active-only default (18 of
                    24 on dev), and giving those a chevron and a pointer made
                    three quarters of the table look clickable and do nothing.
-                   They stay listed — they are still editable rows. #}
+                   They stay listed — they are still editable rows.
+
+                   The trigger goes on the spanning cell, never the <tr>: a
+                   row-level toggle also fires when Edit/Delete are clicked,
+                   and the button cannot stop it (Bootstrap's data-api runs in
+                   the capture phase). Precomputed because the trigger is
+                   conditional. See dashboards/fragments/collapse.html. #}
+                {% set cs_attrs  = collapse_toggle('contract-source-' ~ cs.contract_source_id) if cs_contracts else '' %}
+                {% set cs_cursor = ' cursor-pointer' if cs_contracts else '' %}
                 <tbody>
-                    <tr class="table-subtle fw-semibold{% if not cs.active %} opacity-50{% endif %}
-                               {%- if cs_contracts %} cursor-pointer{% endif %}"
-                        {% if cs_contracts %}
-                        data-bs-toggle="collapse"
-                        data-bs-target="#contract-source-{{ cs.contract_source_id }}"
-                        aria-expanded="false"
-                        {% endif %}>
+                    <tr class="table-subtle fw-semibold{% if not cs.active %} opacity-50{% endif %}">
                         {# One spanning cell rather than name + count + five
                            empty <td>s. A source row is a group header, not a
                            record: it has nothing to put under PI/Monitor/
@@ -65,7 +68,7 @@
                            wrapped onto three lines and undid the row-height
                            fix, while text-nowrap instead made column 1 eat a
                            third of the table and crush Title. #}
-                        <td colspan="7">
+                        <td colspan="7" class="{{ cs_cursor }}" {{ cs_attrs }}>
                             {% if cs_contracts %}
                             <i class="fas fa-chevron-right small text-muted me-1 contract-collapse-icon"
                                style="transition: transform 0.2s;"></i>
@@ -90,13 +93,11 @@
                                 modal_id='editContractSourceModal',
                                 target_id='editContractSourceFormContainer',
                                 title='Edit source',
-                                stop_propagation=True,
                                 permission=Permission.EDIT_CONTRACTS) }}
                             {{ delete_row_button(
                                 url_for('admin_dashboard.htmx_contract_source_delete', source_id=cs.contract_source_id),
                                 confirm="Deactivate source '" ~ cs.contract_source ~ "'?",
                                 title='Deactivate contract source',
-                                stop_propagation=True,
                                 permission=Permission.DELETE_CONTRACTS) }}
                         </td>
                     </tr>

--- a/src/webapp/templates/dashboards/admin/fragments/disk_root_directories_section.html
+++ b/src/webapp/templates/dashboards/admin/fragments/disk_root_directories_section.html
@@ -108,7 +108,6 @@
                         modal_id='editDiskRootModal',
                         target_id='editDiskRootFormContainer',
                         title='Edit root directory',
-                        stop_propagation=True,
                         permission=Permission.EDIT_RESOURCES) }}
                 </td>
             </tr>

--- a/src/webapp/templates/dashboards/admin/fragments/facility_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/facility_card.html
@@ -1,4 +1,5 @@
 {% from 'dashboards/fragments/action_buttons.html' import edit_modal_button, delete_row_button with context %}
+{% from 'dashboards/fragments/collapse.html' import collapse_toggle %}
 {#
   Admin: Facility Card Body (lazy-loaded into the Facilities tab pane)
   Unified hierarchical view: Facilities (collapsible) → Panels → Allocation Types (nested table).
@@ -21,24 +22,26 @@
             {% for f in facilities %}
             {% set visible_panels = (f.panels | selectattr('active') if active_only else f.panels) | sort(attribute='panel_name') %}
 
-            {# ── Facility row (clickable collapse trigger) ── #}
+            {# ── Facility row (the four leading cells are collapse triggers) ──
+               The toggle sits on the cells, not the <tr>: a row-level trigger
+               would also fire when the Edit/Delete buttons are clicked, and
+               nothing on the button can stop it (Bootstrap's data-api runs in
+               the capture phase). See dashboards/fragments/collapse.html. #}
+            {% set f_toggle = 'facility-panels-' ~ f.facility_id %}
             <tbody>
-                <tr class="cursor-pointer table-subtle fw-semibold{% if not f.active %} opacity-50{% endif %}"
-                    data-bs-toggle="collapse"
-                    data-bs-target="#facility-panels-{{ f.facility_id }}"
-                    aria-expanded="false">
-                    <td>
+                <tr class="table-subtle fw-semibold{% if not f.active %} opacity-50{% endif %}">
+                    <td class="cursor-pointer" {{ collapse_toggle(f_toggle) }}>
                         <i class="fas fa-chevron-right small text-muted me-1 facility-collapse-icon"
                            style="transition: transform 0.2s;"></i>
                         {{ f.facility_name }}
                     </td>
-                    <td>
+                    <td class="cursor-pointer" {{ collapse_toggle(f_toggle) }}>
                         {% if f.code %}
                         <span class="badge bg-body-tertiary text-body-emphasis border">{{ f.code }}</span>
                         {% else %}—{% endif %}
                     </td>
-                    <td class="text-muted">{{ f.description or '—' }}</td>
-                    <td>
+                    <td class="text-muted cursor-pointer" {{ collapse_toggle(f_toggle) }}>{{ f.description or '—' }}</td>
+                    <td class="cursor-pointer" {{ collapse_toggle(f_toggle) }}>
                         {{ f.fair_share_percentage | fmt_pct(decimals=2) }}
                     </td>
                     <td class="text-end">
@@ -47,13 +50,11 @@
                             modal_id='editFacilityModal',
                             target_id='editFacilityFormContainer',
                             title='Edit facility',
-                            stop_propagation=True,
                             permission=Permission.EDIT_FACILITIES) }}
                         {{ delete_row_button(
                             url_for('admin_dashboard.htmx_facility_delete', facility_id=f.facility_id),
                             confirm="Deactivate facility '" ~ f.facility_name ~ "'?",
                             title='Deactivate facility',
-                            stop_propagation=True,
                             permission=Permission.DELETE_FACILITIES) }}
                     </td>
                 </tr>

--- a/src/webapp/templates/dashboards/admin/fragments/institutions_table.html
+++ b/src/webapp/templates/dashboards/admin/fragments/institutions_table.html
@@ -1,5 +1,6 @@
 {% from 'dashboards/fragments/action_buttons.html' import edit_modal_button with context %}
 {% from 'dashboards/admin/fragments/institution_filters.html' import institution_filters %}
+{% from 'dashboards/fragments/collapse.html' import collapse_toggle %}
 {#
   Admin Institutions table fragment (HTMX-swapped).
 
@@ -52,23 +53,24 @@
         </thead>
         {% if institution_types_grouped %}
         {% for it, insts in institution_types_grouped %}
-        {# ── Institution Type row (clickable trigger) ── #}
+        {# ── Institution Type row (every cell but Actions is the trigger) ──
+           The toggle cannot live on the <tr>: it would fire on the Edit button
+           too, and no button-side guard can prevent that (Bootstrap's data-api
+           runs in the capture phase). See dashboards/fragments/collapse.html. #}
+        {% set it_toggle = 'inst-type-' ~ it.institution_type_id %}
         <tbody>
-            <tr class="cursor-pointer table-subtle fw-semibold"
-                data-bs-toggle="collapse"
-                data-bs-target="#inst-type-{{ it.institution_type_id }}"
-                aria-expanded="false">
-                <td>
+            <tr class="table-subtle fw-semibold">
+                <td class="cursor-pointer" {{ collapse_toggle(it_toggle) }}>
                     <i class="fas fa-chevron-right small text-muted me-1 inst-type-collapse-icon"
                        style="transition: transform 0.2s;"></i>
                     {{ it.type }}
                 </td>
-                <td class="text-muted small">{{ insts|length }} institution{{ 's' if insts|length != 1 else '' }}</td>
-                <td></td>
-                <td></td>
+                <td class="text-muted small cursor-pointer" {{ collapse_toggle(it_toggle) }}>{{ insts|length }} institution{{ 's' if insts|length != 1 else '' }}</td>
+                <td class="cursor-pointer" {{ collapse_toggle(it_toggle) }}></td>
+                <td class="cursor-pointer" {{ collapse_toggle(it_toggle) }}></td>
                 {% if show_users_projects %}
-                <td></td>
-                <td></td>
+                <td class="cursor-pointer" {{ collapse_toggle(it_toggle) }}></td>
+                <td class="cursor-pointer" {{ collapse_toggle(it_toggle) }}></td>
                 {% endif %}
                 <td class="text-end">
                     {{ edit_modal_button(
@@ -76,7 +78,6 @@
                         modal_id='editInstitutionTypeModal',
                         target_id='editInstitutionTypeFormContainer',
                         title='Edit institution type',
-                        stop_propagation=True,
                         permission=Permission.EDIT_ORG_METADATA) }}
                 </td>
             </tr>

--- a/src/webapp/templates/dashboards/admin/fragments/organization_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/organization_card.html
@@ -1,5 +1,6 @@
 {% from 'dashboards/fragments/action_buttons.html' import edit_modal_button, delete_row_button with context %}
 {% from 'dashboards/fragments/contract_bits.html' import nsf_program_link with context %}
+{% from 'dashboards/fragments/collapse.html' import collapse_toggle %}
 {#
   Admin: Organization Card Body (lazy-loaded into the Organization collapsible section)
   Contains four tabs: Organizations, Institutions (types+institutions combined),
@@ -146,31 +147,31 @@
                     </thead>
                     {% if aoi_groups %}
                     {% for g in aoi_groups %}
-                    {# ── Group row (clickable trigger) ── #}
+                    {# ── Group row (name + count are the trigger) ──
+                       Not the <tr>: a row-level toggle also fires when the
+                       Edit/Delete buttons are clicked, and the button cannot
+                       stop it (Bootstrap's data-api runs in the capture
+                       phase). See dashboards/fragments/collapse.html. #}
+                    {% set g_toggle = 'aoi-group-' ~ g.area_of_interest_group_id %}
                     <tbody>
-                        <tr class="cursor-pointer table-subtle fw-semibold{% if not g.active %} opacity-50{% endif %}"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#aoi-group-{{ g.area_of_interest_group_id }}"
-                            aria-expanded="false">
-                            <td>
+                        <tr class="table-subtle fw-semibold{% if not g.active %} opacity-50{% endif %}">
+                            <td class="cursor-pointer" {{ collapse_toggle(g_toggle) }}>
                                 <i class="fas fa-chevron-right small text-muted me-1 collapse-icon"
                                    style="transition: transform 0.2s;"></i>
                                 {{ g.name }}
                             </td>
-                            <td class="text-muted small">{{ g.areas|length }} area{{ 's' if g.areas|length != 1 else '' }}</td>
+                            <td class="text-muted small cursor-pointer" {{ collapse_toggle(g_toggle) }}>{{ g.areas|length }} area{{ 's' if g.areas|length != 1 else '' }}</td>
                             <td class="text-end">
                                 {{ edit_modal_button(
                                     url_for('admin_dashboard.htmx_aoi_group_edit_form', group_id=g.area_of_interest_group_id),
                                     modal_id='editAoiGroupModal',
                                     target_id='editAoiGroupFormContainer',
                                     title='Edit group',
-                                    stop_propagation=True,
                                     permission=Permission.EDIT_ORG_METADATA) }}
                                 {{ delete_row_button(
                                     url_for('admin_dashboard.htmx_aoi_group_delete', group_id=g.area_of_interest_group_id),
                                     confirm="Deactivate group '" ~ g.name ~ "'?",
                                     title='Deactivate AOI group',
-                                    stop_propagation=True,
                                     permission=Permission.DELETE_ORG_METADATA) }}
                             </td>
                         </tr>

--- a/src/webapp/templates/dashboards/admin/fragments/project_directories_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/project_directories_card.html
@@ -146,7 +146,6 @@
                             modal_id='editProjectDirectoryModal',
                             target_id='editProjectDirectoryFormContainer',
                             title='Edit directory',
-                            stop_propagation=True,
                             permission=Permission.EDIT_PROJECTS) }}
                         {% if has_permission(Permission.EDIT_PROJECTS) and pd.is_active %}
                         <button class="btn btn-sm btn-outline-danger ms-1"

--- a/src/webapp/templates/dashboards/admin/fragments/resources_card.html
+++ b/src/webapp/templates/dashboards/admin/fragments/resources_card.html
@@ -500,7 +500,6 @@
                                     modal_id='editExemptionModal',
                                     target_id='editExemptionFormContainer',
                                     title='Edit exemption',
-                                    stop_propagation=True,
                                     permission=Permission.EDIT_USERS) }}
                                 {% if has_permission(Permission.EDIT_USERS) and e.is_active %}
                                 <button class="btn btn-sm btn-outline-warning ms-1"

--- a/src/webapp/templates/dashboards/fragments/action_buttons.html
+++ b/src/webapp/templates/dashboards/fragments/action_buttons.html
@@ -36,9 +36,23 @@
           permission=Permission.EDIT_PROJECT_MEMBERS,
           project=project) }}
 
-  Pass stop_propagation=True when the button sits inside a row that is
-  itself a Bootstrap collapse trigger, to prevent the click from toggling
-  the parent collapse.
+  ⚠️ stop_propagation=True does NOT work against a Bootstrap collapse
+  trigger, despite what this note used to claim. Bootstrap registers its
+  data-api handlers with `EventHandler.on(document, ...)`, which passes the
+  delegation flag as `addEventListener`'s `useCapture` argument, so they run
+  in the CAPTURE phase on `document` — before any listener on the button.
+  It emits `data-stop-propagation`, whose handler (static/js/actions.js) is
+  element-level and therefore always too late. Four cards shipped with the
+  flag and the bug it was supposed to prevent (issue #356).
+
+  The fix for that case is structural: put the toggle on the individual
+  cells and leave the actions cell out of it — see
+  dashboards/fragments/collapse.html, and the static guard in
+  tests/unit/test_collapse_trigger_rows.py that now enforces it.
+
+  The flag remains for genuine element-level dispatchers (a row wired with
+  `data-action` or an hx-* attribute, where bubbling really is the problem).
+  It has no callers today.
 #}
 
 

--- a/tests/unit/test_collapse_trigger_rows.py
+++ b/tests/unit/test_collapse_trigger_rows.py
@@ -1,0 +1,133 @@
+"""Static guard: no action button inside a Bootstrap collapse-trigger row.
+
+**Why this tier exists.** A group row written as ``<tr data-bs-toggle="collapse">``
+that also contains an action button has a bug: clicking the button expands or
+collapses the row as well as performing the action. The modal still opens, so
+it reads as cosmetic noise rather than a failure — which is why it went
+unnoticed across four cards.
+
+It cannot be fixed from the button. Bootstrap registers its data-api handlers
+via ``EventHandler.on(document, ...)``, which passes the delegation flag as
+``addEventListener``'s ``useCapture`` argument, so they run in the **capture**
+phase on ``document``. Capture descends document → row → button, so Bootstrap
+has already toggled the collapse before any listener on the button executes.
+``data-stop-propagation`` (``static/js/actions.js``) is powerless here by
+construction; its own docstring scopes it to element-level htmx bindings. The
+fix is structural — put the toggle on the individual cells that should react
+and leave the actions cell out of it. See
+``templates/dashboards/fragments/collapse.html`` for the ``collapse_toggle``
+macro and the full rationale.
+
+**Why static rather than rendered.** This replaces
+``test_no_action_button_inside_a_collapse_trigger_row``, which lived in
+``test_htmx_queue_admin.py`` and rendered exactly one fragment
+(``/admin/htmx/resources``). It could only ever see the card it was written
+for, and a fresh instance duly landed in ``contracts_table_htmx.html`` — issue
+#356. Scanning template *source* covers every fragment, including ones no test
+renders and ones that do not exist yet, with no DB and no Flask. Same tier and
+same shape as ``test_modal_shell_contract.py``.
+
+The trade is that source cannot see markup a macro generates, so the scan
+matches the two action-button macro *names* as well as literal ``<button>``.
+Every action button in the admin fragments comes from one of those two macros.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+TEMPLATE_ROOT = Path(__file__).resolve().parents[2] / 'src' / 'webapp' / 'templates'
+
+# Jinja comments are stripped first: collapse.html documents the very pattern
+# this test forbids, and the macro's usage example would otherwise be the
+# loudest "violation" in the tree.
+_JINJA_COMMENT = re.compile(r'{#.*?#}', re.S)
+
+# Jinja delimiters, used to mask '>' that belongs to an expression rather than
+# to the tag: `{% if q.dates|length > 1 %}` inside a <tr ...> would otherwise
+# truncate the tag and make the check silently pass. Two real templates need
+# this (organization_card.html, user_subtree.html).
+_JINJA_SPAN = re.compile(r'{{.*?}}|{%.*?%}', re.S)
+
+_TR_OPEN = re.compile(r'<tr\b[^>]*>', re.S)
+
+# Either spelling of a trigger: the literal attribute, or the macro that emits
+# it (a macro call on the <tr> would be just as wrong, and is easy to write).
+_TRIGGER = re.compile(r'data-bs-toggle="collapse"|collapse_toggle\(')
+
+# Anything clickable that performs an action. The old rendered guard looked
+# only for '<button', so an action *link* would have walked straight past it.
+_ACTION = re.compile(
+    r'<button\b'
+    r'|edit_modal_button\('
+    r'|delete_row_button\('
+    r'|<a\b[^>]*class="[^"]*\bbtn\b',
+    re.S,
+)
+
+
+def _mask_jinja_gt(text):
+    """Blank out '>' inside Jinja spans, preserving every offset.
+
+    Returns a string the same length as ``text``, so match offsets from the
+    masked copy index correctly into the original.
+    """
+    chars = list(text)
+    for span in _JINJA_SPAN.finditer(text):
+        for i in range(span.start(), span.end()):
+            if chars[i] == '>':
+                chars[i] = '\x00'
+    return ''.join(chars)
+
+
+def _trigger_rows():
+    """Yield (template, line, row_html) for every collapse-trigger <tr>."""
+    for path in sorted(TEMPLATE_ROOT.rglob('*.html')):
+        raw = _JINJA_COMMENT.sub(
+            lambda m: re.sub(r'[^\n]', ' ', m.group(0)),  # keep line numbers
+            path.read_text(),
+        )
+        masked = _mask_jinja_gt(raw)
+        for m in _TR_OPEN.finditer(masked):
+            if not _TRIGGER.search(m.group(0)):
+                continue
+            end = raw.find('</tr>', m.end())
+            row = raw[m.end():end] if end != -1 else raw[m.end():]
+            line = raw[:m.start()].count('\n') + 1
+            yield str(path.relative_to(TEMPLATE_ROOT)), line, row
+
+
+def test_no_action_button_inside_a_collapse_trigger_row():
+    offenders = []
+    for template, line, row in _trigger_rows():
+        hit = _ACTION.search(row)
+        if hit:
+            offenders.append(f'{template}:{line} (contains {hit.group(0)!r})')
+
+    assert not offenders, (
+        'A collapse-trigger <tr> contains an action button, so clicking the '
+        'button will also toggle the row. Bootstrap\'s data-api runs in the '
+        'capture phase, so no button-side guard can prevent it — move the '
+        'toggle onto the non-action <td>s with the collapse_toggle macro '
+        '(templates/dashboards/fragments/collapse.html).\n  '
+        + '\n  '.join(offenders)
+    )
+
+
+def test_scan_is_not_vacuous():
+    """Guard against the guard silently passing.
+
+    A markup refactor that renamed the attribute, or a regex that stopped
+    matching, would make the check above pass on an empty set. Rows with no
+    buttons legitimately keep a <tr>-level trigger, so there should always be
+    some.
+    """
+    rows = list(_trigger_rows())
+    assert len(rows) >= 5, (
+        f'only {len(rows)} collapse-trigger rows found across the template '
+        f'tree — the scan has probably stopped matching. Found: '
+        f'{[f"{t}:{n}" for t, n, _ in rows]}'
+    )

--- a/tests/unit/test_htmx_queue_admin.py
+++ b/tests/unit/test_htmx_queue_admin.py
@@ -465,36 +465,7 @@ class TestResourcesCardQueueButtons:
         assert 'Cleanup' in html
         assert 'queue-cleanup-form' in html
 
-    def test_no_action_button_inside_a_collapse_trigger_row(self, auth_client):
-        """Regression guard for the whole Resources card, not just Cleanup.
-
-        A <tr data-bs-toggle="collapse"> that also contains a button is a bug:
-        clicking the button expands the row too. Bootstrap registers its
-        data-api handlers on `document` in the CAPTURE phase, so they run
-        before any listener on the button — nothing the button does
-        (data-stop-propagation included) can prevent it. Rows with buttons
-        must put the toggle on their <td>s (see
-        templates/dashboards/fragments/collapse.html).
-
-        This caught two pre-existing instances (Resource Type and Resource
-        rows) alongside the Cleanup button that prompted it.
-        """
-        import re
-
-        html = auth_client.get('/admin/htmx/resources').get_data(as_text=True)
-
-        trigger_rows = 0
-        for m in re.finditer(r'<tr\b[^>]*>', html):
-            if 'data-bs-toggle="collapse"' not in m.group(0):
-                continue
-            trigger_rows += 1
-            row = html[m.end():html.find('</tr>', m.end())]
-            assert '<button' not in row, (
-                'A collapse-trigger <tr> contains a button, so clicking the '
-                'button will also expand the row. Move the toggle onto the '
-                'non-action <td>s. Offending row:\n' + row[:400]
-            )
-
-        # Guard against the guard silently passing on a fragment with no
-        # collapse rows at all (e.g. a markup refactor or an empty snapshot).
-        assert trigger_rows > 0, 'no collapse-trigger rows found — guard is vacuous'
+    # The collapse-trigger-row guard that used to live here rendered only
+    # /admin/htmx/resources, so it could not see the same bug when it landed in
+    # the contracts card (issue #356). It now scans the whole template tree
+    # statically — see tests/unit/test_collapse_trigger_rows.py.


### PR DESCRIPTION
## Summary

Closes #356.

A group row written as `<tr data-bs-toggle="collapse">` that also holds an action button toggles the row when the button is clicked. It cannot be fixed from the button: Bootstrap registers its data-api handlers via `EventHandler.on(document, ...)`, which passes the delegation flag as `addEventListener`'s `useCapture` argument, so they run in the **capture** phase on `document` — before any listener on the button reaches it.

### Audit against the issue

| Site | State on arrival |
|---|---|
| `facility_card.html:26` | live |
| `institutions_table.html:57` | live |
| `organization_card.html:153` | live (now :151) |
| `organization_card.html:260` | **already resolved** — the NSF Programs table was rebuilt as a flat drill-down link table |
| `contracts_table_htmx.html:52` | **new instance**, landed after the issue was filed |

The contracts row is the point of this PR. The old guard rendered only `/admin/htmx/resources`, so it structurally could not see a regression anywhere else — and one duly arrived.

## Changes

**Templates** — converted the four rows to cell-level triggers with the `collapse_toggle` macro from #355. The contracts row uses the precomputed-attrs idiom from `resources_card.html:96-98`, since its trigger is conditional on the source actually having contracts (18 of 24 sources are empty under the active-only default and deliberately get no chevron).

Dropped `stop_propagation=True` from the 7 buttons on those rows, plus 3 more on rows with no row-level handler at all. Nothing passes it now.

Rewrote the `action_buttons.html` docblock, which prescribed `stop_propagation=True` for exactly the case it cannot fix. **That note is the root cause of the recurrence** — four cards shipped with the flag and the bug it was supposed to prevent. The parameter stays for genuine element-level dispatchers.

No JS change: `SamCollapseChevron.attach()` selects `[data-bs-toggle="collapse"]` element-agnostically and finds the chevron inside the first toggled cell.

**Guards** — two tiers, replacing the single-fragment one:

- `tests/unit/test_collapse_trigger_rows.py` scans template *source* across the whole tree. Strips Jinja comments (or `collapse.html`'s own usage example is the loudest violation), masks `>` inside Jinja spans with a same-length replacement so `{% if q.dates|length > 1 %}` cannot truncate a `<tr>` tag and silently pass, and matches action links and macro calls rather than just `<button`.
- `e2e/test_issue356_collapse_rows.py` pins the behaviour: the pencil must not expand the row, **and** the cells must still expand it — a fix that killed the expander would satisfy the first alone.

## Test Results

- Full suite: **6,249 passed**, 42 skipped, 1 xfailed
- Browser tier (`make e2e`): **78 passed**, 2 skipped

The e2e module was validated against a control — compose `webapp`, built before these changes:

| | result |
|---|---|
| pre-fix, cold cache | 8 failed, 2 passed — every buggy card caught; Resources (fixed in #355) correctly green; nothing skipped |
| post-fix | 10 passed |

The static guard was likewise checked against a fixture carrying a macro-call violation, a literal `<button>` behind a `>`-containing Jinja expression, and an innocent button-free row; it flagged the first two and left the third alone.

## Two things worth knowing

**Shared Redis across compose services.** `webapp` and `webdev` both use `CACHE_REDIS_URL=redis://cache:6379/0`, and the organizations and contracts fragments are `@cache.cached`. A run against one port serves warm HTML to the other — three of four control cases were false passes until the cache was flushed. `facilities_routes.py` is uncached, which is the only reason the contamination surfaced. Same hazard as the chart-cache note in CLAUDE.md, but for fragment HTML.

**A skip is a silent pass.** `#institutions-pane` fetches itself on `shown.bs.tab ... once`, so a tab click plus networkidle can return before the rows exist; the case then skipped against a container that definitely had the bug. Each e2e case now carries an explicit readiness selector and fails loudly if its pane never renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
