### PR TITLE
Give the webapp the scheduled-task kill switch, or the admin card lies

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -59,6 +59,31 @@ spec:
           - name: {{ $key }}
             value: {{ $value | quote }}
           {{- end }}
+          # The scheduled-task kill switch is DECLARED ONCE, on `tasks.env`,
+          # and consumed by BOTH pods: the CronJob obeys it, and the webapp's
+          # Admin -> Configuration card reports it.
+          #
+          # ⚠️ Without this the card reads the *webapp's* own environment,
+          # finds nothing, and renders a kill-switched dispatcher as perfectly
+          # healthy — the exact failure that card exists to prevent. Found by
+          # smoking production, where the card sat there quietly claiming all
+          # was well while `cleanup_status_snapshots` was switched off.
+          #
+          # Cross-block reference rather than a second declaration, on purpose:
+          # two copies of this value can drift, and drift here means the card
+          # lies again. cronjob-tasks.yaml reads .Values.webapp.env the same
+          # way for the DB settings.
+          #
+          # Nested `with` is the nil-safe idiom: `.Values.tasks.env.X` errors
+          # outright when `tasks` is absent.
+          {{- with .Values.tasks }}
+          {{- with .env }}
+          {{- with .SAM_TASKS_DISABLED }}
+          - name: SAM_TASKS_DISABLED
+            value: {{ . | quote }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
           # Concurrency model: gthread (threaded workers). fs-scans on-the-fly
           # scans measured ~76-85% blocked in Postgres and psycopg2 frees the
           # GIL, so threads absorb the waits — a slow scan holds a thread, not a

--- a/helm/tests/test-cronjob-render.sh
+++ b/helm/tests/test-cronjob-render.sh
@@ -140,6 +140,28 @@ assert_contains "$prod_out" 'value: "cleanup_status_snapshots"' \
 assert_contains "$prod_out" 'value: "365"' \
   "STATUS_RETENTION_DAYS must be explicit in GitOps, not implied by a default"
 
+# --- BOTH pods must see the kill switch -------------------------------------
+#
+# The CronJob OBEYS the switch; the webapp's Admin → Configuration card
+# REPORTS it. They are two consumers of ONE declaration in tasks.env.
+#
+# ⚠️ Asserted per-manifest, and that is the whole point. The assertions above
+# run against the *full* render, so the CronJob alone satisfies them — which is
+# exactly how this shipped to production with the webapp not carrying the
+# variable at all. The card read its own environment, found nothing, and
+# rendered a kill-switched dispatcher as perfectly healthy: the precise failure
+# that card exists to prevent.
+#
+# When P5 clears the switch this pair fails too — delete it alongside the block
+# above, for the same reason.
+deploy_out=$(helm template "$RELEASE_NAME" "$CHART_DIR" \
+             -f "$CHART_DIR/values.yaml" -s templates/deployment.yaml)
+
+assert_contains "$deploy_out" 'name: SAM_TASKS_DISABLED' \
+  "the webapp Deployment must carry the kill switch too, or the admin card lies"
+assert_contains "$deploy_out" 'value: "cleanup_status_snapshots"' \
+  "and it must carry the SAME value — one declaration, two consumers"
+
 # ---------------------------------------------------------------------------
 # Local dev render (values.yaml + values-local.yaml)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

**Found by smoking production after #444 deployed.** The Scheduled tasks card
rendered on `samuel.k8s.ucar.edu` showing "Registered 1", zeroes across the
board, and **no kill-switch warning** — a perfectly healthy-looking dispatcher,
while `cleanup_status_snapshots` was in fact switched off.

That is the exact failure the card was built to prevent. From
`SCHEDULED_TASKS.md` § 9:

> The first thing this card will show in production is a dispatcher that runs
> hourly and deliberately does nothing. **If the card does not say so loudly,
> it will look like a healthy system.**

## Root cause

`SAM_TASKS_DISABLED` is declared in `.Values.tasks.env`, which **only**
`cronjob-tasks.yaml` consumes. The webapp Deployment never received it.
`webapp/utils/config_inspect.py` calls `scheduling.runner.disabled_tasks()`,
which reads the *webapp process's* `os.environ` — so it always found nothing
and always reported "not disabled".

The CronJob **obeys** the switch; the webapp card **reports** it. Only one of
them could see it.

## Fix

`deployment.yaml` now takes `SAM_TASKS_DISABLED` from
`.Values.tasks.env.SAM_TASKS_DISABLED` — a cross-block reference rather than a
second declaration, because two copies can drift and drift here means the card
lies again. `cronjob-tasks.yaml` already reads `.Values.webapp.env` the same
way for the DB settings.

Nested `with` is the nil-safe idiom (`.Values.tasks.env.X` errors outright when
`tasks` is absent), and it gives the right **P5** behaviour for free: once the
switch is cleared to `""`, the variable is omitted entirely and the card
correctly reports nothing disabled.

## Why no test caught it

Every layer shared the same false premise — that the webapp can see the
variable:

| Layer | What it did | Why it passed |
|---|---|---|
| `test_admin_scheduled_tasks_card.py` | `monkeypatch.setenv(...)` | sets it in the *webapp* process |
| `e2e/test_scheduled_tasks_card.py` | set it on the webdev container | webdev **is** the webapp |
| `test-cronjob-render.sh` | asserted against the **whole** render | the CronJob alone satisfies it |

That last one is the real gap, so the new gate is asserted **per-manifest**: it
renders `-s templates/deployment.yaml` in isolation and requires both the name
and the same value.

**Verified the gate has teeth.** With the fix temporarily removed it fails with
*"the webapp Deployment must carry the kill switch too, or the admin card
lies"*; it passes once restored.

## Scope

Two files, 47 insertions. Cut fresh from `staging` rather than from the old
`scheduled_tasks` branch — that branch predates #443 and diffing it against
current staging would have silently reverted the lookback-window work.

## Everything else in production was correct

Verified in the browser and against the prod database:

- Build `c25e4eb` live, matching #444's squash.
- Alembic `0006` applied; the run-history page shows a real **empty table**,
  not the "unavailable" panel — so the app can see the migrated table.
- The 16:07 UTC CronJob wake produced **exactly one** ledger row, every field
  as predicted: `occurrence_key=20260813T081500Z`, `state=skipped`,
  `trigger_type=schedule`, `attempt=1`, `detail={"reason": "disabled"}`,
  `runner_id=samuel-tasks-29777287-qdmjg`.
- That single row proves the whole chain: CronJob fires → image runs → task pod
  reaches Postgres → **the kill switch genuinely works** → occurrence math is
  right (02:15 MDT → 08:15 UTC) → naive-UTC timestamps are right → the claim
  INSERT works on prod Postgres → the webapp reads it back.
- Facet chips, badges, the detail modal and its JSON decode all render.
  **Zero console errors.**

So the dispatcher was never misbehaving — only the card's report of it.

### Test Results

```
make helm-test    OK, both render scripts
```

Python tests are untouched by this change (`helm/` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
