### PR TITLE
XRAS cutover: release the capture-only interlock, and a triage playbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,15 @@ megalinter-reports/
 .coverage.*
 Vermilion_NSFNCAR-UCAR-UCP_BrandGuide.pdf
 .playwright-mcp/
+# ⚠️ Playwright/MCP writes snapshots and screenshots to the CWD when a relative
+# filename is passed, not into .playwright-mcp/ — so they land in the repo root.
+# Smoking the XRAS cards means rendering UNSCRUBBED production PII, and two such
+# files (a page snapshot and a full-page PNG) were caught one `git add` away
+# from a public repo. Ignore them by shape rather than relying on the reviewer.
+page-????-??-??T*.yml
+*-pane.md
+*-before.png
+*-after.png
 legacy_sam
 data/
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -49,6 +49,12 @@ services:
       #    fall back to compose service-name defaults. If the user
       #    uncomments PROD in .env, that flows through to in-stack
       #    containers (intentional pass-through).
+      # ⚠️ Match the chart (helm/values.yaml sets TZ: America/Denver). SAM's
+      # MySQL columns are naive-MOUNTAIN, stamped from the app clock — so a
+      # container left on UTC writes `received_time` six hours in the future
+      # relative to the data around it, and any column that renders an age
+      # comes out negative. Prod has always set this; local never did.
+      - "TZ=${TZ:-America/Denver}"
       - "SAM_DB_SERVER=${SAM_DB_SERVER:-mysql}"
       - "SAM_DB_USERNAME=${SAM_DB_USERNAME:-root}"
       - "SAM_DB_PASSWORD=${SAM_DB_PASSWORD:-root}"
@@ -134,6 +140,12 @@ services:
     # when adding new files/functions. Remove for production deployment.
     environment:
       # ── DB routing (see `webapp` for the pass-through reasoning)
+      # ⚠️ Match the chart (helm/values.yaml sets TZ: America/Denver). SAM's
+      # MySQL columns are naive-MOUNTAIN, stamped from the app clock — so a
+      # container left on UTC writes `received_time` six hours in the future
+      # relative to the data around it, and any column that renders an age
+      # comes out negative. Prod has always set this; local never did.
+      - "TZ=${TZ:-America/Denver}"
       - "SAM_DB_SERVER=${SAM_DB_SERVER:-mysql}"
       - "SAM_DB_USERNAME=${SAM_DB_USERNAME:-root}"
       - "SAM_DB_PASSWORD=${SAM_DB_PASSWORD:-root}"

--- a/docs/plans/XRAS_ACCOUNT_QUEUE.md
+++ b/docs/plans/XRAS_ACCOUNT_QUEUE.md
@@ -1,0 +1,118 @@
+# The XRAS account queue — deferred work
+
+**Status: written down, deliberately unbuilt.** Everything here was scoped during the
+2026-08-20 pass that made the worklist legible, and cut from it on purpose so triage week
+ships without new tables or new mail. Each item names what it is, why it was deferred, and
+what would justify picking it up.
+
+Context first: [`../xras/PROJECT_AND_ACCOUNT_LIFECYCLE.md`](../xras/PROJECT_AND_ACCOUNT_LIFECYCLE.md)
+— in particular **SAM never creates users**, which is what makes this a queue handed to
+another team rather than a control surface.
+
+---
+
+## 1 · `xras_account_event` — making it a *worked* queue
+
+**The blocking item.** The card is read-only. Two people working it cannot see each
+other, "asked upstream on the 14th" cannot be recorded, and a row that should not be
+worked at all cannot be set aside.
+
+Already designed at `../xras/outgoing/XRAS_OUTGOING_QUERIES.md` § 7.6. The shape:
+username-keyed, append-only, `event_type` from a small tuple, `comment`, `created_by`,
+`xras_action_log_id` as provenance only.
+
+⚠️ **`XrasActivationEvent` cannot carry it.** Its `project_id` is NOT NULL and
+project-scoped; this worklist is username-keyed and a New request *has no project yet*.
+That is the whole reason for a second table.
+
+⚠️ **Derive state with the action-keyed supersedes idiom in
+`sam/queries/xras_activation.py::_activation_state`** — not the older project-keyed rule
+quoted in the `XrasActivationEvent` docstring.
+
+**The property that keeps it small: only dismissal needs storage.** "Done" is already
+derived — classification is a check against the current `users` table on every render, so
+a row vanishes when the mirror lands and nobody has to close anything. This is a
+note-and-hide table, not a ticket system. Suggested vocabulary: `requested` (we asked
+upstream, with the date), `comment`, `dismissed`, `restored`. Deliberately **no**
+`created` — SAM cannot observe that except by the row disappearing.
+
+DDL applied by hand and recorded in `../xras/incoming/XRAS_CUTOVER_RUNBOOK.md` § 2,
+matching the precedent set by the other XRAS tables; ORM follows the database. Write path
+copies the Pending Activations routes (`webapp/dashboards/allocations/blueprint.py`,
+the `xras_activate` / `xras_dismiss` / `xras_restore` / `xras_comment` family), which
+already carry CSRF, `management_transaction` and the `HX-Trigger` refresh.
+
+**Trigger:** two people working the queue at once, or the first time somebody asks "did
+we already ask about this person?"
+
+---
+
+## 2 · A digest, so nobody has to poll a tab
+
+The audience already fields mail — `webapp/utils/rbac.py:258` records that the XRAS
+failure mail goes to `hdt@ucar.edu` today. A digest replaces mail with mail, which is the
+lowest-friction change for the people receiving it.
+
+~80% of this is copy-paste from `src/scheduling/tasks/expiration_notices.py`: the guards
+(`NotificationsDisabled`, `EmailCapExceeded` from `scheduling/tasks/mail_guards.py`), a
+per-run `SAM_TASKS_*_MAX` cap, the `_drop_already_notified` pre-filter, the own-session
+ledger, `requested_by='task:<name>'`, and `detail` always carrying
+selected/suppressed/audience.
+
+⚠️ **The one genuinely open design question is the dedup key**, because a *snapshot*
+digest matches neither existing shape. `expiration_notices` keys on something that
+changes when the fact changes (the expiration date); `xras_notices` keys on the action id.
+A worklist row persists week over week:
+
+- key on the **week** → an unchanged list re-sends every week (probably right for a digest)
+- key on the **username** → a person is reported exactly once, ever (almost certainly wrong)
+
+**Recommendation:** key on the **occurrence**, as `task_summary` does, and let the body
+carry the delta — *"3 new since last week, 9 still waiting, oldest 37 days"*.
+`sam/notify/templates/task_summary.txt` is already the closest body shape.
+
+Also needed: a new `NotificationKind` (`Notifier` hard-raises on an unregistered kind,
+`sam/notify/kinds.py:150`) plus `{base}.txt` / `{base}.html`, `facility_aware=False`.
+
+⚠️ **Ship it named in `SAM_TASKS_DISABLED` in the same change** — that list is fail-OPEN,
+so a registered task goes live on the next hourly wake unless the chart names it.
+
+**Trigger:** the queue stops being checked daily, or a row is found to have sat for weeks.
+
+---
+
+## 3 · The SAM → XRAS write direction
+
+Three things want it, and they are one capability:
+
+1. **Close abandoned requests.** Requests approved years ago and never pushed still
+   surface as people needing accounts (`NCAR0116` and friends, submitted 2015). That is
+   upstream data hygiene, not a SAM filter problem — the filters are working.
+2. **Buy lead time.** SAM sees these people at *approval*; they are knowable weeks
+   earlier, at submission. `SAM_TASKS_XRAS_SWEEP_STATUS` is already a knob.
+   ⚠️ Price it before building: 4,088 requests total vs 1,640 in-window, and a one-page
+   `status='all'` probe returned 0 rows, so the parameter may not behave as needed.
+3. **Publish the signal back**, so a submitter is told at submission time that a named PI
+   has no site account — rather than a downstream team discovering it eight weeks later.
+
+⚠️ **All three break a property that is currently structural, not conventional.**
+`XrasApiClient` has no verb method other than an internal `_get`, and a test asserts no
+`post`/`put`/`patch`/`delete` callable exists on the class — because the same credential
+can create requests, modify roles and **merge one person into another**. A write direction
+is a **new client with its own credential and its own review**, never a relaxation of this
+one.
+
+**Trigger:** ACCESS agreeing to a write scope, or the abandoned-request tail becoming
+noisy enough to work.
+
+---
+
+## 4 · Smaller things, recorded so they are not rediscovered
+
+| | |
+|---|---|
+| **`--status unmapped` is unreachable from the CLI** | The `click.Choice` in `src/cli/cmds/admin.py` lists five of the six in `XRAS_ACTION_STATUSES`, and `_STATUS_STYLE` in `src/cli/xras/display.py` has no entry for it. One line each; both are restatements of a vocabulary that already exists in one place. #458 edited a *neighbouring* Choice on the same command without noticing this one |
+| **Two implementations of "the lead must exist and be active"** | `validate_fk_existence` checks existence only — the internal path enforces *active* in the picker's search query, so a forged POST naming an inactive user's id passes server-side. `sam/xras/roster.py` enforces both in code. Worth one shared predicate |
+| ⚠️ **Unit tests reach the live XRAS API** | `tests/unit/test_xras_accounts_card.py` was observed making real `GET https://api.xras.org/v1/people/...` calls, because `.env` supplies `XRAS_API_KEY` and the suite inherits it. `tests/conftest.py` blocks `smtplib.SMTP` for exactly this class of reason; the outbound client has no equivalent guard. Not a correctness bug today — the calls 404 harmlessly — but the suite should not depend on a remote host being up, or leak which usernames it tests |
+| **`ExporterRegistry` does not exist in this repo** | `CLAUDE.md` and `src/cli/README.md` describe it; it lives only in the peer `hpc-usage-queries`. `Permission.EXPORT_DATA` is declared and enforced nowhere. Any CSV/JSON export off the card is net-new, modelled on `webapp/dashboards/admin/blueprint.py`'s one instance |
+| **`compose.yaml` had no `TZ`** | Fixed in the same pass: containers ran UTC while writing naive-Mountain columns, so any age column read as negative. The chart has always set `America/Denver`. Mentioned here because the *data* seeded before the fix still carries UTC stamps |

--- a/docs/xras/PROJECT_AND_ACCOUNT_LIFECYCLE.md
+++ b/docs/xras/PROJECT_AND_ACCOUNT_LIFECYCLE.md
@@ -1,0 +1,159 @@
+# How a project and its people reach SAM
+
+**The context every other document in `docs/xras/` assumes and none of them states.**
+The incoming reference explains the wire; the runbook explains cutover day; the triage
+playbook explains a failed action. None of them says where a project *comes from*, who
+creates the people on it, or why SAM cannot fix the most common failure itself.
+
+---
+
+## 1 · Two ways a project is born, and they are not symmetric
+
+### The ARC → XRAS → SAM path — the majority, especially university
+
+```
+researcher                ACCESS / XRAS                     SAM
+    │                          │                             │
+    │  submits a request       │                             │
+    ├─────────────────────────►│                             │
+    │  arc.ucar.edu/           │  reviewed, iterated,        │
+    │  xras_submit/            │  possibly revised           │
+    │  opportunities           │        │                    │
+    │                          │        ▼                    │
+    │                          │    approved                 │
+    │                          ├────────────────────────────►│  POST /api/xras/v1/actions
+    │                          │                             │  → project + allocations
+```
+
+A researcher starts at **`arc.ucar.edu/xras_submit/opportunities`** — call it **ARC**.
+ARC posts the submission into **XRAS**, where it is reviewed and may be iterated on. Only
+once it is **approved** does it come back to us, as a POST to
+`/api/xras/v1/actions`. Legacy SAM performed this until the 2026 cutover;
+`src/sam/xras/` and `src/webapp/api/xras/` are the reimplementation.
+
+We may reimplement the submission step here one day. Not today.
+
+### The internal path — first-class, and it must always work
+
+Staff create a project directly in the SAM webapp: **Admin → Projects → Create Project**
+(`webapp/dashboards/admin/projects_routes.py`). It is not a lesser path and nothing in
+the XRAS work may compromise it.
+
+The two share `next_projcode()` and `GidAllocation.allocate_next_gid()` and nothing else.
+⚠️ They implement the *same* "the lead must exist" rule twice and **do not agree**: the
+internal path checks existence via `validate_fk_existence` and enforces *active* only in
+the picker's search query, while `sam/xras/roster.py` enforces both in code and rejects
+the action with a 422. A forged POST naming an inactive user's id passes the internal
+path server-side. Recorded, not yet fixed.
+
+---
+
+## 2 · ⚠️ SAM never creates users
+
+**This is the fact that explains the whole account worklist, and it is not visible
+anywhere in the code — only in its absence.**
+
+`users` is **mirrored into SAM from an organizational LDAP** by a process that lives
+outside this repository. Enrollment — including 2FA — is an enterprise function performed
+by another team. SAM is a **reader** of identity, not a source of it.
+
+What that looks like in the tree, all of it checkable:
+
+| | |
+|---|---|
+| INSERT into `users` anywhere in `src/` | **none** |
+| `User.create()` | **does not exist** — alone among ~21 models that have one |
+| `User.update()` | **does not exist** either |
+| Anything writing `users.active` or `users.locked` | **nothing**, in the entire repo |
+| The only column SAM ever writes | `primary_gid`, via `User.set_primary_gid()` |
+
+The strongest in-tree evidence is an outage. `src/sam/core/users.py:50-56` records that
+the **2026-08-10 identity-sync cutover** dropped `pdb_modified_time` and
+`idms_sync_token` from production `users` in a DDL SAM neither wrote nor knew about;
+every page 500'd for ~20 minutes, and the incident is now pinned as a contract in
+`tests/api/test_health_endpoints.py`. `PDB` and `IDMS` are the upstream's names, surviving
+as column prefixes. SAM was a passive victim of a table it does not own.
+
+**LDAP appears in this repo only as a *downstream*** — `sam/queries/directory_access.py`
+feeds a "downstream LDAP provisioner", and `sam/provisioning.py` compares what SAM
+believes against what the host actually provisions. The reverse direction, LDAP → `users`,
+has no code here at all. That asymmetry is easy to misread as "SAM owns identity".
+
+### The consequence, and why the worklist exists
+
+An approved XRAS request cannot be applied until **every person on it exists and is
+active in SAM**. `roster.py` rejects the action otherwise, and a missing **PI** is fatal
+(`PI %s is not in database` → 422) while a missing Allocation Manager is explicitly not.
+Unreconciled ARC placeholder identities are, by this repo's own measurement
+(`sam/xras/handlers/new.py:24-27`), **55% of production handoff failures** — the single
+largest cause.
+
+So the fix is **not code that creates accounts.** It is a worklist that tells the team
+who does: *who*, *why*, and — behind `MANAGE_XRAS` — with what detail. That is
+Allocations → XRAS → **Accounts Needed**, and it is why every remedy on that card names
+an artifact ("New account", "Reactivation") rather than an action, and why the card
+carries a banner saying SAM cannot perform either.
+
+⚠️ **Reactivation is upstream too.** It is tempting to read "Reactivate" as something a
+SAM admin does, because Flask-Admin's `UserAdmin` exposes `active`/`locked` and the
+`nusd`/`csg` bundles hold `EDIT_USERS`. That surface is kill-switched off in production
+(`FLASK_ADMIN_ENABLED`) and is not the sanctioned mechanism. Both remedies land upstream.
+
+### The one thing SAM *can* do about it
+
+**Notice early.** A row leaves the worklist by itself the moment the mirror catches up —
+classification is a check against the current `users` table on every render, so there is
+nothing to mark done. What SAM adds is lead time and a single place to look, instead of
+one ticket per project.
+
+---
+
+## 3 · The two feeds, and why there are two tabs
+
+Both tabs on Allocations → XRAS are person-keyed and answer *"who needs an account"*.
+They differ in what they are evidence of, and the difference decides which one you can
+trust when the other is unavailable.
+
+| | **Accounts Needed** | **Pending Requests** |
+|---|---|---|
+| Source | `xras_action_log` — our own audit table | `GET /v1/reports/requests` via `xras_sweep` |
+| Means | precisely the actions that **have posted** | approved in XRAS, **may or may not** have posted |
+| Availability | **always** | only while `XRAS_OUTGOING_ENABLED` is on *and* a sweep has published |
+| Empty means | nothing has posted yet | not configured, not swept, or genuinely nothing pending |
+
+**Overlap between them is normal**, and neither is a subset of the other in general. They
+are kept apart because merging them would trade a guarantee for a maybe: the first is a
+claim we can always make, the second is a lookahead that disappears when a lever is off.
+
+Each tab says what it is and points at the other, so neither reads as the whole queue.
+Where the *union* is actually wanted — scripting, and any digest built later — it is
+`sam-admin xras --accounts`, which merges both on the casefolded username and reports
+`pending_checked` so a caller can tell "Feed B was empty" from "Feed B was unreadable".
+
+⚠️ **The window pills mean "what showed up in the last N days"**, and that is
+`received_time` on one feed and `submitDate` on the other — the same question asked of
+two feeds that date themselves differently. Do not filter Pending Requests on its period
+of performance; that was tried, and because a pending allocation almost always ends a
+year out it keeps every row at every width and the control looks dead.
+
+---
+
+## 4 · Where this is going
+
+`ARC → XRAS → SAM` is the direction that exists. Two follow-ons are recorded, both of
+which need SAM to talk *back*:
+
+- **Closing abandoned requests.** Requests approved years ago and never pushed still
+  surface as people needing accounts. That is upstream data, not a SAM filter problem.
+- **Buying lead time.** SAM currently sees these people at *approval*.
+  `SAM_TASKS_XRAS_SWEEP_STATUS` is already a knob, and submissions are knowable weeks
+  earlier.
+
+⚠️ Both break a property that is currently **structural**, not conventional:
+`XrasApiClient` has no verb method other than an internal `_get`, and a test asserts no
+`post`/`put`/`patch`/`delete` callable exists on the class — because the same credential
+can create requests, modify roles and *merge one person into another*. A write direction
+is a new client with its own credential and its own review, never a relaxation of this
+one.
+
+Design and deferred work: [`../plans/XRAS_ACCOUNT_QUEUE.md`](../plans/XRAS_ACCOUNT_QUEUE.md).

--- a/docs/xras/README.md
+++ b/docs/xras/README.md
@@ -20,6 +20,7 @@ another, so the client has no verb method but an internal `_get`.
 |---|---|
 | [`XRAS_REIMPLEMENTATION.md`](incoming/XRAS_REIMPLEMENTATION.md) | The reference: wire contract, production data, deliberate divergences, phase status |
 | [`XRAS_CUTOVER_RUNBOOK.md`](incoming/XRAS_CUTOVER_RUNBOOK.md) | The day-of sequence. Operational only — no code left. Cutover is **abrupt**: XRAS holds one base URL, so all seven endpoints and all six handlers move at once |
+| [`XRAS_TRIAGE_PLAYBOOK.md`](incoming/XRAS_TRIAGE_PLAYBOOK.md) | The week after. Classify a row, then the 422 catalog with the data fix for each. ⚠️ `--recheck` validates, it cannot apply — every fix ends by asking XRAS to re-post |
 
 ## SAM → XRAS — `outgoing/`
 

--- a/docs/xras/README.md
+++ b/docs/xras/README.md
@@ -14,6 +14,12 @@ Allocations API at `https://api.xras.org/v1/…`. Read-only and GET-only — the
 same credential can create requests, modify roles and merge one person into
 another, so the client has no verb method but an internal `_get`.
 
+## Start here
+
+| Doc | What it is |
+|---|---|
+| [`PROJECT_AND_ACCOUNT_LIFECYCLE.md`](PROJECT_AND_ACCOUNT_LIFECYCLE.md) | Where a project comes from — ARC → XRAS → SAM, and the internal path beside it. ⚠️ **SAM never creates users**: `users` is mirrored in from an organizational LDAP, which is why the account worklist is a worklist and not a button |
+
 ## Live docs — `incoming/`
 
 | Doc | What it is |

--- a/docs/xras/incoming/XRAS_CUTOVER_RUNBOOK.md
+++ b/docs/xras/incoming/XRAS_CUTOVER_RUNBOOK.md
@@ -176,19 +176,45 @@ bootstrap after `terraform apply`, so an existing instance never picks them up. 
 that DB is given the DDL, the XRAS tab and Admin → Notifications 500 there. CIRRUS/k8s
 is the deployment target; ECS-staging is a check-the-render environment.
 
-### 3 · Parity against the deployed host
+### 3 · Parity against the deployed host · ✅ **PASSED 2026-08-19 — 13/13 byte-identical**
 
 ```bash
-python utils/parity/check_legacy_apis.py --api xras   # against sam.hpc.ucar.edu
+python utils/parity/check_legacy_apis.py --api xras \
+       --new-base-url https://sam.hpc.ucar.edu --xras-user benkirk --timeout 120
 ```
 
-Uses our own `samuel` credential. This is the **GET-side** cutover verification and it is
-independent of gate 4.
+Uses the `ROLE_XRAS` credential (`SAM_XRAS_USER` / `SAM_XRAS_PASS`, already in `.env`).
+This is the **GET-side** cutover verification and it is independent of gate 4.
 
-- **Done when** the run is byte-clean across all six endpoints.
+```
+== xras == 13/13 checks passed (65.2s)
+  ✓ people roster: 3,844,518 B identical      ✓ dates/requests single: 120 B identical
+  ✓ people/{username}: 170 B identical        ✓ dates/requests multi:  306 B identical
+  ✓ people/{username} 404: 58 B identical     ✓ requests/request/{SCSG0001,SCSG0002,UCIS0004}
+  ✓ requests/user/benkirk: 6 masters          ✓ requests/role/{pi,co_pi,allocation_manager}
+```
+
+⚠️ **Three flags are load-bearing, and the bare command is a weaker run than it looks.**
+
+- **`--new-base-url`** — the script's default is `samuel.k8s.ucar.edu`. Same app, but the
+  cutover host is the one to prove.
+- **`--xras-user`** — without it the script *samples* the roster for a user with requests,
+  and on a real run **all eight sampled users had none**. It warns and carries on, and the
+  result is `8/8 passed` with `requests/request/*` exercised only against an unknown
+  number and `dates/requests` **not probed at all**. A green 8/8 and a green 13/13 look
+  identical at a glance. Read the check list, not the count.
+- **`--timeout 120`** — legacy answers `requests/request/SCSG0001` in ~6.8 s (the new
+  stack: ~0.67 s) and dropped the connection outright on one run:
+  `RemoteDisconnected('Remote end closed connection without response')`. That is legacy
+  being slow, not a parity failure — both hosts return the same 30,296 bytes. Retry
+  before investigating.
+
+- **Done when** the run is byte-clean across all six endpoints — i.e. **13** checks, with
+  `dates/requests` and a populated `requests/request/{n}` among them.
 - ⚠️ Re-run it if anything changes `xras_resource_repository_key_resource`.
   `resourceRepositoryKey` is *omitted* when a resource is unmapped, so **adding a mapping
