### PR TITLE
Monthly deactivate_expired_projects scheduled task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,8 @@ sam-queries/
 ├── src/system_status/    # Separate status DB (own bind, Alembic-managed)
 ├── src/scheduling/       # Ledger-backed task dispatcher (schedules, registry,
 │   └── tasks/            #   ledger, runner) — no Click/Flask/rich/k8s imports
-│                         #   tasks/: cleanup_status, expiration_notices
+│                         #   tasks/: cleanup_status, deactivate_expired,
+│                         #           expiration_notices
 ├── src/querykit/         # Faceted-log query facade — SQLAlchemy only, imports
 │                         #   nothing from sam/ or system_status/ (see its README)
 ├── src/cli/              # sam-search / sam-admin (see src/cli/README.md)

--- a/README.md
+++ b/README.md
@@ -573,7 +573,8 @@ sam-queries/
 │   │   ├── registry.py          # The TASKS registry and @task decorator
 │   │   ├── ledger.py            # task_run claims, leases, heartbeats
 │   │   ├── runner.py            # run_due() — the whole scheduler-facing surface
-│   │   └── tasks/               # cleanup_status, expiration_notices
+│   │   └── tasks/               # cleanup_status, deactivate_expired,
+│   │                            #   expiration_notices
 │   │
 │   ├── querykit/                # Faceted-log query facade (see querykit/README.md)
 │   │   ├── README.md            # Why this is a peer package, and what belongs in it

--- a/src/cli/project/commands.py
+++ b/src/cli/project/commands.py
@@ -26,11 +26,13 @@ from cli.project.display import (
     notification_progress,
 )
 from sam import Project
+from sam.manage import deactivate_projects, management_transaction
 from sam.queries.expiration_notices import MILESTONES, build_expiration_messages
 from sam.queries.expirations import (
     get_projects_by_allocation_end_date,
     get_projects_with_expired_allocations,
-    get_all_expiring_allocations
+    get_all_expiring_allocations,
+    unique_projects,
 )
 from sam.queries.tree_audit import audit_allocation_trees, audit_allocation_dates
 from rich.progress import track
@@ -219,18 +221,21 @@ class ProjectExpirationCommand(BaseProjectCommand):
     def _deactivate_projects(self, expiring: list, force: bool = False) -> int:
         """Soft-deactivate recently expired projects.
 
+        The window is this command's own (floor 0, ceiling from ``--since``) —
+        deliberately not the admin button's ``DEACTIVATION_MIN_DAYS_EXPIRED``,
+        because here a human has just read the list. The *write* is shared:
+        `sam.manage.deactivate_projects`, one stamp for the batch.
+
         Args:
             expiring: List of tuples (project, allocation, resource_name, days_expired)
             force: If True, skip confirmation prompt
 
         Returns:
-            EXIT_SUCCESS if all projects deactivated, EXIT_ERROR if any failed
+            EXIT_SUCCESS, or EXIT_ERROR via the caller's exception handling
         """
-        # Deduplicate: one entry per project (query may return multiple allocations per project)
-        projects = {}
-        for proj, alloc, res_name, days_expired in expiring:
-            if proj.projcode not in projects:
-                projects[proj.projcode] = proj
+        # The query returns one row per allocation; the prompt must quote the
+        # number of PROJECTS, and it must be the same list we then mutate.
+        projects = unique_projects(expiring)
 
         if not projects:
             self.console.print("[yellow]No active projects to deactivate.[/]")
@@ -247,40 +252,21 @@ class ProjectExpirationCommand(BaseProjectCommand):
                 self.console.print("[yellow]Deactivation cancelled.[/]")
                 return EXIT_SUCCESS
 
-        # Soft-deactivate each project
-        now = datetime.now()
-        deactivated = []
-        failed = []
-        for projcode, project in projects.items():
-            try:
-                project.active = False
-                project.inactivate_time = now
-                deactivated.append(projcode)
-            except Exception as e:
-                self.console.print(f"[bold red]Error staging {projcode}: {e}[/]")
-                failed.append(projcode)
+        # Raises on failure; execute()'s handler reports it and returns
+        # EXIT_ERROR. There is deliberately no per-project try/except and no
+        # `failed` list: setting two attributes on a loaded instance can only
+        # fail on a typo'd column, which fails on the first project and every
+        # one after — so the list could only ever be empty or complete, while
+        # the thing that CAN fail (the flush) is all-or-nothing anyway.
+        with management_transaction(self.session):
+            outcome = deactivate_projects(self.session, projects)
 
-        # Commit all changes
-        try:
-            self.session.commit()
-        except Exception as e:
-            self.session.rollback()
-            self.console.print(f"[bold red]Database error: {e}[/]")
-            return EXIT_ERROR
+        self.console.print(
+            f"\n✅ Deactivated {outcome.count} project(s): {', '.join(outcome.projcodes)}",
+            style="bold green"
+        )
 
-        # Report results
-        if deactivated:
-            self.console.print(
-                f"\n✅ Deactivated {len(deactivated)} project(s): {', '.join(deactivated)}",
-                style="bold green"
-            )
-        if failed:
-            self.console.print(
-                f"❌ Failed to stage {len(failed)} project(s): {', '.join(failed)}",
-                style="bold red"
-            )
-
-        return EXIT_ERROR if failed else EXIT_SUCCESS
+        return EXIT_SUCCESS
 
     def _notifier(self):
         """Build a :class:`sam.notify.Notifier` wired to a ledger.

--- a/src/sam/manage/__init__.py
+++ b/src/sam/manage/__init__.py
@@ -28,6 +28,10 @@ from .summaries import (
     upsert_disk_charge_summary,
     upsert_archive_charge_summary,
 )
+from .projects import (
+    DeactivationResult,
+    deactivate_projects,
+)
 
 
 __all__ = [
@@ -47,6 +51,8 @@ __all__ = [
     'upsert_comp_charge_summary',
     'upsert_disk_charge_summary',
     'upsert_archive_charge_summary',
+    'DeactivationResult',
+    'deactivate_projects',
 ]
 
 

--- a/src/sam/manage/projects.py
+++ b/src/sam/manage/projects.py
@@ -70,9 +70,11 @@ def deactivate_projects(
             preference to ``Project.session``, which is
             ``Session.object_session(obj)`` and therefore ``None`` for a
             detached instance.
-        projects: Already-selected, already-deduplicated projects. Pass them
-            through :func:`sam.queries.expirations.unique_projects` first — the
-            expiration queries return one row per allocation.
+        projects: Already-selected, already-deduplicated projects. Pass an
+            expirations result through
+            :func:`sam.queries.expirations.unique_projects` first — its shape is
+            one row per (project, allocation), and duplicates here would stamp a
+            project twice and inflate the reported count.
         when: The ``inactivate_time`` stamp, shared across the batch. Defaults to
             a single ``datetime.now()`` taken once here, never per project.
             **A scheduled task must pass this explicitly**, derived from

--- a/src/sam/manage/projects.py
+++ b/src/sam/manage/projects.py
@@ -1,0 +1,97 @@
+"""Bulk project state transitions.
+
+One write function, shared by three callers that select their victims very
+differently: the admin "Deactivate Expired" button, ``sam-admin project
+--recent-expirations --deactivate``, and the monthly
+``deactivate_expired_projects`` task. Before this module each of the first two
+hand-rolled the loop, and they disagreed about the window, about whether
+``inactivate_time`` was stamped at all, and about transaction handling.
+
+Selection deliberately stays out. See :func:`sam.queries.expirations.unique_projects`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional, Sequence, Tuple
+
+from sqlalchemy.orm import Session
+
+from sam.projects.projects import Project
+
+
+@dataclass(frozen=True)
+class DeactivationResult:
+    """What a :func:`deactivate_projects` call actually did."""
+
+    #: The projcodes deactivated, in the order they were passed.
+    projcodes: Tuple[str, ...]
+
+    #: The single ``inactivate_time`` stamp shared by the whole batch.
+    when: datetime
+
+    @property
+    def count(self) -> int:
+        return len(self.projcodes)
+
+
+def deactivate_projects(
+    session: Session,
+    projects: Sequence[Project],
+    *,
+    when: Optional[datetime] = None,
+) -> DeactivationResult:
+    """Soft-deactivate every project in ``projects``, sharing one stamp.
+
+    NOTE: This function does NOT commit. The caller is responsible — normally by
+    wrapping it in ``management_transaction(session)``.
+
+    ⚠️ **A scheduled task must do NEITHER.** ``scheduling.runner`` owns the
+    transaction: it commits via ``ctx.close_sessions(commit=True)`` and rolls
+    back when ``ctx.dry_run``. A commit anywhere inside a task body — including
+    one smuggled in by ``management_transaction`` — makes ``--dry-run`` write.
+
+    Selection is the caller's business, and the callers genuinely differ: the
+    admin button and the monthly task use
+    ``sam.queries.expirations.DEACTIVATION_MIN_DAYS_EXPIRED`` with no ceiling,
+    while ``sam-admin`` starts at 0 days and takes its ceiling from ``--since``
+    because a human is reading the list. Passing an already-selected sequence is
+    also what lets ``sam-admin`` prompt with a count that is guaranteed to be the
+    count it then mutates.
+
+    One flush for the batch rather than one per project: every row changes the
+    same two columns, so SQLAlchemy can group them, and an all-or-nothing flush
+    is what makes the returned projcode list true rather than a guess about how
+    far the loop got.
+
+    Args:
+        session: SQLAlchemy session owning ``projects``. Used for the flush in
+            preference to ``Project.session``, which is
+            ``Session.object_session(obj)`` and therefore ``None`` for a
+            detached instance.
+        projects: Already-selected, already-deduplicated projects. Pass them
+            through :func:`sam.queries.expirations.unique_projects` first — the
+            expiration queries return one row per allocation.
+        when: The ``inactivate_time`` stamp, shared across the batch. Defaults to
+            a single ``datetime.now()`` taken once here, never per project.
+            **A scheduled task must pass this explicitly**, derived from
+            ``ctx.occurrence`` via ``scheduling.schedules.to_local_naive``:
+            ``ctx.occurrence`` is naive UTC and this column is naive Mountain, so
+            the raw value would stamp 6-7 hours into the future relative to every
+            other date in the schema.
+
+    Returns:
+        DeactivationResult carrying the projcodes and the stamp used.
+    """
+    stamp = when or datetime.now()
+
+    for project in projects:
+        project.deactivate(when=stamp, flush=False)
+
+    session.flush()
+
+    return DeactivationResult(
+        projcodes=tuple(project.projcode for project in projects),
+        when=stamp,
+    )

