### PR TITLE
Repoint SAM_TASKS_DISABLED: enable cleanup, disable the rest

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -85,6 +85,13 @@ services:
       - "JUPYTERHUB_API_TOKEN=${JUPYTERHUB_API_TOKEN:-}"
       - "JUPYTERHUB_CACHE_TTL=${JUPYTERHUB_CACHE_TTL:-300}"
       - "GOOGLE_CALENDAR_EMBED_URL=${GOOGLE_CALENDAR_EMBED_URL:-https://calendar.google.com/calendar/embed?src=ucar.edu_o09r1n89tid1b8jkrvurc8qio4%40group.calendar.google.com&ctz=America%2FDenver}"
+      # Empty by default, which is also the code default: nothing disabled.
+      # Present only so the kill-switch warning on Admin → Configuration can be
+      # exercised locally the way e2e/test_scheduled_tasks_card.py documents.
+      # Without this line a shell-exported value never reaches the container,
+      # and that test skips instead of running. Nothing here DISPATCHES tasks —
+      # compose runs no CronJob — so this only drives what the card reports.
+      - "SAM_TASKS_DISABLED=${SAM_TASKS_DISABLED:-}"
 
     healthcheck:
       # Probe the app's own readiness endpoint, which pings every configured
@@ -166,6 +173,13 @@ services:
       - "JUPYTERHUB_API_TOKEN=${JUPYTERHUB_API_TOKEN:-}"
       - "JUPYTERHUB_CACHE_TTL=${JUPYTERHUB_CACHE_TTL:-300}"
       - "GOOGLE_CALENDAR_EMBED_URL=${GOOGLE_CALENDAR_EMBED_URL:-https://calendar.google.com/calendar/embed?src=ucar.edu_o09r1n89tid1b8jkrvurc8qio4%40group.calendar.google.com&ctz=America%2FDenver}"
+      # Empty by default, which is also the code default: nothing disabled.
+      # Present only so the kill-switch warning on Admin → Configuration can be
+      # exercised locally the way e2e/test_scheduled_tasks_card.py documents.
+      # Without this line a shell-exported value never reaches the container,
+      # and that test skips instead of running. Nothing here DISPATCHES tasks —
+      # compose runs no CronJob — so this only drives what the card reports.
+      - "SAM_TASKS_DISABLED=${SAM_TASKS_DISABLED:-}"
 
     # Important: watch the current directory, re-syncing as needed based on source changes
     develop:

--- a/docs/README-k8s.md
+++ b/docs/README-k8s.md
@@ -247,7 +247,7 @@ Scheduled tasks, by environment:
 |---|---|---|
 | Local Docker Compose (`webdev`) | n/a — no chart | Run by hand: `sam-admin tasks --run-due` |
 | Local k8s (Docker Desktop) | `false` | Nothing should silently DELETE local data |
-| CIRRUS k8s (this chart) | `true`, kill-switched | `SAM_TASKS_DISABLED=cleanup_status_snapshots` until the soak completes |
+| CIRRUS k8s (this chart) | `true`, kill-switched | Staged enable: only `cleanup_status_snapshots` runs. `SAM_TASKS_DISABLED=deactivate_expired_projects,expiration_notices` |
 
 When the per-environment Entra app strategy is adopted (separate `sam-production`
 and `sam-staging` Entra apps), only the OpenBao / SSM values change — the chart
@@ -325,20 +325,57 @@ kubectl logs -n <namespace> job/tasks-manual-1
 
 ⚠️ **The kill switch.** `tasks.env.SAM_TASKS_DISABLED` is a comma-separated list
 of task names to skip, flippable in `values.yaml` with no code deploy. It ships