-  row changes GET response bytes** and invalidates a previous clean run.
+  row changes GET response bytes** and invalidates a previous clean run. That is the most
+  likely triage-week fix, so expect to re-run this during the week.
 
 ### 4 · The 400/422 contract · ✅ **ANSWERED 2026-08-11**
 

--- a/docs/xras/incoming/XRAS_CUTOVER_RUNBOOK.md
+++ b/docs/xras/incoming/XRAS_CUTOVER_RUNBOOK.md
@@ -28,7 +28,7 @@ no code is left.** The design, the measurements and the reasoning live in
 | 1b | The whole legacy surface is mapped — all eight endpoints, not the seven XRAS calls today | `pytest tests/api/test_xras_roles.py tests/api/test_xras_unmapped.py -q` |
 | 2 | ✅ **Done 2026-08-10.** The audit table carries `action_id`, `service`, `outcome_reason` | `SHOW COLUMNS FROM xras_action_log` on the target DB |
 | 2b | ✅ **Done 2026-08-10.** ⚠️ The DDL applied is the **current** `zz-90`/`zz-91`/`zz-92` — **exactly 7** columns must come back utf8mb4: `raw_payload`, `error_messages`, `comment`, `notified_to`, `recipient_name`, `subject`, `error` | `SELECT TABLE_NAME, COLUMN_NAME, CHARACTER_SET_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA='sam' AND TABLE_NAME IN ('xras_action_log','xras_activation_event','notification_log') AND CHARACTER_SET_NAME='utf8mb4'` |
-| 3 | `XRAS_ACTIONS_CAPTURE_ONLY` is `"1"` | `helm/values.yaml:291` — and confirm it in the running pod's env before anything else |
+| 3 | `XRAS_ACTIONS_CAPTURE_ONLY` is `"1"` | `helm/values.yaml:316` — and confirm it in the running pod's env before anything else |
 | 4 | The replay-and-diff oracle passes | `pytest tests/unit/test_xras_oracle.py -q` |
 | 5 | A notification path exists for `active = 0` projects | Sprint B's pending-activation card on the Allocations dashboard |
 
@@ -213,12 +213,26 @@ thread. Verbatim, because each clause retires something:
   (timestamp 1771966790970)","result":null}` — against ACCESS's own accounting service,
   which explains *why* an action failed. Our accumulated 422 list is exactly that fix.
 
-⚠️ **One thing this opens.** The response body is shown to a human, and a **parked**
-action currently answers `message: 'OK'` — byte-identical to a success. So an admin who
-posts a `Date Adjustment` (or a Transfer, or anything disabled by the triage lever) is
-told it worked. Legacy does the same, so this is not a regression and not a cutover
-blocker, but Steve has explicitly invited an informative body. Cheap to fix and outside
-the parity gate, which covers the six **GET** endpoints only. **Decide before cutover.**
+✅ **The one thing this opened is now closed — 2026-08-19.** The response body is shown
+to a human, and a **parked** action answered `message: 'OK'` — byte-identical to a
+success. So an admin who posted a `Date Adjustment` (or a Transfer, or anything disabled
+by the triage lever) was told it worked. Legacy does the same, so it was never a
+regression or a blocker; but `Date Adjustment` parks and is 4 of the 41 corpus payloads,
+which makes the silent-success arm the *common* one, and Steve explicitly invited an
+informative body.
+
+**Decided: the `manual` arm now answers a distinct message; `processed` still answers
+`'OK'`.** Two constraints shaped it:
+
+- **The status stays 200.** Steve: *"Any status other than 200/OK is considered an
+  error."* A parked action is not an error, so 202 — the tidy REST answer — would have
+  been read as a failure.
+- **The body is a module constant, not `DispatchResult.reason`.** Three of the four
+  parking causes name internal machinery (`XRAS_ACTIONS_ENABLED`, an unregistered
+  handler) that an ACCESS admin can neither act on nor should see. That detail stays in
+  `xras_action_log.outcome_reason`, which is what our own operator surfaces read.
+
+Outside the parity gate, which covers the six **GET** endpoints only.
 
 ⚠️ **Also raised, and not yet triaged.** Steve reports anomalies in the *GET*
 `/v1/requests/*` responses: NCAR does not return `xrasActionId` or `xrasActionResourceId`,
@@ -253,16 +267,38 @@ it later would not either.
 Coordinated with ACCESS. Two things happen, and the order matters:
 
 1. **XRAS repoints** its base URL to `sam.hpc.ucar.edu`.
-2. **`XRAS_ACTIONS_CAPTURE_ONLY` flips to `"0"`** in `helm/values.yaml:291`, and deploy.
+2. **`XRAS_ACTIONS_CAPTURE_ONLY` flips to `"0"`** in `helm/values.yaml:316`, and deploy.
 
 Flipping *before* the repoint is harmless (nothing is arriving). Flipping *after* means
-every post in the gap is captured as `received` and must be replayed by hand — recoverable,
-but work. Flipping **early on a stack XRAS is already posting to** is the double-apply, and
-is the thing this interlock exists to prevent.
+every post in the gap is captured as `received`. Flipping **early on a stack XRAS is
+already posting to** is the double-apply, and is the thing this interlock exists to
+prevent.
+
+✅ **Done 2026-08-19: step 2 landed first, deliberately, ahead of the repoint.** The
+runbook originally read as if the two steps were simultaneous. They are not symmetric,
+and the asymmetry is worth stating because it is the opposite of the intuition that a
+safety interlock should come off last:
+
+> A post that arrives while `CAPTURE_ONLY` is `"1"` is stranded. **`--recheck` cannot
+> apply it** — `dispatch_action(..., validate_only=True)` returns before
+> `management_transaction` opens, structurally — so the only recovery is asking the XRAS
+> admin to push the button again, per action. Meanwhile flipping early costs nothing at
+> all: XRAS is still posting to `sam.ucar.edu`, so the dispatching arm sees no traffic
+> until the repoint.
+
+So the gap has a real price in one direction and none in the other. Verify the log holds
+no `received` rows before flipping — if it does, XRAS has already repointed and those
+posts need to be re-sent.
+
+⚠️ Order the *checks* accordingly: `sam-admin xras --summary` first, flip second.
 
 ---
 
 ## Triage week
+
+➡️ **The full version is [`XRAS_TRIAGE_PLAYBOOK.md`](XRAS_TRIAGE_PLAYBOOK.md)** — how to
+classify a row, the 422 catalog with the data fix for each, and what the levers cost.
+What follows is the short form.
 
 The watch surface, in the order you will reach for it:
 
@@ -294,7 +330,7 @@ The watch surface, in the order you will reach for it:
 **Park one action type by config, without a revert:**
 
 ```yaml
-XRAS_ACTIONS_ENABLED: "Extension,Supplement"   # helm/values.yaml:295
+XRAS_ACTIONS_ENABLED: "Extension,Supplement"   # helm/values.yaml:320
 ```
 
 Narrow it to whatever should keep running. The excluded types take the audited `manual`

--- a/docs/xras/incoming/XRAS_CUTOVER_RUNBOOK.md
+++ b/docs/xras/incoming/XRAS_CUTOVER_RUNBOOK.md
@@ -28,9 +28,15 @@ no code is left.** The design, the measurements and the reasoning live in
 | 1b | The whole legacy surface is mapped — all eight endpoints, not the seven XRAS calls today | `pytest tests/api/test_xras_roles.py tests/api/test_xras_unmapped.py -q` |
 | 2 | ✅ **Done 2026-08-10.** The audit table carries `action_id`, `service`, `outcome_reason` | `SHOW COLUMNS FROM xras_action_log` on the target DB |
 | 2b | ✅ **Done 2026-08-10.** ⚠️ The DDL applied is the **current** `zz-90`/`zz-91`/`zz-92` — **exactly 7** columns must come back utf8mb4: `raw_payload`, `error_messages`, `comment`, `notified_to`, `recipient_name`, `subject`, `error` | `SELECT TABLE_NAME, COLUMN_NAME, CHARACTER_SET_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA='sam' AND TABLE_NAME IN ('xras_action_log','xras_activation_event','notification_log') AND CHARACTER_SET_NAME='utf8mb4'` |
-| 3 | `XRAS_ACTIONS_CAPTURE_ONLY` is `"1"` | `helm/values.yaml:316` — and confirm it in the running pod's env before anything else |
+| 3 | `XRAS_ACTIONS_CAPTURE_ONLY` is `"1"` | `helm/values.yaml`, key `XRAS_ACTIONS_CAPTURE_ONLY` — and confirm it in the running pod's env before anything else |
 | 4 | The replay-and-diff oracle passes | `pytest tests/unit/test_xras_oracle.py -q` |
 | 5 | A notification path exists for `active = 0` projects | Sprint B's pending-activation card on the Allocations dashboard |
+
+⚠️ **This document cites `helm/values.yaml` by key name, never by line number.** Three
+refs here were repaired once (`:291` → `:316`) and were wrong again within the same
+branch, because the commit that repaired them also rewrote the comment above the setting
+and pushed it down sixteen lines. Both keys are unique in the file; `grep` is the stable
+address and a line number is a fact with a half-life.
 
 ⚠️ **Precondition 3 is the interlock and it is the one to physically check**, not assume.
 While it is `"1"` the endpoint authenticates, parses and audits every post and dispatches
@@ -216,6 +222,16 @@ This is the **GET-side** cutover verification and it is independent of gate 4.
   row changes GET response bytes** and invalidates a previous clean run. That is the most
   likely triage-week fix, so expect to re-run this during the week.
 
+✅ **#458 and #459 do NOT invalidate this run** — checked rather than assumed, because the
+default assumption for two large XRAS PRs is that they do. Three independent reasons:
+`src/webapp/api/xras/` is untouched by both merges; `src/sam/xras/roster.py`'s nine new
+lines are a comment block (why exact `String.equals` role matching is correct) with no
+executable change; and neither PR adds a `xras_resource_repository_key_resource` row —
+there is no DDL or seed in either diff. `xras_opportunity_allocation_type` is read only by
+`sam/xras/extractors.py`, i.e. the inbound **POST** path, so it cannot move GET bytes.
+
+The trigger above stays exactly as sharp: it is a *mapping row*, not "an XRAS change".
+
 ### 4 · The 400/422 contract · ✅ **ANSWERED 2026-08-11**
 
 Legacy answers 500 for both a malformed body and a failed validation, and a bare 200 for
@@ -293,7 +309,7 @@ it later would not either.
 Coordinated with ACCESS. Two things happen, and the order matters:
 
 1. **XRAS repoints** its base URL to `sam.hpc.ucar.edu`.
-2. **`XRAS_ACTIONS_CAPTURE_ONLY` flips to `"0"`** in `helm/values.yaml:316`, and deploy.
+2. **`XRAS_ACTIONS_CAPTURE_ONLY` flips to `"0"`** in `helm/values.yaml`, and deploy.
 
 Flipping *before* the repoint is harmless (nothing is arriving). Flipping *after* means
 every post in the gap is captured as `received`. Flipping **early on a stack XRAS is
@@ -330,10 +346,19 @@ The watch surface, in the order you will reach for it:
 
 | Surface | What it answers |
 |---|---|
-| Allocations → XRAS page | Everything, filterable, with the raw payload behind `MANAGE_XRAS` |
+| XRAS → **Pending Activations & Notifications** | Everything received, filterable, raw payload behind `MANAGE_XRAS` |
+| XRAS → **Accounts Needed** | The usernames on received actions with no usable SAM account — the 55% failure class, as a worklist |
+| XRAS → **Pending Requests** | Approved XRAS requests *not yet pushed*: the same problem before the action arrives |
 | `sam-admin xras --summary` | Status counts at a glance |
 | `sam-admin xras --status failed` | The 422s, with their error lists |
 | `sam-admin xras --status manual` | What was parked, and now **why** |
+| `sam-admin xras --accounts [--enrich]` | The account worklist on the CLI |
+| `sam-admin xras --validate-mapping` / `--validate-opportunities` | The two mapping tables, both sides |
+
+⚠️ **A populated Pending Requests tab beside an empty Accounts Needed tab is the correct
+state before the repoint**, not a bug. Accounts Needed reads `xras_action_log`, which is
+at 0 rows until XRAS repoints; Pending Requests reaches `api.xras.org` directly and was
+answering in production on 2026-08-20 (22 requests, 18 accounts needed).
 
 **The three columns C.1b added are what make a row triageable**, so use them:
 
@@ -356,7 +381,7 @@ The watch surface, in the order you will reach for it:
 **Park one action type by config, without a revert:**
 
 ```yaml
-XRAS_ACTIONS_ENABLED: "Extension,Supplement"   # helm/values.yaml:320
+XRAS_ACTIONS_ENABLED: "Extension,Supplement"   # helm/values.yaml
 ```
 
 Narrow it to whatever should keep running. The excluded types take the audited `manual`
@@ -402,7 +427,13 @@ new.
 - **11 active resources have no XRAS mapping.** ✅ **Expected** — not every internal
   resource is offered for allocation through XRAS. `sam-admin xras --validate-mapping` is
   a *diagnostic*, not a gate: it matters only if a resource that **should** be allocatable
-  appears in that list. It exits non-zero only on a dangling key.
+  appears in that list.
+  ⚠️ Since #458 the audit is **two-sided** and exits non-zero on **two** states, not one:
+  a dangling key (a broken FK on our side) *and* `xras_only_keys`, a key XRAS offers that
+  SAM cannot resolve — the one that actually breaks an award. Measured 2026-08-20:
+  **13/13 of the keys XRAS offers resolve**, zero dangling, so that failure cannot fire
+  against today's catalog. Unconfigured or unreachable API degrades to the local half and
+  says so; do not read a one-sided report as a clean two-sided one.
 - **89% of active organizations have no mnemonic soft link** (153 of 171), and 80% of
   institutions. This is the root of New's 24% mnemonic failure class. A data fix, and it
   would move New's success rate more than any code.

--- a/docs/xras/incoming/XRAS_TRIAGE_PLAYBOOK.md
+++ b/docs/xras/incoming/XRAS_TRIAGE_PLAYBOOK.md
@@ -27,12 +27,19 @@ In the order you will reach for them:
 
 | Surface | What it answers |
 |---|---|
-| Allocations → XRAS tab | Everything, filterable, raw payload behind `MANAGE_XRAS` |
+| XRAS → **Pending Activations & Notifications** | Everything received, filterable, raw payload behind `MANAGE_XRAS` |
+| XRAS → **Accounts Needed** | *Feed A.* The usernames on actions already received that have no usable SAM account. This is § 3.3's fix, as a worklist |
+| XRAS → **Pending Requests** | *Feed B.* Approved XRAS requests **not yet pushed** — the same problem *before* the action arrives. Renders the `xras_sweep` snapshot, not a live call |
 | `sam-admin xras --summary --last 24h` | Status counts at a glance |
 | `sam-admin xras --status failed --last 24h` | The 400s and 422s, with their error lists |
 | `sam-admin xras --status manual --last 24h` | What parked, and **why** (`outcome_reason`) |
 | `sam-admin xras --show <id> --payload` | One row in full. ⚠️ `raw_payload` is a verbatim POST body and contains PII |
 | `sam-admin xras --recheck <id>` | "Would this succeed if posted now?" Applies nothing |
+| `sam-admin xras --accounts [--enrich] --last 7d` | Feed A on the CLI. `--enrich` needs `--accounts` and a configured API. **An empty worklist exits 0** — "nobody is blocked" is a successful report |
+| `sam-admin xras --person <username>` | One identity from XRAS. Three outcomes on purpose: found `0`, no such username `1`, could-not-ask `2` |
+| `sam-admin xras --validate-mapping` | The resource-key map, **both sides** — § 3.1 |
+| `sam-admin xras --validate-opportunities` | The `opportunityId` map, both sides — § 3.9, the silent one |
+| `sam-admin tasks --history --task xras_sweep --format json` | Whether the sweep is actually feeding the Pending Requests tab — § 3.9 |
 
 Add `--format json` for anything you want to pipe.
 
@@ -52,6 +59,11 @@ the dashboard — use one of those. Left unfixed on purpose (see § 6).
   this port did not introduce and cannot fix from code (§ 3, rows 2 and 3).
 - **`Date Adjustment` and `Transfer` park.** By design, parity-correct, and now visible.
   A parked row is an outcome, not an incident.
+- **A populated *Pending Requests* tab beside an empty *Accounts Needed* tab is correct
+  before the repoint.** The two feeds fail empty for opposite reasons, which is why both
+  exist. Feed A reads `xras_action_log` — 0 rows until XRAS repoints, a *designed* empty
+  state. Feed B reaches `api.xras.org` directly and worked in production on 2026-08-20:
+  22 requests, 18 accounts needed. Do not spend day one debugging the empty half.
 
 ---
 
@@ -90,14 +102,33 @@ tidy them.
 ### 1. `No resource found in SAM corresponding to key {key}`
 
 The `resourceRepositoryKey` on the award has no row in
-`xras_resource_repository_key_resource`. There are **13 mapping rows** in total and **11
-active SAM resources have none**, so an award citing a resource nobody has mapped fails
-here.
+`xras_resource_repository_key_resource`.
 
-**Fix:** add the mapping row. `sam-admin xras --validate-mapping` reports the three
-groups — unmapped active resources, mappings pointing at decommissioned kit, and dangling
-keys (the last is the only unambiguously broken one, and the only one that makes the
-command exit non-zero).
+⚠️ **Ranked first when this was written; demoted since.** The measurement then was "13
+mapping rows, 11 active SAM resources have none". Both halves are still true, but they are
+different directions and only one of them can cause this 422. #458 measured the direction
+that matters, live: **all 13 `resourceRepositoryKey`s XRAS actually offers resolve to a
+SAM resource** — zero unmapped, zero dangling. So this cannot fire against today's
+catalog. It needs XRAS to start offering a resource we have never seen. The 11 unmapped
+SAM resources are unmapped *by design* and are not keys XRAS can cite.
+
+**Fix:** add the mapping row. `sam-admin xras --validate-mapping` now reports **four**
+groups, and the fourth is the live one:
+
+| Group | Meaning |
+|---|---|
+| `unmapped_active` | Active SAM resources with no mapping. Expected — 11 of them, stably. A diagnostic, not a gap |
+| `mapped_decommissioned` | Mappings pointing at retired kit. Untidy, not broken |
+| `dangling_keys` | A mapping row whose resource does not exist. **Broken** |
+| `xras_only_keys` | A key XRAS offers that SAM cannot resolve. **This is the one that breaks an award** |
+
+⚠️ **It exits non-zero on TWO of those now, not one** — `dangling_keys` *or*
+`xras_only_keys`. An earlier revision of this page said dangling was the only one.
+
+⚠️ **A one-sided report is not a clean report.** The XRAS half is auto-detected: with no
+`XRAS_OUTGOING_ENABLED=1` + `XRAS_API_KEY` it silently reports the local half, and with an
+unreachable API it warns in yellow and does the same. The footer says which you got —
+"Local half only …" versus "Every key XRAS offers resolves to a SAM resource." Read it.
 
 > ⚠️ **Adding a mapping row moves GET response bytes.** `resourceRepositoryKey` is
 > *omitted* from the `requests/*` payloads when a resource has no row, so closing a gap