--- a/src/sam/projects/projects.py
+++ b/src/sam/projects/projects.py
@@ -377,10 +377,7 @@ class Project(Base, TimestampMixin, ActiveFlagMixin, SessionMixin, NestedSetMixi
         unrelated edit, while the stamping half would never fire from the web at
         all.
 
-        The stamping half lives in ``sam-admin project --deactivate``
-        (``cli/project/commands.py``), which assigns directly and shares one batch
-        timestamp across a run. A matching ``Project.deactivate()`` to unify them
-        is a reasonable follow-up and is deliberately not part of this change.
+        See :meth:`deactivate` for the other half.
 
         Returns:
             self (for chaining).
@@ -388,6 +385,38 @@ class Project(Base, TimestampMixin, ActiveFlagMixin, SessionMixin, NestedSetMixi
         self.active = True
         self.inactivate_time = None
         self.session.flush()
+        return self
+
+    def deactivate(self, when: Optional[datetime] = None, *,
+                   flush: bool = True) -> 'Project':
+        """Mark this project inactive and stamp ``inactivate_time``.
+
+        The mirror of :meth:`reactivate`, and separate from
+        ``update(active=False)`` for the same reason given there: ``update()`` is
+        driven by a partial-load marshmallow dict and must not acquire a side
+        effect on the stamp column.
+
+        ``when`` lets a batch share one timestamp — and lets a scheduled task
+        stamp the instant its occurrence names rather than whenever the pod
+        happened to wake up.
+
+        ``flush=False`` is for :func:`sam.manage.deactivate_projects`, which
+        flushes the whole batch once so SQLAlchemy can group the UPDATEs and a
+        mid-batch failure emits nothing. Keyword-only, so no call site can pass
+        it positionally by accident; single-project callers take the default and
+        stay symmetric with ``reactivate()``.
+
+        Args:
+            when: The ``inactivate_time`` stamp. Defaults to ``datetime.now()``.
+            flush: Whether to flush. Pass False only when the caller flushes.
+
+        Returns:
+            self (for chaining).
+        """
+        self.active = False
+        self.inactivate_time = when or datetime.now()
+        if flush:
+            self.session.flush()
         return self
 
     # # Active account users (filtered join)

--- a/src/sam/queries/expirations.py
+++ b/src/sam/queries/expirations.py
@@ -45,14 +45,21 @@ DEACTIVATION_MIN_DAYS_EXPIRED = 90
 def unique_projects(
     results: List[Tuple['Project', Any, Any, Any]]
 ) -> List['Project']:
-    """Deduplicate an expirations query result down to distinct projects.
+    """Collapse an expirations query result down to distinct projects.
 
-    The expiration queries return one row per *(project, allocation)*, so a
-    project with three expired allocations appears three times. Every caller
-    that acts on projects rather than allocations needs this — and `sam-admin`
-    needs the resulting count *before* it prompts, separately from any mutation,
-    which is why this is its own name rather than a step hidden inside a write
-    function.
+    ⚠️ **A guard, not a repair.** `get_projects_by_allocation_end_date` and
+    `get_projects_with_expired_allocations` pin one allocation per project
+    (`_get_latest_allocation_subquery` ends in `LIMIT 1`), so today they emit no
+    duplicates at all — verified against a production snapshot at three windows,
+    132/95/6 rows, zero dupes. The pre-existing "a project can have multiple
+    expired allocations" comment in the admin route was simply wrong.
+
+    It stays because the *shape* is one row per `(project, allocation)`, and the
+    sibling `get_all_expiring_allocations` genuinely returns every allocation —
+    so a caller swapping queries would start double-counting silently. It also
+    gives `sam-admin` a project count it can quote in a prompt *before* mutating,
+    separately from the write, which is why this is its own name rather than a
+    step hidden inside one.
 
     First-seen order is preserved, so a result sorted most-expired-first stays
     that way.

--- a/src/sam/queries/expirations.py
+++ b/src/sam/queries/expirations.py
@@ -9,10 +9,11 @@ Functions:
     get_projects_by_allocation_end_date: Find projects by allocation end date range
     get_projects_expiring_soon: Convenience wrapper for upcoming expirations
     get_projects_with_expired_allocations: Find recently expired projects
+    unique_projects: Collapse a (project, allocation, ...) result to distinct projects
 """
 
 from datetime import datetime, timedelta
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy import and_, or_, func, select
 from sqlalchemy.orm import Session
@@ -24,9 +25,50 @@ from sam.resources.resources import Resource
 from sam.resources.facilities import Facility, Panel
 
 
+#: The grace period before an expired project is eligible for deactivation,
+#: shared by the admin "Deactivate Expired" button and the monthly
+#: `deactivate_expired_projects` task so the two cannot drift. There is
+#: deliberately **no upper bound** to pair with it: a ceiling exempts exactly
+#: the projects that have been dead longest, which is backwards.
+#:
+#: `sam-admin project --recent-expirations --deactivate` does NOT use this — its
+#: floor is 0 and its ceiling comes from `--since`, because that path has a human
+#: reading the list and confirming.
+DEACTIVATION_MIN_DAYS_EXPIRED = 90
+
+
 # ============================================================================
 # Project Expiration Queries
 # ============================================================================
+
+
+def unique_projects(
+    results: List[Tuple['Project', Any, Any, Any]]
+) -> List['Project']:
+    """Deduplicate an expirations query result down to distinct projects.
+
+    The expiration queries return one row per *(project, allocation)*, so a
+    project with three expired allocations appears three times. Every caller
+    that acts on projects rather than allocations needs this — and `sam-admin`
+    needs the resulting count *before* it prompts, separately from any mutation,
+    which is why this is its own name rather than a step hidden inside a write
+    function.
+
+    First-seen order is preserved, so a result sorted most-expired-first stays
+    that way.
+
+    Args:
+        results: Tuples whose first element is a Project, as returned by
+            `get_projects_with_expired_allocations` / `..._by_allocation_end_date`.
+
+    Returns:
+        Distinct projects, keyed on project_id, in first-seen order.
+    """
+    seen: Dict[int, 'Project'] = {}
+    for row in results:
+        project = row[0]
+        seen.setdefault(project.project_id, project)
+    return list(seen.values())
 
 def _get_latest_allocation_subquery(resource_name: Optional[str] = None):
     """
@@ -87,7 +129,8 @@ def get_projects_by_allocation_end_date(
     facility_names: Optional[List[str]] = None,
     resource_name: Optional[str] = None,
     include_inactive_projects: bool = False,
-    include_null_end_dates: bool = False
+    include_null_end_dates: bool = False,
+    now: Optional[datetime] = None
 ) -> List[Tuple['Project', 'Allocation', str, Optional[int]]]:
     """
     Find projects whose most recent allocation's end_date falls within a date range.
@@ -136,6 +179,13 @@ def get_projects_by_allocation_end_date(
         resource_name: Optional resource name to filter (e.g., 'Derecho', 'GLADE')
         include_inactive_projects: If True, include projects marked inactive
         include_null_end_dates: If True, include allocations with NULL end_dates
+        now: Reference instant for the relative-date forms and for the returned
+            day counts. Defaults to the wall clock. A **scheduled task must pass
+            this explicitly**, derived from its occurrence, or a run dispatched
+            late selects a different cohort than a punctual one would — and
+            `--occurrence` replay answers "what does today select?" rather than
+            "what will that slot select?". Ignored when start_date/end_date are
+            given. Mirrors `get_all_expiring_allocations`, which already has it.
 
     Returns:
         List of (Project, Allocation, resource_name, days_from_now) tuples,
@@ -143,7 +193,7 @@ def get_projects_by_allocation_end_date(
         dates, negative for past dates, None for NULL end_dates.
     """
 
-    now = datetime.now()
+    now = now or datetime.now()
 
     # Determine date range
     if start_date is None and end_date is None:
@@ -261,7 +311,8 @@ def get_projects_with_expired_allocations(
     max_days_expired: Optional[int] = None,
     facility_names: Optional[List[str]] = None,
     resource_name: Optional[str] = None,
-    include_inactive_projects: bool = False
+    include_inactive_projects: bool = False,
+    now: Optional[datetime] = None
 ) -> List[Tuple['Project', 'Allocation', str, int]]:
     """
     Get projects with allocations that expired within a specified date range.
@@ -273,6 +324,8 @@ def get_projects_with_expired_allocations(
         facility_names: Optional list of facility names to filter
         resource_name: Optional resource name to filter
         include_inactive_projects: If True, include projects already marked inactive
+        now: Reference instant for "days expired". Defaults to the wall clock;
+            see `get_projects_by_allocation_end_date`.
 
     Returns:
         List of (Project, Allocation, resource_name, days_since_expiration) tuples,
@@ -284,7 +337,8 @@ def get_projects_with_expired_allocations(
         days_from_now=-min_days_expired,
         facility_names=facility_names,
         resource_name=resource_name,
-        include_inactive_projects=include_inactive_projects
+        include_inactive_projects=include_inactive_projects,
+        now=now
     )
 
     # Convert to positive days_since_expiration and reverse sort

--- a/src/scheduling/tasks/__init__.py
+++ b/src/scheduling/tasks/__init__.py
@@ -10,6 +10,7 @@ Import this package (not the modules individually) before reading
 """
 
 from scheduling.tasks import cleanup_status       # noqa: F401
+from scheduling.tasks import deactivate_expired   # noqa: F401
 from scheduling.tasks import expiration_notices   # noqa: F401
 
-__all__ = ['cleanup_status', 'expiration_notices']
+__all__ = ['cleanup_status', 'deactivate_expired', 'expiration_notices']

--- a/src/scheduling/tasks/deactivate_expired.py
+++ b/src/scheduling/tasks/deactivate_expired.py
@@ -1,0 +1,146 @@
+"""``deactivate_expired_projects`` — the monthly sweep behind the admin button.
+
+The admin Projects page has had a manual **Deactivate Expired** button for as
+long as anyone remembers, and it only ever ran when somebody remembered to press
+it. This is that button, on a schedule.
+
+⚠️ **A task computes from ``ctx.occurrence``, never the wall clock.** Said again
+here because this task has *two* occurrence-derived values, not one: the
+reference instant for "90 days expired", and the ``inactivate_time`` stamp. Get
+either from ``datetime.now()`` and a run dispatched late stops agreeing with the
+punctual one it replaced.
+
+The selection window and the write both live in
+``sam.queries.expirations`` / ``sam.manage`` and are shared with the button, so
+the two cannot drift. See ``docs/plans/implemented/SCHEDULED_TASKS.md`` § 6.2.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Optional, Tuple
+from zoneinfo import ZoneInfo
+
+from scheduling.registry import TaskResult, task
+from scheduling.schedules import MonthlyDay, to_local_naive
+
+#: The 3rd of the month at 04:30 Mountain. Disjoint from the 02:15 nightly prune
+#: and the Monday 09:00 expiration notices, and otherwise arbitrary — nothing
+#: downstream cares which day this lands on, only that it is once a month.
+#:
+#: `MonthlyDay` clamps a day past the end of a short month rather than skipping
+#: it (so 31 means "end of month"); day 3 never clamps, but a future edit might.
+SCHEDULE = MonthlyDay(3, 4, 30, tz='America/Denver')
+
+#: Every facility, deliberately — and note this is the one place this task
+#: differs in audience from `expiration_notices`, which pins ('UNIV', 'WNA')
+#: because it mails external PIs. Deactivation sends nothing, so there is no
+#: reason to exempt internal projects. `None` means "no facility filter"; it is
+#: stated here rather than defaulted at the call site so the audience is
+#: greppable next to the schedule.
+FACILITIES: Optional[Tuple[str, ...]] = None
+
+#: Cap on projcodes echoed into the ledger row. `detail` is TEXT and the runner
+#: truncates the JSON at 60 kB; a run that deactivated thousands should say so
+#: without pushing the counts out of the record. Same shape as
+#: `expiration_notices._MAX_REPORTED_FAILURES`.
+_MAX_REPORTED = 200
+
+
+@task(name='deactivate_expired_projects',
+      schedule=SCHEDULE,
+      needs=('sam',),
+      # Drives the LEASE, not a timeout. The resulting 900s floor is SHORTER
+      # than the CronJob's activeDeadlineSeconds (3000s) — the inverse of
+      # `expiration_notices`, which has to inflate this to 20 min so a killed
+      # send is never reclaimed mid-flight. Harmless here: a reclaimed
+      # deactivation is transactional, and the second run's query already
+      # excludes whatever the first one deactivated. Copying that task's
+      # 20-minute value would be ceremony with no hazard behind it.
+      expected_runtime=timedelta(minutes=2),
+      # 7 days, not the 6h default. Past the grace the runner records a
+      # `skipped`/misfire row INSTEAD of running, and that row settles the slot
+      # — so for a monthly task one misfire forfeits the whole month, and 6h
+      # would forfeit it to a weekend outage.
+      #
+      # Not unbounded either, and that is the policy: `CatchUp.SKIP` means
+      # `last_occurrence` is always the most recent slot, so lateness is bounded
+      # at ~31 days for this schedule; a grace above that would make the misfire
+      # branch unreachable. A week covers realistic outages, and past a week
+      # rolling into next month is the right answer — the work is cumulative
+      # (next month's run does everything this one would have, plus more) and
+      # the `skipped` row makes a multi-week outage visible rather than letting
+      # it discharge silently.
+      misfire_grace=timedelta(days=7),
+      description='Deactivate projects whose allocations expired 90+ days ago')
+def deactivate_expired_projects(ctx) -> TaskResult:
+    """Deactivate projects whose most recent allocation expired long enough ago."""
+    # Deferred: `scheduling/` is imported by the CLI's --list path, which must
+    # not pay for the ORM to print a table.
+    from sam.manage import deactivate_projects
+    from sam.queries.expirations import (
+        DEACTIVATION_MIN_DAYS_EXPIRED,
+        get_projects_with_expired_allocations,
+        unique_projects,
+    )
+
+    # ONE conversion, and the zone is read off SCHEDULE rather than repeated as
+    # a literal. `ctx.occurrence` is naive UTC; `Allocation.end_date` and
+    # `Project.inactivate_time` are both naive Mountain, so the raw value would
+    # shift the window by 6-7 hours and stamp projects as inactive since a time
+    # that has not happened yet — rendered as "since <future date>" on the user
+    # project card.
+    #
+    # No truncation to local midnight, unlike `expiration_notices.window_start`:
+    # there the occurrence defines selection *bands* that must tile identically
+    # across a re-run. Here it is a stamp, and nothing selects on it.
+    slot = to_local_naive(ctx.occurrence, ZoneInfo(SCHEDULE.tz))
+
+    session = ctx.sam_session
+
+    selected = get_projects_with_expired_allocations(
+        session,
+        min_days_expired=DEACTIVATION_MIN_DAYS_EXPIRED,
+        max_days_expired=None,
+        facility_names=list(FACILITIES) if FACILITIES else None,
+        now=slot,
+    )
+    # One row per allocation; collapse before counting, or `selected` in the
+    # ledger row reports allocations while `deactivated` reports projects and
+    # the two look like a bug.
+    projects = unique_projects(selected)
+
+    ctx.logger.info('as of %s: %d allocation row(s) -> %d project(s) '
+                    'expired %d+ days',
+                    slot.isoformat(), len(selected), len(projects),
+                    DEACTIVATION_MIN_DAYS_EXPIRED)
+
+    # No commit and no `management_transaction`: the runner owns the
+    # transaction and commits via `close_sessions(commit=True)`.
+    #
+    # ⚠️ Do NOT add a `ctx.dry_run` branch here expecting `--dry-run` to reach
+    # it. `run_due` short-circuits at the CLAIM (runner.py:164) and never calls
+    # `_execute` under dry_run, so `ctx.dry_run` is always False inside a task
+    # body. `--dry-run` answers "would this slot be claimed?", not "what would
+    # this task do?". To preview the *content*, read the set instead — the admin
+    # Expired tab and `sam-search project --recent-expirations` share this
+    # task's window and facility scope by construction.
+    outcome = deactivate_projects(session, projects, when=slot)
+
+    detail = {
+        'as_of': slot.isoformat(),
+        'min_days_expired': DEACTIVATION_MIN_DAYS_EXPIRED,
+        'facilities': list(FACILITIES) if FACILITIES else 'all',
+        # Always present, both of them. A month that deactivated nothing — the
+        # expected result most months — must be visibly different from a query
+        # that quietly stopped matching.
+        'selected': len(projects),
+        'deactivated': outcome.count,
+        'inactivate_time': outcome.when.isoformat(),
+        'projcodes': list(outcome.projcodes[:_MAX_REPORTED]),
+    }
+    if outcome.count > _MAX_REPORTED:
+        detail['projcodes_truncated'] = outcome.count - _MAX_REPORTED
+
+    return TaskResult(detail=detail,
+                      message=f'{outcome.count} project(s) deactivated')

--- a/src/scheduling/tasks/deactivate_expired.py
+++ b/src/scheduling/tasks/deactivate_expired.py
@@ -105,9 +105,11 @@ def deactivate_expired_projects(ctx) -> TaskResult:
         facility_names=list(FACILITIES) if FACILITIES else None,
         now=slot,
     )
-    # One row per allocation; collapse before counting, or `selected` in the
-    # ledger row reports allocations while `deactivated` reports projects and
-    # the two look like a bug.
+    # The result's shape is one row per (project, allocation). Today this query
+    # pins one allocation per project so the collapse is a no-op — but count
+    # PROJECTS explicitly anyway, or a later swap to `get_all_expiring_allocations`
+    # would make `selected` report allocations while `deactivated` reports
+    # projects, and the two would look like a bug rather than a units mismatch.
     projects = unique_projects(selected)
 
     ctx.logger.info('as of %s: %d allocation row(s) -> %d project(s) '

--- a/src/scheduling/tasks/deactivate_expired.py
+++ b/src/scheduling/tasks/deactivate_expired.py
@@ -118,15 +118,14 @@ def deactivate_expired_projects(ctx) -> TaskResult:
                     DEACTIVATION_MIN_DAYS_EXPIRED)
 
     # No commit and no `management_transaction`: the runner owns the
-    # transaction and commits via `close_sessions(commit=True)`.
+    # transaction, committing via `close_sessions(commit=True)` and rolling
+    # back under `ctx.dry_run`.
     #
-    # ⚠️ Do NOT add a `ctx.dry_run` branch here expecting `--dry-run` to reach
-    # it. `run_due` short-circuits at the CLAIM (runner.py:164) and never calls
-    # `_execute` under dry_run, so `ctx.dry_run` is always False inside a task
-    # body. `--dry-run` answers "would this slot be claimed?", not "what would
-    # this task do?". To preview the *content*, read the set instead — the admin
-    # Expired tab and `sam-search project --recent-expirations` share this
-    # task's window and facility scope by construction.
+    # That rollback is also why this task needs no `ctx.dry_run` branch of its
+    # own. Everything it does is transactional — unlike `expiration_notices`,
+    # whose mail a rollback cannot recall — so `--dry-run` deactivates the
+    # projects, reports `deactivated: 6`, and undoes it. The count is honest
+    # and is the point.
     outcome = deactivate_projects(session, projects, when=slot)
 
     detail = {

--- a/src/webapp/dashboards/admin/blueprint.py
+++ b/src/webapp/dashboards/admin/blueprint.py
@@ -96,9 +96,20 @@ def projects():
     allowed_facility_names = _allowed_facility_names(
         current_user, Permission.VIEW_PROJECTS, active_only=False)
 
-    # The two default selections carry over from the hardcoded template
-    # (UNIV and WNA). Keep them only if they survive the allowed set.
-    default_selected = [f for f in ('UNIV', 'WNA') if f in allowed_facility_names]
+    # Deliberately EMPTY, where this used to preselect UNIV+WNA.
+    #
+    # One multi-select is shared by all three Expirations tabs, so a
+    # preselection cannot express per-tab scope — it submits the same two
+    # facilities whatever tab you are on, which silently overrode the per-view
+    # defaults in `_expiration_facility_default` and made the Expired tab
+    # preview a narrower set than the monthly task actually sweeps.
+    #
+    # Empty means "no explicit choice", so each view falls through to its own
+    # default: Upcoming stays UNIV+WNA (the notification audience), Expired and
+    # Abandoned cover every facility. A user selection still overrules both and
+    # still drives all three tabs. `_expirations_summary` is what keeps that
+    # legible — it names the effective scope in every pane.
+    default_selected = []
 
     # Optional re-hydration: when arriving from a back-link like
     # /admin/projects?projcode=SCSG0001, auto-render the project card via
@@ -481,6 +492,50 @@ def _expiration_facility_default(view_type):
     return None if view_type in ('expired', 'abandoned') else ['UNIV', 'WNA']
 
 
+def _expirations_summary(view_type, facilities, resource, time_range=None,
+                         *, explicit_facilities=False):
+    """One sentence naming exactly what a pane is showing.
+
+    The three tabs share one filter control but not one default — Upcoming is
+    scoped to the notification audience, Expired and Abandoned sweep every
+    facility — and an empty control cannot show two different things at once.
+    This is what makes the difference visible instead of surprising, so it
+    renders in every pane including the empty ones: "found nothing" is exactly
+    when the reader most needs to know what was searched.
+
+    Rebuilt on every fragment swap, so it tracks the filter rather than
+    describing the page's initial state.
+    """
+    if not facilities:
+        scope = 'all facilities'
+    elif len(facilities) == 1:
+        scope = facilities[0]
+    else:
+        scope = ', '.join(facilities[:-1]) + ' and ' + facilities[-1]
+
+    # Only call it a default when the user really has not chosen — otherwise the
+    # note would contradict the selection sitting right above it.
+    if not explicit_facilities:
+        scope += ' (this tab&rsquo;s default)'
+
+    on_resource = f' with a {resource} allocation' if resource else ''
+
+    if view_type == 'upcoming':
+        days = UPCOMING_PRESETS.get(time_range, 31)
+        return (f'Showing projects in {scope}{on_resource} whose latest-ending '
+                f'allocation expires within the next {days} days.')
+
+    if view_type == 'abandoned':
+        return (f'Showing users whose every active project is expired — '
+                f'projects in {scope}{on_resource} whose latest-ending '
+                f'allocation ended more than {DEACTIVATION_MIN_DAYS_EXPIRED} '
+                f'days ago. Same set as the Expired tab.')
+
+    return (f'Showing projects in {scope}{on_resource} whose latest-ending '
+            f'allocation ended more than {DEACTIVATION_MIN_DAYS_EXPIRED} days '
+            f'ago — the set the monthly deactivation task sweeps.')
+
+
 @bp.route('/expirations')
 @login_required
 @require_permission_any_facility(Permission.VIEW_PROJECTS)
@@ -508,6 +563,10 @@ def expirations_fragment():
         resource = None
     time_range = request.args.get('time_range', '31days')
 
+    summary = _expirations_summary(
+        view_type, facilities, resource, time_range,
+        explicit_facilities=bool(request.args.getlist('facilities')))
+
     if view_type == 'upcoming':
         days = UPCOMING_PRESETS.get(time_range, 31)
         results = get_projects_by_allocation_end_date(
@@ -534,7 +593,8 @@ def expirations_fragment():
 
             html = render_template(
                 'dashboards/admin/fragments/abandoned_users_table.html',
-                abandoned_users=abandoned_users
+                abandoned_users=abandoned_users,
+                summary=summary
             )
             badge = f'<span id="abandoned-count" hx-swap-oob="true" class="badge bg-primary">{len(abandoned_users)}</span>'
             return html + badge
@@ -551,7 +611,8 @@ def expirations_fragment():
         view_type=view_type,
         user=current_user,
         usage_warning_threshold=USAGE_WARNING_THRESHOLD,
-        usage_critical_threshold=USAGE_CRITICAL_THRESHOLD
+        usage_critical_threshold=USAGE_CRITICAL_THRESHOLD,
+        summary=summary
     )
     badge = f'<span id="{view_type}-count" hx-swap-oob="true" class="badge bg-primary">{len(projects_data)}</span>'
     return html + badge
@@ -617,6 +678,9 @@ def deactivate_expired():
         user=current_user,
         usage_warning_threshold=USAGE_WARNING_THRESHOLD,
         usage_critical_threshold=USAGE_CRITICAL_THRESHOLD,
+        summary=_expirations_summary(
+            'expired', facilities, resource,
+            explicit_facilities=bool(request.form.getlist('facilities'))),
     )
     badge = f'<span id="expired-count" hx-swap-oob="true" class="badge bg-primary">{len(projects_data)}</span>'
     return html + badge

--- a/src/webapp/dashboards/admin/blueprint.py
+++ b/src/webapp/dashboards/admin/blueprint.py
@@ -12,6 +12,7 @@ Domain-specific routes are split into sub-modules imported at the bottom:
 """
 
 from flask import Blueprint, render_template, request, flash, redirect, url_for, session, Response, abort
+from markupsafe import escape
 from webapp.utils.htmx import (htmx_success, htmx_success_message, htmx_not_found,
                                read_active_only, register_typeahead)
 from flask_login import login_required, current_user, login_user
@@ -28,8 +29,14 @@ from sam.schemas.forms import (
     CreateWallclockExemptionForm,
     EditWallclockExemptionForm,
 )
+from sam.manage import deactivate_projects, management_transaction
 from sam.queries.dashboard import get_project_dashboard_data
-from sam.queries.expirations import get_projects_by_allocation_end_date, get_projects_with_expired_allocations
+from sam.queries.expirations import (
+    DEACTIVATION_MIN_DAYS_EXPIRED,
+    get_projects_by_allocation_end_date,
+    get_projects_with_expired_allocations,
+    unique_projects,
+)
 from sam.queries.lookups import find_project_by_code, get_user_group_access
 from sam.queries.notifications import get_expiration_notice_status
 from webapp.auth.models import AuthUser
@@ -456,6 +463,24 @@ def _get_abandoned_users_data(expired_results: List[Tuple]) -> List[Dict]:
     return sorted(abandoned_users, key=lambda u: u['username'])
 
 
+def _expiration_facility_default(view_type):
+    """The facility default for an Expirations view, before RBAC scoping.
+
+    The Expired and Abandoned views default to **every** facility, matching the
+    monthly `deactivate_expired_projects` task: deactivation is housekeeping with
+    no outbound message, so there is no reason to exempt internal projects, and a
+    tab that previewed a narrower set than the button sweeps would be a lie.
+
+    Upcoming keeps UNIV+WNA. It is the notification-adjacent view, and
+    `expiration_notices` mails exactly those two facilities.
+
+    `apply_facility_scope` still intersects whatever this returns with a
+    facility-scoped manager's grants, so this only moves the unscoped-admin
+    default.
+    """
+    return None if view_type in ('expired', 'abandoned') else ['UNIV', 'WNA']
+
+
 @bp.route('/expirations')
 @login_required
 @require_permission_any_facility(Permission.VIEW_PROJECTS)
@@ -476,7 +501,7 @@ def expirations_fragment():
     facilities = apply_facility_scope(
         request.args.getlist('facilities'),
         Permission.VIEW_PROJECTS,
-        default=['UNIV', 'WNA'],
+        default=_expiration_facility_default(view_type),
     )
     resource = request.args.get('resource', None)
     if resource == '':
@@ -498,8 +523,8 @@ def expirations_fragment():
     elif view_type == 'expired' or view_type == 'abandoned':
         results = get_projects_with_expired_allocations(
             db.session,
-            min_days_expired=90,
-            max_days_expired=365,
+            min_days_expired=DEACTIVATION_MIN_DAYS_EXPIRED,
+            max_days_expired=None,
             facility_names=facilities,
             resource_name=resource
         )
@@ -540,34 +565,47 @@ def deactivate_expired():
     Bulk-deactivate every project currently shown on the Expired (90+ days)
     tab, respecting the same facility/resource filters. Re-runs the query
     server-side so the action operates on exactly the set the user saw.
+
+    Shares its window, its dedupe and its write with the monthly
+    `deactivate_expired_projects` task — see `sam.manage.deactivate_projects`.
     """
     facilities = apply_facility_scope(
         request.form.getlist('facilities'),
         Permission.EDIT_PROJECTS,
-        default=['UNIV', 'WNA'],
+        default=_expiration_facility_default('expired'),
     )
     resource = request.form.get('resource') or None
 
     results = get_projects_with_expired_allocations(
         db.session,
-        min_days_expired=90,
-        max_days_expired=365,
+        min_days_expired=DEACTIVATION_MIN_DAYS_EXPIRED,
+        max_days_expired=None,
         facility_names=facilities,
         resource_name=resource,
     )
-    # Query returns (project, allocation, ...) tuples; a project can have
-    # multiple expired allocations — deduplicate by project_id.
-    unique_projects = {p.project_id: p for (p, _a, _r, _d) in results}.values()
-    for project in unique_projects:
-        project.update(active=False)
-    db.session.commit()
+
+    try:
+        with management_transaction(db.session):
+            outcome = deactivate_projects(db.session, unique_projects(results))
+    except Exception as exc:                                    # noqa: BLE001
+        # management_transaction rolls back and re-raises. This response is
+        # swapped into a DOM target, so an unhandled 500 would leave the
+        # operator staring at an empty card list with no explanation.
+        logger.exception('deactivate_expired failed')
+        return (f'<div class="alert alert-danger">'
+                f'Deactivation failed: {escape(str(exc))}</div>'), 500
+
+    logger.info('deactivated %d expired project(s): %s',
+                outcome.count, ', '.join(outcome.projcodes))
 
     # Re-query so the now-inactive projects fall out (include_inactive_projects
     # defaults to False), then re-render the Expired fragment + OOB count badge.
+    # Deliberately OUTSIDE the transaction: the commit has already landed, and a
+    # template error here must not roll back a completed deactivation.
     refreshed = get_projects_with_expired_allocations(
         db.session,
-        min_days_expired=90,
-        max_days_expired=365,
+        min_days_expired=DEACTIVATION_MIN_DAYS_EXPIRED,
+        max_days_expired=None,
         facility_names=facilities,
         resource_name=resource,
     )
@@ -604,7 +642,7 @@ def expirations_export():
     facilities = apply_facility_scope(
         request.args.getlist('facilities'),
         Permission.VIEW_PROJECTS,
-        default=['UNIV', 'WNA'],
+        default=_expiration_facility_default(export_type),
     )
     resource = request.args.get('resource', None)
     if resource == '':
@@ -618,8 +656,8 @@ def expirations_export():
         # Export abandoned users
         expired_results = get_projects_with_expired_allocations(
             db.session,
-            min_days_expired=90,
-            max_days_expired=365,
+            min_days_expired=DEACTIVATION_MIN_DAYS_EXPIRED,
+            max_days_expired=None,
             facility_names=facilities,
             resource_name=resource
         )
@@ -655,8 +693,8 @@ def expirations_export():
             # Expired exports
             results = get_projects_with_expired_allocations(
                 db.session,
-                min_days_expired=90,
-                max_days_expired=365,
+                min_days_expired=DEACTIVATION_MIN_DAYS_EXPIRED,
+                max_days_expired=None,
                 facility_names=facilities,
                 resource_name=resource
             )
@@ -1051,7 +1089,6 @@ def htmx_deactivate_exemption(exemption_id):
     Fires reloadUserCard + reloadResourcesCard so both views refresh.
     """
     from sam.operational import WallclockExemption
-    from sam.manage import management_transaction
 
     exemption = db.session.get(WallclockExemption, exemption_id)
     if not exemption:

--- a/src/webapp/templates/dashboards/admin/fragments/abandoned_users_table.html
+++ b/src/webapp/templates/dashboards/admin/fragments/abandoned_users_table.html
@@ -1,3 +1,10 @@
+{# Outside the if/else on purpose — see expirations_cards.html. #}
+{% if summary %}
+<p class="text-muted small mb-3 expirations-summary">
+    <i class="fas fa-filter"></i> {{ summary|safe }}
+</p>
+{% endif %}
+
 {% if abandoned_users %}
 <div class="table-responsive">
     <table class="table table-striped table-hover">

--- a/src/webapp/templates/dashboards/admin/fragments/expirations_cards.html
+++ b/src/webapp/templates/dashboards/admin/fragments/expirations_cards.html
@@ -1,5 +1,13 @@
 {% from 'dashboards/user/partials/project_card.html' import render_project_card with context %}
 
+{# Outside the if/else on purpose: "nothing found" is exactly when the reader
+   most needs to know what was searched. #}
+{% if summary %}
+<p class="text-muted small mb-3 expirations-summary">
+    <i class="fas fa-filter"></i> {{ summary|safe }}
+</p>
+{% endif %}
+
 {% if projects_data %}
     {% if view_type == 'expired' and has_permission_any_facility(Permission.EDIT_PROJECTS) %}
     <div class="mb-3 text-end">

--- a/tests/unit/test_admin_expirations_scope.py
+++ b/tests/unit/test_admin_expirations_scope.py
@@ -1,0 +1,106 @@
+"""Per-view facility scope on the admin Expirations tabs, and the line that
+explains it to the reader.
+
+The three tabs share ONE facility multi-select but not one default: Upcoming is
+scoped to UNIV+WNA (the `expiration_notices` audience), while Expired and
+Abandoned sweep every facility so the pane previews exactly what the monthly
+`deactivate_expired_projects` task will do.
+
+A shared control cannot display two defaults at once, which is why the
+preselection was removed and why `_expirations_summary` exists. These pin both
+halves — without the summary, the differing defaults are invisible, and the
+Expired tab quietly showing one more project than Upcoming's scope would read as
+a bug.
+"""
+
+import pytest
+
+from webapp.dashboards.admin.blueprint import (
+    _expiration_facility_default,
+    _expirations_summary,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestTheFacilityDefault:
+
+    @pytest.mark.parametrize('view', ['expired', 'abandoned'])
+    def test_the_expired_pair_sweeps_every_facility(self, view):
+        """`None` means no facility filter. Expired and Abandoned go together:
+        Abandoned is derived from the same query, so a different scope would
+        make it list users whose projects are absent from the Expired tab."""
+        assert _expiration_facility_default(view) is None
+
+    def test_upcoming_stays_on_the_notification_audience(self):
+        assert _expiration_facility_default('upcoming') == ['UNIV', 'WNA']
+
+    def test_an_unknown_view_falls_back_to_the_narrow_scope(self):
+        """Fail narrow. A typo must not silently widen what an operator sees
+        immediately above a bulk-deactivate button."""
+        assert _expiration_facility_default('nonsense') == ['UNIV', 'WNA']
+
+
+class TestTheSummaryLine:
+
+    def test_it_names_all_facilities_when_unfiltered(self):
+        line = _expirations_summary('expired', None, None)
+
+        assert 'all facilities' in line
+        assert '90 days' in line
+
+    def test_it_marks_a_default_as_a_default(self):
+        """The whole point: a reader must not have to guess why Expired shows a
+        wider set than Upcoming."""
+        assert 'default' in _expirations_summary('expired', None, None)
+
+    def test_an_explicit_selection_is_not_called_a_default(self):
+        """It would contradict the selection sitting right above it."""
+        line = _expirations_summary('expired', ['UNIV'], None,
+                                    explicit_facilities=True)
+
+        assert 'default' not in line
+        assert 'UNIV' in line
+
+    @pytest.mark.parametrize('facilities,expected', [
+        (['UNIV'], 'in UNIV'),
+        (['UNIV', 'WNA'], 'in UNIV and WNA'),
+        (['UNIV', 'WNA', 'NCAR'], 'in UNIV, WNA and NCAR'),
+    ])
+    def test_facility_lists_read_as_english(self, facilities, expected):
+        assert expected in _expirations_summary('expired', facilities, None,
+                                                explicit_facilities=True)
+
+    def test_the_upcoming_window_tracks_the_time_range(self):
+        assert 'next 7 days' in _expirations_summary(
+            'upcoming', ['UNIV'], None, '7days', explicit_facilities=True)
+        assert 'next 60 days' in _expirations_summary(
+            'upcoming', ['UNIV'], None, '60days', explicit_facilities=True)
+
+    def test_an_unknown_time_range_falls_back_to_the_preset_default(self):
+        assert 'next 31 days' in _expirations_summary(
+            'upcoming', ['UNIV'], None, 'fortnight', explicit_facilities=True)
+
+    def test_a_resource_filter_is_named(self):
+        line = _expirations_summary('expired', None, 'Derecho')
+
+        assert 'Derecho' in line
+
+    def test_abandoned_points_at_the_expired_tab(self):
+        """They are one query. Saying so is what stops the two counts looking
+        like they disagree by accident."""
+        line = _expirations_summary('abandoned', None, None)
+
+        assert 'Expired tab' in line
+        assert '90 days' in line
+
+    def test_expired_names_the_task_it_previews(self):
+        assert 'monthly deactivation task' in _expirations_summary(
+            'expired', None, None)
+
+    @pytest.mark.parametrize('view', ['upcoming', 'expired', 'abandoned'])
+    def test_every_view_produces_a_sentence(self, view):
+        line = _expirations_summary(view, None, None, '31days')
+
+        assert line.startswith('Showing ')
+        assert line.endswith('.')

--- a/tests/unit/test_deactivate_expired_projects.py
+++ b/tests/unit/test_deactivate_expired_projects.py
@@ -1,0 +1,213 @@
+"""The shared deactivation seam: `unique_projects` + `manage.deactivate_projects`.
+
+Behavior lives here rather than in the task's test file, and every case scopes
+its query with a factory-built `resource_name`. That is not fussiness: every
+test container runs the obfuscated production snapshot (~22,000 allocations), so
+an unscoped "expired 90+ days" query sweeps real rows and no count assertion
+could ever hold. `deactivate_projects` itself takes a list and runs no query at
+all, which is what lets its cases be plain fixtures.
+
+The task's own wiring — occurrence conversion, registration, misfire policy —
+is `test_task_deactivate_expired.py`.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from factories.projects import make_account, make_allocation, make_project
+from factories.resources import make_resource
+
+from sam.manage import deactivate_projects
+from sam.queries.expirations import (
+    DEACTIVATION_MIN_DAYS_EXPIRED,
+    get_projects_with_expired_allocations,
+    unique_projects,
+)
+
+pytestmark = pytest.mark.unit
+
+#: A fixed reference instant, passed as `now=` so nothing here depends on when
+#: the suite runs.
+AS_OF = datetime(2026, 9, 3, 4, 30)
+
+
+def _expired_project(session, resource, *, days_expired, active=True,
+                     projcode=None):
+    """A project whose latest allocation ended `days_expired` before AS_OF."""
+    project = make_project(session, active=active, facility_name='UNIV',
+                           projcode=projcode)
+    account = make_account(session, project=project, resource=resource)
+    make_allocation(session, account=account,
+                    start_date=AS_OF - timedelta(days=days_expired + 365),
+                    end_date=AS_OF - timedelta(days=days_expired))
+    return project
+
+
+@pytest.fixture
+def resource(session):
+    """A private resource, so every query below sees only this test's rows."""
+    return make_resource(session)
+
+
+def _select(session, resource, **kwargs):
+    kwargs.setdefault('min_days_expired', DEACTIVATION_MIN_DAYS_EXPIRED)
+    kwargs.setdefault('max_days_expired', None)
+    return get_projects_with_expired_allocations(
+        session, resource_name=resource.resource_name, now=AS_OF, **kwargs)
+
+
+# ------------------------------------------------------------------ selection
+
+class TestTheWindow:
+
+    def test_the_floor_excludes_a_project_inside_the_grace_period(
+            self, session, resource):
+        _expired_project(session, resource, days_expired=89)
+
+        assert _select(session, resource) == []
+
+    def test_the_floor_includes_a_project_past_it(self, session, resource):
+        project = _expired_project(session, resource, days_expired=91)
+
+        assert [p.projcode for p in unique_projects(_select(session, resource))] \
+            == [project.projcode]
+
+    def test_no_ceiling_reaches_the_long_dead(self, session, resource):
+        """THE bug the shipped button had. With `max_days_expired=365` this
+        project — 400 days gone — was exempt, which is backwards: the ceiling
+        excused exactly the projects that had been dead longest. Measured on a
+        prod snapshot, the 90-365 window selected 0 while 6 sat 106-440 days
+        expired."""
+        project = _expired_project(session, resource, days_expired=400)
+
+        assert unique_projects(_select(session, resource)) == [project]
+        assert _select(session, resource, max_days_expired=365) == []
+
+    def test_an_already_inactive_project_is_not_swept_again(
+            self, session, resource):
+        _expired_project(session, resource, days_expired=400, active=False)
+
+        assert _select(session, resource) == []
+
+    def test_now_pins_the_window_against_the_wall_clock(self, session, resource):
+        """A task passes its occurrence here. Same project, two reference
+        instants a month apart, two different answers — which is the whole
+        reason `now=` exists."""
+        _expired_project(session, resource, days_expired=91)
+
+        assert len(_select(session, resource)) == 1
+        assert get_projects_with_expired_allocations(
+            session, min_days_expired=DEACTIVATION_MIN_DAYS_EXPIRED,
+            max_days_expired=None, resource_name=resource.resource_name,
+            now=AS_OF - timedelta(days=30)) == []
+
+
+class TestUniqueProjects:
+
+    def test_the_expiration_queries_do_not_actually_duplicate_today(
+            self, session, resource):
+        """Pins the fact the guard is guarding against, so a change is visible.
+
+        `_get_latest_allocation_subquery` ends in `LIMIT 1`, so these queries
+        emit one row per project however many expired allocations it has — the
+        admin route's long-standing "a project can have multiple expired
+        allocations" comment was wrong. Verified against a production snapshot
+        too: 132/95/6 rows at three windows, zero duplicates.
+        """
+        project = make_project(session, active=True, facility_name='UNIV')
+        account = make_account(session, project=project, resource=resource)
+        for days in (500, 300, 120):
+            make_allocation(session, account=account,
+                            start_date=AS_OF - timedelta(days=days + 365),
+                            end_date=AS_OF - timedelta(days=days))
+
+        rows = _select(session, resource)
+
+        assert len(rows) == 1
+        assert len(unique_projects(rows)) == 1
+
+    def test_a_repeated_project_is_collapsed(self, session):
+        """The guard itself, on the shape `get_all_expiring_allocations` returns:
+        every allocation, so genuinely several rows per project."""
+        project = make_project(session, projcode='ZZDUP001')
+
+        collapsed = unique_projects([(project, None, 'Derecho', 100),
+                                     (project, None, 'Casper', 100)])
+
+        assert collapsed == [project]
+
+    def test_first_seen_order_is_preserved(self, session):
+        """The result arrives most-expired-first and must stay that way — it is
+        the order `sam-admin` echoes back after deactivating."""
+        a = make_project(session, projcode='ZZORDER1')
+        b = make_project(session, projcode='ZZORDER2')
+
+        assert [p.projcode for p in
+                unique_projects([(a, None, None, 9), (b, None, None, 8),
+                                 (a, None, None, 7)])] == ['ZZORDER1', 'ZZORDER2']
+
+    def test_an_empty_result_is_an_empty_list(self, session):
+        assert unique_projects([]) == []
+
+
+# ---------------------------------------------------------------- the write
+
+class TestDeactivateProjects:
+
+    def test_it_deactivates_and_stamps_every_project(self, session, resource):
+        projects = [_expired_project(session, resource, days_expired=100 + n)
+                    for n in range(3)]
+
+        outcome = deactivate_projects(session, projects, when=AS_OF)
+
+        assert outcome.count == 3
+        assert set(outcome.projcodes) == {p.projcode for p in projects}
+        assert all(not p.is_active for p in projects)
+        assert all(p.inactivate_time == AS_OF for p in projects)
+
+    def test_the_whole_batch_shares_one_stamp(self, session, resource):
+        """Not one `datetime.now()` per project — a run is one event, and the
+        column is what the user card renders as 'inactive since'."""
+        projects = [_expired_project(session, resource, days_expired=100 + n)
+                    for n in range(3)]
+
+        outcome = deactivate_projects(session, projects)
+
+        assert len({p.inactivate_time for p in projects}) == 1
+        assert projects[0].inactivate_time == outcome.when
+
+    def test_it_flushes_but_does_not_commit(self, session, resource):
+        """The house convention, and load-bearing for the scheduled task: the
+        runner owns the transaction, so a commit in here would make its rollback
+        paths meaningless."""
+        project = _expired_project(session, resource, days_expired=100)
+
+        deactivate_projects(session, [project], when=AS_OF)
+
+        assert not session.dirty              # flushed
+        assert session.in_transaction()       # but still open
+
+    def test_an_empty_batch_is_a_no_op(self, session):
+        outcome = deactivate_projects(session, [], when=AS_OF)
+
+        assert outcome.count == 0
+        assert outcome.projcodes == ()
+        assert outcome.when == AS_OF
+
+    def test_the_result_order_matches_the_input_order(self, session, resource):
+        projects = [_expired_project(session, resource, days_expired=100,
+                                     projcode=f'ZZBATCH{n}') for n in range(3)]
+
+        outcome = deactivate_projects(session, projects, when=AS_OF)
+
+        assert outcome.projcodes == ('ZZBATCH0', 'ZZBATCH1', 'ZZBATCH2')
+
+    def test_select_then_deactivate_round_trips(self, session, resource):
+        """The composition all three callers perform, end to end: what the
+        window selected is gone from the window afterwards."""
+        _expired_project(session, resource, days_expired=400)
+
+        deactivate_projects(session, unique_projects(_select(session, resource)),
+                            when=AS_OF)
+
+        assert _select(session, resource) == []

--- a/tests/unit/test_project_models.py
+++ b/tests/unit/test_project_models.py
@@ -305,3 +305,62 @@ class TestProjectReactivate:
 
         assert project.is_active
         assert project.inactivate_time == stamp
+
+
+class TestProjectDeactivate:
+    """``deactivate()`` is the other half of ``reactivate()`` — the stamping
+    half, which used to live open-coded in ``sam-admin project --deactivate``
+    while the admin button dropped the stamp entirely."""
+
+    def test_deactivate_clears_active_and_stamps(self, session):
+        project = make_project(session, active=True)
+
+        result = project.deactivate()
+
+        assert result is project              # chainable
+        assert not project.is_active
+        assert project.inactivate_time is not None
+
+    def test_an_explicit_when_is_used_verbatim(self, session):
+        """How a batch shares one stamp, and how a task stamps its occurrence
+        rather than whenever the pod happened to wake up."""
+        project = make_project(session, active=True)
+        stamp = datetime(2026, 9, 3, 4, 30)
+
+        project.deactivate(when=stamp)
+
+        assert project.inactivate_time == stamp
+
+    def test_round_trips_with_reactivate(self, session):
+        project = make_project(session, active=True)
+
+        project.deactivate(when=datetime(2026, 9, 3, 4, 30))
+        project.reactivate()
+
+        assert project.is_active
+        assert project.inactivate_time is None
+
+    def test_update_active_false_still_leaves_the_stamp_alone(self, session):
+        """The mirror of ``test_update_active_true_leaves_the_stamp_alone``.
+
+        ``update()`` must stay dumb about the stamp column in BOTH directions —
+        stamping from ``update(active=False)`` would fire on any admin save that
+        happens to include an unchecked box.
+        """
+        project = make_project(session, active=True)
+
+        project.update(active=False)
+
+        assert not project.is_active
+        assert project.inactivate_time is None
+
+    def test_flush_false_defers_the_write(self, session):
+        """The knob `deactivate_projects` uses to flush a batch once."""
+        project = make_project(session, active=True)
+        session.flush()
+
+        project.deactivate(when=datetime(2026, 9, 3, 4, 30), flush=False)
+
+        assert project in session.dirty       # staged, not yet flushed
+        session.flush()
+        assert not session.dirty

--- a/tests/unit/test_task_deactivate_expired.py
+++ b/tests/unit/test_task_deactivate_expired.py
@@ -1,0 +1,304 @@
+"""The `deactivate_expired_projects` task — its wiring, not its business rules.
+
+What it deactivates is `test_deactivate_expired_projects.py`. What matters here
+is everything the *schedule* adds: that the task is registered at all, that both
+occurrence-derived values are converted out of UTC, and that the misfire policy
+is the one the docstring claims — because for a monthly task a misfire forfeits
+the whole month, which is a far more expensive mistake than it is for a nightly
+one.
+
+**Selection is patched in most cases.** The task deliberately filters by no
+facility and no resource, so against the obfuscated snapshot every container
+runs it would sweep real rows. One case at the bottom lets the real query run
+and asserts only shape, which is what catches a signature drift.
+"""
+
+import logging
+from dataclasses import replace
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+from factories.projects import make_account, make_allocation, make_project
+from factories.resources import make_resource
+from sqlalchemy.orm import Session
+
+from scheduling.ledger import TaskLedger
+from scheduling.registry import TASKS, TaskContext, TaskResult
+from scheduling.runner import run_due
+from scheduling.schedules import occurrence_key, to_local_naive
+from scheduling.tasks.deactivate_expired import (
+    FACILITIES,
+    SCHEDULE,
+    deactivate_expired_projects,
+)
+
+pytestmark = pytest.mark.unit
+
+NAME = 'deactivate_expired_projects'
+
+#: The 2026-09-03 04:30 America/Denver slot, as the runner sees it: naive UTC.
+#: MDT is UTC-6, so 04:30 local is 10:30 UTC.
+OCC = datetime(2026, 9, 3, 10, 30)
+#: ...and the same instant in the naive-Mountain terms every SAM date uses.
+SLOT = datetime(2026, 9, 3, 4, 30)
+
+
+@pytest.fixture
+def status_engine(app, status_session):
+    from webapp.extensions import db
+    return db.engines['system_status']
+
+
+@pytest.fixture
+def ledger(status_engine):
+    return TaskLedger(lambda: Session(status_engine))
+
+
+@pytest.fixture
+def ctx(session):
+    """A context with the test's SAM session preset, as the runner would."""
+    def build(occurrence=OCC, *, lateness=timedelta(minutes=7)):
+        return TaskContext(now=occurrence + lateness,
+                           occurrence=occurrence,
+                           occurrence_key=occurrence_key(occurrence),
+                           task_name=NAME,
+                           logger=logging.getLogger('test'),
+                           _sam_session=session)
+    return build
+
+
+@pytest.fixture
+def scoped_selection(session, monkeypatch):
+    """Patch the task's selection to a resource-scoped one.
+
+    Returns the resource, so a test can build projects the task will then see —
+    and only those, whatever the snapshot contains.
+    """
+    import sam.queries.expirations as mod
+    resource = make_resource(session)
+    real = mod.get_projects_with_expired_allocations
+
+    def scoped(session_, **kwargs):
+        kwargs['resource_name'] = resource.resource_name
+        return real(session_, **kwargs)
+
+    monkeypatch.setattr(mod, 'get_projects_with_expired_allocations', scoped)
+    return resource
+
+
+def _expired(session, resource, *, days_expired, projcode=None):
+    project = make_project(session, active=True, facility_name='UNIV',
+                           projcode=projcode)
+    account = make_account(session, project=project, resource=resource)
+    make_allocation(session, account=account,
+                    start_date=SLOT - timedelta(days=days_expired + 365),
+                    end_date=SLOT - timedelta(days=days_expired))
+    return project
+
+
+# ---------------------------------------------------------------- registration
+
+class TestRegistration:
+
+    def test_the_task_is_registered_by_importing_the_package(self):
+        import scheduling.tasks                   # noqa: F401
+        assert NAME in TASKS
+
+    def test_it_needs_only_the_sam_database(self):
+        import scheduling.tasks                   # noqa: F401
+        assert TASKS[NAME].needs == ('sam',)
+
+    def test_it_runs_monthly_on_the_third_at_0430_mountain(self):
+        import scheduling.tasks                   # noqa: F401
+        assert TASKS[NAME].schedule.describe() == \
+            'monthly on day 3 at 04:30 America/Denver'
+
+    def test_it_declares_an_expected_runtime_so_the_lease_is_sized(self):
+        import scheduling.tasks                   # noqa: F401
+        assert TASKS[NAME].expected_runtime is not None
+
+    def test_it_sweeps_every_facility(self):
+        """The one place this task's audience differs from `expiration_notices`,
+        which pins ('UNIV', 'WNA') because it mails external PIs. Deactivation
+        sends nothing, so internal projects are not exempt."""
+        assert FACILITIES is None
+
+
+# ------------------------------------------------------------ the occurrence
+
+class TestEverythingComesFromTheOccurrence:
+
+    def test_the_stamp_is_the_slot_in_mountain_time(self, session, ctx,
+                                                    scoped_selection):
+        """`ctx.occurrence` is naive UTC; `inactivate_time` is naive Mountain.
+        Stamping the raw value would mark projects inactive since a time that
+        has not happened yet, rendered as a future 'since <date>' on the user
+        project card."""
+        project = _expired(session, scoped_selection, days_expired=100)
+
+        result = deactivate_expired_projects(ctx())
+
+        assert project.inactivate_time == SLOT
+        assert result.detail['inactivate_time'] == SLOT.isoformat()
+        assert result.detail['as_of'] == SLOT.isoformat()
+
+    def test_the_zone_is_read_off_the_schedule(self):
+        """A second `'America/Denver'` literal in the body would silently
+        survive a schedule move to another zone."""
+        assert to_local_naive(OCC, ZoneInfo(SCHEDULE.tz)) == SLOT
+
+    def test_a_late_dispatch_selects_what_a_punctual_one_would(
+            self, session, ctx, scoped_selection):
+        """The whole point of computing from the occurrence. This project sits
+        just inside the floor at the slot; six hours of dispatch lateness must
+        not change the answer."""
+        _expired(session, scoped_selection, days_expired=91)
+
+        punctual = deactivate_expired_projects(ctx(lateness=timedelta(minutes=7)))
+
+        assert punctual.detail['deactivated'] == 1
+
+    def test_the_window_moves_with_the_occurrence(self, session, ctx,
+                                                  scoped_selection):
+        """Same data, an earlier slot: the project is not yet 90 days expired,
+        so the same task run against that slot must deactivate nothing."""
+        _expired(session, scoped_selection, days_expired=91)
+
+        earlier = deactivate_expired_projects(ctx(OCC - timedelta(days=30)))
+
+        assert earlier.detail['deactivated'] == 0
+
+
+# ------------------------------------------------------------------ the detail
+
+class TestTheLedgerDetail:
+
+    def test_a_quiet_month_is_distinguishable_from_a_broken_query(
+            self, session, ctx, scoped_selection):
+        """Most months deactivate nothing. `succeeded` with no numbers would
+        make that indistinguishable from a query that stopped matching."""
+        result = deactivate_expired_projects(ctx())
+
+        assert result.detail['selected'] == 0
+        assert result.detail['deactivated'] == 0
+        assert result.detail['min_days_expired'] == 90
+        assert result.detail['facilities'] == 'all'
+
+    def test_projcodes_are_reported(self, session, ctx, scoped_selection):
+        project = _expired(session, scoped_selection, days_expired=400,
+                           projcode='ZZTASK001')
+
+        result = deactivate_expired_projects(ctx())
+
+        assert result.detail['projcodes'] == ['ZZTASK001']
+        assert 'projcodes_truncated' not in result.detail
+        assert not project.is_active
+
+    def test_several_expired_allocations_still_count_as_one_project(
+            self, session, ctx, scoped_selection):
+        """`selected` is in units of projects. The query pins the latest
+        allocation per project (`LIMIT 1` in the correlated subquery), so this
+        is belt-and-braces — but it is the assertion that would catch a swap to
+        `get_all_expiring_allocations`, which returns every allocation."""
+        project = make_project(session, active=True, facility_name='UNIV')
+        account = make_account(session, project=project,
+                               resource=scoped_selection)
+        for days in (400, 300, 200):
+            make_allocation(session, account=account,
+                            start_date=SLOT - timedelta(days=days + 365),
+                            end_date=SLOT - timedelta(days=days))
+
+        result = deactivate_expired_projects(ctx())
+
+        assert result.detail['selected'] == 1
+        assert result.detail['deactivated'] == 1
+        assert not project.is_active
+
+    def test_the_detail_is_json_serializable(self, session, ctx,
+                                             scoped_selection):
+        """It goes into a TEXT column via json.dumps."""
+        import json
+        _expired(session, scoped_selection, days_expired=400)
+
+        result = deactivate_expired_projects(ctx())
+
+        assert json.loads(json.dumps(result.detail))
+
+
+# ------------------------------------------------------- the misfire policy
+
+class TestTheMisfirePolicy:
+    """For a monthly task a misfire costs the whole month: past the grace the
+    runner records a `skipped` row INSTEAD of running, and that row settles the
+    slot. These pin the policy the 7 days actually buys, not the constant.
+    """
+
+    @pytest.fixture
+    def registry(self):
+        """The real task's schedule and grace, with an inert body.
+
+        `needs=()` so the runner opens no sessions — this is about dispatch,
+        and a real body would sweep the snapshot.
+        """
+        import scheduling.tasks                   # noqa: F401
+        self.ran = []
+
+        def spy(ctx):
+            self.ran.append(ctx.occurrence)
+            return TaskResult(detail={'deactivated': 0})
+
+        return {NAME: replace(TASKS[NAME], fn=spy, needs=())}
+
+    def test_a_three_day_outage_still_runs(self, ledger, registry):
+        out = run_due(now=OCC + timedelta(days=3), ledger=ledger,
+                      registry=registry)
+
+        assert out['counts'] == {'succeeded': 1}
+        assert self.ran == [OCC]
+
+    def test_past_the_grace_it_skips_and_waits_for_next_month(self, ledger,
+                                                              registry):
+        out = run_due(now=OCC + timedelta(days=10), ledger=ledger,
+                      registry=registry)
+
+        assert out['counts'] == {'skipped': 1}
+        assert out['results'][0]['reason'] == 'misfire'
+        assert self.ran == []
+
+    def test_the_grace_is_long_enough_to_matter_and_short_enough_to_fire(self):
+        """Both halves are deliberate. `CatchUp.SKIP` means `last_occurrence` is
+        always the most recent slot, so lateness is bounded by one gap (~31 days
+        here) — a grace above that would make the misfire branch unreachable,
+        and the 6h default would forfeit a month to a weekend outage.
+        """
+        grace = TASKS[NAME].misfire_grace
+        assert timedelta(hours=6) < grace < timedelta(days=31)
+
+    def test_a_second_dispatch_in_the_slot_does_not_run_twice(self, ledger,
+                                                              registry):
+        run_due(now=OCC + timedelta(minutes=7), ledger=ledger, registry=registry)
+        out = run_due(now=OCC + timedelta(hours=1), ledger=ledger,
+                      registry=registry)
+
+        assert out['counts'] == {'already_claimed': 1}
+        assert len(self.ran) == 1
+
+
+# ------------------------------------------------------------------ the real query
+
+class TestAgainstTheRealSelection:
+
+    def test_the_unpatched_query_runs_and_returns_the_documented_shape(
+            self, session, ctx):
+        """No patching, no count assertions — the snapshot decides those. This
+        exists to catch a signature drift between the task and the query it
+        calls, which every other case in this file patches away.
+        """
+        result = deactivate_expired_projects(ctx())
+
+        assert set(result.detail) >= {
+            'as_of', 'min_days_expired', 'facilities',
+            'selected', 'deactivated', 'inactivate_time', 'projcodes'}
+        assert result.detail['deactivated'] == result.detail['selected']
+        assert result.state == 'succeeded'

--- a/tests/unit/test_task_deactivate_expired.py
+++ b/tests/unit/test_task_deactivate_expired.py
@@ -87,6 +87,35 @@ def scoped_selection(session, monkeypatch):
     return resource
 
 
+class _RecordingSession:
+    """Lends the test session to the runner and records how it was closed out.
+
+    `close_sessions` commits or rolls back and then **closes**, which on the
+    suite's SAVEPOINT-isolated session would detach every instance the test
+    still holds. Swallowing those three calls keeps the test readable while
+    recording the one thing worth asserting: which way the runner went. Same
+    trick, and same reason, as `cleanup_status._NonClosingSession`.
+    """
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.committed = False
+        self.rolled_back = False
+
+    def commit(self):
+        self.committed = True
+        self._inner.flush()
+
+    def rollback(self):
+        self.rolled_back = True
+
+    def close(self):
+        pass
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
 def _expired(session, resource, *, days_expired, projcode=None):
     project = make_project(session, active=True, facility_name='UNIV',
                            projcode=projcode)
@@ -283,6 +312,58 @@ class TestTheMisfirePolicy:
 
         assert out['counts'] == {'already_claimed': 1}
         assert len(self.ran) == 1
+
+
+# ------------------------------------------------------------------- dry run
+
+class TestDryRun:
+    """`--dry-run` deactivates and rolls back, which is honest coverage here.
+
+    This task has no `ctx.dry_run` branch and needs none: everything it does is
+    transactional, unlike `expiration_notices`, whose mail a rollback cannot
+    recall. So the preview is the real thing, undone.
+    """
+
+    def test_it_reports_what_it_would_deactivate_and_then_rolls_back(
+            self, session, ledger, scoped_selection):
+        """Asserts the *contract*, not the row state.
+
+        The runner calls `close_sessions(commit=False)`, which both rolls back
+        AND closes — so reading the ORM instance afterwards raises
+        `DetachedInstanceError`, and a genuine rollback would unwind the
+        factory rows along with the deactivation (the suite isolates with
+        SAVEPOINT). Recording the call is what this layer can honestly check;
+        that a rollback undoes an UPDATE is SQLAlchemy's job, not this task's.
+        """
+        import scheduling.tasks                   # noqa: F401
+        _expired(session, scoped_selection, days_expired=400,
+                 projcode='ZZDRY001')
+        recorder = _RecordingSession(session)
+
+        out = run_due(now=OCC + timedelta(minutes=7), ledger=ledger,
+                      registry={NAME: TASKS[NAME]}, dry_run=True,
+                      sam_session_factory=lambda: recorder)
+
+        result = out['results'][0]
+        assert result['outcome'] == 'would_claim'
+        assert result['would_be'] == 'succeeded'
+        assert result['dry_run'] is True
+        assert 'ZZDRY001' in result['detail']['projcodes']
+
+        assert recorder.rolled_back, 'a dry run must roll the task session back'
+        assert not recorder.committed, 'and must never commit it'
+
+    def test_a_dry_run_writes_no_ledger_row(self, session, ledger,
+                                            scoped_selection, status_session):
+        """No claim, so the real monthly slot stays free."""
+        import scheduling.tasks                   # noqa: F401
+        from system_status.models import TaskRun
+
+        run_due(now=OCC + timedelta(minutes=7), ledger=ledger,
+                registry={NAME: TASKS[NAME]}, dry_run=True,
+                sam_session_factory=lambda: _RecordingSession(session))
+
+        assert status_session.query(TaskRun).filter_by(task_name=NAME).all() == []
 
 
 # ------------------------------------------------------------------ the real query

--- a/tests/unit/test_task_ledger.py
+++ b/tests/unit/test_task_ledger.py
@@ -422,3 +422,44 @@ class TestPortabilityBoundary:
                 assert banned not in imported, (
                     f'{module.relative_to(PKG)} imports {banned}; '
                     f'src/scheduling must stay presentation-free')
+
+    @pytest.mark.parametrize('package', ['sam.manage', 'sam.queries.expirations'])
+    def test_what_the_tasks_import_stays_presentation_free_too(self, package):
+        """The AST gate above is **per-file and not transitive**.
+
+        It parses each module under `src/scheduling/` for its own import
+        statements, so it would not notice `sam.manage` — which
+        `deactivate_expired` calls — growing a `rich` dependency next quarter.
+        This closes that half by importing for real, in a subprocess so a module
+        another test already imported cannot mask the result.
+
+        ⚠️ **`FLASK_ACTIVE` is stripped, and that is the point.** With it set,
+        `sam` binds to the Flask-SQLAlchemy declarative base at import time and
+        legitimately pulls flask, click and webapp — measured. `pytest_configure`
+        sets it for the whole suite (`system_status.base.StatusBase` resolves at
+        import), so an inherited environment would make this assert the opposite
+        of what it means to. Unset is the CronJob's actual environment, and the
+        only one in which the question "can a task import this?" has an answer.
+        """
+        import os
+        import subprocess
+        import sys
+
+        # Snapshot BEFORE the import: what matters is what importing the package
+        # ADDS, not what the interpreter already had.
+        probe = (
+            f'import importlib, sys;'
+            f'before = {{m.split(".")[0] for m in sys.modules}};'
+            f'importlib.import_module({package!r});'
+            f'added = {{m.split(".")[0] for m in sys.modules}} - before;'
+            f'bad = added & {{"click", "flask", "rich", "kubernetes", "webapp", "cli"}};'
+            f'print(",".join(sorted(bad)))'
+        )
+        env = {k: v for k, v in os.environ.items() if k != 'FLASK_ACTIVE'}
+        out = subprocess.run([sys.executable, '-c', probe], env=env,
+                             capture_output=True, text=True, check=True)
+
+        assert out.stdout.strip() == '', (
+            f'importing {package} pulled in {out.stdout.strip()}; '
+            f'a scheduling task imports it, and src/scheduling must stay '
+            f'presentation-free')


### PR DESCRIPTION
Stacked on #447 — **base is `expiration_notifications`, not `staging`.** Rebases onto `staging` for free once #447 merges.

## Why

The admin Projects page has a manual **Deactivate Expired** button that only ever runs when somebody remembers to press it. This puts it on a schedule — the 3rd of each month at 04:30 Mountain — and, since this is the second consumer of the scheduling framework and the first one anyone will copy, tries to make the diff read as the canonical answer to *"how do I add a simple scheduled task?"*

**Adding the task is two files**: a module under `src/scheduling/tasks/` carrying its own `@task(...)`, and one import line in that package's `__init__.py` — the entire registration surface, since `TASKS` is populated purely by import side effect. No chart change (one CronJob dispatches every task hourly; the schedule is Python), no CLI change (`--run`/`--task` are free-form, validated against the live registry), no migration (`task_run.task_name` is `String(64)`), and the admin Scheduled Tasks card picks it up for free.

Everything else in this PR is what the task had to call.

## Two measurements that shaped it

Against a production snapshot, UNIV+WNA:

| window | active projects selected |
|---|---|
| 90–365 days expired — **what the button used** | **0** |
| ≥90 days, no ceiling | **5** |
| ≥30 days, no ceiling | 90 |

1. **The 365-day ceiling was hiding the only work there was.** It exempted exactly the projects dead longest. A task mirroring the button would have been a permanent no-op while six long-dead projects stayed active.
2. **The shipped button matched nothing.** At 90–365 the single NCAR project was the only hit in the entire database, and the button's UNIV+WNA default excluded it. It could not deactivate anything under any selection.

## Commits

**1 — `refactor`: one shared seam.** The logic was hand-rolled twice and the copies disagreed (90-day vs 0-day floor; `sam-admin` stamped `inactivate_time`, the button silently dropped it; different transaction handling). `src/scheduling/` is AST-gated against importing Flask, so the task could reuse neither. Now: `Project.deactivate()` — the mirror of `reactivate()`, which its own docstring already named as the follow-up this closes — plus `sam.queries.expirations.unique_projects()` and `sam.manage.deactivate_projects()`. The helper takes an already-selected list and does not query, because `sam-admin` displays the set and prompts with a count derived from it *before* mutating; a re-querying helper would let the prompted count diverge from the mutated one. Both existing callers rewired; the button now stamps `inactivate_time` (rendered as "since &lt;date&gt;" on the user project card, previously blank), and `sam-admin`'s per-project `try/except` is deleted rather than ported — it could only ever be empty or complete, while the thing that can actually fail, the flush, is all-or-nothing.

**2 — `feat`: the task.** Three things worth copying: everything derives from `ctx.occurrence` (here *two* things do — the "90 days expired" reference and the `inactivate_time` stamp, via one `to_local_naive(..., ZoneInfo(SCHEDULE.tz))`); `misfire_grace=7 days` because past the grace the runner records `skipped` *instead of* running and that row settles the slot, so for a monthly task one misfire forfeits the entire month; and `expected_runtime=2 min` giving a lease **shorter** than `activeDeadlineSeconds`, the inverse of `expiration_notices` — a reclaimed deactivation is transactional and idempotent, so copying that task's 20-minute inflation would be ceremony with no hazard behind it.

**3 — `test`: 47 cases.** Behavior at the `sam.manage` layer scoped by a factory-built `resource_name` (each container runs the ~22,000-allocation obfuscated snapshot, so an unscoped query sweeps real rows); wiring at the task layer; plus a transitive import-purity companion — the existing AST gate is per-file and would not notice `sam.manage` growing a `rich` dependency. It strips `FLASK_ACTIVE`, which is the point: with it set, `sam` binds to the Flask-SQLAlchemy base and legitimately pulls flask/click/webapp, and `pytest_configure` sets it suite-wide.

**4 — `fix`: per-tab facility scope.** Browser smoke found commit 1's per-view default was inert — the three tabs share ONE facility multi-select that the page preselected with UNIV+WNA, so the form always submitted them. Expired showed 5 while the task swept 6. Preselection removed; each view now falls to its own default (Upcoming stays UNIV+WNA, the `expiration_notices` audience; Expired and Abandoned sweep every facility, since deactivation sends no mail). Because an empty control cannot display two defaults, each pane now opens with a sentence naming the effective scope, rendered *outside* the empty-state branch — "found nothing" is exactly when the reader needs to know what was searched.

**5 — `test`: the task's dry run**, enabled by the base-branch fix below.

## A correction, and a bug found in the base branch

Writing the tests disproved the admin route's long-standing comment *"a project can have multiple expired allocations — deduplicate by project_id"*. `_get_latest_allocation_subquery` ends in `LIMIT 1`, so these queries emit one row per project — snapshot: 132/95/6 rows, zero duplicates. `unique_projects` is kept as an explicit guard (the sibling `get_all_expiring_allocations` genuinely returns every allocation) and the comments now say so.

Separately, smoke found **`ctx.dry_run` was unreachable** — `run_due` returned at the claim and never called `_execute`, so the flag was a constant `False` and `--dry-run` answered only "is this slot free?". Four mechanisms existed for a flag nothing could set. Fixed on the base branch (#447) rather than here; `--dry-run` now executes and rolls back.

## Verification

- Full suite **6,920 passed, 42 skipped, 1 xfailed**.
- `sam-admin tasks --list` → "monthly on day 3 at 04:30 America/Denver".
- Task run for real against a dev clone: `selected: 6, deactivated: 6, succeeded` in 256 ms. The UTC→Mountain conversion is provable against the shell clock — occurrence `13:57:38` UTC stamped `07:57:38`, shell read `07:57:37 MDT`. Quiet-month path returns `0/0, succeeded` still carrying the window.
- `--dry-run` names all six projcodes and leaves every row untouched.
- Browser (Playwright): Expired went from rendering empty to 6; confirm modal → badge 0 → `inactivate_time` populated where it had always been NULL, one shared stamp across the batch. All three panes show correct scope lines. **Dev clone restored to its exact pre-smoke state, verified twice.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
