### PR TITLE
Probe the scheduled-task CronJob in cirrus_healthcheck

### DIFF
--- a/docs/plans/SCHEDULED_TASKS.md
+++ b/docs/plans/SCHEDULED_TASKS.md
@@ -1028,11 +1028,19 @@ The `main` → CI → `cirrus` → ArgoCD path is the only route
    and write nothing. That is the dedup constraint working, not a broken
    dispatcher.
 
-   So hourly liveness comes from the **Job objects and their stdout**
-   (`successfulJobsHistoryLimit: 3`), not from row count:
+   So hourly liveness comes from the **CronJob object and its Jobs**, not from
+   row count. The scripted form is now
+   `scripts/cirrus_healthcheck.sh` § 12, which is the preferred route because
+   it also cross-checks the image pin and the kill switch across both
+   workloads. By hand:
    ```bash
-   kubectl get jobs -l app.kubernetes.io/component=tasks   # ~24/day
-   sam-admin tasks --history                                # ~1 skipped row/day
+   # ⚠️ The selector is `app=samuel-tasks` (helm tasks.name). An earlier draft
+   # of this document said `app.kubernetes.io/component=tasks`, which the chart
+   # never sets — it matches nothing and reads as "the dispatcher never fired",
+   # the exact false alarm this step exists to avoid.
+   kubectl -n sam-queries get cronjob samuel-tasks       # lastScheduleTime is the heartbeat
+   kubectl -n sam-queries get jobs -l app=samuel-tasks   # ~24/day
+   sam-admin tasks --history                             # ~1 skipped row/day
    ```
    The admin card's **"Last recorded run"** is deliberately named for the same
    reason: it is `max(claimed_at)`, so during this soak it legitimately reads

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,10 +46,13 @@ cluster. All use the same idioms: colored PASS/WARN/FAIL output, exit codes
 `-n/--namespace`, `-r/--release`, `--context`, `-v/--verbose`, `-h/--help`
 flags.
 
-- **`cirrus_healthcheck.sh`** — "is the cluster healthy?" 11-section probe of
+- **`cirrus_healthcheck.sh`** — "is the cluster healthy?" 12-section probe of
   the Helm release: pods, rollout safety, Redis, resource usage, ingress/TLS,
   edge security headers, ExternalSecrets, the in-pod health endpoint, recent
-  logs, and events.
+  logs, events, and the scheduled-task CronJob. That last section is the only
+  place the dispatcher's liveness is observable — `task_run` records
+  *occurrences*, not wake-ups, so a healthy hourly dispatcher writes one row a
+  day and the row count cannot distinguish that from a dead one.
 
 - **`cirrus_weblog_audit.sh`** — "who's hitting the public site, and is anything
   abusive getting through?" Harvests the webapp's stdout (and the Redis

--- a/scripts/cirrus_healthcheck.sh
+++ b/scripts/cirrus_healthcheck.sh
@@ -823,6 +823,136 @@ fi
 explain "Events are short-lived (~1h). 'Warning' rows are worth scanning."
 
 # ============================================================================