@@ -124,13 +155,48 @@ Two neighbours from the same resolution path:
 SelectionParms{panel='…', type='…'}` (the odd rendering is Java's `toString()`,
 reproduced because the operator sees it).
 
+⚠️ **Both of those now mean "the `opportunityId` map missed *and* the ladder declined".**
+Since #459 the map is consulted first, and a map **hit** cannot produce the second message
+at all — the pair is read back off a real `allocation_type` row, so the join cannot miss.
+If you see `No AllocationType for SelectionParms{…}`, the ladder produced it. The map's
+own failure is silent and is in § 3.9.
+
 ### 3. `PI {username} is not in database` · `Username {username} is missing`
 
-**55% of production `New` failures.** Unreconciled ARC placeholder identities — the
-username on the award has never been reconciled to a SAM user.
+**55% of production `New` failures**, and the largest single cause of handoff failure.
+Unreconciled ARC placeholder identities — the username on the award has never been
+reconciled to a SAM user.
 
-**Fix:** identity reconciliation. Note a blank username renders as `Username  is missing`
-with a double space; that is the payload, not a formatting bug.
+**Fix: work the *Accounts Needed* tab, or `sam-admin xras --accounts`.** This used to say
+"identity reconciliation", which is a category rather than a loop. #458 turned it into a
+worklist, and it is the highest-value surface on this page:
+
+- **Two classifications, each with its remedy:** `absent` → **Create**, `inactive` →
+  **Reactivate**. Account creation is manual; the worklist tells you *who*, *why*, and —
+  behind `MANAGE_XRAS` — with what person detail to create them from.
+- ⚠️ **`placeholder` is a flag on the row, not a third classification.** A placeholder
+  identity is still either absent or inactive. Do not filter on it expecting a bucket.
+- **Rows close themselves.** Classification is a check against the *current* `users`
+  table, never against action status, so it is regime-proof across the capture-only flip
+  and a row leaves the list on the next render once the account exists. There is nothing
+  to mark done.
+- ⚠️ **`isReconciled` is not a closure signal**, despite reading like one. It means XRAS
+  linked the username to a real identity — it says nothing about SAM. The UI calls it
+  identified / unidentified, and **unidentified is the harder row**: no detail sheet to
+  create the account from.
+- ⚠️ **`isAccountToBeCreated` is never the predicate.** XRAS sets it when a role is
+  created and never clears it; every username measured carrying the flag was an existing
+  active SAM account. It ships as a hint column with a regression test pinning that a
+  flagged active user does not appear.
+- **Each row carries a `validate_only` pre-flight** (`would_succeed` / `reject_messages`),
+  so the card also surfaces **mnemonic and resource-key** rejections on the same rows —
+  it is not only about accounts. That overlaps § 3.2 deliberately.
+
+Feed B — the *Pending Requests* tab — is the same question asked **before** the action
+arrives, which is the only pre-emptive surface in this document.
+
+Note a blank username renders as `Username  is missing` with a double space; that is the
+payload, not a formatting bug.
 
 Same family, and the wording tells you which check tripped:
 
@@ -207,6 +273,69 @@ status their panel does not expect would be an unreadable rejection.
 > column is cut on message boundaries with a counted tail when a payload overflows the
 > 65,535-byte column, and says so in the stored value.
 
+### 9. ⚠️ The two failures that are **not** in this catalog, and not in § 2 either
+
+§ 2's decision tree is `status` × `http_status` × `service` × `outcome_reason`. Neither of
+the following appears in any of those four columns. Both arrived with #458/#459, and both
+present as *success*.
+
+**9a · A wrong `opportunityId` map row is silent at ingest.**
+`select_allocation_type_mapped` (`src/sam/xras/extractors.py`) consults
+`xras_opportunity_allocation_type` before the free-text ladder and overrides it, with **no
+log line and no ledger entry**. All three miss paths fall through silently too: no
+`opportunityId` on the wire, no row for it, or a row whose `allocation_type.panel_id` is
+NULL.
+
+So the symptom of a bad row is not a failure — it is a **`processed` action carrying the
+wrong projcode series**, because `handlers/new.py` draws the series from
+`allocation_type.panel.facility_id`. Projcodes are not undoable. This is the one XRAS
+mapping gap that does not shout; every other one 422s.
+
+The check is the **map table**, not the action log:
+
+```bash
+sam-admin xras --validate-opportunities        # both sides, if the API is configured
+```
+
+It reports mapped / unmapped / dangling, and for the unmapped ones whether the two
+independent derivations `xras_sweep` uses **agree**. Exit codes follow
+`--validate-mapping`'s discipline: **non-zero only on `dangling_ids`**. An unmapped
+opportunity is *not* a failure — with an empty table every opportunity is unmapped and
+ingestion is perfectly healthy, because the ladder resolves it exactly as it did before
+the table existed.
+
+⚠️ **A withheld row in the `review` bucket is the tool working, not a fault.** Two pairs
+sit there permanently by design — XRAS files the unsponsored family under `Educational`,
+and gives `NCAR - ASD Opportunity` NSC's own type *and* panel, both of which change the
+**facility**. They are `source='manual'` rows a human decided, and the agree-rule will
+keep declining to derive them. The bucket matters when something *new* shows up in it —
+most likely the first Wyoming opportunity, which is exactly the case the rule exists to
+put in front of a person.
+
+**9b · `published: true` is not `publish_backend: 'redis'` by luck.**
+The *Pending Requests* tab renders what `xras_sweep` published, not a live call. The task
+can succeed while publishing into a per-pod cache that dies with the pod — this happened
+in production on 2026-08-20, and the ledger said `published: true` while the tab stayed
+empty. `published` is now true **only** for `redis`.
+
+**Empty Pending Requests tab + a `succeeded` ledger row → read `publish_backend` first:**
+
+```bash
+sam-admin tasks --history --task xras_sweep --format json | jq '.runs[0].detail'
+```
+
+The rest of that `detail`, in the order it is worth reading:
+
+| Key | Says |
+|---|---|
+| `publish_backend` / `published` | `redis` or the dashboard sees nothing — 9b |
+| `skipped` | `XRAS_OUTGOING_ENABLED` is off or there is no key. Success, no work |
+| `budget_exhausted` | The **page** cap bit: the enumeration was truncated, so coverage looked complete and was not |
+| `map_budget_exhausted` | The **write** cap bit. ⚠️ **Absent on most runs — missing means false** |
+| `opportunities_needing_review` | Withheld mappings — 9a. Two are permanent |
+| `opportunities_unknown_pair` | XRAS shipped an allocation product the constant does not name. A code review, never a guess |
+| `unavailable_errors` | XRAS was unreachable at one of four steps; the run still reports what it got |
+
 ---
 
 ## 4 · Action types that park, and are supposed to
@@ -274,13 +403,20 @@ happened is how you end up maintaining the wrong tool. What follows is the *shap
 fix and the **trigger** that would justify building it, so that the decision is quick when
 the evidence arrives and nobody re-derives it under pressure.
 
+Two rows were overtaken by #458/#459 and are marked so; the rest stand unchanged.
+
 | Trigger | Shape of the fix |
 |---|---|
-| Resource-key 422s recur across **different** keys | A mapping writer on `sam-admin xras` (today it is a hand INSERT). Must print the parity warning — closing a mapping moves GET bytes |
+| Resource-key 422s recur across **different** keys | A mapping *writer* on `sam-admin xras` (today it is a hand INSERT). Must print the parity warning — closing a mapping moves GET bytes. ⚠️ **Narrowed:** the *detection* half shipped with #458's two-sided `--validate-mapping`, which exits non-zero when XRAS offers a key SAM cannot resolve. You now learn about this before an award does |
 | Mnemonic failures dominate the `New` failure bucket | A bulk organization-mnemonic linker, plus a report of which orgs would unblock the most awards. This is the highest-leverage data fix available |
 | Operators repeatedly fix a row, re-check it green, and wait on ACCESS | **A re-apply path.** Explicitly deferred in `recheck.py`; it needs an idempotency key enforced on `action_id` *first*, because 4 of the 6 handlers double-apply — Supplement and Adjustment are additive, and a re-applied successful `New` routes to `update` and supplements the allocation it just created. Do not build the second half before the first |
-| You reach for `--status unmapped` and cannot | Derive the CLI `click.Choice` from `XRAS_ACTION_STATUSES` rather than restating it, and give `unmapped` a style in `src/cli/xras/display.py`. One line each; both are restatements of a vocabulary that already exists in one place |
-| Polling the dashboard stops being enough | A digest of `failed` / `manual` / `unmapped` rows. ⚠️ A new entry in `src/scheduling/tasks/` goes live on the next hourly wake unless `SAM_TASKS_DISABLED` names it in the **same** change — the registry is code-side, the list is chart-side, and nothing couples them but the reviewer |
+| You reach for `--status unmapped` and cannot | Derive the CLI `click.Choice` from `XRAS_ACTION_STATUSES` rather than restating it, and give `unmapped` a style in `src/cli/xras/display.py`. One line each; both are restatements of a vocabulary that already exists in one place. ⚠️ Still both unbuilt — and #458 edited a *neighbouring* `click.Choice` on the same command without noticing this one |
+| Polling the dashboard stops being enough | A digest of `failed` / `manual` / `unmapped` rows. ⚠️ A new entry in `src/scheduling/tasks/` goes live on the next hourly wake unless `SAM_TASKS_DISABLED` names it in the **same** change — the registry is code-side, the list is chart-side, and nothing couples them but the reviewer. `xras_sweep` is **not** this: it digests the *outbound* enumeration and mails nobody. Its arrival did make that warning load-bearing, though — three tasks are live now, not one |
+
+**Removed from this table:** *"a withheld opportunity mapping needs a decision"* — built,
+as `sam-admin xras --validate-opportunities` (§ 3.9). It was CLI wiring over a decision
+function and a client method that #459 already shipped, and its trigger lands during
+triage week by construction.
 
 Two known documentation drifts, harmless and recorded here rather than fixed in a
 cutover-week commit: `src/sam/integration/xras.py` documents a `replayed` status the code
@@ -296,6 +432,11 @@ These are listed in full at [`XRAS_CUTOVER_RUNBOOK.md`](XRAS_CUTOVER_RUNBOOK.md)
 
 - **11 active resources have no XRAS mapping** — expected. Not every internal resource is
   offered for allocation through XRAS. `--validate-mapping` is a diagnostic, not a gate.
+  The direction that *would* break an award — a key XRAS offers with no SAM row — is
+  separately checked and was clean 13/13 on 2026-08-20. See § 3.1.
+- **Most XRAS opportunities are unmapped, and that is healthy.** The `opportunityId` map
+  is additive: an empty table reproduces the free-text ladder exactly. `--validate-
+  opportunities` exits non-zero only on a dangling row. See § 3.9.
 - **`POST /v1/roles` answers 404/409 where legacy answered 400.** A 409 means "project or
   user is inactive" and the `message` says which. Zero traffic in 58 days of access logs.
 - **`unmapped` is not a failure.** It means the broker asked for something we do not

--- a/docs/xras/incoming/XRAS_TRIAGE_PLAYBOOK.md
+++ b/docs/xras/incoming/XRAS_TRIAGE_PLAYBOOK.md
@@ -1,0 +1,307 @@
+# XRAS triage playbook
+
+**What to do when a real action arrives and does not land.** The day-of sequence is
+[`XRAS_CUTOVER_RUNBOOK.md`](XRAS_CUTOVER_RUNBOOK.md); the design and every measurement
+are in [`XRAS_REIMPLEMENTATION.md`](XRAS_REIMPLEMENTATION.md). This is the week after.
+
+> ## ⚠️ The one fact that shapes every remediation below
+>
+> **`--recheck` cannot apply anything.** `webapp/api/xras/recheck.py` calls
+> `dispatch_action(..., validate_only=True)`, which returns *before*
+> `management_transaction` ever opens — the no-write property is structural, not
+> configured, and no setting changes it.
+>
+> So a green re-check means **"this would work if XRAS sent it again"**, never "this has
+> been applied". Steven Peckins confirmed on 2026-08-11 that POSTs are triggered by a
+> human pushing a button in `xras_admin` and are never retried automatically.
+>
+> **Every fix therefore ends with a request to ACCESS to re-post the action.** That is
+> the loop. Budget for it: a fix is not done when the data is right, it is done when the
+> action comes back and lands.
+
+---
+
+## 1 · The daily loop
+
+In the order you will reach for them:
+
+| Surface | What it answers |
+|---|---|
+| Allocations → XRAS tab | Everything, filterable, raw payload behind `MANAGE_XRAS` |
+| `sam-admin xras --summary --last 24h` | Status counts at a glance |
+| `sam-admin xras --status failed --last 24h` | The 400s and 422s, with their error lists |
+| `sam-admin xras --status manual --last 24h` | What parked, and **why** (`outcome_reason`) |
+| `sam-admin xras --show <id> --payload` | One row in full. ⚠️ `raw_payload` is a verbatim POST body and contains PII |
+| `sam-admin xras --recheck <id>` | "Would this succeed if posted now?" Applies nothing |
+
+Add `--format json` for anything you want to pipe.
+
+⚠️ **`--status unmapped` is not selectable from the CLI.** The `click.Choice` in
+`src/cli/cmds/admin.py` predates the status and lists only five of the six in
+`XRAS_ACTION_STATUSES`. Those rows *are* counted by `--summary` and *are* filterable on
+the dashboard — use one of those. Left unfixed on purpose (see § 6).
+
+### What "normal" looks like — do not chase these
+
+- **~30% of `/people/{username}` lookups 404.** That is the baseline, measured over 30
+  days of legacy access logs: historical usernames XRAS still asks about. It is not an
+  error rate.
+- **The roster response is ~3.84 MB ±0.2%** and takes ~1.1 s. There is no filter and no
+  paging; that is the legacy contract.
+- **`New` actions succeed ~30% of the time.** Historically, on legacy, for data reasons
+  this port did not introduce and cannot fix from code (§ 3, rows 2 and 3).
+- **`Date Adjustment` and `Transfer` park.** By design, parity-correct, and now visible.
+  A parked row is an outcome, not an incident.
+
+---
+
+## 2 · Classify the row before you fix anything
+
+`status` × `http_status` × `service` × `outcome_reason` is the whole decision tree. The
+three columns C.1b added are what make a row triageable — a NULL `service` means nothing
+matched at all, a populated one means a service was selected and then something stopped
+it.
+
+| What you see | What it means | Whose problem |
+|---|---|---|
+| `failed` / `400` | Body was not JSON, or not an object. `action_type` is NULL because we genuinely do not know it | XRAS-side. Reply with the message |
+| `failed` / `422` | Parsed fine, validation rejected it. `error_messages` is the ordered list, one per line | § 3 — usually **ours**, and usually a data fix |
+| `failed` / `500` | A handler raised. `outcome_reason` carries `handler raised: <ExceptionClass>` | **A bug.** Read the app log for the traceback |
+| `manual`, `service` NULL | Nothing matched the actionType — `Date Adjustment`, `Advance`, or something new | Apply by hand, exactly as today |
+| `manual`, `service='transfer'` | Deliberately not serviced; zero production traffic, no sampled payload | Apply by hand |
+| `manual`, `outcome_reason` names `XRAS_ACTIONS_ENABLED` | **We** parked it, with the triage lever | Ours — did you mean to? |
+| `manual`, `outcome_reason` says no handler registered | The handler registry is empty | **A bug.** See § 5 |
+| `unmapped` / `404` | XRAS called a path we do not implement. Nothing was applied | One row is worth reading; a *run* of them is a conversation with ACCESS |
+| `received`, `processed_time` NULL, past the cutover | A post that arrived while dispatch was off | Ask XRAS to re-post — this cannot be replayed |
+| `rechecked` | You ran `--recheck` and it would now succeed | Ask XRAS to re-post |
+
+**`action_id` answers "have I seen this before?"** Three rows sharing one `action_id` are
+one action posted three times, not three awards.
+
+---
+
+## 3 · The 422 catalog, ranked by expected frequency
+
+Every string below is built by a named function in `src/sam/xras/errors.py`, which cites
+the Java emitter it reproduces. **The typos are deliberate** — a doubled space, a trailing
+`: ` with nothing after it — because they are the wire contract legacy established. Do not
+tidy them.
+
+### 1. `No resource found in SAM corresponding to key {key}`
+
+The `resourceRepositoryKey` on the award has no row in
+`xras_resource_repository_key_resource`. There are **13 mapping rows** in total and **11
+active SAM resources have none**, so an award citing a resource nobody has mapped fails
+here.
+
+**Fix:** add the mapping row. `sam-admin xras --validate-mapping` reports the three
+groups — unmapped active resources, mappings pointing at decommissioned kit, and dangling
+keys (the last is the only unambiguously broken one, and the only one that makes the
+command exit non-zero).
+
+> ⚠️ **Adding a mapping row moves GET response bytes.** `resourceRepositoryKey` is
+> *omitted* from the `requests/*` payloads when a resource has no row, so closing a gap
+> invalidates a previously clean gate-3 parity run. **Re-run it:**
+> `python utils/parity/check_legacy_apis.py --api xras --new-base-url https://sam.hpc.ucar.edu`
+
+There is a second wording for the same failure on the roster path — `No resource found in
+SAM corresponding to name {resource_name}`. Both can appear for one action.
+
+### 2. `Could not determine Mnemonic code for internal PI via organization`
+
+**24% of legacy's XRAS failures.** The lead's organization has no mnemonic soft link: the
+match is `code LIKE '%name%'` against a `varchar(3)` column, and **153 of 171 active
+organizations (89%)** cannot satisfy it. 80% of institutions are in the same state, which
+gives the external twin, `Could not determine Mnemonic code for external PI via
+institution`.
+
+**Fix:** a data fix on the organization or institution. This would move `New`'s success
+rate more than any code change available to us.
+
+Two neighbours from the same resolution path:
+`Could not produce affiliation data for PI {username}`, and
+`Unable to determine allocation type from action data` / `No AllocationType for
+SelectionParms{panel='…', type='…'}` (the odd rendering is Java's `toString()`,
+reproduced because the operator sees it).
+
+### 3. `PI {username} is not in database` · `Username {username} is missing`
+
+**55% of production `New` failures.** Unreconciled ARC placeholder identities — the
+username on the award has never been reconciled to a SAM user.
+
+**Fix:** identity reconciliation. Note a blank username renders as `Username  is missing`
+with a double space; that is the payload, not a formatting bug.
+
+Same family, and the wording tells you which check tripped:
+
+| Message | Note |
+|---|---|
+| `Missing pi role` | lowercase "pi", as in the Java |
+| `PI {u} is not an active user: ` | ⚠️ trailing colon-space, nothing after it |
+| `Allocation Manager {u} is not in database: ` | ⚠️ trailing colon-space |
+| `Allocation Manager {u} is not active ` | ⚠️ trailing bare space, no colon |
+| `Username {u} is inactive` | |
+| `Multiple {role_type} roles are in range for this action: {a, b}` | **Not** a legacy string — legacy picks the first by array order and says nothing |
+
+A **missing Allocation Manager is not an error**; a missing PI is.
+
+### 4. `Cannot find contract for grant number "{grant}" ("{core}")`
+
+⚠️ **The `New` handler LINKS a contract, it does not create one.** A grant number SAM has
+never seen is a 422 naming the *contract*, not the grant.
+
+**Fix:** create or link the contract in SAM first, then ask XRAS to re-post.
+
+### 5. `Ambiguous contract for grant number "{grant}" ("{core}"): matches {a, b}`
+
+Also not a legacy string — legacy raises `NonUniqueResultException` and returns an opaque
+500. Three colliding pairs are known live in production: `1049089`/`PLR-1049089`,
+`OPP-1744587`/`PLR-1744587`, `2146709`/`AGS-2146709`.
+
+**Fix:** disambiguate the contract rows. The message names the candidates precisely so
+that the fix is possible without a database session.
+
+### 6. Date and window rejections
+
+| Message | Raised by | Meaning |
+|---|---|---|
+| `Action end date is before existing allocation end date ({yyyy-MM-dd})` | **Extension** | The award moves an end date backwards |
+| `Action end date before existing allocation end date for {resource_name}` | **Update** | Same idea, different path |
+| `All contract and allocation end dates are null or past for project [{projcode}]` | Supplement, Adjustment | Supplementing an expired project — extend the contract first |
+| `End date of allocation ({end}) must be after commission date of resource({name}).` | New, Update | Award predates the resource. ⚠️ no space before `(` — legacy's `resource(%s)` |
+| `Missing {begin\|end} date for allocation(s)` · `Could not convert {begin\|end} date for allocation(s)` | shared | |
+
+⚠️ **The first two are near-twins and must not be unified.** Update's interpolates a
+*resource name*; Extension's interpolates a *date*. Which one you are looking at is how
+you tell which handler rejected the action.
+
+If the intent really was to move a date backwards, the action type for that is
+`Date Adjustment`, which parks — see § 4.
+
+### 7. Amounts
+
+| Message | Note |
+|---|---|
+| `Awarded amount missing` | |
+| `Could not convert awarded amount "{amount}"  to float` | ⚠️ **two spaces** before `to float`, as in the Java |
+| `Adjustment of {amount} for {resource} would take the allocation below zero (currently {current})` | **Not** a legacy string — legacy has never run an Adjustment at all |
+
+⚠️ **`awardedAmount` on a Supplement is the INCREMENT, not the new total.** The single
+most consequential porting semantic in the whole integration. A Supplement with
+`amount <= 0` is dropped silently with a WARN, matching legacy.
+
+⚠️ **Review `adjust` rejections hardest.** Legacy's `AdjustProjectActionService` tests
+`equals("Adjust")` against a wire that sends `"Adjustment"`, so it is dead code and has
+**never once fired**. Every Adjustment SAM services is the first of its kind, with no
+production outcome to diff against. (SAM accepts both spellings; `XRAS_ACTION_TYPE_ALIASES`
+folds `Adjust` → `Adjustment`, read-side only. The audit column stores the wire value
+verbatim.)
+
+### 8. Miscellaneous
+
+`Missing title` · `No FieldOfScience (fos) objects` · `AreaOfInterest (FOS) id is not in
+database: {fos}` · and an oversized body, which answers **422 not 413** on purpose: a
+status their panel does not expect would be an unreadable rejection.
+
+> The 422 response always carries the **complete** ordered list. The `error_messages`
+> column is cut on message boundaries with a counted tail when a payload overflows the
+> 65,535-byte column, and says so in the stored value.
+
+---
+
+## 4 · Action types that park, and are supposed to
+
+| Type | Why |
+|---|---|
+| `Date Adjustment` | No serviceable in legacy either, so parking is parity-correct. Discovered 2026-08-11; 4 of the 41 corpus payloads. The payloads are Extension-shaped but carry an `actionBeginDate` that Extension ignores, and the type most likely exists to move dates in directions Extension rejects. **Whether to service it is a question for ACCESS** |
+| `Transfer` | Registered handler that parks with a reason. Zero production traffic, no sampled payload |
+| `Advance` | No `select_service` arm. Zero samples |
+
+Since the cutover these answer a **200 with an informative body** rather than a bare
+`OK`, so the admin who posted knows a human has it. The status stays 200 because ACCESS
+treats anything else as an error.
+
+**Never seen in production, so expect surprises:** `Renewal` (zero samples — and the three
+`requestType: 'Renewal'` payloads in the 2026-08-11 forward are *not* the same thing and do
+not reach the Renewal arm), `Advance`, and any **co-PI** `roleType`. Membership ignores
+`roleType` entirely, so the co-PI spelling cannot break a roster; but role *assignment*
+knows only `PI` and `Allocation Manager`, so a co-PI is invisible to it.
+
+---
+
+## 5 · Levers, and what they cost
+
+**Park one action type, no revert** — `helm/values.yaml`:
+
+```yaml
+XRAS_ACTIONS_ENABLED: "Extension,Supplement"
+```
+
+Narrow it to whatever should keep running. Excluded types take the audited `manual`
+path — visible, recorded, applied by a human — rather than being dropped.
+
+- ⚠️ **An unknown token is logged and dropped**, which fails safe in the direction that
+  bites: a typo like `Extention` leaves Extension **disabled**. It deliberately does not
+  refuse to start — this is the lever reached for at 3am and it must not be able to take
+  the app down.
+- ⚠️ It keys on **action type**, so disabling `New` disables both the `add` and `update`
+  services.
+
+**Stop dispatching entirely** — `XRAS_ACTIONS_CAPTURE_ONLY: "1"`. Everything is still
+captured; nothing is applied. ⚠️ But posts arriving while it is on are stranded as
+`received` and can only be recovered by asking XRAS to re-post, so this buys safety at
+the cost of a round-trip with ACCESS. Prefer the per-type lever.
+
+**Full rollback** is a repoint back to `sam.ucar.edu`, i.e. another round-trip with
+ACCESS. Not ours to do alone. Legacy stays running and untouched throughout.
+
+⚠️ **If *every* action suddenly parks with "no handler is registered",** the handler
+registry is empty — `sam.xras.handlers` registers by import side effect, and the import in
+`webapp/api/xras/actions.py` is what triggers it. It fails quietly, as plausible-looking
+`manual` rows rather than as an error.
+
+**What one action wrote:** there is no FK from `xras_action_log` to
+`allocation_transaction` — an Extension averages 3.3 rows, so a column was the wrong
+shape. Use the correlation query in
+[`XRAS_CUTOVER_RUNBOOK.md`](XRAS_CUTOVER_RUNBOOK.md) § *What one action wrote*.
+
+---
+
+## 6 · If a failure class recurs — the sketch, deliberately unbuilt
+
+Nothing below exists, on purpose. Writing remediation tooling for failures that have not
+happened is how you end up maintaining the wrong tool. What follows is the *shape* of each
+fix and the **trigger** that would justify building it, so that the decision is quick when
+the evidence arrives and nobody re-derives it under pressure.
+
+| Trigger | Shape of the fix |
+|---|---|
+| Resource-key 422s recur across **different** keys | A mapping writer on `sam-admin xras` (today it is a hand INSERT). Must print the parity warning — closing a mapping moves GET bytes |
+| Mnemonic failures dominate the `New` failure bucket | A bulk organization-mnemonic linker, plus a report of which orgs would unblock the most awards. This is the highest-leverage data fix available |
+| Operators repeatedly fix a row, re-check it green, and wait on ACCESS | **A re-apply path.** Explicitly deferred in `recheck.py`; it needs an idempotency key enforced on `action_id` *first*, because 4 of the 6 handlers double-apply — Supplement and Adjustment are additive, and a re-applied successful `New` routes to `update` and supplements the allocation it just created. Do not build the second half before the first |
+| You reach for `--status unmapped` and cannot | Derive the CLI `click.Choice` from `XRAS_ACTION_STATUSES` rather than restating it, and give `unmapped` a style in `src/cli/xras/display.py`. One line each; both are restatements of a vocabulary that already exists in one place |
+| Polling the dashboard stops being enough | A digest of `failed` / `manual` / `unmapped` rows. ⚠️ A new entry in `src/scheduling/tasks/` goes live on the next hourly wake unless `SAM_TASKS_DISABLED` names it in the **same** change — the registry is code-side, the list is chart-side, and nothing couples them but the reviewer |
+
+Two known documentation drifts, harmless and recorded here rather than fixed in a
+cutover-week commit: `src/sam/integration/xras.py` documents a `replayed` status the code
+never writes (it writes `rechecked`), and the word "replay" survives in RBAC comments for
+what is now `recheck.py`.
+
+---
+
+## 7 · Known-open and accepted
+
+These are listed in full at [`XRAS_CUTOVER_RUNBOOK.md`](XRAS_CUTOVER_RUNBOOK.md)
+§ *Known-open, and accepted*. The ones most likely to reach you first:
+
+- **11 active resources have no XRAS mapping** — expected. Not every internal resource is
+  offered for allocation through XRAS. `--validate-mapping` is a diagnostic, not a gate.
+- **`POST /v1/roles` answers 404/409 where legacy answered 400.** A 409 means "project or
+  user is inactive" and the `message` says which. Zero traffic in 58 days of access logs.
+- **`unmapped` is not a failure.** It means the broker asked for something we do not
+  implement — `DELETE /v1/roles/…` is the documented candidate.
+- **SMTP is fail-closed.** If `NOTIFY_ENABLED` is unset, every notice records `suppressed`
+  and nothing is delivered, silently. Check Admin → Configuration → Notifications.
+- **`xras_notices`, the hourly automatic-notice task, is switched off** through triage
+  week — notices go out from the **Notify** button on the Pending Activations card, so a
+  human sees each one. Clearing it from `SAM_TASKS_DISABLED` is a follow-up.

--- a/docs/xras/outgoing/XRAS_OPPORTUNITY_ALLOCATION_TYPE.md
+++ b/docs/xras/outgoing/XRAS_OPPORTUNITY_ALLOCATION_TYPE.md
@@ -98,16 +98,16 @@ regenerated, which is what was done for the previous three tables on
 additivity tests `DELETE` inside their SAVEPOINT rather than assuming an empty
 table.
 
-### Still deferred
+### ~~Still deferred~~ · ✅ **BUILT 2026-08-20**
 
-`sam-admin xras --validate-opportunities` (§ 5.1). Two notes for whoever builds
-it: XRAS's `panels[]` is the *review-panel* vocabulary (`CISL Resource
-Support`/`CISL RSD`), **not** SAM's `panel` table — only `CHAP` coincides, so
-`/v1/opportunities`'s `panels: [{panelId}]` is evidence for a human and never a
-derivation. And use `GET /v1/opportunities/list/:ids`, which is batched and
-resolves historic/Terminating opportunities: five of the nine known ids are
-closed, and the open list cannot explain them. § 6's "5-edit CLI recipe" is
-really 7 edit points across 4 files.
+`sam-admin xras --validate-opportunities`. See § 8.6 for what it does and the one
+place it deviates from the recipe below.
+
+The two notes written for whoever built it both held: XRAS's `panels[]` is the
+*review-panel* vocabulary (`CISL Resource Support`/`CISL RSD`), **not** SAM's
+`panel` table — only `CHAP` coincides, so `/v1/opportunities`'s
+`panels: [{panelId}]` is evidence for a human and never a derivation. And § 6's
+"5-edit CLI recipe" is indeed 7 edit points across 4 files.
 
 ---
 
@@ -499,12 +499,44 @@ body — silently, because the name is a decorator argument, and invisibly to
 every unit test that calls `mod.xras_sweep` directly. It fails only at dispatch.
 That happened; `test_the_decorator_is_bound_to_the_task_body` is the guard.
 
-### Still deferred
+### 8.6 `sam-admin xras --validate-opportunities` · ✅ **BUILT 2026-08-20**
 
-`sam-admin xras --validate-opportunities`. The decision function is already
-shared, so it is CLI wiring: option, `execute` kwarg, mode method, builder,
-display. Use `GET /v1/opportunities/list/:ids` (the client method exists) — the
-open list cannot explain the 30-odd closed opportunities.
+CLI wiring over `audit_opportunity_mapping` and `propose_opportunity_mapping`, as
+predicted: option, `execute` kwarg, mode method, `_live_opportunities()`, builder,
+display. Both query functions keep their injection contract — the CLI fetches, they
+take ids or payloads and hold zero network knowledge, and `live_checked`
+distinguishes "nothing unmapped out there" from "we never asked".
+
+**Two decisions the recipe did not settle.**
+
+⚠️ **It reads `GET /v1/opportunities` — the OPEN list — not
+`/v1/opportunities/list/:ids`**, which is the opposite of what this section said
+before it was built. The reasoning it was written with is sound for *backfill* and
+wrong for a **check**:
+
+- The historical tail is not this command's job. `xras_sweep` already resolves
+  closed and Terminating ids by batch from `reports/requests`, hourly, and writes
+  the agreeing ones. Duplicating that in the CLI means a 21-page, 60-90 s
+  enumeration behind an interactive flag — and the ids it would report are ones no
+  future action can cite, because the opportunity is closed.
+- The open list is the only place a **brand-new** opportunity appears. By
+  construction `reports/requests` cannot mention one nobody has submitted against
+  yet — and that is exactly the row that would silently mis-resolve, because there
+  is no request yet to notice it on. The lead indicator is the point.
+
+The display says which scope it used, so a one-sided or open-only report cannot be
+read as a stronger claim than it is.
+
+⚠️ **The proposal runs over the UNMAPPED subset only**, mirroring
+`_map_new_opportunities`. Run over everything and the four `source='manual'` rows —
+the ones a human settled precisely *because* the derivations disagree — reappear in
+`review` on every invocation. A bucket that is never empty is a bucket an operator
+stops reading, and this is the one bucket that must be read.
+
+**Exit code: non-zero on `dangling_ids` only.** Not on `unmapped_ids` (an empty
+table is a healthy table — the ladder resolves everything, as it always did) and
+not on `review` (never empty, by design). This is the same trap `--validate-mapping`
+fell into once and corrected; both guards are negative-tested.
 
 ## 9. Do not
 

--- a/docs/xras/outgoing/XRAS_OUTGOING_QUERIES.md
+++ b/docs/xras/outgoing/XRAS_OUTGOING_QUERIES.md
@@ -741,8 +741,9 @@ report 13/13 against today's catalog (§ 6).
 ### 8.2 `opportunityId` → allocation type — ✅ **BUILT 2026-08-20**
 
 **Superseded by [`XRAS_OPPORTUNITY_ALLOCATION_TYPE.md`](XRAS_OPPORTUNITY_ALLOCATION_TYPE.md)**,
-which carries the design, the corrections the build found, and what stays
-deferred (the `--validate-opportunities` CLI).
+which carries the design, the corrections the build found, and — as of
+2026-08-20 — the `--validate-opportunities` CLI, which is no longer deferred
+(§ 8.6 there).
 
 The deferral reasoning below is kept because it is what the decision was
 reversed *against*: the criterion was "assess after the first triage week under

--- a/e2e/test_xras_accounts_card.py
+++ b/e2e/test_xras_accounts_card.py
@@ -146,8 +146,8 @@ def test_both_classification_chips_render(page):
     different claim from 'none'."""
     card = _load(page)
     text = card.inner_text()
-    assert 'Create account' in text
-    assert 'Reactivate account' in text
+    assert 'New account' in text
+    assert 'Reactivation' in text
 
 
 def test_a_chip_filters_without_a_page_load(page):
@@ -158,7 +158,7 @@ def test_a_chip_filters_without_a_page_load(page):
 
     before = _rows(card).count()
     page.once('load', lambda _: pytest.fail('the chip triggered a full reload'))
-    card.locator('button.facet-chip', has_text='Create account').first.click()
+    card.locator('button.facet-chip', has_text='New account').first.click()
     page.wait_for_timeout(1200)
 
     card = page.locator(CARD)

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -521,8 +521,8 @@ tasks:
     # here until each has been reviewed on its own.
     #
     # Live:     cleanup_status_snapshots     (daily 02:15 MT, status DB only)
-    # Disabled: deactivate_expired_projects  (writes inactivate_time in SAM)
-    #           expiration_notices           (mails external PIs)
+    #           deactivate_expired_projects  (writes inactivate_time in SAM)
+    # Disabled: expiration_notices           (mails external PIs)
     #           xras_notices                 (mails external PIs)
     #
     # `xras_sweep` was enabled once its output became a queue rather than a

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -532,18 +532,33 @@ tasks:
     # "Approved" is the only status that produces a handoff. Widen to any of
     # the API's filter values, or "all", to survey the pipeline pre-approval.
     SAM_TASKS_XRAS_SWEEP_STATUS: "Approved"
+    # Per-run cap on the sweep's ONE write — new xras_opportunity_allocation_type
+    # rows. Pinned here for the same reason SAM_TASKS_XRAS_MAX above is: it is a
+    # policy decision, and it was the only sweep knob the chart did not name, so
+    # the cluster silently ran the code default. Reports `map_budget_exhausted`
+    # when it bites, and the cap selects NEWEST first — a just-posted opportunity
+    # is the case the feature exists for; a historical backfill can wait a slot.
+    SAM_TASKS_XRAS_MAP_MAX: "20"
     # ⚠️ Comma-separated task names to skip, WITHOUT a code deploy. This is a
-    # staged-enable control: exactly one task is live, and the rest are named
-    # here until each has been reviewed on its own.
+    # staged-enable control: the live set is enumerated below and the rest are
+    # named here until each has been reviewed on its own.
     #
     # Live:     cleanup_status_snapshots     (daily 02:15 MT, status DB only)
     #           deactivate_expired_projects  (writes inactivate_time in SAM)
+    #           xras_sweep                   (reads api.xras.org; one narrow write)
     # Disabled: expiration_notices           (mails external PIs)
     #           xras_notices                 (mails external PIs)
     #
     # `xras_sweep` was enabled once its output became a queue rather than a
-    # census (see its module docstring). It is read-only — it calls out to
-    # api.xras.org and writes nothing but a cache entry the dashboard reads.
+    # census (see its module docstring). It calls out to api.xras.org and
+    # publishes a cache entry the dashboard reads.
+    #
+    # ⚠️ It is NOT read-only, and its own comment here said so until #459. It
+    # inserts xras_opportunity_allocation_type rows — "the only write this task
+    # performs", src/scheduling/tasks/xras_sweep.py — and only where two
+    # independent derivations agree, never overwriting an existing row. An
+    # inbound action still reads that table locally and never calls out, so
+    # ingestion does not depend on this task or on api.xras.org being up.
     #
     # ⚠️ There is NO wildcard. `disabled_tasks()` in src/scheduling/runner.py
     # is a case-sensitive exact match against registry keys — `all`, `*` and

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -309,11 +309,27 @@ webapp:
     FS_SCAN_PG_DB: "campaign"
     FS_SCAN_RESOURCE_DATABASES: "Campaign_Store:campaign,Destor:destor"
     # XRAS action ingestion. CAPTURE_ONLY is the safety interlock: while it is "1" the
-    # endpoint authenticates, parses and audits every post but dispatches nothing,
-    # because legacy SAM at sam.ucar.edu is still the system of record. It flips to "0"
-    # only at cutover, in step with XRAS repointing its base URL to sam.hpc.ucar.edu —
-    # dispatching before then would double-apply actions legacy has already applied.
-    XRAS_ACTIONS_CAPTURE_ONLY: "1"
+    # endpoint authenticates, parses and audits every post but dispatches nothing.
+    #
+    # ✅ RELEASED 2026-08-19, deliberately AHEAD of XRAS repointing its base URL to
+    # sam.hpc.ucar.edu. The two directions are not symmetric:
+    #
+    #   - flipping early costs nothing — XRAS still posts to sam.ucar.edu, so the
+    #     dispatching arm sees no traffic at all until the repoint;
+    #   - flipping late strands every post in the gap as status='received', and
+    #     `sam-admin xras --recheck` CANNOT apply one (validate_only returns before
+    #     management_transaction opens). Recovery is asking the XRAS admin to push the
+    #     button again, per action.
+    #
+    # ⚠️ What this must NOT do is flip early on a stack XRAS is ALREADY posting to —
+    # that double-applies actions legacy has already applied, against live allocations,
+    # with no undo. The precondition is therefore checked, not assumed: no
+    # status='received' rows in xras_action_log before this lands.
+    #
+    # Setting it back to "1" stops all dispatch, at the cost above. To park one
+    # misbehaving action type instead, narrow XRAS_ACTIONS_ENABLED below.
+    # Triage: docs/xras/incoming/XRAS_TRIAGE_PLAYBOOK.md
+    XRAS_ACTIONS_CAPTURE_ONLY: "0"
     # Per-type triage lever, checked only once CAPTURE_ONLY is off. "all" | "none" |
     # e.g. "Extension,Supplement". Narrow this to park a misbehaving payload class as
     # manual without a revert; an unknown token leaves that type disabled.

--- a/src/cli/cmds/admin.py
+++ b/src/cli/cmds/admin.py
@@ -676,6 +676,8 @@ def cache(ctx: Context, refresh: bool, category, base_url):
               help='[rollup] Counts by status and action type')
 @click.option('--validate-mapping', is_flag=True,
               help='[check] Report SAM resources XRAS cannot name (pre-cutover gate)')
+@click.option('--validate-opportunities', is_flag=True,
+              help='[check] Report the opportunityId -> allocation-type map')
 @click.option('--accounts', is_flag=True,
               help='[worklist] Accounts to create or reactivate before a handoff')
 @click.option('--enrich', is_flag=True,
@@ -697,7 +699,7 @@ def cache(ctx: Context, refresh: bool, category, base_url):
 @click.option('--verbose', '-v', is_flag=True, help='Show detailed information')
 @pass_context
 def xras(ctx: Context, action_id, show_payload, recheck, summary, validate_mapping,
-         accounts, enrich, person,
+         validate_opportunities, accounts, enrich, person,
          status, action_type, request_number, last, limit, verbose):
     """Inspect and re-check the XRAS action log.
 
@@ -715,6 +717,7 @@ def xras(ctx: Context, action_id, show_payload, recheck, summary, validate_mappi
       --accounts   who must be created or reactivated before a handoff works
       --person U   one username in the XRAS directory
       --validate-mapping  which resources XRAS and SAM can name each other's
+      --validate-opportunities  which XRAS opportunities resolve to a SAM type
 
     \b
     --recheck answers "would this succeed if XRAS posted it now?" It re-parses the
@@ -739,12 +742,22 @@ def xras(ctx: Context, action_id, show_payload, recheck, summary, validate_mappi
     report and says so.
 
     \b
+    --validate-opportunities is the same shape for xras_opportunity_allocation_type,
+    and it exists because that map's failure mode is the only SILENT one in the
+    integration: an unmapped opportunity falls back to the free-text ladder, which
+    cannot name any facility-4 allocation type, so a Wyoming request resolves to a
+    UNIV panel, the join SUCCEEDS, and the project gets a UNIV projcode. Nothing
+    fails. For each unmapped opportunity it reports whether XRAS's own type/panel
+    pair and the ladder AGREE -- the rule xras_sweep writes rows under.
+
+    \b
     Examples:
       sam-admin xras --last 7d
       sam-admin xras --status failed --type Extension
       sam-admin xras --show 42 --payload
       sam-admin xras --summary --last 30d
       sam-admin xras --validate-mapping
+      sam-admin xras --validate-opportunities
       sam-admin xras --accounts
       sam-admin xras --accounts --enrich --last 30d
       sam-admin xras --person somebody-user-00042
@@ -777,6 +790,7 @@ def xras(ctx: Context, action_id, show_payload, recheck, summary, validate_mappi
         recheck=recheck,
         summary=summary,
         validate_mapping=validate_mapping,
+        validate_opportunities=validate_opportunities,
         accounts=accounts,
         enrich=enrich,
         person=person,

--- a/src/cli/xras/builders.py
+++ b/src/cli/xras/builders.py
@@ -170,19 +170,30 @@ def build_opportunity_report(session, *, opportunities=None) -> dict:
 
 
 def build_account_worklist(session, *, since=None, until=None,
-                           enrich=False, max_lookups=100) -> dict:
+                           enrich=False, max_lookups=100,
+                           pending_rows=None, pending_checked=False) -> dict:
     """The ``xras_accounts`` envelope — who needs an account before a handoff.
 
     *enrich* is opt-in because it costs a round trip to XRAS per username. The
     enrichment report rides in the envelope rather than being folded into the
     rows: "we did not ask" and "we asked and XRAS was down" are different facts
     and a consumer diffing two runs needs to tell them apart.
+
+    *pending_rows* is the Feed-B worklist ``xras_sweep`` published, injected by
+    the caller. ⚠️ ``pending_checked`` is the same distinction ``live_checked``
+    draws on the mapping audit and is the reason it is a separate flag rather
+    than ``pending_rows is not None``: a consumer must be able to tell "Feed B
+    is empty" from "we could not read Feed B", because the second one means the
+    number it is looking at is a **subset of the queue** and the first does not.
     """
     from sam.queries.xras_accounts import (enrich_worklist,
                                            get_account_worklist,
+                                           stamp_waiting_days,
                                            worklist_counts)
 
-    rows = get_account_worklist(session, since=since, until=until)
+    rows = get_account_worklist(session, since=since, until=until,
+                                pending_rows=pending_rows)
+    stamp_waiting_days(rows)
     enrichment = (enrich_worklist(rows, max_lookups=max_lookups)
                   if enrich else None)
 
@@ -191,6 +202,7 @@ def build_account_worklist(session, *, since=None, until=None,
         'counts': worklist_counts(rows),
         'enriched': bool(enrich),
         'enrichment': enrichment,
+        'pending_checked': bool(pending_checked),
         'accounts': [_account_row(r) for r in rows],
     }
 
@@ -207,6 +219,8 @@ def _account_row(row) -> dict:
         'is_reconciled': row['is_reconciled'],
         'first_seen': row['first_seen'],
         'last_seen': row['last_seen'],
+        'waiting_since': row.get('waiting_since'),
+        'waiting_days': row.get('waiting_days'),
         'latest_action_log_id': row['latest_action_log_id'],
         'sources': list(row['sources']),
         'person': row['person'],

--- a/src/cli/xras/builders.py
+++ b/src/cli/xras/builders.py
@@ -12,8 +12,10 @@ sees.
 from typing import Any, Dict, List, Optional
 
 from sam.queries.xras_actions import (
+    audit_opportunity_mapping,
     audit_resource_mapping,
     get_recent_xras_actions,
+    propose_opportunity_mapping,
     summarize_xras_actions,
 )
 
@@ -132,6 +134,39 @@ def build_mapping_report(session, *, xras_keys=None) -> dict:
     """
     return {'kind': 'xras_resource_mapping',
             **audit_resource_mapping(session, xras_keys=xras_keys)}
+
+
+def build_opportunity_report(session, *, opportunities=None) -> dict:
+    """The ``xras_opportunity_mapping`` envelope.
+
+    Two query-layer calls, deliberately not one: :func:`audit_opportunity_mapping`
+    answers *what is mapped*, and :func:`propose_opportunity_mapping` answers *what
+    could be, and by whose authority*. Both live in ``sam.queries.xras_actions`` and
+    are shared with ``xras_sweep``, so the CLI and the task cannot drift into two
+    opinions about the same opportunity.
+
+    ⚠️ **The proposal runs over the UNMAPPED subset only**, exactly as
+    ``_map_new_opportunities`` does in the sweep. Run over everything and the two
+    permanent ``manual`` rows — the ones where XRAS is wrong about SAM and a human
+    said so — reappear in ``review`` on every invocation, which is how an operator
+    learns to ignore the bucket that matters.
+
+    *opportunities* is the live open catalog when one could be fetched, making the
+    report two-sided; ``None`` reports the local half with ``live_checked`` False to
+    say so. Injected rather than fetched here for the same reason
+    :func:`build_mapping_report` injects *xras_keys*.
+    """
+    payloads = [o for o in (opportunities or []) if isinstance(o, dict)]
+    ids = [o['opportunityId'] for o in payloads if o.get('opportunityId') is not None]
+
+    audit = audit_opportunity_mapping(
+        session, opportunity_ids=ids if opportunities is not None else None)
+
+    unmapped = set(audit['unmapped_ids'])
+    proposal = propose_opportunity_mapping(
+        session, [o for o in payloads if o.get('opportunityId') in unmapped])
+
+    return {'kind': 'xras_opportunity_mapping', **audit, 'proposal': proposal}
 
 
 def build_account_worklist(session, *, since=None, until=None,

--- a/src/cli/xras/commands.py
+++ b/src/cli/xras/commands.py
@@ -94,7 +94,10 @@ class XrasCommand(BaseCommand):
         try:
             return resource_repository_keys()
         except XrasSourceUnavailable as exc:
-            self.ctx.console.print(
+            # ⚠️ stderr, not stdout. This is a diagnostic about the run, not
+            # part of the report — printed to stdout it lands *inside* the
+            # `--format json` envelope and breaks every consumer piping to jq.
+            self.ctx.stderr_console.print(
                 f'[yellow]Could not reach the XRAS API ({exc}); reporting the '
                 f'local half only.[/yellow]')
             return None
@@ -158,7 +161,7 @@ class XrasCommand(BaseCommand):
         try:
             return XrasApiClient.from_environment().get_open_opportunities()
         except XrasSourceUnavailable as exc:
-            self.ctx.console.print(
+            self.ctx.stderr_console.print(
                 f'[yellow]Could not reach the XRAS API ({exc}); reporting the '
                 f'local half only.[/yellow]')
             return None
@@ -179,14 +182,57 @@ class XrasCommand(BaseCommand):
                     'XRAS_OUTGOING_ENABLED=1 and XRAS_API_KEY.[/red]')
                 return EXIT_ERROR
 
+        pending, checked = self._pending_worklist()
         payload = builders.build_account_worklist(
             self.session, since=filters.get('start_date'),
-            until=filters.get('end_date'), enrich=enrich)
+            until=filters.get('end_date'), enrich=enrich,
+            pending_rows=pending, pending_checked=checked)
         if self.ctx.output_format == 'json':
             output_json(payload)
         else:
             display.display_account_worklist(self.ctx, payload)
         return EXIT_SUCCESS
+
+    def _pending_worklist(self):
+        """Feed B, as ``xras_sweep`` last published it — or ``(None, False)``.
+
+        ⚠️ **This is why the CLI and the dashboard used to disagree.** The card
+        reads the sweep's snapshot; ``--accounts`` only ever read the action
+        log, so on a stack where XRAS had not yet repointed the card showed a
+        real queue and the CLI reported zero. Same question, two answers, and
+        nothing said which was partial.
+
+        Returns the rows and *whether we were able to look*, kept separate for
+        the reason ``live_checked`` exists on the mapping audit: an empty Feed B
+        and an unreadable one are different facts, and only the second means the
+        printed count is a subset.
+
+        Degrades rather than fails. A laptop with no ``CACHE_REDIS_URL`` gets
+        the Feed-A half and is told so — the same posture as an unconfigured
+        ``--validate-mapping``.
+        """
+        from sam.integration.xras_api import xras_api_configured
+
+        if not xras_api_configured():
+            return None, False
+        try:
+            from sam.integration.xras_api.cache import load_pending_worklist
+
+            snapshot = load_pending_worklist()
+        except Exception as exc:                     # noqa: BLE001
+            # The cache backend is infrastructure, not a contract — a laptop
+            # without Redis raises from somewhere in the adapter stack rather
+            # than returning empty, and that must not take the report down.
+            self.ctx.stderr_console.print(
+                f'[yellow]Could not read the published worklist ({exc}); '
+                f'reporting posted actions only.[/yellow]')
+            return None, False
+        if snapshot is None:
+            self.ctx.stderr_console.print(
+                '[yellow]No sweep has published a pending worklist yet; '
+                'reporting posted actions only.[/yellow]')
+            return None, False
+        return list(snapshot.get('rows') or []), True
 
     def _person(self, username) -> int:
         """Probe one username through ``GET /v1/people``.

--- a/src/cli/xras/commands.py
+++ b/src/cli/xras/commands.py
@@ -17,7 +17,8 @@ class XrasCommand(BaseCommand):
     """
 
     def execute(self, *, action_id=None, recheck=None, summary=False,
-                validate_mapping=False, accounts=False, person=None,
+                validate_mapping=False, validate_opportunities=False,
+                accounts=False, person=None,
                 enrich=False,
                 status=(), action_type=(), request_number=None, last=None,
                 show_payload=False, limit=50, **_) -> int:
@@ -26,6 +27,8 @@ class XrasCommand(BaseCommand):
 
             if validate_mapping:
                 return self._validate_mapping()
+            if validate_opportunities:
+                return self._validate_opportunities()
             if person is not None:
                 return self._person(person)
             if accounts:
@@ -90,6 +93,70 @@ class XrasCommand(BaseCommand):
             return None
         try:
             return resource_repository_keys()
+        except XrasSourceUnavailable as exc:
+            self.ctx.console.print(
+                f'[yellow]Could not reach the XRAS API ({exc}); reporting the '
+                f'local half only.[/yellow]')
+            return None
+
+    def _validate_opportunities(self) -> int:
+        """Report the state of ``xras_opportunity_allocation_type``.
+
+        The ``opportunityId`` twin of :meth:`_validate_mapping`, and it exists
+        because this map is the only one in the integration whose failure is
+        **silent**. An unmapped resource key 422s the action; an unmapped
+        opportunity falls through to the free-text ladder, whose twelve
+        ``SelectionParms`` pairs never name ``UW``, ``WRAP`` or ``LCAP`` — so a
+        Wyoming ``Small`` request resolves to panel ``UNIV USS``, the join
+        *succeeds*, and the project is created with a UNIV-series projcode.
+        Nothing fails, and projcodes are not undoable.
+
+        **Exit code discipline is copied from ``--validate-mapping``, including
+        the mistake it already corrected once.** Non-zero is reserved for
+        ``dangling_ids`` — a mapping row whose ``allocation_type`` has vanished
+        or has no panel, which the ingest-side lookup must treat as a miss and
+        which nothing else would surface. It is deliberately **not** returned
+        for:
+
+        * ``unmapped_ids`` — with an empty table *every* opportunity is unmapped
+          and ingestion is completely healthy, because the ladder resolves them
+          exactly as it did before the table existed. A gate keyed on this would
+          fail on the day the feature shipped and every day after.
+        * ``review`` — two pairs sit there **permanently by design** (XRAS files
+          the unsponsored family under ``Educational``, and gives ``NCAR - ASD
+          Opportunity`` NSC's own type *and* panel; both change the facility).
+          A non-zero exit on a bucket that is never empty trains an operator to
+          ignore the bucket that matters.
+        """
+        payload = builders.build_opportunity_report(
+            self.session, opportunities=self._live_opportunities())
+        if self.ctx.output_format == 'json':
+            output_json(payload)
+        else:
+            display.display_opportunity_report(self.ctx, payload)
+        return (EXIT_NOT_FOUND if payload['dangling_ids'] else EXIT_SUCCESS)
+
+    def _live_opportunities(self):
+        """Every currently-open XRAS opportunity, or ``None`` if we could not ask.
+
+        Auto-detecting rather than flagged, for the same reasons as
+        :meth:`_live_keys`: the operator wants the strongest check available and
+        the unconfigured case must degrade rather than fail.
+
+        ⚠️ **Open ones only** (``GET /v1/opportunities``), which is the right
+        scope rather than a limitation. ``reports/requests`` cannot mention an
+        opportunity nobody has submitted against — and that is precisely the one
+        this check exists for, because it is the one an imminent action would
+        silently mis-resolve.
+        """
+        from sam.integration.xras_api import (XrasApiClient,
+                                              XrasSourceUnavailable,
+                                              xras_api_configured)
+
+        if not xras_api_configured():
+            return None
+        try:
+            return XrasApiClient.from_environment().get_open_opportunities()
         except XrasSourceUnavailable as exc:
             self.ctx.console.print(
                 f'[yellow]Could not reach the XRAS API ({exc}); reporting the '

--- a/src/cli/xras/display.py
+++ b/src/cli/xras/display.py
@@ -353,17 +353,24 @@ def display_account_worklist(ctx, payload) -> None:
             '[green]No accounts are waiting on creation or reactivation.[/green]')
         return
 
-    table = Table(title=f"{counts['total']} account(s) blocking XRAS handoffs",
-                  title_style='bold')
+    oldest = counts.get('oldest_days')
+    title = f"{counts['total']} account(s) blocking XRAS handoffs"
+    if oldest:
+        title += f' — oldest waiting {oldest}d'
+    table = Table(title=title, title_style='bold')
     table.add_column('Username', style='cyan')
     table.add_column('Needs')
     table.add_column('Role', style='dim')
     table.add_column('Requests', style='dim')
     table.add_column('XRAS identity')
+    table.add_column('Waiting', justify='right')
 
     for row in payload['accounts']:
-        needs = ('[red]create[/red]' if row['classification'] == 'absent'
-                 else '[yellow]reactivate[/yellow]')
+        # ⚠️ The artifact, not an action — SAM cannot create or reactivate an
+        # account. Same words the card uses, because the terminal and the
+        # dashboard have to teach one vocabulary; the footer says who does.
+        needs = ('[red]new account[/red]' if row['classification'] == 'absent'
+                 else '[yellow]reactivation[/yellow]')
         if row['placeholder']:
             needs += ' [dim](placeholder)[/dim]'
         numbers = [a['request_number'] for a in row['actions'] if a['request_number']]
@@ -373,8 +380,10 @@ def display_account_worklist(ctx, payload) -> None:
         reconciled = {None: BLANK,
                       True: 'identified',
                       False: '[yellow]unidentified[/yellow]'}[row['is_reconciled']]
+        waited = row.get('waiting_days')
         table.add_row(row['username'], needs, ', '.join(row['roles']),
-                      truncate(', '.join(dict.fromkeys(numbers)), 40), reconciled)
+                      truncate(', '.join(dict.fromkeys(numbers)), 40), reconciled,
+                      BLANK if waited is None else f'{waited}d')
 
     ctx.console.print(table)
     ctx.console.print(
@@ -382,8 +391,28 @@ def display_account_worklist(ctx, payload) -> None:
         # SHAPE, reconciliation is whether XRAS has linked it to a confirmed
         # identity. The smoke found all three placeholders reconciled, so
         # conflating them made this line contradict the table above it.
-        f"[dim]{counts['absent']} to create, {counts['inactive']} to reactivate, "
-        f"{counts['placeholder']} ARC placeholder identities.[/dim]")
+        f"[dim]{counts['absent']} new account(s), {counts['inactive']} "
+        f"reactivation(s), {counts['placeholder']} ARC placeholder "
+        f"identities.[/dim]")
+    ctx.console.print(
+        # The invariant, said once. There is no INSERT into `users` anywhere in
+        # this repo and nothing writes `active`/`locked` — both remedies are
+        # somebody else's work, and a list that implies otherwise sends an
+        # operator looking for a button that cannot exist.
+        '[dim]Accounts are mirrored into SAM from the enterprise directory; '
+        'SAM cannot create or reactivate one. Rows clear on the next '
+        'sync.[/dim]')
+
+    # ⚠️ A subset must never be printed as if it were the whole queue. This is
+    # the CLI half of the gap that had `--accounts` reporting 0 while the
+    # dashboard showed a real worklist: the card reads the sweep's published
+    # snapshot and this only ever read the action log.
+    if not payload.get('pending_checked'):
+        ctx.console.print(
+            '[yellow]Posted actions only — the pending-request worklist could '
+            'not be read, so accounts XRAS has approved but not yet sent are '
+            'NOT counted here. Set XRAS_OUTGOING_ENABLED=1 with a reachable '
+            'cache for the full queue.[/yellow]')
 
     enrichment = payload.get('enrichment')
     if enrichment and enrichment['unavailable']:

--- a/src/cli/xras/display.py
+++ b/src/cli/xras/display.py
@@ -237,6 +237,112 @@ def display_mapping_report(ctx, payload) -> None:
             '[green]Every key XRAS offers resolves to a SAM resource.[/green]')
 
 
+def _pair(pair) -> str:
+    """A ``(panel, allocation_type)`` tuple as one cell, or the miss marker."""
+    return f'{pair[0]} / {pair[1]}' if pair else BLANK
+
+
+def display_opportunity_report(ctx, payload) -> None:
+    """Render the opportunityId map, broken rows first, then what is undecided.
+
+    Order is deliberate and is not "worst group first" in the usual sense: a
+    dangling row is the only broken state, but the group an operator is actually
+    here for is ``review`` — the opportunities two independent derivations
+    disagree about, which is where the silent wrong-projcode failure would come
+    from if anyone resolved one by guessing.
+    """
+    ctx.console.rule('[bold]XRAS opportunity mapping')
+    ctx.console.print(
+        f"[bold]{payload['mapped']}[/bold] mapping row(s) in "
+        f"xras_opportunity_allocation_type")
+
+    if payload['dangling_ids']:
+        ctx.console.print(
+            f"[bold red]Rows whose allocation type has vanished or has no "
+            f"panel:[/bold red] "
+            f"{', '.join(str(i) for i in payload['dangling_ids'])}")
+        ctx.console.print(
+            '[dim]The ingest-side lookup treats these as a miss and falls back to '
+            'the free-text ladder, silently. This is the only state this command '
+            'exits non-zero on.[/dim]')
+
+    if not payload['live_checked']:
+        ctx.console.print(
+            '[dim]Local half only — the XRAS API was not configured or not '
+            'reachable, so opportunities XRAS is currently offering are NOT '
+            'checked. Set XRAS_OUTGOING_ENABLED=1 and XRAS_API_KEY for the '
+            'two-sided report.[/dim]')
+        return
+
+    ctx.console.print(
+        f"[bold]{payload['live_id_count']}[/bold] opportunity(ies) currently open "
+        f"in XRAS")
+
+    if not payload['unmapped_ids']:
+        ctx.console.print(
+            '[green]Every open opportunity resolves through the map.[/green]')
+        return
+
+    ctx.console.print(
+        f"[bold]{len(payload['unmapped_ids'])}[/bold] of them have no mapping row")
+    ctx.console.print(
+        '[dim]Not a failure: an unmapped opportunity falls back to the free-text '
+        'ladder, exactly as every opportunity did before the map existed. What '
+        'follows is whether it could be mapped automatically.[/dim]')
+
+    proposal = payload['proposal']
+
+    if proposal['agree']:
+        table = Table(title='Would be mapped automatically (both derivations agree)',
+                      title_style='bold')
+        table.add_column('Id', justify='right', style='cyan')
+        table.add_column('Opportunity', style='dim')
+        table.add_column('Panel / type', style='green')
+        for entry in proposal['agree']:
+            table.add_row(str(entry['opportunity_id']),
+                          truncate(text(entry['opportunity_name']), 44),
+                          _pair(entry['pair']))
+        ctx.console.print(table)
+        ctx.console.print(
+            '[dim]xras_sweep writes these on its next run, newest first, capped by '
+            'SAM_TASKS_XRAS_MAP_MAX. Nothing to do.[/dim]')
+
+    if proposal['review']:
+        table = Table(title='Withheld — the two derivations disagree',
+                      title_style='bold')
+        table.add_column('Id', justify='right', style='cyan')
+        table.add_column('Opportunity', style='dim')
+        table.add_column('XRAS says', style='yellow')
+        table.add_column('Ladder says', style='yellow')
+        for entry in proposal['review']:
+            table.add_row(str(entry['opportunity_id']),
+                          truncate(text(entry['opportunity_name']), 36),
+                          _pair(entry.get('xras')),
+                          _pair(entry.get('ladder')))
+        ctx.console.print(table)
+        ctx.console.print(
+            '[dim]A human decides these, as a `source=manual` row. Disagreement is '
+            'the rule working: XRAS is not authoritative about SAM, and each known '
+            'case changes the FACILITY, which is what reaches next_projcode. A '
+            'Wyoming opportunity lands here by construction.[/dim]')
+
+    if proposal['unknown_pair']:
+        table = Table(title='Unknown to the reference map — a new allocation product',
+                      title_style='bold')
+        table.add_column('Id', justify='right', style='cyan')
+        table.add_column('Opportunity', style='dim')
+        table.add_column('Ladder says', style='yellow')
+        for entry in proposal['unknown_pair']:
+            table.add_row(str(entry['opportunity_id']),
+                          truncate(text(entry['opportunity_name']), 44),
+                          _pair(entry.get('ladder')))
+        ctx.console.print(table)
+        ctx.console.print(
+            '[dim]XRAS shipped an (allocationTypeId, panelId) pair that '
+            'sam/xras/opportunity_types.py does not name. Adding it is a one-line '
+            'edit to the constant — a code review, never a silent DB write.[/dim]')
+
+
 def display_account_worklist(ctx, payload) -> None:
     """Render the account-creation worklist, absent before inactive."""
     counts = payload['counts']

--- a/src/sam/queries/xras_accounts.py
+++ b/src/sam/queries/xras_accounts.py
@@ -49,7 +49,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import date, datetime
 from typing import (Any, Callable, Dict, Iterable, List, Mapping, Optional,
                     Sequence, Tuple)
 
@@ -382,6 +382,40 @@ def records_from_report_requests(payloads: Iterable[dict]) -> List[RosterRecord]
 
 # ── the classifier ──────────────────────────────────────────────────────
 
+def _waiting_since(first_seen: Optional[datetime],
+                   actions: Sequence[Dict[str, Any]]) -> Optional[date]:
+    """The earliest date this person is known to have been blocking something.
+
+    ⚠️ **Neither feed alone answers this**, which is why it is derived here
+    rather than read off a column. Feed A knows ``received_time`` — when XRAS
+    pushed the action at us — and leaves ``submit_date`` null. Feed B is the
+    exact inverse: a request that has not been pushed has no arrival, only the
+    ``submitDate`` it got in XRAS. A merged row carries both.
+
+    Returned as a **date**, not a datetime: the answer is rendered as a whole
+    number of days waiting, and a spurious time-of-day on one feed and not the
+    other would imply a precision the two sources do not share.
+
+    Distinct from ``last_seen``, which is when we most recently *heard* about
+    the person — on a freshly seeded log that is today for every row, which is
+    exactly the reading that makes it useless as a queue order.
+    """
+    candidates = []
+    if first_seen is not None:
+        candidates.append(first_seen.date())
+    for action in actions:
+        raw = action.get('submit_date')
+        if not raw:
+            continue
+        try:
+            candidates.append(date.fromisoformat(str(raw)[:10]))
+        except ValueError:
+            # A feed that changes its date format must not take the card down;
+            # the row simply has no age, and renders as such.
+            continue
+    return min(candidates) if candidates else None
+
+
 def _sorted_roles(names: Iterable[str]) -> Tuple[str, ...]:
     """Strongest first, then anything unrecognised, alphabetically."""
     unique = set(names)
@@ -461,6 +495,7 @@ def classify_accounts(session: Session,
                     'latest_action_log_id': None,
                     'first_seen': None,
                     'last_seen': None,
+                    'waiting_since': None,
                     'person': None,
                     'is_reconciled': None,
                     'sources': set(),
@@ -508,6 +543,7 @@ def classify_accounts(session: Session,
         stamps = [a['received_time'] for a in row['actions'] if a['received_time']]
         row['first_seen'] = min(stamps) if stamps else None
         row['last_seen'] = max(stamps) if stamps else None
+        row['waiting_since'] = _waiting_since(row['first_seen'], row['actions'])
         # Deliberately the future notes-table FK target.
         row['latest_action_log_id'] = next(
             (a['action_log_id'] for a in row['actions'] if a['action_log_id']), None)
@@ -523,11 +559,85 @@ def get_account_worklist(session: Session, *,
                          since: Optional[datetime] = None,
                          until: Optional[datetime] = None,
                          validate: bool = True,
-                         limit: Optional[int] = None) -> List[Dict[str, Any]]:
-    """Feed A composed with the classifier — what the card and CLI call."""
-    return classify_accounts(session, records_from_action_log(
+                         limit: Optional[int] = None,
+                         pending_rows: Optional[Sequence[Dict[str, Any]]] = None
+                         ) -> List[Dict[str, Any]]:
+    """Feed A composed with the classifier, optionally unioned with Feed B.
+
+    *pending_rows* is the worklist ``xras_sweep`` published — **injected, never
+    fetched**, exactly as :func:`~sam.queries.xras_actions.audit_resource_mapping`
+    takes *xras_keys*. This module stays free of cache and network knowledge;
+    the caller decides whether it can reach the snapshot.
+
+    ``None`` reproduces the Feed-A-only answer byte for byte, which is what a
+    consumer with no Redis gets — and it must be able to tell that apart from
+    "Feed B is empty", so a caller that *tried* should say so rather than
+    reporting a smaller queue as if it were the whole one.
+
+    ⚠️ **Overlap is normal**, and this is a union, not a concatenation. The two
+    feeds answer adjacent questions — Feed A is precisely the actions that have
+    **posted**, Feed B is what XRAS has approved and *may or may not* have
+    posted — so the same person legitimately appears in both. They are merged
+    on the casefolded username (``users.username`` is ``utf8mb3_general_ci``,
+    so two spellings are one account) with their provenance unioned.
+    """
+    rows = classify_accounts(session, records_from_action_log(
         session, statuses=statuses, since=since, until=until,
         validate=validate, limit=limit))
+    if pending_rows is None:
+        return rows
+    return merge_worklists(rows, pending_rows)
+
+
+def merge_worklists(primary: Sequence[Dict[str, Any]],
+                    secondary: Sequence[Dict[str, Any]]
+                    ) -> List[Dict[str, Any]]:
+    """Union two already-classified worklists on the casefolded username.
+
+    Both sides were classified against the same ``users`` table by the same
+    :func:`classify_accounts`, so this merges answers rather than recomputing
+    one. Where a username is in both, *primary* wins the scalar fields: it is
+    the live classification, while *secondary* is as old as the last sweep.
+
+    What is unioned rather than overwritten: ``roles``, ``actions`` and
+    ``sources`` — a person can be a PI on a posted action and a User on a
+    pending one, and losing either would misreport why they are blocking.
+    ``waiting_since`` takes the **earlier** of the two, because the question is
+    how long they have been waiting, not which feed noticed first.
+    """
+    merged: Dict[str, Dict[str, Any]] = {}
+    for row in list(primary) + list(secondary):
+        key = (row.get('username') or '').casefold()
+        if not key:
+            continue
+        seen = merged.get(key)
+        if seen is None:
+            merged[key] = dict(row)
+            merged[key]['roles'] = tuple(row.get('roles') or ())
+            merged[key]['actions'] = list(row.get('actions') or [])
+            merged[key]['sources'] = list(row.get('sources') or [])
+            continue
+        seen['roles'] = _sorted_roles((*seen['roles'], *(row.get('roles') or ())))
+        seen['actions'] = list(seen['actions']) + list(row.get('actions') or [])
+        seen['sources'] = sorted(set(seen['sources']) | set(row.get('sources') or []))
+        for field_name in ('first_seen', 'waiting_since'):
+            other = row.get(field_name)
+            if other is not None and (seen.get(field_name) is None
+                                      or other < seen[field_name]):
+                seen[field_name] = other
+        if row.get('last_seen') is not None and (
+                seen.get('last_seen') is None
+                or row['last_seen'] > seen['last_seen']):
+            seen['last_seen'] = row['last_seen']
+        # Person detail and the XRAS identity flag ride whichever feed carried
+        # them; Feed B always does, Feed A only after an --enrich pass.
+        for field_name in ('person', 'is_reconciled', 'latest_action_log_id'):
+            if seen.get(field_name) is None and row.get(field_name) is not None:
+                seen[field_name] = row[field_name]
+
+    return sorted(merged.values(),
+                  key=lambda r: (r['classification'] != CLASSIFICATION_ABSENT,
+                                 r['username']))
 
 
 # ── enrichment ──────────────────────────────────────────────────────────
@@ -609,4 +719,54 @@ def worklist_counts(rows: Sequence[Dict[str, Any]]) -> Dict[str, int]:
             1 for r in rows if r['classification'] == CLASSIFICATION_INACTIVE),
         'placeholder': sum(1 for r in rows if r['placeholder']),
         'reconciled': sum(1 for r in rows if r.get('is_reconciled') is True),
+        # How long the oldest row has been blocking something, in days. The
+        # single number that says whether this queue is being worked — a count
+        # alone reads the same on a healthy day and a neglected one.
+        'oldest_days': max(
+            (r['waiting_days'] for r in rows
+             if r.get('waiting_days') is not None), default=None),
     }
+
+
+def waiting_days(row: Dict[str, Any], *, today: Optional[date] = None
+                 ) -> Optional[int]:
+    """Whole days since :func:`_waiting_since`, or ``None`` if undatable.
+
+    *today* is injectable because a test that read the wall clock would pass or
+    fail depending on the day it ran — the same reason
+    ``sam/queries/xras_accounts.py``'s window predicate takes its boundary.
+    """
+    since = row.get('waiting_since')
+    if since is None:
+        return None
+    # ⚠️ Clamped at zero. `received_time` is naive-Mountain from the app clock,
+    # so a process running in a different zone stamps rows that read as the
+    # future — a container with no TZ set does exactly this, six hours ahead of
+    # the data it is writing. A negative age is never a fact about the queue,
+    # only about the clock, and "-1d waiting" is a worse thing to render than
+    # "0d". The cause is fixed where it belongs (compose sets TZ, as the chart
+    # already does); this keeps the column honest if it ever recurs.
+    return max(0, ((today or date.today()) - since).days)
+
+
+def stamp_waiting_days(rows: Sequence[Dict[str, Any]], *,
+                       today: Optional[date] = None) -> None:
+    """Stamp ``waiting_days`` onto each row, in place.
+
+    Separate from classification and applied by the caller, for the same reason
+    :func:`enrich_worklist` is: it is the only field whose value depends on
+    *when you asked*, and a cached row carrying a stale age would be worse than
+    one carrying none.
+    """
+    when = today or date.today()
+    for row in rows:
+        # ⚠️ Backfill rather than assume. A Feed-B row is read back from a
+        # snapshot the *task* published, and the task can be running older code
+        # than the reader — mid-deploy that is guaranteed, and a cached
+        # snapshot outlives a rollback. So a row with no `waiting_since` is a
+        # version skew, not a row with no age, and it is recomputed from the
+        # provenance every row carries.
+        if row.get('waiting_since') is None:
+            row['waiting_since'] = _waiting_since(row.get('first_seen'),
+                                                  row.get('actions') or ())
+        row['waiting_days'] = waiting_days(row, today=when)

--- a/src/webapp/api/xras/actions.py
+++ b/src/webapp/api/xras/actions.py
@@ -27,7 +27,7 @@ Order of operations, and the part that is not negotiable
              ├─ capture-only    → row stays 'received'                      → 200
              ├─ success         → 'processed' + projcode_result             → 200
              ├─ validation errs → 'failed' + error_messages                 → 422
-             └─ no serviceable  → 'manual'                                  → 200
+             └─ no serviceable  → 'manual'                                  → 200 †
 
 Legacy's only record of an action is an email and its only replay mechanism is pasting
 JSON into a form, so a row written *only on success* would be a success log rather than
@@ -51,14 +51,16 @@ wanted: *"the response body is saved and made available in xras_admin for the ad
 see, so it's nice to include something informative"*, quoting legacy's opaque
 ``Unhandled SAM exception ... (timestamp ...)`` as the thing to fix.
 
-⚠️ **A parked action is NOT distinguished on the wire.** ``processed`` and ``manual``
-both return ``xras_response(message='OK')``, byte-identical, so an admin who posts an
-action SAM quietly deferred to a human is told it worked. That is what legacy does too,
-so it is not a regression — and it is now the *common* case rather than a hypothetical,
-because ``Date Adjustment`` parks and is 4 of the 41 corpus payloads. The four outcomes
-are distinguished in ``xras_action_log`` (``status`` / ``service`` /
-``outcome_reason``), not in the response. Whether to change that is an open decision:
-``docs/xras/incoming/XRAS_CUTOVER_RUNBOOK.md`` § gate 4.
+† **A parked action is distinguished on the wire** — this is the one place the POST
+contract deliberately leaves legacy behind. Legacy answered a bare ``'OK'`` for an action
+it had silently deferred to a human, byte-identical to a success, so the admin who pushed
+the button was told it worked. That stopped being hypothetical once ``Date Adjustment``
+was discovered: it parks, and it is 4 of the 41 corpus payloads. ACCESS asked for exactly
+this on 2026-08-11 — *"the response body is saved and made available in xras_admin for the
+admin to see, so it's nice to include something informative"* — so ``manual`` now answers
+:data:`_MANUAL_MESSAGE` while ``processed`` keeps ``'OK'``. The **status stays 200**:
+ACCESS treats any other status as an error, and a parked action is not one. Decision
+recorded at ``docs/xras/incoming/XRAS_CUTOVER_RUNBOOK.md`` § gate 4.
 """
 
 import json
@@ -124,6 +126,18 @@ _TEXT_WIDTH = 65_535
 
 #: Room reserved for the truncation marker itself, which must always fit.
 _TRUNCATION_MARGIN = 512
+
+#: The wire message a **parked** action gets, in place of the ``'OK'`` a success gets.
+#:
+#: ⚠️ Deliberately **not** ``DispatchResult.reason``. Three of the four park causes name
+#: internal machinery — ``XRAS_ACTIONS_ENABLED``, an unregistered handler — that an ACCESS
+#: admin can neither act on nor should see. The internal reason keeps going to
+#: ``xras_action_log.outcome_reason``, which is what the operator surfaces read; this
+#: string is the half that crosses the wire, and it is a contract.
+_MANUAL_MESSAGE = (
+    'Received and recorded. SAM does not apply this action automatically; '
+    'NSF NCAR staff will apply it by hand. Nothing was changed by this request.'
+)
 
 
 def _truncate_bytes(text, width):
@@ -520,7 +534,7 @@ def _dispatch(log_id, action):
     current_app.logger.warning(
         'XRAS action parked for a human: id=%s service=%s projcode=%s reason=%s',
         log_id, result.service, result.projcode, result.reason)
-    return xras_response(message='OK')
+    return xras_response(message=_MANUAL_MESSAGE)
 
 
 @bp.route('/actions', methods=['POST'])

--- a/src/webapp/dashboards/allocations/blueprint.py
+++ b/src/webapp/dashboards/allocations/blueprint.py
@@ -66,6 +66,7 @@ from sam.queries.xras_accounts import (
     CLASSIFICATION_INACTIVE,
     enrich_worklist,
     get_account_worklist,
+    stamp_waiting_days,
     worklist_counts,
 )
 from sam.queries.usage_cache import cached_allocation_usage, purge_usage_cache, usage_cache_info
@@ -1630,9 +1631,21 @@ def xras_pending_fragment():
 
 #: Display labels for the classification facet. The slug is what round-trips
 #: through the form; an operator should never see it.
+#: ⚠️ These name the ARTIFACT, not an action SAM performs — and that is the
+#: whole point of the wording. `users` is mirrored into SAM from the enterprise
+#: directory by a process outside this codebase: there is no INSERT into
+#: `users` anywhere in the tree, `User` alone among the models has no
+#: `create()`, and nothing here ever writes `active` or `locked`. So both
+#: remedies are somebody else's work, and the earlier labels — "Create
+#: account" / "Reactivate account" — read as instructions to a SAM operator who
+#: has no way to carry them out.
+#:
+#: Naming the artifact rather than the team is deliberate too: the owning group
+#: can change without touching 26 rows and the CLI's JSON envelope, and the
+#: banner names it once where it can be kept current.
 _ACCOUNT_CLASSIFICATION_LABELS = {
-    CLASSIFICATION_ABSENT: 'Create account',
-    CLASSIFICATION_INACTIVE: 'Reactivate account',
+    CLASSIFICATION_ABSENT: 'New account',
+    CLASSIFICATION_INACTIVE: 'Reactivation',
 }
 
 _ACCOUNTS_FORM_ID = 'xras-accounts-filters'
@@ -1643,14 +1656,40 @@ _ACCOUNTS_TARGET = 'alloc-xras-accounts'
 #: past it still render, just without person detail.
 _ACCOUNTS_ENRICH_BUDGET = 25
 
+#: The ``placeholder`` facet's two values. Strings rather than a bool because a
+#: form round-trips strings, and ``'false'`` is truthy on the way back in.
+ORIGIN_PLACEHOLDER = 'placeholder'
+ORIGIN_KNOWN = 'known'
 
-def _filter_accounts(rows, *, classifications=None, roles=None):
-    """Facet filters: ANDed across dimensions, ORed within one."""
+_ORIGIN_LABELS = {
+    ORIGIN_PLACEHOLDER: 'ARC placeholder',
+    ORIGIN_KNOWN: 'Known identity',
+}
+
+
+def _filter_accounts(rows, *, classifications=None, roles=None, origins=None):
+    """Facet filters: ANDed across dimensions, ORed within one.
+
+    *origins* is the ``placeholder`` dimension, expressed as the two values a
+    form can round-trip. It earns a facet because it separates the two
+    populations that share this card: an ARC placeholder is a researcher who
+    has never had a site account, while a non-placeholder is a real identity
+    whose account lapsed. Those are different pieces of work for different
+    people, and until now the only way to tell them apart was to read the shape
+    of the username.
+
+    ⚠️ Deliberately **not** defaulted. The rule on this card is *no selection =
+    no filter*, and defaulting one dimension on would make an empty facet row
+    mean something different here than on every other card.
+    """
     out = rows
     if classifications:
         out = [r for r in out if r['classification'] in classifications]
     if roles:
         out = [r for r in out if any(role in roles for role in r['roles'])]
+    if origins:
+        wanted = {o == ORIGIN_PLACEHOLDER for o in origins}
+        out = [r for r in out if bool(r['placeholder']) in wanted]
     return out
 
 
@@ -1725,7 +1764,47 @@ def _account_facets(rows, dimension, *, classifications=None, roles=None):
                 counts[role] = counts.get(role, 0) + 1
         return dict(sorted(counts.items()))
 
+    if dimension == 'origin':
+        scoped = _filter_accounts(rows, classifications=classifications,
+                                  roles=roles)
+        return {
+            ORIGIN_PLACEHOLDER: sum(1 for r in scoped if r['placeholder']),
+            ORIGIN_KNOWN: sum(1 for r in scoped if not r['placeholder']),
+        }
+
     raise ValueError(f'unknown account facet dimension {dimension!r}')
+
+
+def _pending_account_total():
+    """How many accounts the *other* tab is holding, or ``None``.
+
+    ⚠️ Counts only. Reading the sibling feed's rows into this card would undo
+    the split the two tabs exist to draw — one is what has posted, the other is
+    a lookahead at what XRAS may send. But a card that reports "8" while 18
+    more sit one click away is a queue that reads as smaller than it is, and
+    that is the failure this whole change is about.
+
+    ``None`` means "could not look", which is the honest answer when the
+    outbound API is off or no sweep has published — distinct from zero.
+    """
+    from sam.integration.xras_api import xras_api_configured
+
+    if not xras_api_configured():
+        return None
+    try:
+        from sam.integration.xras_api.cache import load_pending_worklist
+
+        snapshot = load_pending_worklist()
+    except Exception:                                # noqa: BLE001
+        # Cache backends are infrastructure. A cross-reference is a courtesy;
+        # it must never be the reason the worklist 500s.
+        current_app.logger.warning(
+            'xras accounts: could not read the pending worklist for the '
+            'cross-reference', exc_info=True)
+        return None
+    if not snapshot:
+        return None
+    return (snapshot.get('counts') or {}).get('total')
 
 
 @bp.route('/xras_accounts_fragment')
@@ -1758,9 +1837,19 @@ def xras_accounts_fragment():
     window = _parse_activity_window(request.args)
     selected_classes = [c for c in request.args.getlist('classification') if c]
     selected_roles = [r for r in request.args.getlist('role') if r]
+    selected_origins = [o for o in request.args.getlist('origin') if o]
 
     rows = get_account_worklist(db.session,
                                 since=window['since'], until=window['until'])
+
+    # ⚠️ Feed A ONLY, on purpose — this tab is precisely the accounts blocking
+    # actions that have already POSTED, which is a claim we can always make
+    # from our own audit table. The lookahead at what XRAS has approved but not
+    # yet sent is the sibling tab, and it is contingent on the outbound API
+    # being configured. Merging them would trade a guarantee for a maybe. The
+    # union is available where it is actually needed — `sam-admin xras
+    # --accounts`, and whatever digest comes after it.
+    stamp_waiting_days(rows)
 
     # Enrichment is best-effort and never fatal: an outage or an unconfigured
     # deployment leaves `person` None and flags the batch, so the card degrades
@@ -1777,10 +1866,13 @@ def xras_accounts_fragment():
 
     class_facets = _account_facets(rows, 'classification', roles=selected_roles)
     role_facets = _account_facets(rows, 'role', classifications=selected_classes)
+    origin_facets = _account_facets(rows, 'origin',
+                                    classifications=selected_classes,
+                                    roles=selected_roles)
     request_facets = _request_facets(rows, classifications=selected_classes)
 
     rows = _filter_accounts(rows, classifications=selected_classes,
-                            roles=selected_roles)
+                            roles=selected_roles, origins=selected_origins)
     if selected_requests:
         # The operator working one project's activation wants only its rows.
         rows = [r for r in rows
@@ -1802,9 +1894,16 @@ def xras_accounts_fragment():
              'count': class_facets.get(key, 0)}
             for key in (CLASSIFICATION_ABSENT, CLASSIFICATION_INACTIVE)],
         role_values=[{'value': k, 'count': v} for k, v in role_facets.items()],
+        origin_values=[{'value': k, 'label': _ORIGIN_LABELS[k],
+                        'count': origin_facets.get(k, 0)}
+                       for k in (ORIGIN_PLACEHOLDER, ORIGIN_KNOWN)],
         request_values=request_facets,
+        # What the sibling tab holds, so neither reads as the whole queue.
+        # Counts only — never its rows, which would defeat the tab split.
+        pending_total=_pending_account_total(),
         selected_classifications=selected_classes,
         selected_roles=selected_roles,
+        selected_origins=selected_origins,
         selected_requests=selected_requests,
         form_id=_ACCOUNTS_FORM_ID,
         fragment_url=url_for('allocations_dashboard.xras_accounts_fragment'),
@@ -1872,6 +1971,11 @@ def xras_pending_requests_fragment():
     snapshot = load_pending_worklist() if configured else None
 
     rows = list(snapshot.get('rows') or []) if snapshot else []
+    # The snapshot is written by the task and read here, so the two can be on
+    # different code — `stamp_waiting_days` backfills rather than assuming the
+    # publisher already derived it. Stamped on read, never cached: an age is
+    # the one field whose value depends on when you asked.
+    stamp_waiting_days(rows)
     window = _parse_activity_window(request.args)
     selected_requests = [r for r in request.args.getlist('request_number') if r]
     selected_classes = [c for c in request.args.getlist('classification') if c]

--- a/src/webapp/templates/dashboards/allocations/partials/xras_accounts_card.html
+++ b/src/webapp/templates/dashboards/allocations/partials/xras_accounts_card.html
@@ -9,12 +9,14 @@
     rows            classify_accounts(...) rows, already filtered
     counts          worklist_counts(rows)
     may_manage      bool — MANAGE_XRAS
-    enrichment      {'looked_up','found','closed','unavailable','budget_exhausted','error'}
+    enrichment      {'looked_up','found','reconciled','unavailable','budget_exhausted','error'}
     window          {'days','since','until','start_date','end_date','custom'}
     window_pill_choices  ((days, label), ...)
     classification_values  [{'value','label','count'}]  self-excluding
     role_values            [{'value','count'}]          self-excluding
-    selected_classifications, selected_roles  [str]
+    origin_values          [{'value','label','count'}]  self-excluding
+    pending_total          int|None — what the sibling tab holds, or None
+    selected_classifications, selected_roles, selected_origins  [str]
     form_id, fragment_url, target_id
 
   ── ONE ROW PER USERNAME, NOT PER ACTION ─────────────────────────────────
@@ -37,6 +39,14 @@
     <div class="card-header d-flex align-items-center flex-wrap gap-2">
         <strong>Accounts Needed for XRAS Handoffs</strong>
         <span class="badge bg-secondary">{{ counts.total | fmt_number }}</span>
+        {% if counts.oldest_days %}
+        {# The number that says whether the queue is being WORKED. A count
+           alone reads identically on a healthy day and a neglected one. #}
+        <span class="badge bg-body-secondary text-body-secondary border fw-normal"
+              title="How long the longest-waiting account has been blocking a handoff">
+            oldest {{ counts.oldest_days | fmt_number }}d
+        </span>
+        {% endif %}
         {% if counts.placeholder %}
         {# ⚠️ "placeholder", NOT "unreconciled". These are two different facts
            and the smoke caught the badge conflating them: all three
@@ -58,12 +68,42 @@
                          'classification', active=selected_classifications) }}
             {{ facet_row('Role', role_values, form_id, 'role',
                          active=selected_roles) }}
+            {# Separates the two populations that share this card: an ARC
+               placeholder never had a site account, a known identity had one
+               that lapsed. Different work, different people. Deliberately NOT
+               defaulted — on this card no selection means no filter. #}
+            {{ facet_row('Identity', origin_values, form_id, 'origin',
+                         active=selected_origins) }}
             {# The operator working one project's activation filters to it
                here; the same value is a column below so it is visible before
                it is selectable. #}
             {{ facet_row('Request', request_values, form_id, 'request_number',
                          active=selected_requests) }}
         </div>
+        {# ── The invariant, said once ──────────────────────────────────
+           Every other worklist in SAM ends in a button that does the thing.
+           This one cannot: `users` is mirrored from the enterprise directory
+           by a process outside SAM, so neither remedy on this card is an
+           action anyone here can take. Saying so once beats implying
+           otherwise 26 times. #}
+        <div class="small text-muted mt-2">
+            <i class="fas fa-circle-info"></i>
+            Accounts are mirrored into SAM from the enterprise directory —
+            SAM cannot create or reactivate one. These rows are handed to the
+            team that does, and clear on their own once the next sync lands.
+        </div>
+        {% if pending_total %}
+        {# So "8" never reads as the whole queue when 18 more sit one click
+           away. Counts only — the rows stay on their own tab, because what
+           has POSTED and what XRAS MAY SEND are different claims. #}
+        <div class="small text-muted mt-1">
+            <i class="fas fa-arrow-right-long"></i>
+            These are accounts blocking actions that have already posted.
+            <strong>Pending Requests</strong> holds
+            {{ pending_total | fmt_number }} more that XRAS has approved and
+            may send soon.
+        </div>
+        {% endif %}
         {% if enrichment.unavailable %}
         {# The designed unconfigured/degraded state. The worklist above is
            complete — only XRAS-sourced detail is missing. #}
@@ -95,7 +135,13 @@
                     <th style="width:99%; min-width:12rem;">Person</th>
                     {% endif %}
                     <th style="width:120px; white-space:nowrap;">XRAS identity</th>
-                    <th style="width:130px; white-space:nowrap;">Last seen</th>
+                    {# ⚠️ Waiting, NOT "last seen". `last_seen` is when we most
+                       recently HEARD about the person, which on a freshly
+                       seeded log is today for every row — an order that tells
+                       an operator nothing. This is how long they have been
+                       blocking something, which is the only field on the card
+                       that says whether the queue is being worked. #}
+                    <th style="width:120px; white-space:nowrap;">Waiting</th>
                 </tr>
             </thead>
             <tbody>
@@ -117,16 +163,29 @@
 
                     <td>
                         {% if row.classification == 'absent' %}
-                        <span class="badge bg-danger-subtle text-danger-emphasis border border-danger-subtle">Create</span>
+                        <span class="badge bg-danger-subtle text-danger-emphasis border border-danger-subtle">New account</span>
                         {% else %}
-                        <span class="badge bg-warning-subtle text-warning-emphasis border border-warning-subtle">Reactivate</span>
+                        <span class="badge bg-warning-subtle text-warning-emphasis border border-warning-subtle">Reactivation</span>
                         {% endif %}
 
                     </td>
 
                     <td>
+                        {# ⚠️ PI carries weight because a missing PI is the only
+                           one that HARD-FAILS the handoff — `roster.py` reports
+                           `PI %s is not in database` and the action 422s, while
+                           a missing Allocation Manager is explicitly not an
+                           error and a missing User just drops from the roster.
+                           Same list, three very different consequences, and the
+                           row read identically for all of them. #}
                         {% for role in row.roles %}
-                        <span class="badge bg-body-secondary text-body-secondary border fw-normal">{{ role }}</span>
+                        {% if role == 'PI' %}
+                        <span class="badge bg-danger-subtle text-danger-emphasis border border-danger-subtle"
+                              title="A missing or inactive PI rejects the whole action (422). This row blocks its handoff.">{{ role }}</span>
+                        {% else %}
+                        <span class="badge bg-body-secondary text-body-secondary border fw-normal"
+                              title="Not fatal on its own — only a missing PI rejects the action">{{ role }}</span>
+                        {% endif %}
                         {% endfor %}
                     </td>
 
@@ -180,7 +239,13 @@
                     </td>
 
                     <td class="text-nowrap small text-muted">
-                        {{ row.last_seen | fmt_date }}
+                        {% if row.waiting_days is none %}
+                        <span class="text-muted" title="No dated provenance on this row">—</span>
+                        {% else %}
+                        <span title="Blocking since {{ row.waiting_since | fmt_date }}">
+                            {{ row.waiting_days | fmt_number }}d
+                        </span>
+                        {% endif %}
                     </td>
                 </tr>
 
@@ -234,7 +299,7 @@
        until ACCESS is repointed and the action log starts filling. #}
     <div class="card-body text-center text-muted py-4">
         No accounts are waiting on creation or reactivation
-        {%- if selected_classifications or selected_roles %} for these filters{% endif %}.
+        {%- if selected_classifications or selected_roles or selected_origins or selected_requests %} for these filters{% endif %}.
     </div>
     {% endif %}
 </div>

--- a/src/webapp/templates/dashboards/allocations/partials/xras_pending_requests_card.html
+++ b/src/webapp/templates/dashboards/allocations/partials/xras_pending_requests_card.html
@@ -89,6 +89,25 @@
             {{ facet_row('Request', request_values, form_id, 'request_number',
                          active=selected_requests) }}
         </div>
+        {# ── What this tab IS, so it is not read as a record ───────────────
+           A LOOKAHEAD, not a worklist of record: these are requests approved
+           on the XRAS side that may or may not have posted to SAM yet. It is
+           also the contingent half — it exists only while the outbound API is
+           configured and a sweep has published, whereas the sibling tab is
+           derived from our own audit table and always works. Keeping the two
+           apart is the point; conflating them would trade a guarantee for a
+           maybe. #}
+        <div class="small text-muted mt-2">
+            <i class="fas fa-binoculars"></i>
+            A look ahead at what XRAS has approved and may send soon — not a
+            record of what has been sent. Accounts blocking actions that have
+            <em>already</em> posted are on <strong>Accounts Needed</strong>.
+        </div>
+        <div class="small text-muted mt-1">
+            <i class="fas fa-circle-info"></i>
+            Accounts are mirrored into SAM from the enterprise directory —
+            SAM cannot create or reactivate one.
+        </div>
     </div>
 
     {% if rows %}
@@ -124,9 +143,9 @@
                     </td>
                     <td>
                         {% if row.classification == 'absent' %}
-                        <span class="badge bg-danger-subtle text-danger-emphasis border border-danger-subtle">Create</span>
+                        <span class="badge bg-danger-subtle text-danger-emphasis border border-danger-subtle">New account</span>
                         {% else %}
-                        <span class="badge bg-warning-subtle text-warning-emphasis border border-warning-subtle">Reactivate</span>
+                        <span class="badge bg-warning-subtle text-warning-emphasis border border-warning-subtle">Reactivation</span>
                         {% endif %}
                     </td>
                     <td>

--- a/src/webapp/templates/dashboards/allocations/xras.html
+++ b/src/webapp/templates/dashboards/allocations/xras.html
@@ -86,6 +86,12 @@
 <form id="xras-accounts-filters" class="d-none">
     <select name="classification" multiple hidden></select>
     <select name="role" multiple hidden></select>
+    {# ⚠️ A facet_row whose `field` has no control here renders as chips that
+       silently do nothing — the click writes into a form field that does not
+       exist and the re-submit carries no value. Caught by the smoke, and the
+       macro says so in as many words. Every dimension the card offers needs a
+       line in this form. #}
+    <select name="origin" multiple hidden></select>
     <select name="request_number" multiple hidden></select>
 </form>
 <form id="xras-pending-filters" class="d-none">

--- a/tests/api/test_xras_access.py
+++ b/tests/api/test_xras_access.py
@@ -31,7 +31,7 @@ from xras_helpers import (  # noqa: F401  — pytest resolves fixtures by name
     xras_keys,
 )
 
-from webapp.api.xras import serialize
+from webapp.api.xras import actions, serialize
 
 
 # ---------------------------------------------------------------------------
@@ -653,8 +653,10 @@ class TestPostActionsCapture:
             self, app, xras_client, action_log, no_handlers):
         """With capture off and no handler for the service, the action parks as 'manual'.
 
-        Legacy answers a bare 200 here too, but leaves no record that SAM quietly
-        deferred the action to a human — the distinction this table exists to make.
+        Legacy answers a bare 200 here too, and leaves no record that SAM quietly
+        deferred the action to a human — the distinction this table exists to make. We
+        keep the 200 (ACCESS treats anything else as an error) but say so in the body;
+        see ``TestParkedActionsAreVisibleToTheCaller``.
 
         ``no_handlers`` empties the registry for the duration. Two reasons, and the
         second is the one that bites: a real handler would **commit** through
@@ -671,7 +673,8 @@ class TestPostActionsCapture:
             app.config['XRAS_ACTIONS_CAPTURE_ONLY'] = True
 
         assert resp.status_code == 200
-        assert json.loads(resp.data) == {'message': 'OK', 'result': None}
+        assert json.loads(resp.data) == {'message': actions._MANUAL_MESSAGE,
+                                         'result': None}
         row = action_log.one()
         assert row['status'] == 'manual'
         assert row['processed_time'] is not None
@@ -951,6 +954,69 @@ class TestDispatchArms:
                          content_type='application/json', headers=_auth())
         assert ran == []
         assert action_log.one()['status'] == 'received'
+
+    # -- the parked/processed wire split -------------------------------------
+    #
+    # Gate 4 of the cutover runbook. Legacy answered a bare 'OK' for an action it had
+    # silently deferred to a human, byte-identical to a success, so the admin who
+    # pushed the button in xras_admin was told it worked. `Date Adjustment` parks and
+    # is 4 of the 41 corpus payloads, so that is the common case, not a corner. ACCESS
+    # asked for an informative body on 2026-08-11; these three pin what moved and,
+    # more importantly, what did not.
+
+    def _post_body(self, xras_client):
+        resp = xras_client.post(
+            self.PATH, data=_payload('extension_ucub0166_ok.json'),
+            content_type='application/json', headers=_auth())
+        return resp.status_code, json.loads(resp.data)
+
+    def test_a_parked_action_is_not_byte_identical_to_a_success(
+            self, xras_client, action_log, dispatching):
+        """The whole point: the caller can tell "we applied it" from "a human will"."""
+        dispatching.register('extend', lambda s, a, *, validate_only=False: dispatching.DispatchResult(
+            status='manual', service='extend', projcode='UCUB0166',
+            reason='parked on purpose'))
+
+        status, body = self._post_body(xras_client)
+
+        assert action_log.one()['status'] == 'manual'
+        # Still 200 — ACCESS treats any other status as an error, and a parked action
+        # is not one. Only the body moved.
+        assert status == 200
+        assert body == {'message': actions._MANUAL_MESSAGE, 'result': None}
+        assert body['message'] != 'OK'
+
+    def test_the_parked_body_does_not_leak_the_internal_reason(
+            self, xras_client, action_log, dispatching):
+        """``outcome_reason`` names machinery an ACCESS admin cannot act on.
+
+        Three of the four park causes cite ``XRAS_ACTIONS_ENABLED`` or an unregistered
+        handler. Those belong in the audit row, which is ours; the wire gets one stable
+        sentence. Returning ``result.reason`` verbatim would have been the obvious
+        implementation and is the thing this forbids.
+        """
+        dispatching.register('extend', lambda s, a, *, validate_only=False: dispatching.DispatchResult(
+            status='manual', service='extend', projcode='UCUB0166',
+            reason="actionType='Extension' is disabled by XRAS_ACTIONS_ENABLED"))
+
+        _, body = self._post_body(xras_client)
+
+        assert action_log.one()['outcome_reason'] == (
+            "actionType='Extension' is disabled by XRAS_ACTIONS_ENABLED")
+        assert 'XRAS_ACTIONS_ENABLED' not in body['message']
+        assert body['message'] == actions._MANUAL_MESSAGE
+
+    def test_a_processed_action_still_answers_exactly_OK(
+            self, xras_client, action_log, dispatching):
+        """The half that must NOT move. ``'OK'`` on success is legacy's byte-exact
+        success body, and the parked split is not a licence to redesign it."""
+        dispatching.register('extend', lambda s, a, *, validate_only=False: dispatching.DispatchResult(
+            status='processed', service='extend', projcode='UCUB0166'))
+
+        status, body = self._post_body(xras_client)
+
+        assert action_log.one()['status'] == 'processed'
+        assert (status, body) == (200, {'message': 'OK', 'result': None})
 
 
 class TestPostActionsErrors:

--- a/tests/unit/test_admin_xras_cli.py
+++ b/tests/unit/test_admin_xras_cli.py
@@ -216,14 +216,72 @@ class TestAccountsMode:
         assert result.exit_code == EXIT_SUCCESS
 
     def test_the_json_envelope_carries_the_expected_kind(self, runner, cli_session):
+        # ⚠️ `result.stdout`, not `result.output` — the latter merges stderr,
+        # and the whole point of the split below is that a degradation notice
+        # must not land inside the envelope.
         result = runner.invoke(cli, ['--format', 'json', 'xras', '--accounts'])
         assert result.exit_code == EXIT_SUCCESS
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
         assert payload['kind'] == 'xras_accounts'
         assert set(payload['counts']) >= {'total', 'absent', 'inactive',
-                                          'placeholder'}
+                                          'placeholder', 'oldest_days'}
         assert payload['enriched'] is False
         assert payload['enrichment'] is None
+        # "Feed B was empty" and "we could not read Feed B" are different
+        # facts, and only the second means this count is a subset.
+        assert payload['pending_checked'] is False
+
+    def test_a_degradation_notice_never_lands_inside_the_json(
+            self, runner, cli_session, monkeypatch):
+        """⚠️ Regression: `ctx.console` is **stdout**.
+
+        Every "could not reach X, reporting the local half" notice on this
+        command used to print there, which put prose ahead of the envelope and
+        broke `sam-admin --format json xras ... | jq` for exactly the runs an
+        operator most needs to pipe. They belong on stderr; the envelope
+        already carries the machine-readable form of the same fact.
+        """
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        monkeypatch.setattr(
+            'sam.integration.xras_api.cache.load_pending_worklist',
+            lambda: (_ for _ in ()).throw(RuntimeError('no redis here')))
+
+        result = runner.invoke(cli, ['--format', 'json', 'xras', '--accounts'])
+
+        json.loads(result.stdout)                    # parses, i.e. clean
+        assert 'no redis here' not in result.stdout
+        assert json.loads(result.stdout)['pending_checked'] is False
+
+    def test_the_worklist_unions_both_feeds(self, runner, cli_session,
+                                            monkeypatch):
+        """The gap this closes: `--accounts` reported 0 in production while the
+        dashboard showed a real queue, because it only ever read the action log
+        and the card reads the sweep's published snapshot.
+
+        ⚠️ Overlap between the feeds is normal — Feed A is precisely what has
+        POSTED, Feed B what XRAS approved and may or may not have sent — so
+        this is a union on the casefolded username, not a concatenation.
+        """
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        monkeypatch.setattr(
+            'sam.integration.xras_api.cache.load_pending_worklist',
+            lambda: {'rows': [{'username': 'ghostpendingonly',
+                               'classification': 'absent', 'remedy': 'create',
+                               'placeholder': False, 'roles': ('PI',),
+                               'actions': [], 'sources': ['reports'],
+                               'is_account_to_be_created': False,
+                               'first_seen': None, 'last_seen': None,
+                               'person': None, 'is_reconciled': None,
+                               'latest_action_log_id': None}]})
+
+        result = runner.invoke(cli, ['--format', 'json', 'xras', '--accounts'])
+        payload = json.loads(result.stdout)
+
+        assert payload['pending_checked'] is True
+        names = [a['username'] for a in payload['accounts']]
+        assert 'ghostpendingonly' in names
 
     def test_enrich_without_the_api_is_an_error(self, runner, cli_session,
                                                 monkeypatch):

--- a/tests/unit/test_admin_xras_cli.py
+++ b/tests/unit/test_admin_xras_cli.py
@@ -366,6 +366,216 @@ class TestTwoSidedMappingAudit:
         assert report['dangling_keys'] == local['dangling_keys']
 
 
+class TestOpportunityAudit:
+    """``--validate-opportunities`` — the map whose failure mode is silent.
+
+    Every other XRAS mapping gap 422s the action. An unmapped ``opportunityId``
+    falls through to the free-text ladder, which cannot name any facility-4
+    allocation type — so a Wyoming request resolves to a UNIV panel, the join
+    *succeeds*, and the project is created with a UNIV projcode. Nothing fails.
+    That is why this command exists and why its exit code is so narrow.
+    """
+
+    #: One open-opportunity payload, in the shape ``GET /v1/opportunities``
+    #: returns: the type id lives under ``allocationTypeInfo`` and the panel is
+    #: the one flagged ``isPrimary``, never ``panels[0]``.
+    @staticmethod
+    def _payload(opportunity_id, *, type_id, panel_id, name, alloc_type=None):
+        return {
+            'opportunityId': opportunity_id,
+            'opportunityName': name,
+            'allocationType': alloc_type,
+            'allocationTypeInfo': {'allocationTypeId': type_id},
+            'panels': [{'panelId': panel_id, 'isPrimary': True}],
+        }
+
+    def _run(self, runner, payloads, monkeypatch, *, fmt_json=True):
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        client = MagicMock()
+        client.get_open_opportunities.return_value = payloads
+        monkeypatch.setattr(
+            'sam.integration.xras_api.XrasApiClient.from_environment',
+            classmethod(lambda cls, *a, **k: client))
+        args = ['xras', '--validate-opportunities']
+        return runner.invoke(cli, (['--format', 'json'] + args) if fmt_json
+                             else args)
+
+    # -- the degraded halves ------------------------------------------------
+
+    def test_unconfigured_reports_the_local_half_and_says_so(self, runner,
+                                                             cli_session,
+                                                             monkeypatch):
+        """Fail-closed, exactly as ``--validate-mapping`` degrades.
+
+        ``live_checked`` False is the whole point: "nothing is unmapped out
+        there" and "we never asked" must not render as the same report.
+        """
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '0')
+        monkeypatch.delenv('XRAS_API_KEY', raising=False)
+        result = runner.invoke(cli, ['--format', 'json', 'xras',
+                                     '--validate-opportunities'])
+        payload = json.loads(result.output)
+        assert payload['kind'] == 'xras_opportunity_mapping'
+        assert payload['live_checked'] is False
+        assert payload['live_id_count'] is None
+        assert payload['unmapped_ids'] == []
+        assert payload['proposal'] == {'agree': [], 'review': [],
+                                       'unknown_pair': []}
+        assert result.exit_code == EXIT_SUCCESS
+
+    def test_an_unreachable_api_warns_and_degrades(self, runner, cli_session,
+                                                   monkeypatch):
+        """The local half is still worth reporting, and it is still exit 0."""
+        from sam.integration.xras_api.base import XrasSourceUnavailable
+
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        client = MagicMock()
+        client.get_open_opportunities.side_effect = XrasSourceUnavailable('down')
+        monkeypatch.setattr(
+            'sam.integration.xras_api.XrasApiClient.from_environment',
+            classmethod(lambda cls, *a, **k: client))
+        result = runner.invoke(cli, ['xras', '--validate-opportunities'])
+        assert result.exit_code == EXIT_SUCCESS
+        assert 'local half only' in result.output
+
+    # -- the exit-code contract, which is the easy thing to get wrong -------
+
+    def test_an_unmapped_opportunity_is_not_a_failure(self, runner, cli_session,
+                                                      monkeypatch):
+        """With an EMPTY table every opportunity is unmapped and ingestion is
+        completely healthy — the ladder resolves them exactly as it did before
+        the table existed. A gate keyed on this would fail forever, which is
+        the mistake ``--validate-mapping`` already made once and corrected."""
+        result = self._run(runner, [self._payload(
+            9_100_001, type_id=500024, panel_id=500021,
+            name='Small Allocation (University)', alloc_type='Small')],
+            monkeypatch)
+        payload = json.loads(result.output)
+        assert 9_100_001 in payload['unmapped_ids']
+        assert result.exit_code == EXIT_SUCCESS
+
+    def test_a_dangling_row_is_the_one_failing_state(self, runner, cli_session,
+                                                     monkeypatch, session):
+        """A mapping row whose allocation type has no panel. The ingest-side
+        lookup must treat it as a miss and fall through *silently*, so nothing
+        else would ever surface it."""
+        from factories import make_allocation_type, make_xras_opportunity_mapping
+
+        alloc_type = make_allocation_type(session)
+        alloc_type.panel_id = None
+        session.flush()
+        row = make_xras_opportunity_mapping(session, allocation_type=alloc_type)
+
+        result = self._run(runner, [], monkeypatch)
+        payload = json.loads(result.output)
+        assert row.opportunity_id in payload['dangling_ids']
+        assert result.exit_code == EXIT_NOT_FOUND
+
+    # -- the agree rule -----------------------------------------------------
+
+    def test_an_agreed_pair_is_reported_as_mappable(self, runner, cli_session,
+                                                    monkeypatch):
+        """Both derivations produce ``CHAP``/``CHAP``, so the sweep would write
+        it and there is nothing for a human to decide."""
+        result = self._run(runner, [self._payload(
+            9_100_002, type_id=500023, panel_id=500022,
+            name='Large Allocation (University) - Fall 2026',
+            alloc_type='Large')], monkeypatch)
+        payload = json.loads(result.output)
+        agreed = {e['opportunity_id']: e for e in payload['proposal']['agree']}
+        assert 9_100_002 in agreed
+        assert agreed[9_100_002]['pair'] == ['CHAP', 'CHAP']
+        assert result.exit_code == EXIT_SUCCESS
+
+    def test_a_disagreement_is_withheld_and_reported_with_both_answers(
+            self, runner, cli_session, monkeypatch):
+        """The known live case: XRAS files the unsponsored family under
+        ``Educational`` — the same type id as Classroom — while SAM means
+        ``Small (No NSF award)``. It changes the answer, so a human decides.
+
+        ⚠️ Reported with **both** derivations, so the row explains itself
+        without a second query. That is what makes it actionable rather than
+        merely alarming.
+        """
+        result = self._run(runner, [self._payload(
+            9_100_003, type_id=500026, panel_id=500021,
+            name='University small request - unsponsored',
+            alloc_type='Exploratory')], monkeypatch)
+        payload = json.loads(result.output)
+        review = {e['opportunity_id']: e for e in payload['proposal']['review']}
+        assert 9_100_003 in review
+        assert review[9_100_003]['xras'] != review[9_100_003]['ladder']
+        assert payload['proposal']['agree'] == []
+        # A withheld row is the rule WORKING. Two pairs sit here permanently by
+        # design, so exiting non-zero would train an operator to ignore the one
+        # bucket that matters.
+        assert result.exit_code == EXIT_SUCCESS
+
+    def test_an_unknown_pair_is_reported_never_guessed(self, runner, cli_session,
+                                                       monkeypatch):
+        """A genuinely new allocation product. Adding it is a one-line edit to
+        ``sam/xras/opportunity_types.py`` — a code review, not a silent write."""
+        result = self._run(runner, [self._payload(
+            9_100_004, type_id=999_001, panel_id=999_002,
+            name='Wyoming Small Allocation', alloc_type='Small')], monkeypatch)
+        payload = json.loads(result.output)
+        unknown = [e['opportunity_id']
+                   for e in payload['proposal']['unknown_pair']]
+        assert 9_100_004 in unknown
+        assert payload['proposal']['agree'] == []
+        assert result.exit_code == EXIT_SUCCESS
+
+    # -- the scoping rule ---------------------------------------------------
+
+    def test_the_proposal_covers_only_unmapped_opportunities(
+            self, runner, cli_session, monkeypatch, session):
+        """⚠️ The rule that keeps the ``review`` bucket meaningful.
+
+        Two rows in production are ``source='manual'`` *because* the two
+        derivations disagree and a human settled it. Run the proposal over
+        everything and those reappear in ``review`` on every invocation, which
+        is precisely how an operator learns to ignore the bucket. So the
+        proposal sees the unmapped subset only — the same scoping
+        ``_map_new_opportunities`` uses in ``xras_sweep``.
+        """
+        from factories import make_allocation_type, make_xras_opportunity_mapping
+
+        row = make_xras_opportunity_mapping(
+            session, allocation_type=make_allocation_type(session),
+            opportunity_name='already decided by a human')
+
+        result = self._run(runner, [self._payload(
+            row.opportunity_id, type_id=500026, panel_id=500021,
+            name='already decided by a human',
+            alloc_type='Exploratory')], monkeypatch)
+        payload = json.loads(result.output)
+
+        assert row.opportunity_id in payload['mapped_ids']
+        assert row.opportunity_id not in payload['unmapped_ids']
+        seen = [e['opportunity_id']
+                for bucket in payload['proposal'].values() for e in bucket]
+        assert row.opportunity_id not in seen
+
+    # -- rendering ----------------------------------------------------------
+
+    def test_rich_mode_renders_all_three_buckets(self, runner, cli_session,
+                                                 monkeypatch):
+        result = self._run(runner, [
+            self._payload(9_100_005, type_id=500023, panel_id=500022,
+                          name='agrees', alloc_type='Large'),
+            self._payload(9_100_006, type_id=500026, panel_id=500021,
+                          name='disagrees', alloc_type='Exploratory'),
+            self._payload(9_100_007, type_id=999_001, panel_id=999_002,
+                          name='unknown to the constant', alloc_type='Small'),
+        ], monkeypatch, fmt_json=False)
+        assert result.exit_code == EXIT_SUCCESS
+        assert 'Would be mapped automatically' in result.output
+        assert 'the two derivations disagree' in result.output
+        assert 'a new allocation product' in result.output
+
+
 class TestWorklistRendering:
     """The rich renderers on a populated worklist.
 

--- a/tests/unit/test_xras_accounts_card.py
+++ b/tests/unit/test_xras_accounts_card.py
@@ -148,7 +148,7 @@ class TestRenderStates:
             self, auth_client, committed_worklist_action):
         body = auth_client.get(URL).get_data(as_text=True)
         assert 'placeholder38-user-00038' in body
-        assert 'Create' in body
+        assert 'New account' in body
 
 
 class TestPiiGating:
@@ -201,7 +201,24 @@ class TestFacets:
     def test_both_classifications_render_even_at_zero(self, auth_client):
         """An absent chip reads as 'not measured' — a different claim."""
         body = auth_client.get(URL).get_data(as_text=True)
-        assert 'Create account' in body and 'Reactivate account' in body
+        assert 'New account' in body and 'Reactivation' in body
+
+    def test_the_labels_do_not_tell_an_operator_to_do_what_SAM_cannot(
+            self, auth_client):
+        """⚠️ The remedies are somebody else's work, and the card must not
+        imply otherwise.
+
+        There is no INSERT into ``users`` anywhere in this repo, ``User`` alone
+        among the models has no ``create()``, and nothing writes ``active`` or
+        ``locked`` — identities are mirrored in from the enterprise directory.
+        So "Create account" as a badge was an instruction to a SAM operator who
+        has no way to carry it out. The wire values are unchanged; only what a
+        human reads moved.
+        """
+        body = auth_client.get(URL).get_data(as_text=True)
+        assert 'Create account' not in body
+        assert 'Reactivate account' not in body
+        assert 'mirrored into SAM from the enterprise directory' in body
 
     def test_facets_are_self_excluding(self):
         """Scope a dimension by itself and every unselected value reads 0 the

--- a/tests/unit/test_xras_accounts_query.py
+++ b/tests/unit/test_xras_accounts_query.py
@@ -25,7 +25,7 @@ those payloads may enter a commit.
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 
 import pytest
@@ -37,8 +37,10 @@ from sam.queries.xras_accounts import (
     classify_accounts,
     enrich_worklist,
     is_placeholder,
+    merge_worklists,
     records_from_action_log,
     records_from_report_requests,
+    stamp_waiting_days,
     worklist_counts,
 )
 
@@ -55,6 +57,17 @@ PLACEHOLDER_USERNAME = 'placeholder38-user-00038'
 
 def _payload(name: str) -> dict:
     return json.loads((FIXTURES / name).read_text())
+
+
+def _pending_record(*usernames, submit_date='2026-07-14', **kwargs):
+    """A Feed-B RosterRecord: no arrival of its own, only a ``submitDate``.
+
+    The inverse of :func:`_record`, and the pair is the point — the two feeds
+    date a row from different fields, so anything deriving an age has to handle
+    both or it silently reports one feed as undatable.
+    """
+    return _record(*usernames, action_log_id=None, received_time=None,
+                   submit_date=submit_date, source='reports', **kwargs)
 
 
 def _record(*usernames, roles=None, flags=None, people=None, **ref_kwargs):
@@ -577,3 +590,124 @@ class TestUsernameCaseFolding:
         present one the mismatch is itself worth seeing."""
         rows = classify_accounts(session, [_record('GhostCaseUser')])
         assert rows[0]['username'] == 'GhostCaseUser'
+
+
+class TestWaitingSince:
+    """How long a row has been blocking something.
+
+    ⚠️ **Neither feed alone answers this**, which is the whole reason it is
+    derived rather than read off a column. Feed A knows ``received_time`` —
+    when XRAS pushed the action at us — and leaves ``submit_date`` null. Feed B
+    is the exact inverse: a request that has not been pushed has no arrival,
+    only the ``submitDate`` it got in XRAS.
+    """
+
+    def test_feed_a_dates_from_when_the_action_arrived(self, session):
+        rows = classify_accounts(session, [_record('ghostwaiting')])
+        stamp_waiting_days(rows, today=date(2026, 8, 20))
+        assert rows[0]['waiting_since'] is not None
+
+    def test_feed_b_dates_from_the_xras_submit_date(self, session):
+        """A pending request has no arrival of its own — only a submitDate."""
+        rows = classify_accounts(session, [_pending_record(
+            'ghostpending', submit_date='2026-07-14')])
+        stamp_waiting_days(rows, today=date(2026, 8, 20))
+        assert rows[0]['waiting_since'] == date(2026, 7, 14)
+        assert rows[0]['waiting_days'] == 37
+
+    def test_the_earliest_signal_wins_across_feeds(self, session):
+        """A person on both feeds has been waiting since the EARLIER of them,
+        not since whichever feed happened to notice second."""
+        rows = classify_accounts(session, [
+            _pending_record('ghostboth', submit_date='2026-07-14'),
+            _pending_record('ghostboth', submit_date='2026-08-01')])
+        stamp_waiting_days(rows, today=date(2026, 8, 20))
+        assert rows[0]['waiting_since'] == date(2026, 7, 14)
+
+    def test_a_negative_age_is_clamped_not_rendered(self, session):
+        """⚠️ Clock skew, not a fact about the queue.
+
+        ``received_time`` is naive-Mountain from the app clock, so a process
+        running in another zone stamps rows that read as the future — a
+        container with no TZ set does exactly this, six hours ahead of the data
+        it is writing. "-1d waiting" is a worse thing to render than "0d".
+        """
+        rows = classify_accounts(session, [_pending_record(
+            'ghostfuture', submit_date='2026-08-25')])
+        stamp_waiting_days(rows, today=date(2026, 8, 20))
+        assert rows[0]['waiting_days'] == 0
+
+    def test_an_undatable_row_has_no_age_rather_than_a_wrong_one(self, session):
+        rows = classify_accounts(session, [_pending_record(
+            'ghostnodate', submit_date=None)])
+        for row in rows:
+            row['first_seen'] = None
+            row['waiting_since'] = None
+            row['actions'] = [dict(a, received_time=None) for a in row['actions']]
+        stamp_waiting_days(rows, today=date(2026, 8, 20))
+        assert rows[0]['waiting_days'] is None
+
+    def test_a_snapshot_written_by_older_code_is_backfilled(self, session):
+        """⚠️ The publisher and the reader can be on different code.
+
+        Feed B is read back from a snapshot ``xras_sweep`` wrote; mid-deploy the
+        task is guaranteed to be older than the reader, and a cached snapshot
+        outlives a rollback. A row with no ``waiting_since`` is version skew,
+        not a row with no age.
+        """
+        rows = classify_accounts(session, [_pending_record(
+            'ghostskew', submit_date='2026-07-14')])
+        del rows[0]['waiting_since']          # as an older publisher left it
+        stamp_waiting_days(rows, today=date(2026, 8, 20))
+        assert rows[0]['waiting_days'] == 37
+
+
+class TestMergeWorklists:
+    """The union behind ``sam-admin xras --accounts``.
+
+    ⚠️ **Overlap is normal.** Feed A is precisely the actions that have
+    *posted*; Feed B is what XRAS approved and *may or may not* have posted. The
+    same person legitimately appears in both, so this is a union on the
+    casefolded username, not a concatenation.
+    """
+
+    def test_a_person_on_both_feeds_is_one_row_of_work(self):
+        a = [{'username': 'Ghost', 'classification': 'absent',
+              'roles': ('PI',), 'actions': [{'request_number': 'NCAR0001'}],
+              'sources': ['action_log'], 'first_seen': None, 'last_seen': None,
+              'waiting_since': date(2026, 8, 1), 'person': None,
+              'is_reconciled': None, 'latest_action_log_id': 7}]
+        b = [{'username': 'ghost', 'classification': 'absent',
+              'roles': ('User',), 'actions': [{'request_number': 'NCAR0002'}],
+              'sources': ['reports'], 'first_seen': None, 'last_seen': None,
+              'waiting_since': date(2026, 7, 1), 'person': {'lastName': 'X'},
+              'is_reconciled': True, 'latest_action_log_id': None}]
+        merged = merge_worklists(a, b)
+        assert len(merged) == 1
+        row = merged[0]
+        # Provenance is unioned — a person can be a PI on a posted action and a
+        # User on a pending one, and losing either misreports why they block.
+        assert set(row['roles']) == {'PI', 'User'}
+        assert row['sources'] == ['action_log', 'reports']
+        assert len(row['actions']) == 2
+        # Earliest wins: the question is how long they have waited, not which
+        # feed noticed first.
+        assert row['waiting_since'] == date(2026, 7, 1)
+        # Detail rides whichever feed carried it.
+        assert row['person'] == {'lastName': 'X'}
+        assert row['is_reconciled'] is True
+        assert row['latest_action_log_id'] == 7
+
+    def test_disjoint_feeds_concatenate(self):
+        a = [{'username': 'one', 'classification': 'absent', 'roles': (),
+              'actions': [], 'sources': ['action_log'], 'waiting_since': None}]
+        b = [{'username': 'two', 'classification': 'inactive', 'roles': (),
+              'actions': [], 'sources': ['reports'], 'waiting_since': None}]
+        assert len(merge_worklists(a, b)) == 2
+
+    def test_absent_still_sorts_before_inactive(self):
+        a = [{'username': 'zzz', 'classification': 'absent', 'roles': (),
+              'actions': [], 'sources': [], 'waiting_since': None}]
+        b = [{'username': 'aaa', 'classification': 'inactive', 'roles': (),
+              'actions': [], 'sources': [], 'waiting_since': None}]
+        assert [r['username'] for r in merge_worklists(a, b)] == ['zzz', 'aaa']


### PR DESCRIPTION
## Summary

Closes out [#433](https://github.com/benkirk/sam-queries/issues/433). Four commits: one behaviour change, one config flip, and the two documents triage week will actually be run from.

Verified against the live systems on 2026-08-19, before any of this:

| | State |
|---|---|
| `sam.hpc.ucar.edu` | Real InCommon cert, SANs for both hosts, valid to 2027-02-13. Serves `/api/xras/v1/*`, answers the 41-byte 401 unauthenticated |
| Production | `sha-6e05e29`, `XRAS_ACTIONS_CAPTURE_ONLY=1`, `NOTIFY_ENABLED=1`, `NOTIFY_TRANSPORT=smtp` |
| `xras_action_log` on prod | **0 rows, every status** — so XRAS has not repointed, nothing is stranded, and nothing can have been double-applied |
| Runbook gates 1, 2, 4 | Closed |

## 1 · Tell XRAS when an action was parked rather than applied

`processed` and `manual` both answered `{"message":"OK","result":null}`, byte for byte. So an admin who pushes the button in `xras_admin` for an action SAM does not service is told it worked.

Legacy does the same, which is why this shipped as parity. It stopped being a corner case when `Date Adjustment` was discovered on 2026-08-11: it parks, and it is 4 of the 41 corpus payloads. `Transfer` parks by design too. The silent-success arm is the **common** one.

Steven Peckins asked for exactly this on the thread that settled the 400/422 contract — *"the response body is saved and made available in xras_admin for the admin to see, so it's nice to include something informative"*. Both halves of his reply are load-bearing:

- **The status stays 200.** *"Any status other than 200/OK is considered an error."* A parked action is not one; 202 would have been the tidy REST answer and would have read as a failure.
- **Only the `manual` body moves.** `processed` still answers exactly `OK`, and so does the capture-only arm.

The message is a module constant, deliberately *not* `DispatchResult.reason` — three of the four parking causes name internal machinery (`XRAS_ACTIONS_ENABLED`, an unregistered handler) an ACCESS admin can neither act on nor should see. That detail keeps going to `xras_action_log.outcome_reason`, which is what our own surfaces read.

This is gate 4's open decision, now closed.

## 2 · Release the capture-only interlock

`XRAS_ACTIONS_CAPTURE_ONLY: "1"` → `"0"`.

**Deliberately ahead of the repoint, not in step with it.** The runbook read as if the two steps were simultaneous. They are not symmetric, and the asymmetry runs opposite to the intuition that a safety interlock comes off last:

- **Early costs nothing.** XRAS still posts to `sam.ucar.edu`, so the dispatching arm sees no traffic until the repoint.
- **Late costs a round-trip with ACCESS, per action.** Posts in the gap are stranded as `status='received'`, and `--recheck` **cannot apply one** — `dispatch_action(..., validate_only=True)` returns before `management_transaction` opens, structurally. Recovery is asking the XRAS admin to push the button again for each.

The thing that must not happen is a flip on a stack XRAS is *already* posting to, which double-applies against live allocations with no undo. So it is checked rather than assumed: the summary above is that check, and it is clean.

`XRAS_ACTIONS_ENABLED` stays `"all"`. `xras_notices` stays in `SAM_TASKS_DISABLED` for triage week, so handoff notices go out from the Notify button with a human looking at each one; clearing it is a follow-up after the week.

## 3 · The triage playbook

`docs/xras/incoming/XRAS_TRIAGE_PLAYBOOK.md`. The runbook ends at the repoint and gives triage four bullets; from Monday the question is *"this action did not land, now what"*, and that answer was spread across `errors.py` docstrings and three sprint records.

- **The daily loop**, and what normal looks like — the ~30% `/people` 404 baseline, the 3.84 MB roster, `New`'s historical ~30% success. The numbers that otherwise get chased on day one.
- **Classify before you fix**: `status` × `http_status` × `service` × `outcome_reason` as one table.
- **The 422 catalog**, ranked, each with its data fix. The top three are all data, not code: unmapped resource keys (13 mapping rows exist, 11 active resources have none), the organization mnemonic gap (153 of 171 orgs — 24% of legacy's failures), and unreconciled ARC identities (55% of `New` failures).
- **Levers**, and what each costs.

Two things it insists on, because both are easy to get wrong under pressure:

- **`--recheck` validates, it cannot apply.** Green means "this would work if XRAS sent it again". Every fix ends by asking ACCESS to re-post, and is not done until the action comes back and lands.
- **Adding a resource mapping moves GET response bytes**, because `resourceRepositoryKey` is omitted when a resource has no row. The most obvious triage-week fix silently invalidates the gate-3 parity run, so the re-run command sits next to the fix.

**§ 6 sketches five remediation tools and builds none of them**, naming the *trigger* for each instead — including the re-apply path, which needs an idempotency key on `action_id` first because 4 of the 6 handlers double-apply. Writing remediation code for failures that have not happened is how you end up maintaining the wrong tool.

## 4 · Runbook housekeeping

- **Stale helm line refs.** The runbook cited `values.yaml:291`/`:295`; the settings are at **316**/**320**, and 291/295 now hold fs-scans comments. Cutover day is exactly when someone follows a line number without reading around it.
- Gate 4 recorded as decided, gate 5 recorded with the asymmetry above, playbook linked.
- A `values.yaml` comment still listed `deactivate_expired_projects` as disabled after #455 turned it on.