-**non-empty** (`cleanup_status_snapshots`) so that merging the chart deploys a
-dispatcher which runs hourly, writes `skipped` rows and deletes nothing — the
-24 h soak that proves credentials, DNS, image and Postgres reachability from a
-pod that is not the webapp, with zero blast radius. Clearing it is a separate,
-reviewable one-line commit.
+**non-empty** because tasks are enabled in stages: each one stays named here
+until it has been reviewed on its own, so the dispatcher wakes hourly and the
+untried task writes a `skipped` row instead of running. Today only
+`cleanup_status_snapshots` is live; `deactivate_expired_projects` and
+`expiration_notices` are switched off. Enabling one is a separate, reviewable
+one-line commit.
+
+⚠️ **It is an enumeration, and it is fail-OPEN.** `disabled_tasks()` in
+`src/scheduling/runner.py` is a case-sensitive exact match against registry
+keys. There is **no wildcard** — `all`, `*` and `none` are just names that
+match nothing — and an unknown name is never validated or warned about, so a
+typo silently disables nothing. A task added to `src/scheduling/tasks/`
+therefore **dispatches on the next hourly wake** unless its name is added here
+in the same change.
+
+`deactivate_expired_projects` and `expiration_notices` are exactly that case:
+both were registered without this list being touched, so the image promotion
+that carries them into production would have started both immediately. The
+list is a chart-side decision and the registry is a code-side one, and nothing
+couples them — so adding a task means editing both, in the same change.
+
+Two behaviors worth knowing before flipping it:
+
+- **A skip settles the slot.** A disabled task writes a terminal `skipped` row
+  (`detail={'reason': 'disabled'}`), so re-enabling one mid-slot does not
+  backfill — the first real run is the *next* occurrence of its schedule.
+- **It outranks the CLI.** The switch is checked ahead of dueness and ahead of
+  `only`/`force`, so `sam-admin tasks --run <name> --force` cannot override it.
+  Remove the name from `values.yaml` instead.
+
+The value is declared **once** and consumed twice: the CronJob obeys it, and
+the webapp Deployment carries it so Admin → Configuration reports it. Keep them
+in sync — `helm/tests/test-cronjob-render.sh` asserts per-manifest agreement,
+and `scripts/cirrus_healthcheck.sh` compares the two deployed values.
 
 `tasks.enabled: false` in `values-local.yaml`: on Docker Desktop nothing should
-silently DELETE local data. To smoke-test it there:
+silently DELETE local data. To smoke-test it there, disable **every** task —
+what is being proved is that the dispatcher wakes and writes ledger rows, and
+that needs no task to actually do anything:
 
 ```bash
 helm upgrade --install samuel ./helm -f helm/values.yaml -f helm/values-local.yaml \
   -n samuel-dev --set tasks.enabled=true --set tasks.schedule='*/5 * * * *' \
-  --set 'tasks.env.SAM_TASKS_DISABLED=cleanup_status_snapshots'
+  --set 'tasks.env.SAM_TASKS_DISABLED=cleanup_status_snapshots\,deactivate_expired_projects\,expiration_notices'
 ```
+
+⚠️ `--set` **replaces** the list rather than adding to it, and the commas need
+escaping. Naming only one task here leaves the other two live against your
+local databases — including `expiration_notices`, whose audience is external
+PIs. (`NOTIFY_ENABLED` is fail-closed and unset locally, so nothing would
+actually send, but do not rely on that as the only guard.)
 
 ### Destroy
 

--- a/e2e/test_scheduled_tasks_card.py
+++ b/e2e/test_scheduled_tasks_card.py
@@ -9,10 +9,15 @@ Two scenarios, both chosen because they are about what the operator actually
    Only a browser proves the tile is really there after the swap.
 
 2. **The kill-switch warning.** The single most important pixel here.
-   Production ships with ``SAM_TASKS_DISABLED: "cleanup_status_snapshots"``
-   (``helm/values.yaml``), so the first thing this card shows in production is
-   a dispatcher waking hourly and deliberately doing nothing. If the card does
-   not say so loudly it looks like a healthy system.
+   Production ships ``SAM_TASKS_DISABLED`` non-empty (``helm/values.yaml``,
+   currently the two tasks awaiting review), so the card always has a
+   dispatcher waking hourly and deliberately doing nothing to report. If it
+   does not say so loudly the system looks healthy.
+
+   The assertions below deliberately do **not** name a task: which tasks are
+   switched off is a chart decision that changes without this file, and a
+   pinned name turns that ordinary edit into a red e2e run. What is asserted
+   is the shape — a warning, and an explanation of what disabled *means*.
 
 Everything else about this feature is cheaper and less fragile at the unit
 tier: the ``unavailable`` degrade needs a table-less database (there is no
@@ -20,9 +25,10 @@ monkeypatch here — this tier drives a live stack over HTTP), and the 403
 boundary is covered by ``tests/unit/test_admin_scheduled_tasks_page.py``'s
 ``config_only_client``.
 