+section "12. Scheduled tasks (CronJob)"
+# ============================================================================
+#
+# The one workload in this release the ledger cannot report on. `task_run`
+# records *occurrences*, not wake-ups: a daily task writes one row a day while
+# the dispatcher fires hourly, and the other 23 wakes find the slot already
+# settled and write nothing. So "is the dispatcher alive?" is answerable only
+# from the CronJob object and its Jobs — which is what this section reads.
+
+if ! "${KCTL_NS[@]}" get cronjob "$TASKS_NAME" >/dev/null 2>&1; then
+    warn "CronJob '$TASKS_NAME' not found — scheduled tasks may be disabled (helm tasks.enabled=false)"
+else
+    run "${KCTL_NS[@]}" get cronjob "$TASKS_NAME"
+    CJ_JSON=$("${KCTL_NS[@]}" get cronjob "$TASKS_NAME" -o json)
+
+    CJ_SUSPEND=$(echo "$CJ_JSON" | jq -r '.spec.suspend // false')
+    CJ_SCHED=$(echo   "$CJ_JSON" | jq -r '.spec.schedule')
+    CJ_TZ=$(echo      "$CJ_JSON" | jq -r '.spec.timeZone // "(node local)"')
+    CJ_LAST=$(echo    "$CJ_JSON" | jq -r '.status.lastScheduleTime // ""')
+
+    if [[ "$CJ_SUSPEND" == "true" ]]; then
+        fail "CronJob is SUSPENDED — nothing is being dispatched at all"
+    else
+        pass "CronJob active: schedule '$CJ_SCHED' (timeZone $CJ_TZ)"
+    fi
+
+    # --- Liveness: has it actually been scheduled recently? -----------------
+    if [[ -z "$CJ_LAST" ]]; then
+        warn "no lastScheduleTime yet — the CronJob has never fired"
+    else
+        AGE_S=$(seconds_since "$CJ_LAST" || echo "")
+        if [[ -z "$AGE_S" ]]; then
+            info "lastScheduleTime $CJ_LAST (could not compute age)"
+        elif [[ "$AGE_S" -gt "$TASKS_MAX_SILENCE_S" ]]; then
+            fail "last scheduled $((AGE_S/60)) min ago (>$((TASKS_MAX_SILENCE_S/60)) min) — the dispatcher has stopped waking"
+        else
+            pass "last scheduled $((AGE_S/60)) min ago ($CJ_LAST)"
+        fi
+    fi
+    explain "This — not the task_run row count — is the dispatcher's heartbeat."
+
+    # --- Recent Jobs --------------------------------------------------------
+    echo
+    echo "  Recent Jobs (selector $TASKS_SELECTOR):"
+    run "${KCTL_NS[@]}" get jobs -l "$TASKS_SELECTOR" \
+        --sort-by=.metadata.creationTimestamp \
+        -o custom-columns='NAME:.metadata.name,SUCCEEDED:.status.succeeded,FAILED:.status.failed,START:.status.startTime,END:.status.completionTime'
+
+    JOBS_JSON=$("${KCTL_NS[@]}" get jobs -l "$TASKS_SELECTOR" -o json 2>/dev/null || echo '{"items":[]}')
+    N_JOBS=$(echo   "$JOBS_JSON" | jq '[.items[]] | length')
+    N_FAILED=$(echo "$JOBS_JSON" | jq '[.items[] | select((.status.failed // 0) > 0)] | length')
+
+    if [[ "$N_JOBS" -eq 0 ]]; then
+        warn "no Jobs retained — either none has run, or history limits pruned them"
+    elif [[ "$N_FAILED" -gt 0 ]]; then
+        fail "$N_FAILED of $N_JOBS retained Job(s) failed — inspect with 'kubectl logs job/<name>'"
+    else
+        pass "$N_JOBS retained Job(s), none failed"
+    fi
+    explain "backoffLimit is 0, so a failed dispatch means a failed Job, retained by failedJobsHistoryLimit."
+
+    # --- The image invariant, verified LIVE ---------------------------------
+    #
+    # The CronJob renders .Values.webapp.container.image — the SAME key the
+    # Deployment uses — so CI's one sed pins both. helm/tests/ guards that at
+    # render time; this guards the DEPLOYED state, where a partial sync or a
+    # hand-edit could still split them. A unique sha- tag is also what makes
+    # imagePullPolicy: IfNotPresent safe.
+    CJ_IMG=$(echo "$CJ_JSON" | jq -r '.spec.jobTemplate.spec.template.spec.containers[0].image')
+    WEB_IMG=$("${KCTL_NS[@]}" get deploy "$WEBAPP_NAME" \
+              -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || echo "")
+    echo
+    info "CronJob image:  $CJ_IMG"
+    info "webapp image:   ${WEB_IMG:-<not found>}"
+    if [[ -n "$WEB_IMG" && "$CJ_IMG" == "$WEB_IMG" ]]; then
+        pass "dispatcher and webapp run the SAME image"
+    elif [[ -n "$WEB_IMG" ]]; then
+        fail "image drift — the dispatcher is running different code from the webapp"
+    fi
+    if [[ "$CJ_IMG" == *":main" || "$CJ_IMG" == *":latest" ]]; then
+        fail "image is a MOVING tag ($CJ_IMG) — with imagePullPolicy IfNotPresent a node serves its cached layer for ever"
+    else
+        pass "image is pinned, not a moving tag"
+    fi
+
+    # --- The kill switch, on BOTH workloads ---------------------------------
+    #
+    # SAM_TASKS_DISABLED is declared once (helm tasks.env) and consumed twice:
+    # the CronJob OBEYS it, the webapp's Admin -> Configuration card REPORTS it.
+    # They shipped out of sync once — the card rendered a kill-switched
+    # dispatcher as perfectly healthy — so compare the deployed values.
+    CJ_SW=$(echo "$CJ_JSON" | jq -r '
+        .spec.jobTemplate.spec.template.spec.containers[0].env[]?
+        | select(.name=="SAM_TASKS_DISABLED") | .value // ""' | head -1)
+    WEB_SW=$("${KCTL_NS[@]}" get deploy "$WEBAPP_NAME" -o json 2>/dev/null | jq -r '
+        .spec.template.spec.containers[0].env[]?
+        | select(.name=="SAM_TASKS_DISABLED") | .value // ""' | head -1)
+    echo
+    if [[ -n "$CJ_SW" ]]; then
+        warn "kill switch ACTIVE on the dispatcher: '$CJ_SW' — these tasks wake and do nothing"
+    else
+        info "kill switch not set — every registered task may run"
+    fi
+    if [[ "$CJ_SW" == "$WEB_SW" ]]; then
+        pass "webapp agrees (admin card will report it correctly)"
+    else
+        fail "MISMATCH — dispatcher='$CJ_SW' webapp='$WEB_SW'; the admin card will misreport the kill switch"
+    fi
+
+    # --- Last dispatch stdout ----------------------------------------------
+    #
+    # The CronJob is log-scraped: `sam-admin --format json tasks` must emit a
+    # clean envelope. A stray print to stdout broke this once already.
+    LAST_JOB=$(echo "$JOBS_JSON" | jq -r '[.items[]] | sort_by(.metadata.creationTimestamp) | last | .metadata.name // ""')
+    if [[ -n "$LAST_JOB" ]]; then
+        echo
+        echo "  Last dispatch stdout ($LAST_JOB):"
+        LOGS=$("${KCTL_NS[@]}" logs "job/$LAST_JOB" --tail=40 2>/dev/null || echo "")
+        echo "$LOGS" | sed 's/^/    /'
+        if [[ -z "$LOGS" ]]; then
+            warn "no logs retained for $LAST_JOB"
+        elif echo "$LOGS" | jq -e . >/dev/null 2>&1; then
+            pass "dispatch output parses as JSON"
+        else
+            fail "dispatch output is NOT valid JSON — something is printing to stdout ahead of the envelope"
+        fi
+    fi
+fi
+
+# ============================================================================
 section "Summary"
 # ============================================================================
 

--- a/scripts/lib/cirrus_common.sh
+++ b/scripts/lib/cirrus_common.sh
@@ -34,6 +34,14 @@ WEBAPP_NAME="samuel"
 WEBAPP_PORT=5050
 REDIS_NAME="samuel-redis"
 REDIS_PORT=6379
+# The scheduled-task dispatcher (helm tasks.name). Its Jobs and pods carry
+# `app: samuel-tasks` — NOT `app.kubernetes.io/component=tasks`, which matches
+# nothing and reads as "the dispatcher never fired". See TASKS_SELECTOR.
+TASKS_NAME="samuel-tasks"
+TASKS_SELECTOR="app=${TASKS_NAME}"
+# The dispatcher wakes hourly (helm tasks.schedule "7 * * * *"), so anything
+# past one interval plus slack means it has stopped being scheduled.
+TASKS_MAX_SILENCE_S=4200
 # INGRESS_HOST is the platform-primary name (helm webapp.tls.fqdn) and the CN of
 # the issued cert. INGRESS_HOSTS is every name the ingress answers for — primary
 # plus helm webapp.tls.extraHosts — all covered by the one multi-SAN TLS_SECRET.


### PR DESCRIPTION
## Summary

`cirrus_healthcheck.sh` calls itself an opinionated probe of the samuel
release, but the release gained a workload it did not inspect at all. This
adds **§ 12 Scheduled tasks (CronJob)** — the one part of the scheduled-task
feature whose health is not observable anywhere else.

`task_run` records **occurrences, not wake-ups**: a daily task writes one row a
day while the dispatcher fires hourly, and the other 23 wakes find the slot
already settled and write nothing. So the ledger structurally cannot
distinguish a healthy hourly dispatcher from a dead one. Only the CronJob
object can.

## Checks

| Check | Why it belongs here |
|---|---|
| CronJob exists, not suspended, schedule + timeZone | invisible to the app and to the ledger |
| **`lastScheduleTime` within 70 min** | the actual heartbeat |
| Retained Jobs, and whether any failed | `backoffLimit: 0`, so a failed dispatch is a failed Job |
| **Image == the webapp Deployment's image** | verified *live*, not only at render time |
| **Image is not a moving tag** | `:main` + `IfNotPresent` would serve a cached layer for ever |
| **`SAM_TASKS_DISABLED` matches across both workloads** | the bug that shipped in #444 and was fixed in #445 |
| Last dispatch stdout parses as JSON | a stray `print` broke this envelope once already |

Two deserve emphasis: the image and kill-switch checks already have helm render
tests guarding the **chart**; this guards the **deployed state**, where a
partial sync or a hand-edit could still split what the chart keeps unified. The
kill-switch mismatch is exactly what reached production and rendered a
kill-switched dispatcher as perfectly healthy on the admin card.

## Also fixes a wrong selector I had put in the docs

`SCHEDULED_TASKS.md` rollout step 2 told the operator to run

```bash
kubectl get jobs -l app.kubernetes.io/component=tasks
```

The chart never sets that label — it uses `app: samuel-tasks`. The documented
command matches nothing and reads as *"the dispatcher never fired"*, which is
the precise false alarm that step exists to prevent. Corrected, with the reason
recorded, and `TASKS_SELECTOR` now lives in `lib/cirrus_common.sh` beside the
other release names.

## Scope

One section, using the existing `section` / `pass` / `warn` / `fail` /
`explain` helpers and the `KCTL_NS` builder. Read-only, like the rest of the
script.

Deliberately **not** a replacement for the deferred `/api/v1/health/tasks` or
the `tasks_watchdog` task (`SCHEDULED_TASKS.md` § 9). Those answer *"is it
healthy, automatically, for a monitor"*; this answers *"show me, as an
operator, right now"* — and it reads k8s facts (suspended? image drift? env
mismatch?) that neither the webapp nor the task pod can see.

## Verified against the live cluster

Run read-only against `nwc1` / `sam-queries`. Every check exercised on real
state, with the kill switch correctly surfacing as a WARN:

```
═══ 12. Scheduled tasks (CronJob) ═══
    NAME           SCHEDULE    TIMEZONE   SUSPEND   ACTIVE   LAST SCHEDULE   AGE
    samuel-tasks   7 * * * *   Etc/UTC    False     0        49m             84m
  ✔ PASS — CronJob active: schedule '7 * * * *' (timeZone Etc/UTC)
  ✔ PASS — last scheduled 49 min ago (2026-08-13T16:07:00Z)
  ↳ This — not the task_run row count — is the dispatcher's heartbeat.

  Recent Jobs (selector app=samuel-tasks):
    NAME                    SUCCEEDED   FAILED   START                  END
    samuel-tasks-29777287   1           <none>   2026-08-13T16:07:00Z   2026-08-13T16:07:10Z
  ✔ PASS — 1 retained Job(s), none failed

  ℹ CronJob image:  ghcr.io/benkirk/sam-queries/webapp:sha-7cda49c
  ℹ webapp image:   ghcr.io/benkirk/sam-queries/webapp:sha-7cda49c
  ✔ PASS — dispatcher and webapp run the SAME image
  ✔ PASS — image is pinned, not a moving tag

  ⚠ WARN — kill switch ACTIVE on the dispatcher: 'cleanup_status_snapshots'
  ✔ PASS — webapp agrees (admin card will report it correctly)

  ✔ PASS — dispatch output parses as JSON
```

Shell syntax checked (`bash -n`). No Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