## Test Results

```
pytest -q                      7054 passed, 42 skipped, 1 xfailed   (83s)
pytest -m stress -n 0            22 passed
tests/api/test_xras_access.py   155 passed
helm lint                         0 failed
```

Three new tests in `TestDispatchArms` pin what moved and what did not: parked is not byte-identical to a success, the parked body does not leak `outcome_reason`, and a processed action still answers exactly `OK`.

---

# Rebased onto staging, 2026-08-20 — three more commits

#458 and #459 both merged after this branch opened. Rebased so triage week rides on the combined capability, and because a `workflow_dispatch` from a stale branch would revert their chart changes (below).

## ⚠️ The interlock flip is currently **reverted in production**

`origin/cirrus` is `68cf9b9`, dispatched from `xras_opportunityId`, and its `helm/values.yaml` is staging's — so `XRAS_ACTIONS_CAPTURE_ONLY` is back to `"1"`. That deploy force-pushed its own branch's chart over this branch's flip. It is the trap the note below already warned about, and it has now fired: the `update-helm` job checks out `ref: ${{ github.ref }}` and pushes *that ref's* chart, so whichever branch dispatched last wins.

**Harmless as of now** — `xras_action_log` is still 0 rows, ACCESS has not repointed, so nothing was stranded and nothing double-applied. But the "confirm `CAPTURE_ONLY=0` in the pod env" box below described a state that no longer holds, and a redeploy from this branch is what restores it.