-To exercise scenario 2 locally the stack has to actually carry the switch::
+To exercise scenario 2 locally the stack has to actually carry the switch.
+``compose.yaml`` passes the host variable through (empty by default), so::
 
-    SAM_TASKS_DISABLED=cleanup_status_snapshots docker compose up webdev --watch
+    SAM_TASKS_DISABLED=expiration_notices docker compose up webdev --watch
     make e2e SAM_E2E_BASE_URL=http://localhost:5050
 
 Without it that test skips rather than passing vacuously.
@@ -115,15 +121,19 @@ class TestTheKillSwitchWarning:
         if 'Disabled:' not in card.inner_text():
             pytest.skip(
                 'this stack has no SAM_TASKS_DISABLED set, so there is no '
-                'warning to assert. Re-run with '
-                'SAM_TASKS_DISABLED=cleanup_status_snapshots on the webapp.')
+                'warning to assert. Re-run with e.g. '
+                'SAM_TASKS_DISABLED=expiration_notices on the webapp.')
 
         assert card.locator('.alert-warning').count() >= 1, \
             'a disabled task is named but not rendered as a warning — ' \
             'production ships kill-switched and this is the pixel that ' \
             'stops it reading as healthy'
         text = card.inner_text()
-        assert 'cleanup_status_snapshots' in text
+        # Shape, not identity: assert the warning actually NAMES something,
+        # rather than pinning whichever tasks the chart switches off today.
+        named = text.split('Disabled:', 1)[1].lstrip()
+        assert named[:1].isalpha(), \
+            f'the warning says "Disabled:" but names no task — got {named[:60]!r}'
         assert 'do nothing' in text, \
             'the warning must say what being disabled MEANS, not just name ' \
             'the task'

--- a/helm/tests/test-cronjob-render.sh
+++ b/helm/tests/test-cronjob-render.sh
@@ -129,14 +129,27 @@ assert_contains "$prod_out" 'value: "America/Denver"' \
 
 # --- Ships kill-switched ----------------------------------------------------
 #
-# This is a deliberate, temporary state: the P5 rollout is 24h of `skipped`
-# rows proving creds/DNS/image with zero blast radius, and only THEN a second
-# commit clearing the switch. If you are here because this assertion failed
-# after that second commit, delete it.
+# A deliberate, ongoing state: the chart enables tasks in stages, so the switch
+# is expected to stay non-empty for as long as any registered task is awaiting
+# review.
+#
+# ⚠️ Read the expected value OUT of values.yaml rather than pinning a literal.
+# The literal version had to be edited in lockstep with every change to the
+# list, in two places — and the comment here used to instruct the next reader
+# to DELETE these assertions instead, which would have dropped the
+# one-declaration-two-consumers guarantee below. Derive it, and neither
+# happens.
+switch=$(grep -E '^[[:space:]]+SAM_TASKS_DISABLED:' "$CHART_DIR/values.yaml" \
+         | sed 's/.*: *//' | tr -d '"')
+[[ -n "$switch" ]] || {
+  echo "FATAL: could not read SAM_TASKS_DISABLED out of values.yaml" >&2
+  exit 1
+}
+
 assert_contains "$prod_out" 'name: SAM_TASKS_DISABLED' \
   "the kill switch must be present in the rendered env"
-assert_contains "$prod_out" 'value: "cleanup_status_snapshots"' \
-  "P4 ships with the destructive task disabled; P5 clears it separately"
+assert_contains "$prod_out" "value: \"${switch}\"" \
+  "the CronJob must carry the kill-switch value declared in values.yaml"
 assert_contains "$prod_out" 'value: "365"' \
   "STATUS_RETENTION_DAYS must be explicit in GitOps, not implied by a default"
 
@@ -187,14 +200,20 @@ assert_contains "$cron_out" "value: \"${notify_enabled}\"" \
 # rendered a kill-switched dispatcher as perfectly healthy: the precise failure
 # that card exists to prevent.
 #