## 5 · Chart: the task roster after #455, #458 and #459

Three comment corrections plus one missing knob.

The Live/Disabled roster still said *"exactly one task is live"* and still listed `deactivate_expired_projects` as disabled after #455 enabled it — and never gained `xras_sweep` after #458 shipped it on. Three tasks are live. That comment is the only human-readable index of what runs in production, because `SAM_TASKS_DISABLED` is fail-OPEN and names only the exceptions.

⚠️ **`xras_sweep` is no longer read-only and its own comment said it was.** #458 wrote *"writes nothing but a cache entry the dashboard reads"*; #459 made it insert `xras_opportunity_allocation_type` rows — what `xras_sweep.py` itself calls "the only write this task performs".

`SAM_TASKS_XRAS_MAP_MAX` was the one sweep knob the chart never named, so the cluster silently ran the code default while `MAX_PAGES` / `MAX_PEOPLE` / `WINDOW_DAYS` / `STATUS` were all pinned beside it. Pinned at that default — behaviourally a no-op — and confirmed rendering into the CronJob.

## 6 · `sam-admin xras --validate-opportunities`

The last deferred piece of #459, and the exception to the playbook's "sketch it, don't build it" rule. The reason is the failure *mode*, not the likelihood.

Every other XRAS mapping gap shouts: an unmapped `resourceRepositoryKey` 422s the action. An unmapped `opportunityId` does not — it falls through to the free-text ladder, whose twelve `SelectionParms` pairs never name `UW`, `WRAP` or `LCAP`, so a Wyoming `Small` request resolves to panel `UNIV USS`, the join **succeeds**, and the project gets a UNIV-series projcode. Nothing fails. **So the trigger cannot arrive as a symptom** — there is no row to classify, and the check has to run against the map ahead of the action.