-# When P5 clears the switch this pair fails too — delete it alongside the block
-# above, for the same reason.
+# Value derived from values.yaml, same as the CronJob assertion above: what is
+# being proved is that the two manifests AGREE, not what the list happens to
+# say today.
+#
+# One caveat if the list is ever emptied: deployment.yaml guards the key with
+# `{{- with .SAM_TASKS_DISABLED }}`, and an empty string is falsy, so the
+# webapp renders no variable at all. That is correct behavior — the card then
+# reports nothing disabled — but this pair would need to become conditional.
 deploy_out=$(helm template "$RELEASE_NAME" "$CHART_DIR" \
              -f "$CHART_DIR/values.yaml" -s templates/deployment.yaml)
 
 assert_contains "$deploy_out" 'name: SAM_TASKS_DISABLED' \
   "the webapp Deployment must carry the kill switch too, or the admin card lies"
-assert_contains "$deploy_out" 'value: "cleanup_status_snapshots"' \
+assert_contains "$deploy_out" "value: \"${switch}\"" \
   "and it must carry the SAME value — one declaration, two consumers"
 
 # ---------------------------------------------------------------------------

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -455,12 +455,28 @@ tasks:
     # would otherwise mean both "nothing was due" and "the task never ran".
     # Unset it to turn the summary off; the notices themselves are unaffected.
     SAM_TASKS_SUMMARY_TO: "benkirk@ucar.edu"
-    # ⚠️ Comma-separated task names to skip, WITHOUT a code deploy.
+    # ⚠️ Comma-separated task names to skip, WITHOUT a code deploy. This is a
+    # staged-enable control: exactly one task is live, and the rest are named
+    # here until each has been reviewed on its own.
     #
-    # Ships non-empty on purpose. The rollout is: merge with the destructive
-    # task named here, let the dispatcher run hourly for 24 h writing `skipped`
-    # rows and deleting nothing — proving credentials, DNS, image,
-    # securityContext and Postgres reachability from a pod that is not the
-    # webapp, with zero blast radius — then clear this in a SECOND commit.
-    # That soak is the entire reason the kill switch exists.
-    SAM_TASKS_DISABLED: "cleanup_status_snapshots"
+    # Live:     cleanup_status_snapshots     (daily 02:15 MT, status DB only)
+    # Disabled: deactivate_expired_projects  (writes inactivate_time in SAM)
+    #           expiration_notices           (mails external PIs)
+    #
+    # ⚠️ There is NO wildcard. `disabled_tasks()` in src/scheduling/runner.py
+    # is a case-sensitive exact match against registry keys — `all`, `*` and
+    # `none` are just names that match nothing, and an unknown name is not
+    # validated or warned about. So this list is an ENUMERATION, and it is
+    # fail-OPEN: a task added to src/scheduling/tasks/ dispatches on the next
+    # hourly wake unless its name is added here in the same change.
+    #
+    # Both disabled tasks above are exactly that case. They were registered
+    # without this list being touched, so the image promotion carrying them
+    # would have put both into production live — no soak, no separate review.
+    # Naming them here is what makes that promotion a non-event.
+    #
+    # A disabled task still writes a terminal `skipped` row that SETTLES its
+    # slot, so re-enabling one mid-slot does not backfill — the first real run
+    # is the next occurrence. The switch is also checked ahead of `only`/
+    # `force`, so `sam-admin tasks --run X --force` cannot override it.
+    SAM_TASKS_DISABLED: "deactivate_expired_projects,expiration_notices"


### PR DESCRIPTION
## Summary

`SAM_TASKS_DISABLED` shipped in 80568c6 as a P5 rollout switch: name the one destructive task, soak the dispatcher for 24 h, then clear it in a second commit. **That second commit was never written** — `git log --all -S'SAM_TASKS_DISABLED' -- helm/values.yaml` returns exactly one commit, and every ref still carries the original value.

Meanwhile the registry grew from one task to three, and the chart's list was never touched.

**Verified against nwc1.** Production runs `sha-80568c6`, whose registry holds `cleanup_status_snapshots` alone — and that is the one name in the disable list, so today's dispatcher wakes hourly and does nothing at all:

```
$ kubectl exec -n sam-queries deploy/samuel -- sam-admin --format json tasks --list
{ "disabled": ["cleanup_status_snapshots"],
  "tasks": [{"name": "cleanup_status_snapshots", "enabled": false, ...}] }
```