CLI wiring over machinery #459 already shipped (`audit_opportunity_mapping`, `propose_opportunity_mapping`, `get_open_opportunities`). Three decisions:

- **Exit non-zero on `dangling_ids` only.** Not `unmapped_ids` — with an empty table every opportunity is unmapped and ingestion is perfectly healthy. Not `review` — two pairs sit there permanently by design, and a bucket that is never empty is a bucket an operator stops reading. Same trap `--validate-mapping` fell into once and corrected.
- **The proposal covers the unmapped subset only**, mirroring `_map_new_opportunities`, or the four `source='manual'` rows reappear in `review` every run.
- ⚠️ **It reads the OPEN list, not `/v1/opportunities/list/:ids`** — the opposite of what the design doc specified. That instruction is right for backfill and wrong for a check: the historical tail is `xras_sweep`'s job and those ids are closed, while the open list is the only place a brand-new opportunity appears. Recorded in § 8.6 of the design doc rather than left as a silent divergence.

Both guards negative-tested: widening the proposal fails exactly one test, exiting non-zero on `unmapped_ids` fails five.

## 7 · Reconciling the playbook with what now exists

The playbook was written the day before #458/#459 landed.

| | |
|---|---|
| **One sentence was flatly wrong** | § 3.1 said dangling keys were "the only one that makes the command exit non-zero". `--validate-mapping` is two-sided since #458 and also exits non-zero on `xras_only_keys` |
| **The #1 ranked 422 is demoted** | "13 mapping rows, 11 active SAM resources have none" is still true, but those are opposite directions and only one can cause the 422. #458 measured the one that matters: **13/13 of the keys XRAS actually offers resolve.** It now needs XRAS to offer a resource we have never seen |
| **The largest cause got a queue** | 55% of `New` failures had the fix "identity reconciliation" — a category. It is now the Accounts Needed tab and `--accounts`, documented with the three traps: `placeholder` is a flag not a classification, `isReconciled` says nothing about SAM, `isAccountToBeCreated` is never the predicate |
| **§ 3.9 is new** | The two failures that appear in *none* of `status`/`http_status`/`service`/`outcome_reason`, because both present as success: a wrong opportunity map row (silent at ingest — the symptom is a `processed` action with the wrong projcode series), and `published: true` with `publish_backend != redis` |
| **The pre-repoint empty state** | A populated Pending Requests tab beside an empty Accounts Needed tab is **correct**. Without that line, day one goes on debugging a designed empty state |

✅ **Gate 3 does not need re-running** — checked, not assumed, because for two large XRAS PRs the assumption runs the other way. `webapp/api/xras/` is untouched by both; `roster.py`'s nine new lines are a comment block; neither adds a resource-mapping row; the opportunity map is read only by the inbound POST path. Recorded in the runbook so nobody burns the job on a hunch, and so the real trigger stays sharp.

⚠️ **The `values.yaml` line refs were wrong again.** `8dd454d` repaired `:291` → `:316` — against the *base*, while the same branch's comment rewrite pushed the settings down sixteen lines. Now cited by key name, with a note saying why, so they do not come back a third time.

## Test Results — rebased

```
pytest -q                          7338 passed, 42 skipped, 1 xfailed  (94s)
pytest -m stress -n 0                22 passed
tests/unit/test_admin_xras_cli.py    52 passed  (9 new)
helm lint + test-cronjob-render.sh    0 failed
```

Exercised by hand against the live API from the test database, all three arms: lever off → local half only, exit 0; unreachable host → yellow warning, local half, exit 0; configured → 6 open opportunities, 2 unmapped, both agreeing, exit 0. That last one is real content — `Large Allocation (University) - Fall 2026` is an opportunity the map does not have yet and the sweep will write.

---

## Before merging / deploying

- [x] **Gate 3 parity** — passed 2026-08-19, 13/13 byte-identical, and **not invalidated** by #458/#459 (§ 7).
- [x] Re-run the empty-log check immediately before the deploy: `sam-admin xras --summary` → **0 rows, every status**, so the early flip was safe.
- [x] **Redeploy CIRRUS from this branch** → `sha-82d8c00`, 2026-08-20 19:04 MDT.
- [x] After deploy: `XRAS_ACTIONS_CAPTURE_ONLY=0` in both pods **and parsed `False` by the app**; mailer verified live via `NotifyConfig.from_environment()` (not `app.config`, which misreads — see the validation comment below).

⚠️ A `workflow_dispatch` from this branch force-pushes **this branch's** `helm/values.yaml` onto `cirrus`. Keep it rebased on `staging` for the duration, or a dispatch reverts anything merged to staging since — the trap #367 hit, and the trap that just cost this branch its flip.

Issue #433 is also stale and worth updating before the call: it still presents the broker-retry question as *"the only thing blocking us"*, but Steve answered it on 2026-08-11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