The other two tasks are on staging awaiting promotion and are **named nowhere in the chart**. The image promotion carrying them would therefore have started both in production immediately — one writing to the SAM database, one mailing external PIs — with no soak and no separate review. This repoints the switch ahead of that promotion rather than after it.

| Task | Schedule | Before | After |
|---|---|---|---|
| `cleanup_status_snapshots` | Daily 02:15 MT | disabled | **enabled** |
| `deactivate_expired_projects` | Monthly day 3, 04:30 MT | not in list | **disabled** |
| `expiration_notices` | Weekly Mon 09:00 MT | not in list | **disabled** |

Config only — nothing under `src/scheduling/` changed.

## Changes

- **`helm/values.yaml`** — the fix, plus a comment block rewritten off the finished soak narrative. It now records that the list is an enumeration with no wildcard, that it is fail-open for newly registered tasks, that a skip settles the slot, and that the switch outranks `--force`.
- **`helm/tests/test-cronjob-render.sh`** — the two hardcoded `value: "cleanup_status_snapshots"` assertions now derive the expected value from `values.yaml`, mirroring the `NOTIFY_ENABLED` assertion in the same file. The old comments instructed the next reader to *delete* these checks, which would have dropped the one-declaration-two-consumers guarantee that shipped broken once before (#445). Verified non-vacuous — a simulated drift render still fails the assertion.
- **`docs/README-k8s.md`** — env matrix row and kill-switch section. The local smoke-test recipe named only one task, which under `--set` **replaces** the list and left the other two live against local databases; it now disables all three.
- **`compose.yaml`** — pass `SAM_TASKS_DISABLED` through to `webapp`/`webdev`, empty by default. The e2e docstring has documented this workflow since the card landed, but no passthrough ever existed, so that test always skipped.
- **`e2e/test_scheduled_tasks_card.py`** — assert the warning's shape rather than a pinned task name, so a chart-side change to the list no longer turns an unrelated e2e run red.

## Operational notes

⚠️ **Ordering matters.** This should reach `main` before or alongside the image promotion that carries the two new tasks. Landing it afterwards leaves a window in which both dispatch.

⚠️ **Enabling cleanup causes the first real deletion in production.** `cleanup_status_snapshots` has never executed — the ledger holds exactly two rows, both `skipped/disabled`, one per daily occurrence since the CronJob was created:

```
cleanup_status_snapshots  occ=20260814T081500Z  skipped/disabled  runner=samuel-tasks-29778307-cs7cs
cleanup_status_snapshots  occ=20260813T081500Z  skipped/disabled  runner=samuel-tasks-29777287-qdmjg
```

The first run after deploy deletes `system_status` snapshots older than `STATUS_RETENTION_DAYS` (365) and `task_run` rows older than `TASK_RUN_RETENTION_DAYS` (180). The 365-day pin keeps this from being a multi-year DELETE, but it is the one irreversible thing here.

**Disabling is not retroactive** — it takes effect at the next occurrence, which records `skipped` rather than running.

### Test Results

- `helm/tests/test-cronjob-render.sh` — passes; CronJob and Deployment both render `"deactivate_expired_projects,expiration_notices"`.
- Drift check — a deployment render with an overridden value fails the derived assertion, confirming it is not vacuous.
- Registry cross-check — every name in the chart resolves to a registry key. `disabled_tasks()` never validates these, so a typo would silently disable nothing.
- `pytest tests/unit/test_task_runner.py tests/unit/test_admin_tasks_cli.py tests/unit/test_admin_scheduled_tasks_card.py` — **115 passed**.
- **Live probe** — `scripts/cirrus_healthcheck.sh` against nwc1: 42 PASS, 2 WARN, 0 FAIL. Dispatcher and webapp on the same pinned image, kill switch agreeing across both workloads, dispatch stdout valid JSON, no failed Jobs.
- YAML / bash / Python syntax checks on all five edited files.

### Follow-up, not in this PR

The list is fail-open: the chart-side list and the code-side registry are not coupled, so adding a task means remembering to edit both. The durable fix is a `SAM_TASKS_ENABLED` allow-list in `runner.py`, touching the parser, admin card, CLI display and docs. Deliberately out of scope for a config hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
