### PR TITLE
XRAS outgoing queries: an account-creation worklist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,29 @@ STATUS_API_KEY="YOUR_GENERATED_API_KEY_HERE"
 # SAM_XRAS_PASS=
 
 #-------------------------------------------------
+# XRAS Allocations API — SAM calling OUT to XRAS  (docs/xras/outgoing/)
+#
+# ⚠️ NOT the same thing as SAM_XRAS_USER / SAM_XRAS_PASS above. Those are XRAS's
+#    credential for calling SAM — a production WRITE credential in the inbound
+#    direction. This key is SAM's credential for calling api.xras.org.
+#
+# The SAME key can create requests, merge one person into another, and modify
+# roles. That is why the client is structurally GET-only: its one transport
+# primitive is an internal _get, and a test pins that no write verb exists.
+#
+# Production reads the key from OpenBao (csg/xras-api-key, property `token`)
+# via ExternalSecret. Locally, paste it below — and never commit a value.
+#
+# Fail-closed: with XRAS_OUTGOING_ENABLED=0 the dashboard card renders its
+# unconfigured state, the xras_sweep task records a skip, and the CLI degrades.
+# Nothing raises for lack of a key.
+XRAS_OUTGOING_ENABLED=0
+XRAS_API_KEY=
+XRAS_API_BASE=https://api.xras.org
+XRAS_ALLOCATIONS_PROCESS=NCAR
+XRAS_API_USER=arcguest
+
+#-------------------------------------------------
 # JupyterHub Live Statistics API
 # Used for real-time JupyterHub stats endpoints
 JUPYTERHUB_API_URL=https://jupyterhub.hpc.ucar.edu

--- a/docs/README-k8s.md
+++ b/docs/README-k8s.md
@@ -247,7 +247,7 @@ Scheduled tasks, by environment:
 |---|---|---|
 | Local Docker Compose (`webdev`) | n/a — no chart | Run by hand: `sam-admin tasks --run-due` |
 | Local k8s (Docker Desktop) | `false` | Nothing should silently DELETE local data |
-| CIRRUS k8s (this chart) | `true`, kill-switched | Staged enable: only `cleanup_status_snapshots` runs. `SAM_TASKS_DISABLED=deactivate_expired_projects,expiration_notices,xras_notices` |
+| CIRRUS k8s (this chart) | `true`, kill-switched | Staged enable: only `cleanup_status_snapshots` runs. `SAM_TASKS_DISABLED=deactivate_expired_projects,expiration_notices,xras_notices,xras_sweep` |
 
 When the per-environment Entra app strategy is adopted (separate `sam-production`
 and `sam-staging` Entra apps), only the OpenBao / SSM values change — the chart
@@ -329,7 +329,8 @@ of task names to skip, flippable in `values.yaml` with no code deploy. It ships
 until it has been reviewed on its own, so the dispatcher wakes hourly and the
 untried task writes a `skipped` row instead of running. Today only
 `cleanup_status_snapshots` is live; `deactivate_expired_projects`,
-`expiration_notices` and `xras_notices` are switched off. Enabling one is a
+`expiration_notices`, `xras_notices` and `xras_sweep` are switched off.
+Enabling one is a
 separate, reviewable one-line commit.
 
 ⚠️ **It is an enumeration, and it is fail-OPEN.** `disabled_tasks()` in
@@ -368,7 +369,7 @@ that needs no task to actually do anything:
 ```bash
 helm upgrade --install samuel ./helm -f helm/values.yaml -f helm/values-local.yaml \
   -n samuel-dev --set tasks.enabled=true --set tasks.schedule='*/5 * * * *' \
-  --set 'tasks.env.SAM_TASKS_DISABLED=cleanup_status_snapshots\,deactivate_expired_projects\,expiration_notices\,xras_notices'
+  --set 'tasks.env.SAM_TASKS_DISABLED=cleanup_status_snapshots\,deactivate_expired_projects\,expiration_notices\,xras_notices\,xras_sweep'
 ```
 
 ⚠️ `--set` **replaces** the list rather than adding to it, and the commas need

--- a/docs/plans/XRAS_OPPORTUNITY_ALLOCATION_TYPE.md
+++ b/docs/plans/XRAS_OPPORTUNITY_ALLOCATION_TYPE.md
@@ -1,0 +1,332 @@
+# `opportunityId` → allocation type — a mapping table, built additively
+
+**Status:** designed, **not implemented**. Sketched 2026-08-20 with the operator.
+**Base:** stacks on **PR #458** (`probing_xras` → `staging`, 19 commits, all CI
+green). Branch from that head; do not branch from `staging`.
+**Origin:** the deferred § 8.2 item in
+`docs/xras/outgoing/XRAS_OUTGOING_QUERIES.md`, reshaped around one hard
+constraint (§ 2).
+
+This is a handoff document. It assumes **no prior context** — an implementation
+session should be able to start cold from here.
+
+---
+
+## 1. What you need to know first
+
+XRAS is the ACCESS allocations broker. It **pushes** allocation decisions into
+SAM at `POST /api/xras/v1/actions`; `src/sam/xras/` is the handler stack that
+applies them. PR #458 added the opposite direction — a **read-only, GET-only**
+client at `src/sam/integration/xras_api/` that calls `https://api.xras.org/v1/…`
+— plus a dashboard worklist of accounts that must exist before a handoff can
+succeed, and an hourly `xras_sweep` task.
+
+None of that is required reading for this work. What matters here is one field
+on the **inbound** wire that SAM currently ignores.
+
+### The ladder, as it stands
+
+`resolve_allocation_type(session, action, errs)` — `src/sam/xras/extractors.py:323`
+— decides which `allocation_type` row a project gets. It runs an
+**11-strategy chain** of string matching over the wire fields `allocationType`,
+`opportunityName` and `requestTitle`, producing a
+`SelectionParms(panel: str, allocation_type: str)`, then joins:
+
+```python
+row = (session.query(AllocationType)
+       .join(Panel, AllocationType.panel_id == Panel.panel_id)
+       .filter(Panel.panel_name == parms.panel)
+       .filter(AllocationType.allocation_type == parms.allocation_type).first())
+```
+
+Facts worth having in front of you:
+
+| | |
+|---|---|
+| Strategy signature | `_x_strategy(action) -> Optional[SelectionParms]` — **pure, sessionless, no I/O** (module docstring, `extractors.py:23-26`) |
+| Pure entry point | `select_allocation_type_parms(action)` — `extractors.py:308` |
+| Session-aware entry point | `resolve_allocation_type(session, action, errs)` — `extractors.py:323` |
+| Consumers | `handlers/new.py:108,200` and `handlers/update.py:159,280` → `project.allocation_type_id` |
+| Also | `handlers/new.py:175` → `facility_id = self.allocation_type.panel.facility_id` → `next_projcode(..., allocate=True)` |
+| On failure | `errs.report(...)` then a hard **422**: `raise_if_any()` fires *before* any transaction opens, action recorded `failed`, nothing written |
+| Coverage | **5 of 11** strategies are exercised by all 41 committed fixtures (`tests/unit/test_xras_extractors.py::EXPECTED`, pinned by `test_five_distinct_strategies_are_exercised`) |
+
+### The field nobody reads
+
+`opportunityId` is present in **41/41** fixtures and declared at
+`src/sam/schemas/forms/xras.py:395` — and `grep -rn opportunityId src/` returns
+that declaration and **nothing else**. It survives validation, lands in the
+stored raw payload, and is ignored.
+
+⚠️ `opportunityName` **is** read, at nine sites in `extractors.py` *and* at
+`extractors.py:537` in `resolve_mnemonic_code`, where `opportunity.startswith('NCAR ')`
+selects the lab mnemonic route. That last one is a **separate consumer** and
+must not be disturbed by this work.
+
+---
+
+## 2. The constraint that shapes everything
+
+From the operator, verbatim:
+
+> Suppose XRAS_OUTGOING is disabled or entirely absent, we still need to be able
+> to ingest incoming records. So I would like to see a path where
+> "opportunityId → allocation type" is implementable but purely additive — that
+> is, it adds fidelity when outgoing XRAS is plumbed, but does not break
+> anything in its absence.
+
+**One rule satisfies it: ingestion reads a local table and never calls out.**
+The outgoing API is used only to *populate and audit* that table, offline.
+
+| | outgoing absent / disabled | outgoing plumbed |
+|---|---|---|
+| Ingest | table empty → lookup returns `None` → **today's ladder, unchanged** | table hit → deterministic pair |
+| Discovery | rows added by hand (there are 9) | audit CLI proposes rows, flags unknown ids |
+
+This is not a novel shape. It is exactly `xras_resource_repository_key_resource`
+(`src/sam/integration/xras.py:9`): a local table mapping an XRAS key to a SAM
+entity, populated out-of-band, read at ingest by `handlers/_fields.py:144`,
+audited two-sidedly by `audit_resource_mapping`. **SAM has no precedent for an
+external API writing a `sam` table, and this design deliberately does not create
+one.**
+
+---
+
+## 3. Why bother — the panel collision
+
+The thin part of the ladder is the **panel**, not the type. Each strategy
+hardcodes a panel, but the pair is genuinely ambiguous in production:
+
+| `allocation_type` | panels it exists on |
+|---|---|
+| `Small` | **UNIV USS** (id 8) **and UW** (id 3) |
+| `Education` | **UNIV USS** (id 9, inactive) **and UW** (id 18) |
+
+**Operator context:** University of Wyoming (WNA) does not submit through XRAS
+today, but **may in future**. So this is a latent risk to design around, not a
+live bug — and three properties make it worth pre-empting:
+
+1. **It fails silently.** Every other mapping gap here shouts: an unmapped
+   resource key 422s the action and writes nothing. This one does not. The
+   ladder returns `('UNIV USS', 'Small')`, the join **succeeds** — that is a
+   perfectly valid row — and the action is *processed*. The only symptom is a
+   WNA project holding a UNIV projcode, drawn from the wrong facility's series
+   by `new.py:175`. Projcodes are not undoable.
+2. **The deferral criterion cannot produce evidence.** § 8.2 says "assess after
+   the first triage week under live dispatch". Triage week will be 100%
+   `(University)` traffic and will report the same five exercised strategies and
+   zero collisions the 41-payload audit already reports. A historical audit
+   returns "no problem" every time, right up until the day WNA onboards.
+   Waiting cannot generate the signal that would justify acting.
+3. **The map buys lead time on exactly that day.** A new WNA opportunity gets a
+   new `opportunityId`, visible in the sweep's enumeration **before any action is
+   pushed** — the same "reachable ahead of the push" property PR #458 already
+   ships for accounts. Map one row; the first WNA request lands correctly
+   instead of being discovered later by its projcode.
+
+### The domain is tiny
+
+**9** distinct `opportunityId` across all 41 payloads; **5** opportunities open
+today. This is a lookup table, not an algorithm.
+
+Observed (from the committed, scrubbed corpus):
+
+| opportunityId | wire `allocationType` | opportunity name |
+|---|---|---|
+| 532221 ×14 | Exploratory | Exploratory Allocation (University) |
+| 532220 ×11 | Small | Small Allocation (University) |
+| 532222 ×5 | Data Analysis | Data Analysis Allocation (University) |
+| 532223 ×4 | Educational | Classroom Allocation (University) |
+| 533144 ×3 | Large | Large Allocation (University) - Spring 2024 |
+| 533606, 531428, 533936 ×1 | Large | …Fall 2024 / University Large Request - Fall 2021 / …Spring 2025 |
+| 530902 ×1 | Small | University small request — with NSF award |
+
+`GET /v1/opportunities` (live, verified 2026-08-20) returns 5 open
+opportunities carrying `opportunityId`, `opportunityName`,
+`displayOpportunityName`, `allocationType`, `panels: [{panelId, isPrimary}]`
+and `allocationTypeInfo: {allocationTypeId, allocationType, description}` —
+i.e. **XRAS already knows the answer the ladder is guessing at**, including the
+panel.
+
+⚠️ Do **not** key the map on the wire `allocationType` string. Its vocabulary
+differs from SAM's and it is not unique (`schemas/forms/xras.py` says so
+explicitly). Key on `opportunityId`.
+
+---
+
+## 4. Phase 1 — needs no outgoing API at all
+
+This phase is the entire safety argument. It is independently shippable.
+
+### 4.1 Table + ORM
+
+`xras_opportunity_allocation_type`, modelled on `XrasResourceRepositoryKeyResource`:
+
+- `opportunity_id` — PK, from the wire
+- `allocation_type_id` — FK → `allocation_type.allocation_type_id`, NOT NULL
+- `opportunity_name` — snapshot, for humans reading the table
+
+**FK to `allocation_type_id`, not the `(panel, type)` string pair.** § 8.2 says
+"keep the two-column join"; an FK satisfies that constraint *more* strongly — it
+resolves the ambiguity by construction and cannot drift when a type is renamed.
+
+### 4.2 One shared lookup
+
+In `extractors.py`:
+
+```python
+def select_allocation_type_mapped(session, action) -> Optional[SelectionParms]:
+    """Map hit → SelectionParms from the FK'd row; miss → the pure ladder."""
+```
+
+A hit yields `SelectionParms(row.allocation_type.panel.panel_name,
+row.allocation_type.allocation_type)`. A miss falls through to the existing
+`select_allocation_type_parms(action)`, untouched.
+
+> ⚠️ **THE TRAP — both call sites must use it.**
+> `auth_at_panel_meeting(session, action)` (`handlers/_allocations.py:222`)
+> calls the **pure** entry point directly and tests
+> `parms.allocation_type in {'CSL','CHAP'}` (`_PANEL_AUTHORISED`,
+> `_allocations.py:59`) to set `auth_at_panel_mtg` on written
+> **allocation_transaction** rows. It is called from `new.py:122`,
+> `update.py:168`, `supplement.py:65`, `adjustment.py:88`.
+>
+> Wiring only `resolve_allocation_type` would let a project's allocation type
+> come from the map while its transactions' panel-authorisation flag still came
+> from the ladder — inconsistent rows, written, silently. It already takes a
+> session, so it can share the same lookup. Do that.
+
+### 4.3 Seed, then prove equivalence
+
+Seed the 9 known ids with **the pair the ladder already produces today**, then
+assert the corpus is unchanged. That is what makes this a drop-in rather than a
+behaviour change: divergence becomes a later, deliberate, visible edit.
+
+---
+
+## 5. Phase 2 — additive, needs outgoing
+
+1. **`sam-admin xras --validate-opportunities`**, mirroring `--validate-mapping`
+   exactly — *including its injection contract*: the CLI fetches
+   `/v1/opportunities`, the query function takes `opportunity_ids=None` and has
+   **zero network knowledge**, and a `live_checked` flag distinguishes "XRAS
+   sends nothing we lack" from "we never asked". Reports ids seen on the wire
+   with no map row, and proposes a row using XRAS's own `allocationType` +
+   `panels[]` as evidence.
+2. **`xras_sweep` counts unmapped opportunity ids** in its `TaskResult.detail`.
+   It **does not write** — keep its read-only posture.
+
+Copy the exit-code discipline from `src/cli/xras/commands.py:71` — only
+genuinely broken states are non-zero. `audit_resource_mapping` originally
+failed on "unmapped by design" and *"made the command unusable as the deploy
+gate its own docstring claimed it could be: it would have failed every time,
+forever."*
+
+---
+
+## 6. Files
+
+| | |
+|---|---|
+| `src/sam/integration/xras.py` | new model beside `XrasResourceRepositoryKeyResource` |
+| `src/sam/__init__.py` | stage-9 import **and** `__all__` — registration is what the schema tests iterate |
+| `src/sam/xras/extractors.py` | `select_allocation_type_mapped`; `resolve_allocation_type` consults it |
+| `src/sam/xras/handlers/_allocations.py` | `auth_at_panel_meeting` uses the same lookup (§ 4.2 trap) |
+| `src/sam/queries/xras_actions.py` | `audit_opportunity_mapping(session, *, opportunity_ids=None)` beside `audit_resource_mapping` |
+| `src/cli/cmds/admin.py`, `src/cli/xras/{commands,builders,display}.py` | the 5-edit CLI-mode recipe (option + `execute` kwarg + `_mode()` + `build_*` + `display_*`) |
+| `containers/sam-sql-dev/initdb.d/zz-9x-*.sql` | dev/CI DDL hook |
+
+### DDL reality
+
+`sam` has **no migrations** — Alembic covers only `system_status`
+(`migrations/README.md`). A new ORM model with no table fails
+`tests/integration/test_schema_validation.py::TestModelCoverage::test_all_models_have_tables`.
+
+The precedent is the retired `zz-90` initdb hook: recover it with
+`git show 24965d9:containers/sam-sql-dev/initdb.d/zz-90-xras_action_log.sql`.
+It is a self-retiring dev/CI hook that lets the schema tests pass honestly until
+the DBA applies the DDL to production and the snapshot is regenerated.
+
+Applied-DDL procedure of record: `docs/xras/incoming/XRAS_CUTOVER_RUNBOOK.md`
+§ 2. `hpc-writer` holds `CREATE, ALTER, INDEX, REFERENCES` on `sam.*`
+(deliberately **no `DROP`** — get the DDL right the first time).
+⚠️ `REFERENCES` is the non-obvious grant MySQL 8 needs on the **parent** of an
+FK; this table has one.
+
+---
+
+## 7. Verification
+
+- **The additivity guarantee, as a test.** With the table **empty**, the full
+  `EXPECTED` corpus in `tests/unit/test_xras_extractors.py` (41 entries, 5
+  distinct pairs) is unchanged and `test_five_distinct_strategies_are_exercised`
+  still passes. This is the literal statement of "does not break anything in its
+  absence" — write it first.
+- **The equivalence guarantee.** With the 9 rows seeded, that same corpus is
+  *still* unchanged.
+- **The WNA case** — the one that cannot be observed in production until it is
+  too late. A synthetic UW-panel opportunity with wire `allocationType: 'Small'`:
+  assert the ladder resolves it to `UNIV USS` *and succeeds* (documenting the
+  divergence, not just the fix), the map resolves it to `UW`, and the resulting
+  `panel.facility_id` differs — since that is what reaches `next_projcode`.
+- **Consistency.** `auth_at_panel_meeting` agrees with `resolve_allocation_type`
+  for both a mapped and an unmapped action.
+- **Schema tier.** A per-table guard modelled on
+  `tests/integration/test_schema_validation.py:561` (the existing
+  `test_xras_resource_repository_key_resource_schema`, which exists because that
+  model *was wrong once, with 5 columns instead of 2*).
+- **Wire vocabulary.** Add the new read to `tests/unit/test_xras_wire_vocabulary.py`.
+  ⚠️ Read `handlers/_fields.py:150-163` first: the resource resolver read
+  `'key'` instead of `'resourceRepositoryKey'` for an entire sprint, so **every
+  resource on every action** silently reported `No resource found in SAM
+  corresponding to key ` with nothing after it. It survived because every test
+  built its own `{'key': ...}` fixtures. Copy that test, not just the resolver.
+- `pytest tests/unit tests/integration tests/api` (7,233 passing on #458's head).
+
+---
+
+## 8. Cost, and the honest counter-argument
+
+The ladder **works on 41/41 payloads today**, and will keep working for as long
+as XRAS traffic stays all-University. This fixes no present failure.
+
+What it buys: (a) it disarms a wrong-facility projcode that fails *silently* the
+day WNA onboards, (b) it makes a new opportunity a one-row data fix instead of a
+ladder edit plus a deploy — the reason to have it **before** triage week, since
+triage would otherwise produce code patches under time pressure — and (c) a
+two-sided audit of the one wire field SAM currently ignores entirely.
+
+Against that: a hand-applied DDL, a new ORM model, and a second place where
+allocation type is decided. The `auth_at_panel_mtg` coupling is the sharp edge.
+
+**Scope note.** Phase 1 is the whole safety argument and needs no outgoing API.
+Phase 2 is convenience. If the DDL is the blocker, Phase 1 alone is still worth
+doing. They are separable on purpose.
+
+---
+
+## 9. Do not
+
+- ❌ Call the XRAS API from the ingest path. That is the circularity this design
+  exists to avoid, and it would make ingestion depend on `XRAS_OUTGOING_ENABLED`
+  and on a remote host being up.
+- ❌ Put the lookup inside a strategy. The chain is pure and sessionless by
+  construction; a DB read belongs in `resolve_allocation_type` or a
+  session-taking pre-step.
+- ❌ Key the map on the wire `allocationType` string (§ 3).
+- ❌ Displace `opportunityName` — `resolve_mnemonic_code` (`extractors.py:537`)
+  reads it for the lab mnemonic route.
+- ❌ Delete or rewrite the ladder. It is the fallback, and it is what an empty
+  table falls through to.
+- ❌ Let the sweep write the table.
+
+## 10. Reference
+
+| | |
+|---|---|
+| `docs/xras/outgoing/XRAS_OUTGOING_QUERIES.md` | § 8.2 is the original deferral; § 0 records PR #458 as built |
+| `src/sam/xras/extractors.py` | the ladder, the two entry points, `resolve_mnemonic_code` |
+| `src/sam/integration/xras.py` | `XrasResourceRepositoryKeyResource` — the model to copy |
+| `src/sam/xras/handlers/_fields.py:144` | `resolve_resource` — the ingest-side read to copy |
+| `src/sam/queries/xras_actions.py:652` | `audit_resource_mapping` — the two-sided audit to copy |
+| `docs/xras/incoming/XRAS_CUTOVER_RUNBOOK.md` § 2 | applied-DDL procedure and the `hpc-writer` grant |

--- a/docs/plans/XRAS_OUTGOING_QUERIES.md
+++ b/docs/plans/XRAS_OUTGOING_QUERIES.md
@@ -1,28 +1,31 @@
 # XRAS "outgoing" queries — an account-creation worklist
 
-**Status:** research complete, design drafted, **not implemented**.
+**Status:** research and live probing complete, design settled, **not implemented**.
 **Branch:** `probing_xras`. **Probed:** 2026-08-19 against production
-`https://api.xras.org`, cross-checked against the XRAS-admin web app.
+`https://api.xras.org` (two rounds: the original survey, then a follow-up after
+the full API documentation was located), cross-checked against the XRAS-admin
+web app.
 
 This is a handoff document. It is written so an implementation session that has
-never seen the original conversation can start cold. It records what the XRAS
-API *can* and *cannot* do — including every dead end, with the command that
-closed it, so nobody spends a second session re-probing a path that is already
-known to fail.
+never seen the original conversations can start cold. It records what the XRAS
+API *can* and *cannot* do — including every dead end, with enough detail that
+nobody re-probes a path that is already closed — and the design decisions
+already made with the operator, so the implementation session builds rather
+than re-litigates.
 
 > **Direction of travel.** Everything in `docs/xras/incoming/` is XRAS → SAM
 > (they push actions, they pull our GETs). This document is the opposite
 > direction: **SAM calling out to XRAS**. There is no such code in the repo
-> today — `api.xras.org` is zero hits.
+> today — `api.xras.org` is zero hits outside this document.
 
 ---
 
 ## 1. Why
 
-**Goal: a dashboard listing the user accounts that must be created (or
-reactivated) in SAM before an XRAS handoff can succeed** — who, why, with notes.
-Account creation is a manual process. This complements the XRAS action-log card
-rather than replacing it.
+**Goal: a dashboard card listing the user accounts that must be created (or
+reactivated) in SAM before an XRAS handoff can succeed** — who, why, with
+detail. Account creation is a manual process. This complements the XRAS
+action-log card rather than replacing it.
 
 This targets the largest known failure mode. `src/sam/xras/handlers/new.py:24-27`
 records the measured causes of the legacy 70% failure rate:
@@ -36,10 +39,31 @@ records the measured causes of the legacy 70% failure rate:
 worklist addresses, by the repo's own measurements, the single biggest cause of
 XRAS handoff failure.
 
-**Timing context.** PR #457 lands the capture-only receive path; ACCESS is
-repointed at SAM shortly after, at which point `xras_action_log` begins filling
-(it is at 0 rows until then). Capture-only is an *advantage* here: it means
-every action can be pre-flighted **before** it is ever processed.
+**Timing context.** PR #457 landed the capture-only receive path; the next step
+disables capture-only (live dispatch) and ACCESS is repointed at SAM, at which
+point `xras_action_log` begins filling (it is at 0 rows until then).
+**Consequence for this design:** actions in the log may be `received` (under
+capture-only) *or* `processed` / `failed` / `manual` (under live dispatch), so
+the worklist derivation must be regime-proof — it classifies against the
+*current* state of `users`, never against the action's `status`.
+
+### 1.1 Scope decisions, already settled with the operator
+
+These were decided on 2026-08-19; the implementation session should not reopen
+them without new information:
+
+1. **Step 0 — the API key moves into OpenBao first** (§ 11). It currently sits
+   in cleartext in the operator's home directory and on `crlogin` hosts.
+2. **Read-only card first — no new table in this PR.** The worklist derives
+   entirely from existing data; the operator-notes/dismissal table
+   (`xras_account_event`, § 7.6) is an immediate follow-up PR.
+3. **Cheap win (a) only** — the two-sided `--validate-mapping` (§ 8.1) rides
+   along. Cheap win (b), the `opportunityId` → allocation-type map (§ 8.2), is
+   **deferred**: assess after the first triage week under live dispatch.
+4. **The `xras_sweep` scheduled task ships in this PR, switched off** — its
+   name added to `SAM_TASKS_DISABLED` in the same change (the fail-open trap;
+   see the `xras_notices` precedent).
+5. One PR vs `staging`, as an ordered commit series (§ 12).
 
 ---
 
@@ -50,50 +74,114 @@ Two different services are easy to confuse.
 | | |
 |---|---|
 | **XRAS Rules Service** — `xras-rules-service-demo.xsede.org/apidoc/` | A separate, mostly-POST engine (notifications, validate, required_documents, clone rules). Paths are `/api/v1/...`. **Our key does not open it.** Not useful here. |
-| **XRAS Allocations API** — `https://api.xras.org/v1/...` | ✅ **This is the one.** Live docs: `api.xras.org/api/overview`, `api.xras.org/api/request_headers`, `api.xras.org/api/data_models` (that last renders empty). `api.xras.org/apidoc` 404s. |
+| **XRAS Allocations API** — `https://api.xras.org/v1/...` | ✅ **This is the one.** |
 
 The two share endpoint *names* (`opportunities`, `requests`), which is exactly
 why they get confused. Note the path prefix differs: `/api/v1/` for the rules
 service, `/v1/` for the allocations API. `api.xras.org/api/v1/...` 404s.
 
-### Authentication
+### 2.1 The documentation — and where it hides
+
+`https://api.xras.org/` is a two-iframe page. The left frame's **"API"** link
+targets `https://api.xras.org/apidoc` — **which 404s when fetched directly**,
+and that decoy is why the first survey concluded no endpoint documentation
+existed. The real page is
+**`https://api.xras.org/apidoc.html`** ("ALLOCATIONS API 1.0"), with static
+per-endpoint detail pages under `https://api.xras.org/apidoc/1.0/...`. Those
+pages carry parameter tables and example responses and are fetchable with plain
+curl. Also useful: `api.xras.org/api/overview` and
+`api.xras.org/api/request_headers`.
+
+### 2.2 Authentication
 
 ```
-XA-API-KEY:             <key>          # see § 10 — not in this repo
+XA-API-KEY:             <key>          # see § 11 — never in this repo
 XA-ALLOCATIONS-PROCESS: NCAR
 XA-CONTEXT:             submit | report        ✅ 200
                         review | admin         ❌ 401 (key not provisioned)
-XA-USER:                <username>     # scopes every per-user response
-XA-PERMISSIONS:         <optional>     # accepted; changes nothing (see § 4)
+XA-USER:                <username>     # required header; scopes /v1/requests only
 ```
 
 Omitting `XA-CONTEXT` gives `400 {"message":"XA-CONTEXT header missing"}`.
-The documented context vocabulary is `submit`, `report`, `review`, `admin`;
-our key holds the first two. `submit` and `report` expose an **identical**
-surface — `report` unlocks nothing extra.
+
+⚠️ **`submit` and `report` are NOT the same surface.** The first survey
+concluded they were identical, but that held only for the endpoints it knew
+about. The **Reports family (§ 3.2) answers only under `XA-CONTEXT: report`**
+— the same paths 401 under `submit`. Everything else this project reads
+(`/v1/people`, `/v1/resources`, `/v1/requests`, `/v1/types/*`,
+`/v1/search/people`) works under `report` as well. **Design consequence: the
+client hardcodes `XA-CONTEXT: report`** — one context, read-only semantics, no
+knob.
+
+`XA-USER` is a required header on every call, but outside `/v1/requests` it
+scopes nothing — the reports endpoints return process-wide data regardless of
+its value. The existing operator scripts use `arcguest`; the client takes it
+from `XRAS_API_USER` (default `arcguest`). Per-user impersonation is **not
+needed anywhere in this design** (the enumeration made it obsolete, § 3.2).
 
 Server is Rails behind Apache/Passenger. A Rails HTML 404 page means "no such
 route"; a JSON `{"message":..., "result":null}` means the route exists and the
-request was refused or found nothing. That distinction is useful when probing.
+request was refused or found nothing. Every JSON response wraps its payload in
+that `{message, result}` envelope — the client unwraps it centrally.
 
 ---
 
-## 3. The readable surface — seven endpoints
+## 3. The readable surface
+
+### 3.1 Per-user and global endpoints (work under `submit` and `report`)
 
 | Endpoint | Scope | Returns |
 |---|---|---|
-| `GET /v1/people/:username` | **global directory** | firstName, middleName, lastName, email, phone, organization, academicStatus, **residenceCountry**, **isReconciled**, orcid, hasOrcidToken |
+| `GET /v1/people/:username` | global directory | firstName, middleName, lastName, email, phone, organization, academicStatus, **residenceCountry**, **isReconciled**, orcid, hasOrcidToken |
+| `GET /v1/search/people?q=...` | global directory | the same person shape, matched on name/username fragments |
 | `GET /v1/requests` | **`XA-USER`-scoped** | every request that user is PI / CoPI / Allocation Manager on, in full |
 | `GET /v1/requests/:requestId` | `XA-USER`-scoped | one request; **401** if the user has no role on it |
-| `GET /v1/opportunities` | global | currently-open opportunities, full detail |
-| `GET /v1/opportunities/:id` | global | one opportunity — **including historic/Terminating ones** |
-| `GET /v1/opportunities/list/:id,:id,...` | global | batch form of the above |
+| `GET /v1/opportunities` · `/:id` · `/list/:ids` | global | open opportunities; the id forms also resolve **historic/Terminating** ones |
 | `GET /v1/resources` · `/v1/resources/:id` | global | 13 resources, **including `resourceRepositoryKey`** |
 | `GET /v1/panels` · `/v1/panels/:id` | global | 5 panels **with member rosters** |
+| `GET /v1/types/roles`, `/v1/types/actions`, `/v1/types/request_status`, ... `/v1/types/all` | global | the process's own vocabularies (§ 3.4) |
+| `GET /v1/permissions/:username` | global | XRAS permission grants for a person |
 
 **Unknown username** gives a clean `404 {"message":"username=X not found"}`.
 
-### `/v1/requests` payload shape
+### 3.2 The Reports family — `XA-CONTEXT: report` only ⭐
+
+This is the finding that reshapes the whole design. The first survey probed
+`/v1/reports` bare (404, § 4.7) and closed the path; the real routes live
+*under* it and were located via `apidoc.html`. All verified 200 with our
+existing key under `report` context, 401 under `submit`:
+
+| Endpoint | Returns |
+|---|---|
+| `GET /v1/reports/requests` ⭐ | **Every request in the NCAR process, unscoped.** Paginated: `?limit=N&prevMinRequestId=M` (descending `requestId`; strictly-less-than, so pass the smallest id seen to get the next page). Filters: `?status=` (one of `Submitted, Approved, Rejected, Incomplete, Under Review`) or `?active=true|false` (Approved with end date in future/past — mutually exclusive with `status`). Optional `fosTypeId`, `piOrganizationId`. |
+| `GET /v1/reports/request_numbers/:requestNumber` ⭐ | **Look up by request number — i.e. by projcode.** Same response as `/v1/requests/:requestId` minus the `rules` object. Optional `?status=active|inactive`. |
+| `GET /v1/reports/allocations` | All allocations (`?status=active` → ~7.9 MB for NCAR today): actionId, actionType, begin/end dates, requestNumber, PI name/institution/**username**, opportunity, per-action `resources[]` and `requestedResources[]`. |
+| `GET /v1/reports/username/:username` | Roles and panels for one person: requests grouped by role name. |
+| `GET /v1/reports/opportunity_requests/:opportunityId` | Requests for one opportunity. |
+| `GET /v1/reports/requests/:requestId` | One request via the reports path. |
+| `GET /v1/reports/fos/:fosId` | Requests by field of science. |
+
+**The `reports/requests` rows are complete**: verified top-level keys include
+`roles[]` — each with the **full person object inline** (all `/v1/people`
+fields, including `isReconciled` and `residenceCountry`) — plus full
+`actions[]` (resources with Requested/Recommended/Approved amounts, dates,
+states, documents), `fos`, `grants`, `conflicts`, `publications`.
+
+Three consequences, each load-bearing:
+
+1. **Enumeration exists today, on our key.** No per-identity polling, no
+   roster crawling, no impersonation, and no "please provision an admin
+   credential" ask — the original Phase-2 request to XRAS is moot.
+2. **Dropped-push detection is nearly free**: diff the Approved set's
+   `requestNumber` against `project.projcode` (§ 6) wholesale.
+3. **The worklist's hardest population — a brand-new PI on a solo New request,
+   connected to nobody SAM knows — is reachable *before* the push**, with
+   their person detail already inline.
+
+### 3.3 `/v1/requests` payload shape
+
+(One request from `reports/requests` / `reports/request_numbers` is this same
+shape minus `rules`.)
 
 ```
 rules:
@@ -119,126 +207,129 @@ fos[{fosTypeId, fosNum, isPrimary}], grants[],
 conflicts[{conflictId, conflictType, conflictPerson}], publications[]
 ```
 
-### Vocabularies observed in live NCAR data
+### 3.4 Vocabularies — verified against the live process
 
-| Field | Values seen |
+| Field | Values |
 |---|---|
-| `requestStatus` | Approved, Rejected, Incomplete |
+| `requestStatus` | Submitted, Approved, Rejected, Incomplete, Under Review (the filter's full enum; Approved/Rejected/Incomplete observed) |
 | `requestType` | New, Renewal |
 | `actionType` | New, Renewal, Supplement, Extension, Transfer, Adjustment, Date Adjustment |
 | `actionStatus` | Approved, Declined, Incomplete |
 | action `states[]` | "Conflicts Verified", "Reviewers Assigned" |
-| resource `type` | **Requested / Recommended / Approved** — the full award trail |
+| resource `type` | Requested / Recommended / Approved — the full award trail |
 | `allocationDateType` | Requested, Approved |
-| **`roleTypeId`** | **13 = PI, 14 = Allocation Manager, 19 = User** |
+
+**The co-PI question is settled.** `GET /v1/types/roles` for the NCAR process
+returns **exactly three role types**:
+
+```json
+[{"roleTypeId": 13, "roleType": "PI",                 "displayRoleType": "Project Lead"},
+ {"roleTypeId": 14, "roleType": "Allocation Manager", "displayRoleType": "Project Admin"},
+ {"roleTypeId": 19, "roleType": "User",               "displayRoleType": "User"}]
+```
+
+**There is no co-PI role type in the NCAR process, so one can never appear on
+the wire.** This closes the open risk carried in
+`docs/xras/incoming/XRAS_REIMPLEMENTATION.md` and explains why zero co-PIs
+exist across 101 role entries in 41 captured fixtures and all live sampling.
+(The generic XRAS product vocabulary — visible in the apidoc example — does
+define `CoPI` with roleTypeId 1; those generic ids are per-process, which is
+why NCAR's are 13/14/19.) The hedging comments at
+`src/sam/schemas/forms/xras.py:204-208`, the `!=` role match at
+`src/sam/xras/roster.py:233`, and the stress scenarios' `Co-PI`/`CoPi`
+variants can all be annotated with this answer (comment-only changes).
 
 ⚠️ A request still being drafted has `requestNumber: null` and
-`requestStatus: "Incomplete"` — in-flight work is visible before it has a number.
-
-### Role types — and the CoPI question
-
-`docs/xras/incoming/XRAS_REIMPLEMENTATION.md` carries "co-PI roleType still
-unknown" as an open risk, and `src/sam/schemas/forms/xras.py:204-208` explains
-the field is not enum-validated because no co-PI has ever appeared in a sampled
-payload. Stress scenarios hedge across `Co-PI` / `CoPi` / `Co-Investigator`.
-
-Two findings:
-
-- **The outgoing API carries a numeric `roleTypeId` (13/14/19); the inbound wire
-  carries none at all** — only a `roleType` *string*, matched with a plain `!=`
-  at `src/sam/xras/roster.py:233`. `grep -rn roleTypeId src tests` returns
-  nothing.
-- **Still zero co-PIs** — none across 101 role entries in the 41 captured
-  fixtures, and none in any live request sampled. Consistent with NCAR's process
-  using PI / Allocation Manager / User only, which is exactly the roster SAM
-  models.
-
-Note the two vocabularies must not be conflated: inbound uses `PI` /
-`Allocation Manager` (spaced), while SAM's own outbound GET side uses `Pi` /
-`CoPi` / `AllocationManager` (`src/webapp/api/xras/requests.py:33-37`), where the
-`CoPi` branch is structurally always empty (`src/sam/queries/xras_access.py:260-276`).
+`requestStatus: "Incomplete"` — in-flight work is visible before it has a
+number. Also note: inbound-wire role strings are `PI` / `Allocation Manager`
+(spaced), while SAM's own outbound GET side uses `Pi` / `CoPi` /
+`AllocationManager` (`src/webapp/api/xras/requests.py:33-37`), where the
+`CoPi` branch is structurally always empty — now provably so.
 
 ---
 
-## 4. Negative results — closed paths, do not re-probe
+## 4. Closed paths — do not re-probe
 
-Every row below was tested. The point of this section is to stop a future
-session rediscovering them.
+Every row was tested. Entries marked **[submit-only]** were originally tested
+under `XA-CONTEXT: submit` before the Reports family was known; their
+conclusions were re-checked under `report` where it mattered.
 
-### 4.1 There is no enumeration
+### 4.1 `review` / `admin` contexts are refused at the auth layer
 
-No endpoint lists requests, people, or actions across the process. `/v1/requests`
-is always and only `XA-USER`-scoped.
+`401` with `X-Runtime: 0.003` — rejected before any lookup. A property of
+**the API key**, not of the header or the user. (Not needed: everything this
+design requires works under `report`.)
 
 ### 4.2 `XA-PERMISSIONS` does nothing
 
-Tested against a real Approved request the impersonated user had no role on, in
-all four contexts, with each of: `Administrator`, `XRAS - Admin read permission`,
-`XRAS - Review impersonator`, `Resource Provider User`,
-`Allocations Process Manager`, and a comma-joined pair. **All 401.**
-(The permission strings are real — they are listed on a person's admin page.)
+Tested against a real Approved request the impersonated user had no role on,
+in all four contexts, with each of: `Administrator`, `XRAS - Admin read
+permission`, `XRAS - Review impersonator`, `Resource Provider User`,
+`Allocations Process Manager`, and a comma-joined pair. **All 401.** The
+permission strings are real (`GET /v1/permissions/:username` lists them); the
+header is inert.
 
-### 4.3 `review` / `admin` contexts are refused at the auth layer
-
-`401` with `X-Runtime: 0.003` — rejected before any lookup. This is a property
-of **the API key**, not of the header or the user.
-
-### 4.4 Probing by project code / request number does not work
-
-This is the most tempting idea and it fails for three independent reasons:
+### 4.3 `/v1/requests` is strictly role-scoped; its path key is `requestId`
 
 | Probe | Result |
 |---|---|
-| `GET /v1/requests/<requestNumber>` **as its own PI** | **401** — `requestNumber` is not a valid path key at all. The numeric `GET /v1/requests/<requestId>` for the same request returns 200. |
-| `GET /v1/requests/<requestNumber>` as a non-member | 401 |
-| `?requestNumber=...`, `?opportunityId=...`, `?all=true` | **silently ignored** — the unfiltered list is returned |
+| `GET /v1/requests/<requestNumber>` (as its own PI or anyone) | **401** — `requestNumber` is not a valid key on *this* route. Use `GET /v1/reports/request_numbers/<n>` instead (§ 3.2). |
+| `?requestNumber=...`, `?opportunityId=...`, `?all=true` on `/v1/requests` | silently ignored — the `XA-USER`-scoped list is returned |
 | `/v1/requests/number/<n>`, `/v1/requests/request/<n>` | 404 |
+| Impersonating genuine XRAS administrators via `XA-USER` | only *their own* role-scoped requests; a foreign Approved request still 401s |
 
-Scanning the **numeric** `requestId` space is equally futile: ids are dense and
-guessable, but reading one still requires a role, so a scan yields only 401s.
+Scanning the numeric `requestId` space through `/v1/requests/:id` yields only
+401s without a role. All of this is now academic — the reports family answers
+every one of these questions properly.
 
-### 4.5 Admin identities gain no breadth
-
-Impersonating genuine XRAS administrators (members of the admin panel) returns
-only *their own* role-scoped requests — counts of 1, 2 and 6 for the three
-tested. Adding `XA-PERMISSIONS: Administrator` changes nothing, and a foreign
-Approved request still 401s for them.
-
-**This is an important design input:** the admin web app's queue view
-demonstrably does **not** come through this API. See § 8 for how that reshapes
-the ask.
-
-### 4.6 Unreconciled people cannot be addressed by id or email
+### 4.4 People endpoints that do not exist
 
 `GET /v1/people/<personId>`, `/v1/people/<email>`, `/v1/people/unreconciled`
-and `/v1/people` all 404. `/v1/people/:username` is username-keyed, full stop.
+and bare `/v1/people` all 404. `/v1/people/:username` is username-keyed —
+**but `/v1/search/people?q=` exists** (§ 3.1) and matches on names, so people
+are findable without knowing a username. Whether search matches *placeholder*
+identities' display names is **untested** — a nice-to-know, not load-bearing
+(placeholders arrive with usernames via both feeds).
 
-**But see § 5 — this does not mean unreconciled people are unreachable.**
+### 4.5 Routes that do not exist (Rails 404) **[submit-only]**
 
-### 4.7 Endpoints that do not exist
+`/v1/actions`, `/v1/allocations`, `/v1/awards`, `/v1/reviews`, `/v1/grants`,
+`/v1/organizations`, `/v1/allocation_types`, `/v1/fields_of_science`,
+`/v1/publications`, `/v1/users`, `/v1/roles` (as a GET), `/v1/requests/:id/actions`,
+`/v1/people/:u/requests`, `/v2/*`. (`/v1/reports` *bare* also 404s — the
+family lives one segment deeper, § 3.2. Several of these have proper
+equivalents there: `/v1/reports/allocations`, `/v1/types/fos`, etc.)
 
-`/v1/actions`, `/v1/allocations`, `/v1/awards`, `/v1/reviews`, `/v1/reports`,
-`/v1/grants`, `/v1/organizations`, `/v1/allocation_types`,
-`/v1/fields_of_science`, `/v1/publications`, `/v1/users`, `/v1/roles`,
-`/v1/requests/:id/actions`, `/v1/people/:u/requests`, `/v2/*` — all 404.
+### 4.6 `/v1/projects` is another service entirely
 
-Curiosity note: `/v1/projects` returns a **Tomcat** 404 rather than the Rails
-one, so some other service is routed at that path. It is not ours and did not
-respond usefully to anything tried.
+Returns a **Tomcat** 404 (everything else here is Rails) under both contexts
+and with a valid `XA-USER`. It is documented in the generic apidoc (an
+ACCESS-style per-user project/resource state view) but is not routed for our
+process. Confirmed dead for NCAR; do not re-probe.
+
+### 4.7 The write surface — why GET-only must be structural
+
+The documented API is far more write-capable than the first survey knew, and
+**our submit-context key holds at least some of it** (it is the credential the
+ARC submission UI uses). Documented POSTs/PUTs/DELETEs include: create/delete
+requests, submit/withdraw actions, add/remove roles and users
+(`/v1/roles/<requestNumber>/Users`), **merge one person into another**
+(`/v1/people/:u/merge/:new`), update resources, set ORCID data. None of that
+may ever be reachable from SAM code. The client therefore has **no generic
+verb method at all** — its only transport primitive is an internal `_get`
+(§ 7.1), and a test pins that no post/put/patch/delete callable exists.
 
 ---
 
-## 5. The finding that makes the worklist possible
+## 5. The placeholder finding
 
 The XRAS-admin "Recent submissions" queue shows Approved requests whose Project
-Lead is badged **"Unreconciled user"** — a researcher with no site account. That
-is precisely the population the worklist is for, and at first it looked
-unreachable (§ 4.6).
+Lead is badged **"Unreconciled user"** — a researcher with no site account.
+That is precisely the population the worklist is for.
 
-**It is reachable.** Every unreconciled person still has an **ARC placeholder
-username** of the shape `<name>-user-<token>`. The admin UI shows it only on the
-person's own page, not on the request summary — which is what made it look
-absent. That username resolves fully:
+**Every unreconciled person has an ARC placeholder username** of the shape
+`<name>-user-<token>` (the admin UI shows it only on the person's own page,
+not on the request summary). That username resolves fully:
 
 ```
 GET /v1/people/<name>-user-<token>
@@ -247,20 +338,20 @@ GET /v1/people/<name>-user-<token>
   "organization": "...", "isReconciled": false, "orcid": null }
 ```
 
-Three consequences, each load-bearing:
+Three consequences:
 
 1. **It is the account-creation detail sheet.** Name, email, organization,
    academic status, and **`residenceCountry`** — the last of which the inbound
    payload does **not** carry and account creation needs.
-2. **`isReconciled` is the closure signal.** Re-poll the same username; when it
-   flips, the item closes itself with nobody updating SAM by hand.
-3. **Impersonating the placeholder reads the request in full** — so approved
-   amounts and dates can be verified even for a handoff SAM never received.
+2. **`isReconciled` is the closure signal.** Re-poll the same username; when
+   it flips, the worklist item closes itself with nobody updating SAM by hand.
+3. The placeholder username is **already on the inbound wire**: fixture
+   `tests/fixtures/xras/actions/new_ncar4214_ok.json` carries a role with
+   `"username": "placeholder34-user-00034"` and `"isAccountToBeCreated": true`.
 
-And the placeholder username is **already on the inbound wire**: fixture
-`tests/fixtures/xras/actions/new_ncar4214_ok.json` carries a role with
-`"username": "placeholder34-user-00034"` and `"isAccountToBeCreated": true`.
-The push names these people; the API describes them.
+And via the reports family (§ 3.2), the same person object — placeholder
+username, `isReconciled: false`, and all — arrives **inline in every request's
+roster**, so the enumeration feed needs no separate person fetch at all.
 
 ### Two traps
 
@@ -283,390 +374,489 @@ a quarter of the real cases.
 Reconciled live against the local SAM DB: **13/13 exact, zero unmapped, zero
 dangling.** The API also exposes `productionBeginDate` / `productionEndDate`
 per resource — and at probe time the two current flagship compute resources
-carried a `productionEndDate` roughly three months in the past, which nothing in
-SAM would notice. Whether that is XRAS staleness or a telegraphed retirement is
-an open question worth asking.
+carried a `productionEndDate` roughly three months in the past, which nothing
+in SAM would notice. Whether that is XRAS staleness or a telegraphed
+retirement is an open question worth asking (§ 13).
 
-**`requestNumber` == `project.projcode`.** Verified both directions: an Approved
-request's number exists as a SAM project; a **Rejected** request's number
-(`NCAR3116`, which is the SAM author's own test request) does **not**, because no
-project is ever created for a rejected request. This is exactly the existence
-test `dispatch.select_service()` uses to tell a "New that is really an update"
-from a genuine New.
+**`requestNumber` == `project.projcode`.** Verified both directions: an
+Approved request's number exists as a SAM project; a **Rejected** request's
+number (`NCAR3116`, the SAM author's own test request) does **not**, because
+no project is ever created for a rejected request. This is exactly the
+existence test `dispatch.select_service()` uses to tell a "New that is really
+an update" from a genuine New — and it is what makes wholesale dropped-push
+detection a set difference.
 
 ---
 
-## 7. Phase 1 — buildable now, no new key
+## 7. The design
 
-### 7.1 The central question, answered
+### 7.0 Shape of the whole
 
-> *Can we see Approved requests before XRAS pushes them?*
+Two feeds produce normalized roster records; one classifier turns them into
+the worklist; one card renders it; one scheduled task runs the enumeration.
 
-**Yes — for any identity SAM already knows.** The ceiling is **discovery**, not
-**reading**. `XA-USER` may be set to any username we know, so any request that
-user has a role on is fully readable.
-
-Verified end-to-end: the admin queue showed an Approved Extension on an existing
-SAM project. Polling that project's known lead through `/v1/requests` returned
-the same action — its `actionId`, `entryDate`, approved end date and full roster
-— with no push and no admin key. All six extension-type Approved rows in the
-sampled queue mapped to SAM projects with known leads.
-
-### 7.2 The three populations
-
-Checking the Approved queue's project leads against SAM:
-
-| Class | Visible in Phase 1? | Remedy |
-|---|---|---|
-| **Known + active** in SAM | ✅ by polling | usually none — may just need adding to a project |
-| **Known but `active = 0`** | ✅ by polling | **reactivate** |
-| **Absent entirely** — ARC placeholder identity | ❌ push-only until Phase 2 | **create** |
-
-Roughly a quarter of the Approved queue is Extensions/Transfers on existing
-projects (fully visible today). The rest are New requests spread across all
-three classes. **The third class is the residual gap — and it is the
-55%-of-failures population.** Phase 1 catches it *at push time, before
-processing*; Phase 2 (§ 8) would catch it *before the push*.
-
-### 7.3 Feed A — pre-flight over captured actions
-
-**Reuse what exists; build nothing.**
-`dispatch_action(session, action, validate_only=True)`
-(`src/sam/xras/dispatch.py:222-263`) runs the handler's assemble-and-check half
-and returns **before `management_transaction` opens**.
-`src/webapp/api/xras/recheck.py:195-202` already drives it.
-
-Because production runs **capture-only**, running this across captured actions
-pre-flights every action *before* it is ever processed — literally "detect users
-that need creating before the task can succeed".
-
-It yields exactly five error strings from `src/sam/xras/errors.py`, and those
-five **are** the worklist, with the remedy already distinguished:
-
-| `errors.py` | Meaning | Remedy |
-|---|---|---|
-| `pi_not_in_database` :143 | PI has no `users` row | create |
-| `pi_not_active` :149 | PI row inactive | reactivate |
-| `manager_not_in_database` :154 | Allocation Manager absent | create |
-| `manager_not_active` :160 | Allocation Manager inactive | reactivate |
-| `username_missing` :185 / `username_inactive` :190 | roster member | create / reactivate |
-
-### 7.4 Feed B — known-identity polling, with a roster crawl
-
-A scheduled sweep calling `GET /v1/requests` per known identity, recording
-Approved and in-flight actions. Two things it buys beyond Feed A:
-
-- **Pre-push visibility** for extensions/transfers on existing projects and for
-  New requests from people SAM already knows.
-- **Discovery of unknown people through known ones.** A known PI's roster names
-  their collaborators, *including placeholder usernames SAM has never seen*.
-
-**Roster crawl.** Every newly-seen username is itself pollable, so the sweep
-should be transitive: poll seeds → harvest usernames from their rosters → poll
-the new ones → repeat to a fixed point, bounded by a depth cap and a per-run
-budget. This widens coverage well past the seed set with no enumeration.
-
-Its limit, stated plainly: the crawl reaches people who **share a request with
-someone we know**. A wholly-new PI submitting a solo New request connects to
-nothing SAM knows, so no crawl reaches them. Push-only until Phase 2.
-
-**Measured cost.** `GET /v1/requests` ≈ **0.84 s, ~22 KB** per identity
-(3 consecutive runs: 0.844 / 0.826 / 0.837 s).
-
-| Seed tier | Count (local snapshot) | Serial | ~8-way |
-|---|---:|---:|---:|
-| Active project leads + admins | 1,518 | ~21 min | ~3 min |
-| All active, unlocked users | 6,310 | ~88 min | ~11 min |
-| All non-deleted users | 28,344 | ~6.6 h | ~50 min |
-
-Nightly over the first tier is the right default. Hit rate is low — of five real
-project leads sampled, **three returned zero requests** — so a full sweep is
-mostly empty and the crawl matters more than the seed breadth.
-
-### 7.5 Enrichment and closure
-
-For each worklist username, `GET /v1/people/:username` supplies the detail
-sheet. Re-poll to close on `isReconciled`. Cache **hours, not days** — this is a
-closure signal and must not go stale.
-
-### 7.6 New code
-
-`src/sam/integration/xras_api/` — follow `src/sam/integration/awards/` exactly.
-It is the closest template in the repo and already a sibling of
-`src/sam/integration/xras.py`.
-
-- **`client.py`** — one persistent `requests.Session`; explicit `timeout=` on
-  every call; `2 ** attempt` backoff; **404 → return `None`**; other 4xx →
-  raise immediately (a client error is deterministic, never retried); 5xx →
-  warn + retry; exhausted → raise `XrasSourceUnavailable`. Preserve the
-  three-outcome model (**found / not-found / unreachable**) all the way to CLI
-  exit codes, as `AwardSourceUnavailable` does.
-- **GET-only allowlist, enforced structurally.** The API exposes POSTs
-  (`/v1/resources/update`, the notification endpoints, `new_request_number`)
-  that must never be reachable from SAM. Do not rely on convention.
-- **`cache.py`** — `BucketedTTLCache`, registered by adding the module to
-  `_BUCKETED_CACHE_MODULES` in `src/webapp/caching/__init__.py:48-53`. That one
-  line gives `sam-admin cache --refresh --category`, the Admin Configuration
-  card row, `stats()` and `clear()` for free. Cache successes *and* definite
-  negatives; never cache an `XrasSourceUnavailable`.
-- **Config** via `os.getenv` — `XRAS_API_KEY`, `XRAS_API_BASE`,
-  `XRAS_ALLOCATIONS_PROCESS` — declared in `.env.example` and
-  `helm/values.yaml`, **fail-closed** when unset. No Click / Flask / rich /
-  kubernetes imports anywhere under `src/sam/` or `src/scheduling/`.
-
-`src/sam/queries/xras_accounts.py` — the worklist query: group pre-flight
-failures by username, classify (absent / inactive / placeholder-shaped), join
-the most recent `xras_action_log` row for provenance.
-
-⚠️ **Do not export the new query module from `sam/queries/__init__.py`** if it
-imports `sam.notify` — that file imports its submodules eagerly. See the
-existing trap documented for `expiration_notices` / `xras_notices`.
-
-**The sweep is a scheduled task** under `src/scheduling/tasks/`.
-⚠️ `SAM_TASKS_DISABLED` is **fail-open**: registering a task puts it live on the
-next hourly wake unless its name is added to `helm/values.yaml` **in the same
-change**. Ship it switched off, as `xras_notices` was, and add the
-`values.yaml` grep assertion the existing task tests use.
-
-### 7.7 Schema — one new table, not zero
-
-**The worklist itself needs no storage.** It derives entirely from
-`xras_action_log.raw_payload` (roles and usernames), `users` (existence and
-activity), the pre-flight (the reason), and `/v1/people` (the detail, cached).
-This follows `XrasActivationEvent`'s own rule: *state is DERIVED, never stored*.
-
-**Operator notes and dismissals do need storage, and `XrasActivationEvent`
-cannot carry them.** Its key is
-
-```python
-project_id = Column(Integer, ForeignKey('project.project_id'), nullable=False)
+```
+Feed A  xras_action_log.raw_payload  ──┐
+        (inbound pushes, at push time) │   normalized          classify vs
+                                       ├── RosterRecord ──►  users table ──► worklist rows
+Feed B  GET /v1/reports/requests       │   (feed-neutral)    absent/inactive   │
+        (enumeration, ahead of push)  ──┘                                      ▼
+                                                              card (Feed A now; Feed B
+        GET /v1/people/:username ── enrichment + isReconciled closure          via task detail,
+                                    (Feed A only; Feed B carries it inline)    table later)
 ```
 
-— project-scoped and NOT NULL. The account worklist is **username-keyed**, and
-for a New request *the project does not exist yet*. That is the entire case.
-So reuse the **pattern**, not the table.
+The feed-agnostic seam — a `RosterRecord` dataclass that both feeds construct
+— is the one decision that keeps every downstream piece (classifier,
+enrichment, card, CLI, eventual notes table) single-sourced.
 
-Proposed `xras_account_event`, mirroring the existing table deliberately:
-append-only (a new row, never an edit of an existing one); `username`
-`varchar(35)` (`users.username` width) in place of `project_id`; `event_type`
-from a small tuple; `comment`; `created_by` `varchar(35)` ("the human who
-clicked"); `xras_action_log_id` as **provenance only**. Derive current state by
-timestamp comparison against the latest action naming that username — exactly as
-the activation card does. That gets re-open-on-new-information and anti-spam for
-free, and avoids a `done` boolean that would be wrong the moment the same person
-appears on a second request.
+### 7.1 The client — `src/sam/integration/xras_api/`
 
-⚠️ **Adding a table is no longer a DBA round-trip.**
-`docs/plans/implemented/DBA_PRIVILEGE_REQUEST.md` records
-`GRANT CREATE, ALTER, INDEX, REFERENCES ON sam.* TO 'hpc-writer'@'%'` granted
-**2026-08-10**, with the applied sequence and verification queries in
-`docs/xras/incoming/XRAS_CUTOVER_RUNBOOK.md` § 2 as precedent. There is
-deliberately **no `DROP`** — so get the DDL right the first time. SAM has no
-migrations (Alembic covers only `system_status`): the table is created by hand
-and the ORM model written to match.
+Follow `src/sam/integration/awards/` (the repo's outbound-client template —
+same transport semantics, cache idiom, and test patterns), minus its
+multi-provider registry (there is exactly one XRAS API; a registry would be
+ceremony). Modules: `base.py` (exceptions), `config.py`, `client.py`,
+`people.py` (cached wrappers), `cache.py`.
 
-**Faster option:** ship the card **read-only** first — the worklist derives with
-*zero* schema change — and land the notes table as an immediate follow-up. That
-takes DDL off the critical path without changing any query or classifier work.
+```python
+class XrasApiClient:
+    def __init__(self, *, api_key, base_url, allocations_process,
+                 api_user='arcguest', timeout=10, max_retries=3): ...
+    @classmethod
+    def from_env(cls, env=None): ...      # raises XrasApiNotConfigured
 
-### 7.8 The dashboard
+    def get_person(self, username) -> Optional[dict]
+    def get_resources(self) -> Optional[list]
+    def get_request_by_number(self, request_number) -> Optional[list]
+    def iter_requests(self, *, status='Approved', page_size=50,
+                      max_pages=None) -> Iterator[dict]
+    def search_people(self, q) -> Optional[list]
+```
 
-A card beside the existing XRAS surfaces in
-`src/webapp/dashboards/allocations/blueprint.py` (which already serves `/xras`,
-`/xras_fragment`, `/xras_pending_fragment`), with templates under
-`src/webapp/templates/dashboards/allocations/`.
+- **Transport semantics copied from `AwardHttpClient` verbatim**: one
+  persistent `requests.Session`; explicit `timeout=` (10 s — this can run
+  inside an htmx round-trip); 404 → `None`; other 4xx → raise immediately (a
+  client error is deterministic, never retried); 5xx → warn + `2**attempt`
+  backoff; non-JSON or exhausted retries → `XrasSourceUnavailable`. The
+  three-outcome model (**found / not-found / unreachable**) is preserved all
+  the way to CLI exit codes, as `AwardSourceUnavailable` does.
+- `XrasApiNotConfigured(XrasSourceUnavailable)` — an unconfigured client
+  degrades identically to an unreachable one at every call site.
+- **GET-only, structural** (§ 4.7): `_get` is the only transport primitive.
+- Headers: `XA-API-KEY` / `XA-ALLOCATIONS-PROCESS` / `XA-CONTEXT: report`
+  (hardcoded, § 2.2) / `XA-USER` (static, from config). Every call logged at
+  INFO. The `{message, result}` envelope unwrapped centrally.
+- **Config** via `os.getenv`, read per call, never at import: `XRAS_API_KEY`,
+  `XRAS_API_BASE`, `XRAS_ALLOCATIONS_PROCESS`, `XRAS_API_USER`, and the master
+  lever **`XRAS_OUTGOING_ENABLED` (default off, fail-closed)** in the style of
+  `XRAS_ACTIONS_CAPTURE_ONLY`. Two layers: `xras_api_configured()` is the
+  cheap predicate callers branch on; `from_env()` raising is the backstop.
+- **`cache.py`** — `BucketedTTLCache('xras_api', 'xras_api', ...)` with
+  buckets `xras_people` (TTL 4 h — `isReconciled` is a closure signal and must
+  not go stale) and `xras_resources` (TTL 1 d — a 13-row catalog). Registered
+  by adding the module to `_BUCKETED_CACHE_MODULES`
+  (`src/webapp/caching/__init__.py:48-53`) — that one line buys
+  `sam-admin cache --refresh --category`, the Admin card row, `stats()` and
+  `clear()`. Plus the hand-maintained `click.Choice` at
+  `src/cli/cmds/admin.py:590-591`. Cache successes *and* definite negatives;
+  never cache an `XrasSourceUnavailable` (the raise propagates before the
+  store). Bucket names are global Redis prefixes — keep the `xras_` prefix.
+- No Click / Flask / rich / kubernetes imports anywhere under `src/sam/` or
+  `src/scheduling/` (AST-gated by existing tests).
 
-Columns: username · why (the five classes of § 7.3) · person detail from
-`/v1/people` · which request / projcode and action needs them · XRAS
-`isReconciled` · notes.
+### 7.2 The worklist query — `src/sam/queries/xras_accounts.py`
 
-Follow the house rules in `CLAUDE.md`: **§9** for the form schema
-(`sam.schemas.forms`) and the smallest handler tier that fits, **§8** for the
-access decorator on any project-scoped route, **§10** for any active-only
-toggle (`read_active_only`), and `sam.fmt` filters for all formatting.
+**Not exported from `sam/queries/__init__.py`** (that file imports its
+submodules eagerly; the unexported precedent is `expiration_notices` /
+`xras_notices`).
 
-### 7.9 Two cheap wins worth folding in
+```python
+WORKLIST_STATUSES = ('received', 'failed', 'manual')
+PLACEHOLDER_USERNAME_RE = re.compile(r'^\S+-user-\S+$')
 
-**(a) Make `--validate-mapping` two-sided.** `audit_resource_mapping`
-(`src/sam/queries/xras_actions.py:652`, body at :678-713) reads two local tables and nothing
-else; its own docstring concedes it has no list of the keys XRAS will actually
-send. So the failure that genuinely breaks an award — XRAS sends a
-`resourceRepositoryKey` SAM has no row for — is **invisible** to the command and
-surfaces only at runtime as `No resource found in SAM corresponding to key %s`
-(`src/sam/xras/errors.py:201`, raised from `src/sam/xras/handlers/_fields.py:148`).
-`GET /v1/resources` **is** that missing list. One global GET closes the gap.
+@dataclass(frozen=True)
+class ActionRef:            # provenance — feed-neutral
+    action_log_id: Optional[int]      # None for a Feed-B record
+    request_number, action_type, status, received_time
+    would_succeed: Optional[bool]     # validate_only verdict; None = not run
+    reject_messages: Tuple[str, ...]  # verbatim, display-only — NEVER parsed
 
-**(b) `opportunityId` → allocation type.** SAM derives allocation type with a
-~676-line, 11-strategy chain (`src/sam/xras/extractors.py`). Exactly one arm is
-a keyed lookup; the rest are string matching on operator-authored free text
-(a regex on `requestTitle` for `CSL`, case-sensitive `contains` of
-`'no NSF award'` / `'unsponsored'`, literal `startswith` prefixes). Only 5 of
-the 11 strategies are exercised by all 41 production payloads.
+@dataclass(frozen=True)
+class RosterRecord:         # one action's roster, already normalized
+    ref: ActionRef
+    usernames: Tuple[str, ...]
+    roles_by_username: Mapping[str, Tuple[str, ...]]   # 'PI'/'Allocation Manager'/'User'
+    account_flag: Mapping[str, bool]                   # isAccountToBeCreated — hint only
+    person_by_username: Mapping[str, dict]             # inline person detail (Feed B)
 
-Meanwhile **`opportunityId` is already on the inbound wire in 41/41 fixtures**
-(declared at `src/sam/schemas/forms/xras.py:381`) and
-`grep -rn opportunityId src tests --include=*.py` returns **one** hit — that
-declaration. Nothing reads it.
+def records_from_action_log(session, *, statuses=WORKLIST_STATUSES,
+                            since=None, until=None) -> List[RosterRecord]   # Feed A
+def records_from_report_requests(payloads) -> List[RosterRecord]            # Feed B
+def classify_accounts(session, records) -> List[dict]                       # the core
+def get_account_worklist(session, *, statuses=..., since=None, until=None)  # A ∘ classify
+def enrich_worklist(rows, *, person_lookup=None, max_lookups=25) -> dict
+```
 
-The outgoing API closes the loop because `/v1/opportunities/:id` and
-`/list/:ids` **resolve historic and `Terminating` opportunities**, not just
-currently-open ones — verified for every opportunityId in the fixture corpus.
-That defeats the objection that would otherwise sink a static table: the `Large`
-window mints a **new opportunityId every semester**, so a hardcoded map rots
-twice a year, but an unknown id can simply be fetched and cached.
+- **Feed A** parses `raw_payload` with `json.loads` +
+  `XrasActionSchema().load()` (`sam.schemas.forms` — the same path the webapp's
+  `_parse_action` takes, with no webapp import), then extracts the roster with
+  the structured helpers in `src/sam/xras/roster.py` (`roster_usernames`,
+  `role_candidates`, `normalize_username`) — **never by parsing the
+  byte-pinned error strings in `errors.py`**, which are a wire contract, not
+  an interface. For actions in `WORKLIST_STATUSES` it additionally runs
+  `dispatch_action(session, action, validate_only=True)`
+  (`src/sam/xras/dispatch.py`; the validate path structurally cannot write —
+  `management_transaction` only opens in `handlers/base.py` after the seam),
+  catching `XrasActionRejected` to fill `would_succeed` / `reject_messages`.
+  The verdict is *provenance*, not the classifier — it also catches non-account
+  failures (mnemonic, resource key), which the card shows as "action would
+  fail for other reasons".
+- **Feed B** maps the outgoing wire shape — `roles[].person.username` +
+  `roles[].roles[].role` — and carries the inline person dict, so Feed-B rows
+  never need a `/v1/people` call.
+- **Classification is a current-state check** against `users`: no row →
+  `absent` (remedy: create); row failing `User.is_active` → `inactive`
+  (remedy: reactivate); active rows are dropped. It never keys off the
+  action's `status` — regime-proof across the capture-only → live-dispatch
+  transition (§ 1). The placeholder flag comes from the username shape.
+- **Row shape** (username-keyed, grouped across all actions naming the
+  username): `username, classification, placeholder, roles (PI→AM→User
+  union), is_account_to_be_created (hint only), actions (newest first),
+  latest_action_log_id, first_seen, last_seen`, and — post-enrichment —
+  `person` (PII subset) + `is_reconciled`. `latest_action_log_id` is
+  deliberately the future notes-table FK target (§ 7.6).
+- **Enrichment is separate and injected** (`person_lookup` defaults to the
+  cached `xras_api.people.get_person`): the query layer stays fully
+  offline-capable; one `XrasSourceUnavailable` marks the batch
+  `unavailable=True` and leaves `person=None` rather than raising, so the card
+  degrades to counts/usernames instead of 500ing. `max_lookups` bounds a
+  cold-cache render.
 
-Design constraints for this one:
+### 7.3 The dashboard card — read-only this PR
 
-- **Key the map on `opportunityId`, not on the wire `allocationType` string.**
-  XRAS's vocabulary (`Small`, `Large`, `Educational`, `Exploratory`,
-  `Data Analysis`, `NCAR External Projects`) is a *different* vocabulary from
-  SAM's `allocation_type` table, and it does not disambiguate — two different
-  opportunities both report `Small`, while `Exploratory` must land on SAM's
-  `Small (No NSF award)`.
-- **Keep the existing two-column `(panel, allocation_type)` join**
-  (`extractors.py:346-350`): `allocation_type.allocation_type` is not unique
-  (`Small` exists under two panels, `Education` under two more).
-- **Leave the 11-strategy ladder as the fallback** for an unresolvable id.
+A fragment beside the existing XRAS surfaces in
+`src/webapp/dashboards/allocations/blueprint.py` (which already serves
+`/xras`, `/xras_fragment`, `/xras_pending_fragment`), template under
+`templates/dashboards/allocations/partials/`.
+
+- One route `/xras_accounts_fragment`: `@login_required` +
+  `@require_permission(Permission.VIEW_XRAS)`, embedded in `xras.html` with a
+  lazy `hx-get`.
+- **PII is gated route-level**, following `xras_pending_fragment`
+  (`blueprint.py:1539-1551`) and the Notifications precedent (counts at one
+  level, rows naming people higher): person columns (name, email,
+  organization, academicStatus, residenceCountry) are assembled **only** when
+  the viewer holds `MANAGE_XRAS`; a `VIEW_XRAS` response carries username,
+  classification, placeholder badge, roles, naming actions, the
+  `is_reconciled` boolean, and counts — never the person dict.
+- **The unconfigured state is first-class** (it is what staging shows): the
+  Feed-A worklist renders fully without the API; a muted note marks person
+  detail and reconciliation as unavailable. The **empty state is designed,
+  not broken** — production is 0 rows until ACCESS repoints.
+- Columns: username · why (absent/inactive + placeholder badge) · roles ·
+  which request/projcode and action needs them · `isReconciled` · person
+  detail (permission-gated). Classification facet chips with self-exclusion
+  (the house pattern). `sam.fmt` filters for all formatting. Route-map parity
+  snapshot regenerated in the same commit as the route.
+- No dead UI: notes and dismissal ship with the table (§ 7.6), not before.
+
+### 7.4 The `xras_sweep` scheduled task — enumerate-and-diff, shipped disabled
+
+`src/scheduling/tasks/xras_sweep.py`, `Daily(hour=3, minute=30,
+tz='America/Denver')`, `needs=('sam',)`, `expected_runtime=timedelta(minutes=20)`
+(lease `3 × 20 min = 3600 s` > the CronJob's `activeDeadlineSeconds: 3000` —
+the drift test pattern from `test_task_xras_notices.py` applies). Template:
+`src/scheduling/tasks/xras_notices.py` — deferred `sam.*` imports, pure env
+readers, `to_local_naive(ctx.occurrence, ...)`.
+
+Per run (persists nothing but `TaskResult.detail` — there is no table yet):
+
+1. `xras_api_configured()` false → a visible **skip** detail, not a raise
+   (the ledger row is the record; this is the shipped state).
+2. **Enumerate**: `iter_requests(status='Approved', page_size=200,
+   max_pages=...)` — page cap from `SAM_TASKS_XRAS_SWEEP_MAX_PAGES` (default
+   25 → 5,000 requests; junk/zero refused, per the `xras_email_max` idiom),
+   with a client-side recency filter on action dates to bound work.
+3. **Dropped/pending-push detection**: diff `requestNumber` against
+   `project.projcode` → `pending_push` count + capped list in detail.
+4. **Classify**: `records_from_report_requests` → `classify_accounts` →
+   absent/inactive/placeholder counts + capped username lists in detail.
+5. **Warm the closure signal**: fresh `/v1/people` fetch for each current
+   Feed-A worklist username → `closures` count (and a warm cache for the
+   card's morning renders).
+
+`detail` always carries: pages, requests_seen, pending_push, worklist counts,
+placeholders, people_refreshed, closures, budget_exhausted,
+unavailable_errors — "0 findings, succeeded" must be distinguishable from "did
+not look".
+
+**What was deliberately dropped from an earlier draft of this design**: the
+per-identity `/v1/requests` polling sweep (measured at 0.84 s × 1,518 seed
+identities nightly) and its transitive roster crawl. The reports enumeration
+(§ 3.2) reaches strictly more people — including wholly-new solo PIs the crawl
+could never connect to — in a handful of paginated calls. Do not resurrect the
+crawl.
+
+⚠️ **Ship-disabled mechanics** (fail-open trap): the task's name goes into
+`SAM_TASKS_DISABLED` in `helm/values.yaml` **in the same commit** that
+registers it, plus the values.yaml-grep test (`test_it_ships_switched_off`
+pattern), the `docs/README-k8s.md` mentions (3 places), and the module added
+to `tests/unit/test_task_ledger.py`'s subprocess import matrix.
+
+### 7.5 CLI — `sam-admin xras` grows three things
+
+Extending the existing mode-dispatch in `src/cli/xras/commands.py`
+(builders/display split per the awards pattern; exit codes 0/1/2/130):
+
+- `--accounts [--enrich]` — the worklist as a table / JSON envelope
+  (`kind: xras_accounts`). `--enrich` requires configuration (else exit 2).
+  An empty worklist exits 0 — a successful report, not a miss.
+- `--person USERNAME` — direct `/v1/people` probe: found → 0, 404 → 1,
+  unavailable/unconfigured → 2 (`kind: xras_person`).
+- `--validate-mapping` becomes two-sided automatically (§ 8.1).
+
+### 7.6 Schema — none now, one table next
+
+**The worklist itself needs no storage.** It derives from
+`xras_action_log.raw_payload`, `users`, the pre-flight verdict, and
+`/v1/people` (cached). This follows `XrasActivationEvent`'s own rule: *state
+is DERIVED, never stored*.
+
+**Operator notes and dismissals do need storage, and `XrasActivationEvent`
+cannot carry them** — its `project_id` is NOT NULL and project-scoped, while
+the account worklist is **username-keyed** and for a New request *the project
+does not exist yet*. The follow-up PR adds `xras_account_event`, mirroring the
+existing table deliberately: append-only; `username varchar(35)` in place of
+`project_id`; `event_type` from a small tuple; `comment`; `created_by
+varchar(35)`; `xras_action_log_id` as provenance only. Derive current state by
+timestamp comparison against the latest action naming that username — **copy
+the current action-keyed supersedes idiom in
+`src/sam/queries/xras_activation.py` (`_activation_state`, the `supersedes`
+comparison), not the older project-keyed rule quoted in the
+`XrasActivationEvent` docstring** (the card was re-keyed since that was
+written).
+
+DDL context: `docs/plans/implemented/DBA_PRIVILEGE_REQUEST.md` records the
+2026-08-10 `CREATE/ALTER/INDEX/REFERENCES` grant; the applied-DDL precedent is
+`docs/xras/incoming/XRAS_CUTOVER_RUNBOOK.md` § 2. There is deliberately no
+`DROP` — get the DDL right the first time. SAM has no migrations (Alembic
+covers only `system_status`): table by hand, ORM to match.
 
 ---
 
-## 8. Phase 2 — if a broader credential is granted
+## 8. The cheap win riding along (and the one deferred)
 
-**Frame the ask as a capability, not a flag.** The obvious request — "provision
-our key for `XA-CONTEXT: admin`" — is probably *insufficient on its own*,
-because genuine XRAS administrators get no extra breadth through this API
-(§ 4.5). The admin web app's queue view comes from somewhere else.
+### 8.1 Two-sided `--validate-mapping` — in this PR
 
-Better: **"a credential that lets SAM enumerate NCAR's Approved requests — the
-same set the Recent Submissions queue shows."** Let XRAS choose the mechanism
-(an admin-context key, a reporting role, a service identity, or a webhook).
+`audit_resource_mapping` (`src/sam/queries/xras_actions.py:652`, body
+:678-713) reads two local tables and nothing else; its own docstring concedes
+it has no list of the keys XRAS will actually send. So the failure that
+genuinely breaks an award — XRAS sends a `resourceRepositoryKey` SAM has no
+row for — is invisible to the command and surfaces only at runtime as
+`No resource found in SAM corresponding to key %s` (`errors.py:201`, raised
+from `handlers/_fields.py:148`). `GET /v1/resources` is that missing list.
 
-What it would add, in value order:
+Design: `audit_resource_mapping(session, *, xras_keys=None)` — an optional
+injected iterable, so the function keeps zero network knowledge; new report
+keys `xras_only_keys` and `live_checked`. The CLI auto-detects: it fetches the
+live list iff `xras_api_configured()`, and degrades to the one-sided report
+(byte-compatible with today) when unconfigured or unavailable. Exit 1 when
+`dangling_keys` **or** `xras_only_keys` is non-empty. Self-verifying: must
+report 13/13 against today's catalog (§ 6).
 
-1. **Mirror the whole Approved queue.** The worklist stops depending on the push
-   *or* on SAM already knowing the person — closing the third population
-   (brand-new placeholder identities) **ahead of** the push rather than at it.
-2. **Dropped-push detection.** Today a push that never arrives is invisible
-   until somebody notices a missing project. With enumeration, XRAS's Approved
-   set diffs against `projcode` wholesale (§ 6).
-3. **An unreconciled-people report** — the admin app has one; there is no API
-   equivalent.
-4. **Review / panel state** — `states[]` exposes "Conflicts Verified" and
-   "Reviewers Assigned" per action, but the review queue itself is admin-only.
+### 8.2 `opportunityId` → allocation type — DEFERRED
 
-**Phase 1 is not throwaway.** Phase 2 changes only the **feed**. The classifier,
-the five error classes, the person enrichment, the closure signal, the notes
-table and the card are all unchanged. **Design the worklist query to accept a
-set of `(action, roster)` records from either source** — that one decision is
-what makes Phase 2 additive.
+Assess **after the first triage week under live dispatch**. The case is
+recorded so it isn't lost: SAM derives allocation type with an 11-strategy
+free-text ladder (`src/sam/xras/extractors.py`) of which only 5 strategies are
+exercised by all 41 production payloads; `opportunityId` is on the inbound
+wire in 41/41 fixtures and read by nothing; `/v1/opportunities/:id` resolves
+historic and Terminating opportunities, so an unknown id can be fetched and
+cached rather than hardcoded. Constraints when built: key on `opportunityId`
+(never the wire `allocationType` string — different vocabulary from SAM's, and
+non-unique); keep the two-column `(panel, allocation_type)` join; keep the
+ladder as fallback. Note the strategy chain is pure/sessionless by design — an
+id lookup needing cache or DB belongs in `resolve_allocation_type` or a
+session-taking pre-step, not inside a strategy.
 
 ---
 
-## 9. Verification
+## 9. What no longer needs asking
 
-- **Unit tests with recorded fixtures; no live calls in CI.** Mirror
-  `tests/unit/test_award_*` and the `AwardSourceUnavailable` three-outcome model.
-- **Pre-flight correctness**: the worklist must reproduce the five `errors.py`
-  strings against `tests/fixtures/xras/actions/`, with the
-  `placeholder34-user-00034` entry classified *absent* and a known-inactive
-  username classified *inactive*.
-- **Predicate regression**: a case where `isAccountToBeCreated` is true but the
-  SAM user exists and is active must **not** appear on the worklist. This is the
-  live counterexample of § 5 and the whole reason that flag is not the predicate.
-- **§ 7.9(a) self-verifies**: it must report 13/13 against today's catalog.
-- **Live opt-in probe script** under `scripts/xras/`, gated on `XRAS_API_KEY`
-  being set, that **skips** rather than fails when absent — mirroring
-  `utils/parity/`'s `_resolve_xras_credentials()` behaviour.
-- **Route-map parity**: regen with `ROUTE_MAP_REGEN=1` and commit the snapshot
-  diff in the same change as the new dashboard routes.
-- **Helm**: assert the new task's name appears in `SAM_TASKS_DISABLED`
-  **per-manifest** (`-s templates/cronjob-tasks.yaml`) — a whole-render grep
+An earlier draft of this document had a "Phase 2" that asked XRAS for an
+enumeration credential. **That ask is moot** — `XA-CONTEXT: report` on the
+existing key already enumerates the process (§ 3.2). Of the four things Phase
+2 was for: mirroring the Approved queue ✅ (`reports/requests`), dropped-push
+detection ✅ (§ 7.4), an unreconciled-people view ✅ (inline in every roster,
+plus `search/people`), review/panel state — `states[]` is visible per action;
+the review queue itself remains admin-only and remains not-needed.
+
+The only remaining external conversations with XRAS are operational, § 13.
+
+---
+
+## 10. Verification
+
+- **Unit tests with canned fixtures; no live calls in CI.** Mirror
+  `tests/unit/test_award_providers.py`: payloads as module dict constants with
+  invented identities, transport tests via a mocked `session.request` +
+  no-op sleep, the three-outcome model, an "outage is never memoised" case,
+  and the cache-reset autouse fixture (`reset_for_tests()` +
+  `delenv CACHE_REDIS_URL`).
+- **Pre-flight correctness**: the worklist reproduces the expected
+  classifications against `tests/fixtures/xras/actions/` — the
+  `placeholder34-user-00034` entry classified **absent** (and
+  placeholder-flagged), a factory-made inactive user classified **inactive**.
+- **Predicate regression**: `isAccountToBeCreated: true` on an existing,
+  active SAM user must **not** appear on the worklist (the § 5 trap).
+- **Feed-agnostic proof**: a canned `reports/requests` payload through
+  `records_from_report_requests` reaches the same classifier and classifies
+  identically.
+- **Two-sided mapping audit** self-verifies 13/13 with injected keys; a
+  synthetic extra key is reported and flips the exit code.
+- **Task tests**: the `values.yaml` ships-switched-off grep, the
+  lease-vs-`activeDeadlineSeconds` drift test, registration, page-cap reader
+  matrix, skip-when-unconfigured, enumerate+diff+classify with a stub client.
+- **Route-map parity**: `ROUTE_MAP_REGEN=1`, snapshot committed in the same
+  commit as the new route.
+- **Helm**: per-manifest assertions (`-s templates/cronjob-tasks.yaml`) for
+  the new `tasks.env` keys and the secret injection — a whole-render grep
   passes on the Deployment's copy and proves nothing.
+- **Live opt-in probe script** `scripts/xras/probe_outgoing.py`, gated on
+  `XRAS_API_KEY` — **skips** (exit 0 + message) when absent, mirroring
+  `utils/parity/`'s `_resolve_xras_credentials()` behavior.
 - **End-to-end**: `docker compose up webdev --watch`, seed via
   `scripts/xras/seed_dev_actions.py`, confirm the card lists a seeded
-  placeholder identity and that adding a note writes an event row.
+  placeholder identity as *absent*, and that the person columns appear only
+  for a `MANAGE_XRAS` viewer.
 
 ### The Tier-III test bed — `~/xras_payloads_raw/`
 
 **Only unscrubbed payloads can validate the core predicate, and this is
 structural.** The anonymizer rewrites every username to `user_<hex>` (or
-`placeholder<NN>-user-<NNNNN>`), so for the in-tree fixtures "no `users` row" is
-trivially true for **all** of them and proves nothing. Distinguishing a
+`placeholder<NN>-user-<NNNNN>`), so for the in-tree fixtures "no `users` row"
+is trivially true for **all** of them and proves nothing. Distinguishing a
 genuinely-unknown user from an artifact of scrubbing requires real usernames
 posted against the cloned development database.
 
-That corpus already exists outside the tree, deliberately uncommitted:
-**41 payloads** (8 top-level plus 33 under `incoming_2026-08-11/`), spanning
-`New` ×13, `Extension` ×7, `Supplement` ×7, `Date Adjustment` ×4,
-`Adjustment` ×2 — and it carries the cases that matter: **6 role entries with
-`isAccountToBeCreated=true` and ~4 distinct ARC placeholder identities**.
-Locally, `xras_action_log` and `xras_activation_event` both exist at 0 rows, so
-the path is ready.
+That corpus exists outside the tree, deliberately uncommitted: **41 payloads**
+(8 top-level plus 33 under `incoming_2026-08-11/`), spanning `New` ×13,
+`Extension` ×7, `Supplement` ×7, `Date Adjustment` ×4, `Adjustment` ×2 — with
+6 role entries carrying `isAccountToBeCreated=true` and ~4 distinct ARC
+placeholder identities.
 
 Procedure: POST a payload naming an unknown user to the local
 `/api/xras/v1/actions` (`scripts/xras/seed_dev_actions.py` does the posting,
-reading `SAM_XRAS_USER` / `SAM_XRAS_PASS`), then confirm the pre-flight
-classifies that username **absent** rather than **inactive**, that `/v1/people`
-enriches it, and that an operator note writes an event row.
+reading `SAM_XRAS_USER` / `SAM_XRAS_PASS`), then confirm the worklist
+classifies that username **absent** rather than **inactive**, and that
+`/v1/people` enriches it.
 
-⚠️ **These payloads are unscrubbed and name real people.** They stay outside the
-tree. Nothing derived from them — usernames, emails, or counts tied to
-identities — may enter a commit, a test fixture, or a docstring. Any regression
-test that must *persist* is built from the scrubbed corpus; the raw run is a
-one-time manual verification recorded only as pass/fail.
+⚠️ **These payloads are unscrubbed and name real people.** They stay outside
+the tree. Nothing derived from them — usernames, emails, or counts tied to
+identities — may enter a commit, a test fixture, or a docstring. Any
+regression test that must *persist* is built from the scrubbed corpus; the raw
+run is a one-time manual verification recorded only as pass/fail.
 
 ---
 
-## 10. Safety and secrets
+## 11. Safety and secrets
 
-- **Read-only, GET-only**, enforced in the client (§ 7.6), not by convention.
-- **`XA-USER` impersonation is how per-user reads work.** Every polled username
-  must originate in SAM or in a received payload, must be logged, and the whole
-  feature sits behind a fail-closed flag in the style of the existing
-  `XRAS_ACTIONS_CAPTURE_ONLY` / `XRAS_ACTIONS_ENABLED` levers.
-- **The API key must not enter this repo.** It currently sits in cleartext in a
-  shell script in the operator's home directory. Move it to the `SAM_keys`
-  credential store and a k8s secret. Note it is a *submit*-context key — the same
-  credential that can `POST /v1/resources/update`, which is precisely why the
-  client's GET-only allowlist matters.
-- **Do not confuse it with `SAM_XRAS_USER` / `SAM_XRAS_PASS`**, which are
-  credentials for calling *SAM* (`.env.example:107-108`) and are a production
-  **write** credential in the inbound direction.
+- **Read-only, GET-only**, enforced structurally in the client (§ 4.7, § 7.1)
+  — not by convention. The same key can create requests, merge people, and
+  modify roles.
+- **Step 0 — the key moves into OpenBao before anything deploys.** Follow the
+  `jupyterhubCredentials` token pattern exactly: store at `csg/xras-api-key`,
+  property `token`, readable by the `csg-ro` SecretStore; chart side is a
+  `webapp.xrasApiCredentials` block (same fields as `jupyterhubCredentials`,
+  `helm/values.yaml:378-383`) rendering an ExternalSecret and injecting
+  `XRAS_API_KEY` via `secretKeyRef` into **both** `deployment.yaml` and
+  `cronjob-tasks.yaml` (they share no env anchor — this is the same
+  cross-referencing trap `NOTIFY_*` hit). After cutover, retire the cleartext
+  copies in the operator's home directory and on `crlogin`; a key **rotation**
+  request to XRAS is worth raising, since the key has lived in cleartext.
+- **The key never enters this repo** — not in `.env` files with values, not in
+  fixtures, not in test constants, not in probe output pasted into docs.
+- **Fail-closed lever**: `XRAS_OUTGOING_ENABLED` defaults off everywhere;
+  `helm/values.yaml` pins it `"0"` visibly in both env maps. With the lever
+  off, the card renders its unconfigured state, the sweep records a skip, and
+  the CLI degrades — nothing raises for lack of a key.
+- **Do not confuse `XRAS_API_KEY` with `SAM_XRAS_USER` / `SAM_XRAS_PASS`** —
+  the latter are credentials for calling *SAM* (`.env.example:107-108`), a
+  production **write** credential in the inbound direction.
 - **The worklist names real people, emails, organizations and
-  `residenceCountry`.** Gate the card on an existing permission — follow the
-  Notifications pattern, where counts are visible at one level and rows naming
-  real addresses require `SYSTEM_ADMIN`.
+  `residenceCountry`.** PII is gated route-level on `MANAGE_XRAS` (§ 7.3);
+  a `VIEW_XRAS` response never carries it.
 - **The local dev database may hold unobfuscated production data.** Nothing
   derived from a local query goes into a commit.
 
 ---
 
-## 11. Open questions for the implementation session
+## 12. Implementation plan — one PR vs `staging`
 
-1. **Will XRAS grant an enumeration credential?** (§ 8.) Ask early — it does not
-   block Phase 1 but it determines how much of Phase 2 is worth designing now.
-2. **Are the two flagship compute resources really production-ended?** The API
-   reports a `productionEndDate` months in the past for both (§ 6). Confirm with
-   XRAS whether that is stale data or a telegraphed retirement.
-3. **What seed tier and crawl depth?** § 7.4 gives measured costs; the right
-   default is probably nightly over leads+admins with a shallow crawl, but that
-   should be tuned once real hit rates are known post-cutover.
-4. **Does the co-PI role type ever appear?** Still zero across all fixtures and
-   all live sampling. The outgoing API is the one place that could settle the
-   spelling definitively, since it carries a numeric `roleTypeId`.
-5. **Read-only card first, or wait for the notes table?** (§ 7.7.)
+**Step 0 (operator, pre-deploy prerequisite):** key into OpenBao per § 11.
+The PR does not block on it, but the chart's `xrasApiCredentials.enabled: true`
+must not reach the cirrus deploy before the secret exists.
+
+Commit series, each self-testing:
+
+| # | Commit | Contents |
+|---|---|---|
+| 1 | `sam/integration/xras_api: GET-only client for the XRAS Allocations API` | § 7.1 package + tests + `probe_outgoing.py`; `_BUCKETED_CACHE_MODULES` + cache-category `click.Choice` registrations |
+| 2 | `sam/queries/xras_accounts: derive the account-creation worklist` | § 7.2 query module + both feed builders + classifier + enrichment, tests incl. the predicate regression |
+| 3 | `allocations dashboard: account-creation worklist card (read-only)` | § 7.3 route + template + PII gating tests + route-map snapshot regen |
+| 4 | `sam-admin xras: accounts worklist, person lookup, two-sided --validate-mapping` | § 7.5 CLI modes + § 8.1 audit change + tests |
+| 5 | `scheduling: xras_sweep enumerate-and-diff nightly (ships disabled)` | § 7.4 task + registration + `SAM_TASKS_DISABLED` + README-k8s + tests (same commit — fail-open trap) |
+| 6 | `env/helm: XRAS outgoing API configuration, fail-closed, key via ExternalSecret` | `.env.example` block (JUPYTERHUB_* style); values.yaml env in both maps; `xrasApiCredentials` + ExternalSecret + secretKeyRef in both manifests; per-manifest render assertions |
+| 7 | `docs: file XRAS outgoing under docs/xras/outgoing/` | `git mv` this document to `docs/xras/outgoing/`, status → implemented-as-built; co-PI annotation comments (`sam/schemas/forms/xras.py`, `sam/xras/roster.py`, `XRAS_REIMPLEMENTATION.md` open-risks); `docs/xras/README.md` index; deferred register (notes table, § 8.2, sweep enablement, key rotation) |
+
+PR notes: `--base staging`; the card renders legitimately **empty in
+production until ACCESS repoints** — say so in the description; no skip-ci
+tokens anywhere in title/body/commits.
+
+Verification commands (the operator runs pytest):
+
+```
+pytest tests/unit/test_xras_api_client.py tests/unit/test_xras_accounts_query.py \
+       tests/unit/test_xras_accounts_card.py tests/unit/test_task_xras_sweep.py
+pytest tests/unit/test_task_ledger.py tests/unit/test_admin_tasks_cli.py
+ROUTE_MAP_REGEN=1 pytest tests/unit/test_route_map_parity.py
+pytest tests/unit
+bash helm/tests/test-cronjob-render.sh
+helm template samuel helm -f helm/values.yaml -s templates/cronjob-tasks.yaml | grep XRAS
+helm template samuel helm -f helm/values.yaml -s templates/deployment.yaml   | grep XRAS
+helm template samuel helm -f helm/values.yaml -s templates/external_secret.yaml
+XRAS_OUTGOING_ENABLED=1 XRAS_API_KEY=… python scripts/xras/probe_outgoing.py
+```
 
 ---
 
-## 12. Reference — related documents
+## 13. Open questions
+
+1. **Are the two flagship compute resources really production-ended?** The API
+   reports a `productionEndDate` months in the past for both (§ 6). Confirm
+   with XRAS whether that is stale data or a telegraphed retirement.
+2. **Key rotation** (§ 11) — worth requesting once OpenBao holds it.
+3. **Sweep tuning** — page cap and recency window are defaults to revisit with
+   real post-cutover volumes; the enumeration is cheap enough that this is a
+   dial, not a design question.
+4. **Does `search/people` match placeholder identities?** Untested,
+   nice-to-know only (§ 4.4).
+5. ~~Co-PI role type~~ — settled (§ 3.4). ~~Enumeration credential~~ — moot
+   (§ 9). ~~Read-only card vs notes table~~ — decided (§ 1.1).
+
+---
+
+## 14. Reference — related documents
 
 | Document | Why it matters here |
 |---|---|
-| `docs/xras/README.md` | Index; explains the `incoming/` vs `incoming/implemented/` lifecycle convention this document's eventual sibling would follow |
-| `docs/xras/incoming/XRAS_REIMPLEMENTATION.md` | The inbound wire contract, action semantics, the allocation-type extractor's design, and the open-risks list (incl. the co-PI question) |
-| `docs/xras/incoming/XRAS_CUTOVER_RUNBOOK.md` | § 2 has the applied DDL sequence and verification queries — the precedent for § 7.7 |
-| `docs/plans/implemented/DBA_PRIVILEGE_REQUEST.md` | Records the 2026-08-10 DDL grant that makes a new table cheap |
-| `docs/xras/incoming/implemented/XRAS_SPRINT_B.md` | The operator surface, activation worklist and `sam-admin xras` — the closest existing analogue to the proposed card |
-| `src/sam/integration/awards/` | The outbound-client template to copy: client + cache + registry + base, with a CLI wrapper |
-| `src/webapp/api/xras/actions.py` | The inbound handler; `_record`/`_finish` and the audit-row width guards |
-| `src/sam/xras/dispatch.py` | `select_service()` and the `validate_only` seam Phase 1 is built on |
+| `docs/xras/README.md` | Index; the `incoming/` lifecycle convention this document's `outgoing/` destination mirrors |
+| `docs/xras/incoming/XRAS_REIMPLEMENTATION.md` | The inbound wire contract, action semantics, the allocation-type extractor, and the open-risks list (co-PI now answerable) |
+| `docs/xras/incoming/XRAS_CUTOVER_RUNBOOK.md` | § 2 has the applied DDL sequence — the precedent for the follow-up table (§ 7.6) |
+| `docs/plans/implemented/DBA_PRIVILEGE_REQUEST.md` | The 2026-08-10 DDL grant that makes the follow-up table cheap |
+| `docs/xras/incoming/implemented/XRAS_SPRINT_B.md` | The operator surface and activation worklist — the closest existing analogue to the proposed card |
+| `src/sam/integration/awards/` | The outbound-client template: client + cache, transport semantics, test patterns |
+| `src/sam/xras/dispatch.py` | `select_service()` and the `validate_only` seam Feed A is built on |
+| `src/sam/xras/roster.py` | The structured roster helpers the classifier uses instead of parsing error strings |
+| `src/sam/queries/xras_activation.py` | The action-keyed derived-state idiom the follow-up notes table will copy |
+| `src/scheduling/tasks/xras_notices.py` | The shipped-disabled task recipe `xras_sweep` follows |

--- a/docs/plans/XRAS_OUTGOING_QUERIES.md
+++ b/docs/plans/XRAS_OUTGOING_QUERIES.md
@@ -1,0 +1,672 @@
+# XRAS "outgoing" queries — an account-creation worklist
+
+**Status:** research complete, design drafted, **not implemented**.
+**Branch:** `probing_xras`. **Probed:** 2026-08-19 against production
+`https://api.xras.org`, cross-checked against the XRAS-admin web app.
+
+This is a handoff document. It is written so an implementation session that has
+never seen the original conversation can start cold. It records what the XRAS
+API *can* and *cannot* do — including every dead end, with the command that
+closed it, so nobody spends a second session re-probing a path that is already
+known to fail.
+
+> **Direction of travel.** Everything in `docs/xras/incoming/` is XRAS → SAM
+> (they push actions, they pull our GETs). This document is the opposite
+> direction: **SAM calling out to XRAS**. There is no such code in the repo
+> today — `api.xras.org` is zero hits.
+
+---
+
+## 1. Why
+
+**Goal: a dashboard listing the user accounts that must be created (or
+reactivated) in SAM before an XRAS handoff can succeed** — who, why, with notes.
+Account creation is a manual process. This complements the XRAS action-log card
+rather than replacing it.
+
+This targets the largest known failure mode. `src/sam/xras/handlers/new.py:24-27`
+records the measured causes of the legacy 70% failure rate:
+
+> an unresolvable mnemonic (24%, a frozen `user_organization` table),
+> **unreconciled ARC placeholder identities (55%)**, and resource keys with no
+> mapping row.
+
+`scripts/xras/scrub_payload.py:32-34` independently states that
+`<name>-user-<token>` identities "are 55% of production failures". So the
+worklist addresses, by the repo's own measurements, the single biggest cause of
+XRAS handoff failure.
+
+**Timing context.** PR #457 lands the capture-only receive path; ACCESS is
+repointed at SAM shortly after, at which point `xras_action_log` begins filling
+(it is at 0 rows until then). Capture-only is an *advantage* here: it means
+every action can be pre-flighted **before** it is ever processed.
+
+---
+
+## 2. Which API — read this first
+
+Two different services are easy to confuse.
+
+| | |
+|---|---|
+| **XRAS Rules Service** — `xras-rules-service-demo.xsede.org/apidoc/` | A separate, mostly-POST engine (notifications, validate, required_documents, clone rules). Paths are `/api/v1/...`. **Our key does not open it.** Not useful here. |
+| **XRAS Allocations API** — `https://api.xras.org/v1/...` | ✅ **This is the one.** Live docs: `api.xras.org/api/overview`, `api.xras.org/api/request_headers`, `api.xras.org/api/data_models` (that last renders empty). `api.xras.org/apidoc` 404s. |
+
+The two share endpoint *names* (`opportunities`, `requests`), which is exactly
+why they get confused. Note the path prefix differs: `/api/v1/` for the rules
+service, `/v1/` for the allocations API. `api.xras.org/api/v1/...` 404s.
+
+### Authentication
+
+```
+XA-API-KEY:             <key>          # see § 10 — not in this repo
+XA-ALLOCATIONS-PROCESS: NCAR
+XA-CONTEXT:             submit | report        ✅ 200
+                        review | admin         ❌ 401 (key not provisioned)
+XA-USER:                <username>     # scopes every per-user response
+XA-PERMISSIONS:         <optional>     # accepted; changes nothing (see § 4)
+```
+
+Omitting `XA-CONTEXT` gives `400 {"message":"XA-CONTEXT header missing"}`.
+The documented context vocabulary is `submit`, `report`, `review`, `admin`;
+our key holds the first two. `submit` and `report` expose an **identical**
+surface — `report` unlocks nothing extra.
+
+Server is Rails behind Apache/Passenger. A Rails HTML 404 page means "no such
+route"; a JSON `{"message":..., "result":null}` means the route exists and the
+request was refused or found nothing. That distinction is useful when probing.
+
+---
+
+## 3. The readable surface — seven endpoints
+
+| Endpoint | Scope | Returns |
+|---|---|---|
+| `GET /v1/people/:username` | **global directory** | firstName, middleName, lastName, email, phone, organization, academicStatus, **residenceCountry**, **isReconciled**, orcid, hasOrcidToken |
+| `GET /v1/requests` | **`XA-USER`-scoped** | every request that user is PI / CoPI / Allocation Manager on, in full |
+| `GET /v1/requests/:requestId` | `XA-USER`-scoped | one request; **401** if the user has no role on it |
+| `GET /v1/opportunities` | global | currently-open opportunities, full detail |
+| `GET /v1/opportunities/:id` | global | one opportunity — **including historic/Terminating ones** |
+| `GET /v1/opportunities/list/:id,:id,...` | global | batch form of the above |
+| `GET /v1/resources` · `/v1/resources/:id` | global | 13 resources, **including `resourceRepositoryKey`** |
+| `GET /v1/panels` · `/v1/panels/:id` | global | 5 panels **with member rosters** |
+
+**Unknown username** gives a clean `404 {"message":"username=X not found"}`.
+
+### `/v1/requests` payload shape
+
+```
+rules:
+  allowedOperations[], allowedActions[]          ← what this PI may do NEXT
+  allowedActionsRes[{actionType, availableResourceIds[]}]
+  existingActions[{actionId, actionType, reviewsViewable}]
+requestId, requestType, requestStatus, requestNumber, opportunityId,
+opportunity_name, title, shortTitle, abstract, submitDate, isDeleted,
+isSupportedByGrants, grantTypeId, publicURL
+actions[]:
+  actionId, actionType, actionStatus, entryDate, userComments, adminComments,
+  collaborators, returnedForCorrections, finalReview, finalReviews[], states[],
+  resources[{resourceId, resourceName, resourceUnits, amount,
+             type: Requested | Recommended | Approved, comments}]
+  documents[{documentId, documentType, title, filename, size}]
+  allocationDates[{allocationDateId, allocationDateType, beginDate, endDate}]
+  opportunityAttributes[], resourceAttributes[]
+roles[]:
+  person{username, firstName, middleName, lastName, email, phone, organization,
+         academicStatus, residenceCountry, isReconciled, orcid, hasOrcidToken}
+  roles[{roleId, role, roleTypeId, beginDate, endDate, isAccountToBeCreated}]
+fos[{fosTypeId, fosNum, isPrimary}], grants[],
+conflicts[{conflictId, conflictType, conflictPerson}], publications[]
+```
+
+### Vocabularies observed in live NCAR data
+
+| Field | Values seen |
+|---|---|
+| `requestStatus` | Approved, Rejected, Incomplete |
+| `requestType` | New, Renewal |
+| `actionType` | New, Renewal, Supplement, Extension, Transfer, Adjustment, Date Adjustment |
+| `actionStatus` | Approved, Declined, Incomplete |
+| action `states[]` | "Conflicts Verified", "Reviewers Assigned" |
+| resource `type` | **Requested / Recommended / Approved** — the full award trail |
+| `allocationDateType` | Requested, Approved |
+| **`roleTypeId`** | **13 = PI, 14 = Allocation Manager, 19 = User** |
+
+⚠️ A request still being drafted has `requestNumber: null` and
+`requestStatus: "Incomplete"` — in-flight work is visible before it has a number.
+
+### Role types — and the CoPI question
+
+`docs/xras/incoming/XRAS_REIMPLEMENTATION.md` carries "co-PI roleType still
+unknown" as an open risk, and `src/sam/schemas/forms/xras.py:204-208` explains
+the field is not enum-validated because no co-PI has ever appeared in a sampled
+payload. Stress scenarios hedge across `Co-PI` / `CoPi` / `Co-Investigator`.
+
+Two findings:
+
+- **The outgoing API carries a numeric `roleTypeId` (13/14/19); the inbound wire
+  carries none at all** — only a `roleType` *string*, matched with a plain `!=`
+  at `src/sam/xras/roster.py:233`. `grep -rn roleTypeId src tests` returns
+  nothing.
+- **Still zero co-PIs** — none across 101 role entries in the 41 captured
+  fixtures, and none in any live request sampled. Consistent with NCAR's process
+  using PI / Allocation Manager / User only, which is exactly the roster SAM
+  models.
+
+Note the two vocabularies must not be conflated: inbound uses `PI` /
+`Allocation Manager` (spaced), while SAM's own outbound GET side uses `Pi` /
+`CoPi` / `AllocationManager` (`src/webapp/api/xras/requests.py:33-37`), where the
+`CoPi` branch is structurally always empty (`src/sam/queries/xras_access.py:260-276`).
+
+---
+
+## 4. Negative results — closed paths, do not re-probe
+
+Every row below was tested. The point of this section is to stop a future
+session rediscovering them.
+
+### 4.1 There is no enumeration
+
+No endpoint lists requests, people, or actions across the process. `/v1/requests`
+is always and only `XA-USER`-scoped.
+
+### 4.2 `XA-PERMISSIONS` does nothing
+
+Tested against a real Approved request the impersonated user had no role on, in
+all four contexts, with each of: `Administrator`, `XRAS - Admin read permission`,
+`XRAS - Review impersonator`, `Resource Provider User`,
+`Allocations Process Manager`, and a comma-joined pair. **All 401.**
+(The permission strings are real — they are listed on a person's admin page.)
+
+### 4.3 `review` / `admin` contexts are refused at the auth layer
+
+`401` with `X-Runtime: 0.003` — rejected before any lookup. This is a property
+of **the API key**, not of the header or the user.
+
+### 4.4 Probing by project code / request number does not work
+
+This is the most tempting idea and it fails for three independent reasons:
+
+| Probe | Result |
+|---|---|
+| `GET /v1/requests/<requestNumber>` **as its own PI** | **401** — `requestNumber` is not a valid path key at all. The numeric `GET /v1/requests/<requestId>` for the same request returns 200. |
+| `GET /v1/requests/<requestNumber>` as a non-member | 401 |
+| `?requestNumber=...`, `?opportunityId=...`, `?all=true` | **silently ignored** — the unfiltered list is returned |
+| `/v1/requests/number/<n>`, `/v1/requests/request/<n>` | 404 |
+
+Scanning the **numeric** `requestId` space is equally futile: ids are dense and
+guessable, but reading one still requires a role, so a scan yields only 401s.
+
+### 4.5 Admin identities gain no breadth
+
+Impersonating genuine XRAS administrators (members of the admin panel) returns
+only *their own* role-scoped requests — counts of 1, 2 and 6 for the three
+tested. Adding `XA-PERMISSIONS: Administrator` changes nothing, and a foreign
+Approved request still 401s for them.
+
+**This is an important design input:** the admin web app's queue view
+demonstrably does **not** come through this API. See § 8 for how that reshapes
+the ask.
+
+### 4.6 Unreconciled people cannot be addressed by id or email
+
+`GET /v1/people/<personId>`, `/v1/people/<email>`, `/v1/people/unreconciled`
+and `/v1/people` all 404. `/v1/people/:username` is username-keyed, full stop.
+
+**But see § 5 — this does not mean unreconciled people are unreachable.**
+
+### 4.7 Endpoints that do not exist
+
+`/v1/actions`, `/v1/allocations`, `/v1/awards`, `/v1/reviews`, `/v1/reports`,
+`/v1/grants`, `/v1/organizations`, `/v1/allocation_types`,
+`/v1/fields_of_science`, `/v1/publications`, `/v1/users`, `/v1/roles`,
+`/v1/requests/:id/actions`, `/v1/people/:u/requests`, `/v2/*` — all 404.
+
+Curiosity note: `/v1/projects` returns a **Tomcat** 404 rather than the Rails
+one, so some other service is routed at that path. It is not ours and did not
+respond usefully to anything tried.
+
+---
+
+## 5. The finding that makes the worklist possible
+
+The XRAS-admin "Recent submissions" queue shows Approved requests whose Project
+Lead is badged **"Unreconciled user"** — a researcher with no site account. That
+is precisely the population the worklist is for, and at first it looked
+unreachable (§ 4.6).
+
+**It is reachable.** Every unreconciled person still has an **ARC placeholder
+username** of the shape `<name>-user-<token>`. The admin UI shows it only on the
+person's own page, not on the request summary — which is what made it look
+absent. That username resolves fully:
+
+```
+GET /v1/people/<name>-user-<token>
+{ "username": "...", "firstName": "...", "lastName": "...", "email": "...",
+  "academicStatus": "Graduate Student", "residenceCountry": "United States",
+  "organization": "...", "isReconciled": false, "orcid": null }
+```
+
+Three consequences, each load-bearing:
+
+1. **It is the account-creation detail sheet.** Name, email, organization,
+   academic status, and **`residenceCountry`** — the last of which the inbound
+   payload does **not** carry and account creation needs.
+2. **`isReconciled` is the closure signal.** Re-poll the same username; when it
+   flips, the item closes itself with nobody updating SAM by hand.
+3. **Impersonating the placeholder reads the request in full** — so approved
+   amounts and dates can be verified even for a handoff SAM never received.
+
+And the placeholder username is **already on the inbound wire**: fixture
+`tests/fixtures/xras/actions/new_ncar4214_ok.json` carries a role with
+`"username": "placeholder34-user-00034"` and `"isAccountToBeCreated": true`.
+The push names these people; the API describes them.
+
+### Two traps
+
+**⚠️ `isAccountToBeCreated` is stale — never use it as the predicate.**
+Live data shows an active, present SAM user carrying
+`isAccountToBeCreated: true` on a PI role. XRAS sets the flag when the role is
+created and never clears it. Surface it as a hint column only.
+
+**⚠️ The predicate is SAM-side and has two classes.** Of 19 live roster
+usernames checked against `users`, all 19 existed — but five had `active = 0`.
+*Absent* and *inactive* block the handoff identically and need different
+remedies (create vs reactivate). A predicate that only checks existence misses
+a quarter of the real cases.
+
+---
+
+## 6. Join keys — both verified
+
+**`resourceRepositoryKey` ↔ `xras_resource_repository_key_resource.resource_repository_key`.**
+Reconciled live against the local SAM DB: **13/13 exact, zero unmapped, zero
+dangling.** The API also exposes `productionBeginDate` / `productionEndDate`
+per resource — and at probe time the two current flagship compute resources
+carried a `productionEndDate` roughly three months in the past, which nothing in
+SAM would notice. Whether that is XRAS staleness or a telegraphed retirement is
+an open question worth asking.
+
+**`requestNumber` == `project.projcode`.** Verified both directions: an Approved
+request's number exists as a SAM project; a **Rejected** request's number
+(`NCAR3116`, which is the SAM author's own test request) does **not**, because no
+project is ever created for a rejected request. This is exactly the existence
+test `dispatch.select_service()` uses to tell a "New that is really an update"
+from a genuine New.
+
+---
+
+## 7. Phase 1 — buildable now, no new key
+
+### 7.1 The central question, answered
+
+> *Can we see Approved requests before XRAS pushes them?*
+
+**Yes — for any identity SAM already knows.** The ceiling is **discovery**, not
+**reading**. `XA-USER` may be set to any username we know, so any request that
+user has a role on is fully readable.
+
+Verified end-to-end: the admin queue showed an Approved Extension on an existing
+SAM project. Polling that project's known lead through `/v1/requests` returned
+the same action — its `actionId`, `entryDate`, approved end date and full roster
+— with no push and no admin key. All six extension-type Approved rows in the
+sampled queue mapped to SAM projects with known leads.
+
+### 7.2 The three populations
+
+Checking the Approved queue's project leads against SAM:
+
+| Class | Visible in Phase 1? | Remedy |
+|---|---|---|
+| **Known + active** in SAM | ✅ by polling | usually none — may just need adding to a project |
+| **Known but `active = 0`** | ✅ by polling | **reactivate** |
+| **Absent entirely** — ARC placeholder identity | ❌ push-only until Phase 2 | **create** |
+
+Roughly a quarter of the Approved queue is Extensions/Transfers on existing
+projects (fully visible today). The rest are New requests spread across all
+three classes. **The third class is the residual gap — and it is the
+55%-of-failures population.** Phase 1 catches it *at push time, before
+processing*; Phase 2 (§ 8) would catch it *before the push*.
+
+### 7.3 Feed A — pre-flight over captured actions
+
+**Reuse what exists; build nothing.**
+`dispatch_action(session, action, validate_only=True)`
+(`src/sam/xras/dispatch.py:222-263`) runs the handler's assemble-and-check half
+and returns **before `management_transaction` opens**.
+`src/webapp/api/xras/recheck.py:195-202` already drives it.
+
+Because production runs **capture-only**, running this across captured actions
+pre-flights every action *before* it is ever processed — literally "detect users
+that need creating before the task can succeed".
+
+It yields exactly five error strings from `src/sam/xras/errors.py`, and those
+five **are** the worklist, with the remedy already distinguished:
+
+| `errors.py` | Meaning | Remedy |
+|---|---|---|
+| `pi_not_in_database` :143 | PI has no `users` row | create |
+| `pi_not_active` :149 | PI row inactive | reactivate |
+| `manager_not_in_database` :154 | Allocation Manager absent | create |
+| `manager_not_active` :160 | Allocation Manager inactive | reactivate |
+| `username_missing` :185 / `username_inactive` :190 | roster member | create / reactivate |
+
+### 7.4 Feed B — known-identity polling, with a roster crawl
+
+A scheduled sweep calling `GET /v1/requests` per known identity, recording
+Approved and in-flight actions. Two things it buys beyond Feed A:
+
+- **Pre-push visibility** for extensions/transfers on existing projects and for
+  New requests from people SAM already knows.
+- **Discovery of unknown people through known ones.** A known PI's roster names
+  their collaborators, *including placeholder usernames SAM has never seen*.
+
+**Roster crawl.** Every newly-seen username is itself pollable, so the sweep
+should be transitive: poll seeds → harvest usernames from their rosters → poll
+the new ones → repeat to a fixed point, bounded by a depth cap and a per-run
+budget. This widens coverage well past the seed set with no enumeration.
+
+Its limit, stated plainly: the crawl reaches people who **share a request with
+someone we know**. A wholly-new PI submitting a solo New request connects to
+nothing SAM knows, so no crawl reaches them. Push-only until Phase 2.
+
+**Measured cost.** `GET /v1/requests` ≈ **0.84 s, ~22 KB** per identity
+(3 consecutive runs: 0.844 / 0.826 / 0.837 s).
+
+| Seed tier | Count (local snapshot) | Serial | ~8-way |
+|---|---:|---:|---:|
+| Active project leads + admins | 1,518 | ~21 min | ~3 min |
+| All active, unlocked users | 6,310 | ~88 min | ~11 min |
+| All non-deleted users | 28,344 | ~6.6 h | ~50 min |
+
+Nightly over the first tier is the right default. Hit rate is low — of five real
+project leads sampled, **three returned zero requests** — so a full sweep is
+mostly empty and the crawl matters more than the seed breadth.
+
+### 7.5 Enrichment and closure
+
+For each worklist username, `GET /v1/people/:username` supplies the detail
+sheet. Re-poll to close on `isReconciled`. Cache **hours, not days** — this is a
+closure signal and must not go stale.
+
+### 7.6 New code
+
+`src/sam/integration/xras_api/` — follow `src/sam/integration/awards/` exactly.
+It is the closest template in the repo and already a sibling of
+`src/sam/integration/xras.py`.
+
+- **`client.py`** — one persistent `requests.Session`; explicit `timeout=` on
+  every call; `2 ** attempt` backoff; **404 → return `None`**; other 4xx →
+  raise immediately (a client error is deterministic, never retried); 5xx →
+  warn + retry; exhausted → raise `XrasSourceUnavailable`. Preserve the
+  three-outcome model (**found / not-found / unreachable**) all the way to CLI
+  exit codes, as `AwardSourceUnavailable` does.
+- **GET-only allowlist, enforced structurally.** The API exposes POSTs
+  (`/v1/resources/update`, the notification endpoints, `new_request_number`)
+  that must never be reachable from SAM. Do not rely on convention.
+- **`cache.py`** — `BucketedTTLCache`, registered by adding the module to
+  `_BUCKETED_CACHE_MODULES` in `src/webapp/caching/__init__.py:48-53`. That one
+  line gives `sam-admin cache --refresh --category`, the Admin Configuration
+  card row, `stats()` and `clear()` for free. Cache successes *and* definite
+  negatives; never cache an `XrasSourceUnavailable`.
+- **Config** via `os.getenv` — `XRAS_API_KEY`, `XRAS_API_BASE`,
+  `XRAS_ALLOCATIONS_PROCESS` — declared in `.env.example` and
+  `helm/values.yaml`, **fail-closed** when unset. No Click / Flask / rich /
+  kubernetes imports anywhere under `src/sam/` or `src/scheduling/`.
+
+`src/sam/queries/xras_accounts.py` — the worklist query: group pre-flight
+failures by username, classify (absent / inactive / placeholder-shaped), join
+the most recent `xras_action_log` row for provenance.
+
+⚠️ **Do not export the new query module from `sam/queries/__init__.py`** if it
+imports `sam.notify` — that file imports its submodules eagerly. See the
+existing trap documented for `expiration_notices` / `xras_notices`.
+
+**The sweep is a scheduled task** under `src/scheduling/tasks/`.
+⚠️ `SAM_TASKS_DISABLED` is **fail-open**: registering a task puts it live on the
+next hourly wake unless its name is added to `helm/values.yaml` **in the same
+change**. Ship it switched off, as `xras_notices` was, and add the
+`values.yaml` grep assertion the existing task tests use.
+
+### 7.7 Schema — one new table, not zero
+
+**The worklist itself needs no storage.** It derives entirely from
+`xras_action_log.raw_payload` (roles and usernames), `users` (existence and
+activity), the pre-flight (the reason), and `/v1/people` (the detail, cached).
+This follows `XrasActivationEvent`'s own rule: *state is DERIVED, never stored*.
+
+**Operator notes and dismissals do need storage, and `XrasActivationEvent`
+cannot carry them.** Its key is
+
+```python
+project_id = Column(Integer, ForeignKey('project.project_id'), nullable=False)
+```
+
+— project-scoped and NOT NULL. The account worklist is **username-keyed**, and
+for a New request *the project does not exist yet*. That is the entire case.
+So reuse the **pattern**, not the table.
+
+Proposed `xras_account_event`, mirroring the existing table deliberately:
+append-only (a new row, never an edit of an existing one); `username`
+`varchar(35)` (`users.username` width) in place of `project_id`; `event_type`
+from a small tuple; `comment`; `created_by` `varchar(35)` ("the human who
+clicked"); `xras_action_log_id` as **provenance only**. Derive current state by
+timestamp comparison against the latest action naming that username — exactly as
+the activation card does. That gets re-open-on-new-information and anti-spam for
+free, and avoids a `done` boolean that would be wrong the moment the same person
+appears on a second request.
+
+⚠️ **Adding a table is no longer a DBA round-trip.**
+`docs/plans/implemented/DBA_PRIVILEGE_REQUEST.md` records
+`GRANT CREATE, ALTER, INDEX, REFERENCES ON sam.* TO 'hpc-writer'@'%'` granted
+**2026-08-10**, with the applied sequence and verification queries in
+`docs/xras/incoming/XRAS_CUTOVER_RUNBOOK.md` § 2 as precedent. There is
+deliberately **no `DROP`** — so get the DDL right the first time. SAM has no
+migrations (Alembic covers only `system_status`): the table is created by hand
+and the ORM model written to match.
+
+**Faster option:** ship the card **read-only** first — the worklist derives with
+*zero* schema change — and land the notes table as an immediate follow-up. That
+takes DDL off the critical path without changing any query or classifier work.
+
+### 7.8 The dashboard
+
+A card beside the existing XRAS surfaces in
+`src/webapp/dashboards/allocations/blueprint.py` (which already serves `/xras`,
+`/xras_fragment`, `/xras_pending_fragment`), with templates under
+`src/webapp/templates/dashboards/allocations/`.
+
+Columns: username · why (the five classes of § 7.3) · person detail from
+`/v1/people` · which request / projcode and action needs them · XRAS
+`isReconciled` · notes.
+
+Follow the house rules in `CLAUDE.md`: **§9** for the form schema
+(`sam.schemas.forms`) and the smallest handler tier that fits, **§8** for the
+access decorator on any project-scoped route, **§10** for any active-only
+toggle (`read_active_only`), and `sam.fmt` filters for all formatting.
+
+### 7.9 Two cheap wins worth folding in
+
+**(a) Make `--validate-mapping` two-sided.** `audit_resource_mapping`
+(`src/sam/queries/xras_actions.py:652`, body at :678-713) reads two local tables and nothing
+else; its own docstring concedes it has no list of the keys XRAS will actually
+send. So the failure that genuinely breaks an award — XRAS sends a
+`resourceRepositoryKey` SAM has no row for — is **invisible** to the command and
+surfaces only at runtime as `No resource found in SAM corresponding to key %s`
+(`src/sam/xras/errors.py:201`, raised from `src/sam/xras/handlers/_fields.py:148`).
+`GET /v1/resources` **is** that missing list. One global GET closes the gap.
+
+**(b) `opportunityId` → allocation type.** SAM derives allocation type with a
+~676-line, 11-strategy chain (`src/sam/xras/extractors.py`). Exactly one arm is
+a keyed lookup; the rest are string matching on operator-authored free text
+(a regex on `requestTitle` for `CSL`, case-sensitive `contains` of
+`'no NSF award'` / `'unsponsored'`, literal `startswith` prefixes). Only 5 of
+the 11 strategies are exercised by all 41 production payloads.
+
+Meanwhile **`opportunityId` is already on the inbound wire in 41/41 fixtures**
+(declared at `src/sam/schemas/forms/xras.py:381`) and
+`grep -rn opportunityId src tests --include=*.py` returns **one** hit — that
+declaration. Nothing reads it.
+
+The outgoing API closes the loop because `/v1/opportunities/:id` and
+`/list/:ids` **resolve historic and `Terminating` opportunities**, not just
+currently-open ones — verified for every opportunityId in the fixture corpus.
+That defeats the objection that would otherwise sink a static table: the `Large`
+window mints a **new opportunityId every semester**, so a hardcoded map rots
+twice a year, but an unknown id can simply be fetched and cached.
+
+Design constraints for this one:
+
+- **Key the map on `opportunityId`, not on the wire `allocationType` string.**
+  XRAS's vocabulary (`Small`, `Large`, `Educational`, `Exploratory`,
+  `Data Analysis`, `NCAR External Projects`) is a *different* vocabulary from
+  SAM's `allocation_type` table, and it does not disambiguate — two different
+  opportunities both report `Small`, while `Exploratory` must land on SAM's
+  `Small (No NSF award)`.
+- **Keep the existing two-column `(panel, allocation_type)` join**
+  (`extractors.py:346-350`): `allocation_type.allocation_type` is not unique
+  (`Small` exists under two panels, `Education` under two more).
+- **Leave the 11-strategy ladder as the fallback** for an unresolvable id.
+
+---
+
+## 8. Phase 2 — if a broader credential is granted
+
+**Frame the ask as a capability, not a flag.** The obvious request — "provision
+our key for `XA-CONTEXT: admin`" — is probably *insufficient on its own*,
+because genuine XRAS administrators get no extra breadth through this API
+(§ 4.5). The admin web app's queue view comes from somewhere else.
+
+Better: **"a credential that lets SAM enumerate NCAR's Approved requests — the
+same set the Recent Submissions queue shows."** Let XRAS choose the mechanism
+(an admin-context key, a reporting role, a service identity, or a webhook).
+
+What it would add, in value order:
+
+1. **Mirror the whole Approved queue.** The worklist stops depending on the push
+   *or* on SAM already knowing the person — closing the third population
+   (brand-new placeholder identities) **ahead of** the push rather than at it.
+2. **Dropped-push detection.** Today a push that never arrives is invisible
+   until somebody notices a missing project. With enumeration, XRAS's Approved
+   set diffs against `projcode` wholesale (§ 6).
+3. **An unreconciled-people report** — the admin app has one; there is no API
+   equivalent.
+4. **Review / panel state** — `states[]` exposes "Conflicts Verified" and
+   "Reviewers Assigned" per action, but the review queue itself is admin-only.
+
+**Phase 1 is not throwaway.** Phase 2 changes only the **feed**. The classifier,
+the five error classes, the person enrichment, the closure signal, the notes
+table and the card are all unchanged. **Design the worklist query to accept a
+set of `(action, roster)` records from either source** — that one decision is
+what makes Phase 2 additive.
+
+---
+
+## 9. Verification
+
+- **Unit tests with recorded fixtures; no live calls in CI.** Mirror
+  `tests/unit/test_award_*` and the `AwardSourceUnavailable` three-outcome model.
+- **Pre-flight correctness**: the worklist must reproduce the five `errors.py`
+  strings against `tests/fixtures/xras/actions/`, with the
+  `placeholder34-user-00034` entry classified *absent* and a known-inactive
+  username classified *inactive*.
+- **Predicate regression**: a case where `isAccountToBeCreated` is true but the
+  SAM user exists and is active must **not** appear on the worklist. This is the
+  live counterexample of § 5 and the whole reason that flag is not the predicate.
+- **§ 7.9(a) self-verifies**: it must report 13/13 against today's catalog.
+- **Live opt-in probe script** under `scripts/xras/`, gated on `XRAS_API_KEY`
+  being set, that **skips** rather than fails when absent — mirroring
+  `utils/parity/`'s `_resolve_xras_credentials()` behaviour.
+- **Route-map parity**: regen with `ROUTE_MAP_REGEN=1` and commit the snapshot
+  diff in the same change as the new dashboard routes.
+- **Helm**: assert the new task's name appears in `SAM_TASKS_DISABLED`
+  **per-manifest** (`-s templates/cronjob-tasks.yaml`) — a whole-render grep
+  passes on the Deployment's copy and proves nothing.
+- **End-to-end**: `docker compose up webdev --watch`, seed via
+  `scripts/xras/seed_dev_actions.py`, confirm the card lists a seeded
+  placeholder identity and that adding a note writes an event row.
+
+### The Tier-III test bed — `~/xras_payloads_raw/`
+
+**Only unscrubbed payloads can validate the core predicate, and this is
+structural.** The anonymizer rewrites every username to `user_<hex>` (or
+`placeholder<NN>-user-<NNNNN>`), so for the in-tree fixtures "no `users` row" is
+trivially true for **all** of them and proves nothing. Distinguishing a
+genuinely-unknown user from an artifact of scrubbing requires real usernames
+posted against the cloned development database.
+
+That corpus already exists outside the tree, deliberately uncommitted:
+**41 payloads** (8 top-level plus 33 under `incoming_2026-08-11/`), spanning
+`New` ×13, `Extension` ×7, `Supplement` ×7, `Date Adjustment` ×4,
+`Adjustment` ×2 — and it carries the cases that matter: **6 role entries with
+`isAccountToBeCreated=true` and ~4 distinct ARC placeholder identities**.
+Locally, `xras_action_log` and `xras_activation_event` both exist at 0 rows, so
+the path is ready.
+
+Procedure: POST a payload naming an unknown user to the local
+`/api/xras/v1/actions` (`scripts/xras/seed_dev_actions.py` does the posting,
+reading `SAM_XRAS_USER` / `SAM_XRAS_PASS`), then confirm the pre-flight
+classifies that username **absent** rather than **inactive**, that `/v1/people`
+enriches it, and that an operator note writes an event row.
+
+⚠️ **These payloads are unscrubbed and name real people.** They stay outside the
+tree. Nothing derived from them — usernames, emails, or counts tied to
+identities — may enter a commit, a test fixture, or a docstring. Any regression
+test that must *persist* is built from the scrubbed corpus; the raw run is a
+one-time manual verification recorded only as pass/fail.
+
+---
+
+## 10. Safety and secrets
+
+- **Read-only, GET-only**, enforced in the client (§ 7.6), not by convention.
+- **`XA-USER` impersonation is how per-user reads work.** Every polled username
+  must originate in SAM or in a received payload, must be logged, and the whole
+  feature sits behind a fail-closed flag in the style of the existing
+  `XRAS_ACTIONS_CAPTURE_ONLY` / `XRAS_ACTIONS_ENABLED` levers.
+- **The API key must not enter this repo.** It currently sits in cleartext in a
+  shell script in the operator's home directory. Move it to the `SAM_keys`
+  credential store and a k8s secret. Note it is a *submit*-context key — the same
+  credential that can `POST /v1/resources/update`, which is precisely why the
+  client's GET-only allowlist matters.
+- **Do not confuse it with `SAM_XRAS_USER` / `SAM_XRAS_PASS`**, which are
+  credentials for calling *SAM* (`.env.example:107-108`) and are a production
+  **write** credential in the inbound direction.
+- **The worklist names real people, emails, organizations and
+  `residenceCountry`.** Gate the card on an existing permission — follow the
+  Notifications pattern, where counts are visible at one level and rows naming
+  real addresses require `SYSTEM_ADMIN`.
+- **The local dev database may hold unobfuscated production data.** Nothing
+  derived from a local query goes into a commit.
+
+---
+
+## 11. Open questions for the implementation session
+
+1. **Will XRAS grant an enumeration credential?** (§ 8.) Ask early — it does not
+   block Phase 1 but it determines how much of Phase 2 is worth designing now.
+2. **Are the two flagship compute resources really production-ended?** The API
+   reports a `productionEndDate` months in the past for both (§ 6). Confirm with
+   XRAS whether that is stale data or a telegraphed retirement.
+3. **What seed tier and crawl depth?** § 7.4 gives measured costs; the right
+   default is probably nightly over leads+admins with a shallow crawl, but that
+   should be tuned once real hit rates are known post-cutover.
+4. **Does the co-PI role type ever appear?** Still zero across all fixtures and
+   all live sampling. The outgoing API is the one place that could settle the
+   spelling definitively, since it carries a numeric `roleTypeId`.
+5. **Read-only card first, or wait for the notes table?** (§ 7.7.)
+
+---
+
+## 12. Reference — related documents
+
+| Document | Why it matters here |
+|---|---|
+| `docs/xras/README.md` | Index; explains the `incoming/` vs `incoming/implemented/` lifecycle convention this document's eventual sibling would follow |
+| `docs/xras/incoming/XRAS_REIMPLEMENTATION.md` | The inbound wire contract, action semantics, the allocation-type extractor's design, and the open-risks list (incl. the co-PI question) |
+| `docs/xras/incoming/XRAS_CUTOVER_RUNBOOK.md` | § 2 has the applied DDL sequence and verification queries — the precedent for § 7.7 |
+| `docs/plans/implemented/DBA_PRIVILEGE_REQUEST.md` | Records the 2026-08-10 DDL grant that makes a new table cheap |
+| `docs/xras/incoming/implemented/XRAS_SPRINT_B.md` | The operator surface, activation worklist and `sam-admin xras` — the closest existing analogue to the proposed card |
+| `src/sam/integration/awards/` | The outbound-client template to copy: client + cache + registry + base, with a CLI wrapper |
+| `src/webapp/api/xras/actions.py` | The inbound handler; `_record`/`_finish` and the audit-row width guards |
+| `src/sam/xras/dispatch.py` | `select_service()` and the `validate_only` seam Phase 1 is built on |

--- a/docs/xras/README.md
+++ b/docs/xras/README.md
@@ -9,12 +9,23 @@ the **site-side server** it talks to: XRAS **pushes** allocation decisions in
 Java/Tomcat server (deployed build 2.0.3), as a drop-in replacement: same URLs,
 same auth headers, same response bytes.
 
+`outgoing/` is the **opposite direction**: SAM calling out to the XRAS
+Allocations API at `https://api.xras.org/v1/…`. Read-only and GET-only — the
+same credential can create requests, modify roles and merge one person into
+another, so the client has no verb method but an internal `_get`.
+
 ## Live docs — `incoming/`
 
 | Doc | What it is |
 |---|---|
 | [`XRAS_REIMPLEMENTATION.md`](incoming/XRAS_REIMPLEMENTATION.md) | The reference: wire contract, production data, deliberate divergences, phase status |
 | [`XRAS_CUTOVER_RUNBOOK.md`](incoming/XRAS_CUTOVER_RUNBOOK.md) | The day-of sequence. Operational only — no code left. Cutover is **abrupt**: XRAS holds one base URL, so all seven endpoints and all six handlers move at once |
+
+## SAM → XRAS — `outgoing/`
+
+| Doc | What it is |
+|---|---|
+| [`XRAS_OUTGOING_QUERIES.md`](outgoing/XRAS_OUTGOING_QUERIES.md) | The account-creation worklist: the readable API surface, every closed path, and the two-feed design. Implemented 2026-08-20; § 0 records what the build learned |
 
 ## Shipped — `incoming/implemented/`
 

--- a/docs/xras/incoming/XRAS_REIMPLEMENTATION.md
+++ b/docs/xras/incoming/XRAS_REIMPLEMENTATION.md
@@ -129,7 +129,9 @@ Three sequencing points that are easy to get wrong:
   eight-payload corpus supported and revealed an `actionType` — `Date Adjustment` — that no
   document listed. What remains unsampled is now *measured* rather than merely absent: no co-PI
   role in 41 payloads across ~35 projects, and `Transfer` / `Renewal` / `Advance` still at zero.
-  Production capture is the only remaining way to get those.
+  Production capture is the only remaining way to get those — **except for the co-PI, which is
+  now closed outright** (2026-08-19): `GET /v1/types/roles` on the live process returns exactly
+  three role types, so the absence was never a sampling gap. See the § 3.6 note below.
 - **SMTP can genuinely be deferred.** XRAS projects arrive `active = 0` and the success email is
   the human activation trigger — but **legacy keeps sending those emails until `POST /actions`
   cuts over**, which is cutover step 4, after Sprint C. No notification gap opens before then.
@@ -1335,9 +1337,19 @@ three-module domain pattern in `src/cli/README.md:137-168`.
      this path — legacy reads it only on the GET side — so this is a trap, not a blocker.
 
    **The bulk forward happened (2026-08-11)** and closed less than hoped — which is itself the
-   result. At 41 payloads: **still no co-PI role**, so its spelling remains unknown, but the
-   vocabulary is now measured as exactly `PI` / `Allocation Manager` / `User` across ~35 projects,
-   which says this site does not send one. `Transfer` / `Renewal` / `Advance` still have zero
+   result. At 41 payloads: **still no co-PI role**, and the vocabulary is measured as exactly
+   `PI` / `Allocation Manager` / `User` across ~35 projects.
+
+   ✅ **RESOLVED 2026-08-19 — and not by sampling.** Asking the XRAS Allocations API directly,
+   `GET /v1/types/roles` returns the NCAR process's *declared* role types: exactly three, `13 PI`
+   / `14 Allocation Manager` / `19 User`. So **a co-PI cannot appear on this wire at all**, its
+   "unknown spelling" was never observable, and no amount of production capture would have closed
+   it. The generic XRAS product defines `CoPI` at `roleTypeId` 1; those ids are per-process, which
+   is why NCAR's are 13/14/19. Live sampling agrees: zero co-PIs across 64 role entries in 25
+   Approved requests. Consequences — the `CoPi` branch at `webapp/api/xras/requests.py:33-37` is
+   **provably** empty rather than merely unobserved, and the `Co-PI`/`CoPi` stress scenarios test
+   an input that cannot occur (harmless, and worth keeping as a robustness check).
+   See `docs/xras/outgoing/XRAS_OUTGOING_QUERIES.md` § 3.4 for the probe. `Transfer` / `Renewal` / `Advance` still have zero
    samples as `actionType` (three payloads carry `requestType: 'Renewal'`, a different field that
    dispatches nothing). Only production capture can close these now.
 

--- a/docs/xras/outgoing/XRAS_OUTGOING_QUERIES.md
+++ b/docs/xras/outgoing/XRAS_OUTGOING_QUERIES.md
@@ -1,7 +1,8 @@
 # XRAS "outgoing" queries — an account-creation worklist
 
-**Status:** research and live probing complete, design settled, **not implemented**.
-**Branch:** `probing_xras`. **Probed:** 2026-08-19 against production
+**Status:** **implemented as built**, 2026-08-20, on `probing_xras`. The design
+below stands as written except where § 0 records a deviation.
+**Probed:** 2026-08-19 against production
 `https://api.xras.org` (two rounds: the original survey, then a follow-up after
 the full API documentation was located), cross-checked against the XRAS-admin
 web app.
@@ -17,6 +18,79 @@ than re-litigates.
 > (they push actions, they pull our GETs). This document is the opposite
 > direction: **SAM calling out to XRAS**. There is no such code in the repo
 > today — `api.xras.org` is zero hits outside this document.
+
+---
+
+## 0. As built — deviations and findings
+
+Seven commits. Everything in §§ 7-8.1 shipped; §§ 7.6 (the notes table) and
+8.2 stay deferred as planned. What follows is only what the implementation
+learned that this document did not already say.
+
+### The plan was wrong about one fixture
+
+§ 10 named `new_ncar4214_ok.json` as the pre-flight case whose
+`placeholder34-user-00034` should classify **absent**. It does not, and
+should not: that role carries `endDate: 2026-07-28` against an action
+beginning `2026-07-30`, so the roster's date window correctly excludes it —
+the role is over and the handoff does not need the account.
+`new_ncar4227_failed.json` carries an in-window placeholder and is the test
+case instead. A second test pins the exclusion itself, so the window rule
+cannot silently loosen.
+
+### Tier-III measured, against the unscrubbed corpus + the dev database
+
+41/41 payloads parsed, 72 distinct real usernames, **9 worklist rows: 4
+absent, 5 inactive**. Two numbers matter:
+
+- An existence-only predicate would have found 4 of 9. The `inactive` class
+  is the majority of real work, not an edge case.
+- **All 5 usernames carrying `isAccountToBeCreated: true` were existing,
+  *active* SAM accounts** — the flag was 100% stale in this corpus. Using it
+  as the predicate would have produced 5 false positives and found none of
+  the 9 real cases. § 5's trap, confirmed on production data.
+
+Nothing derived from that run is committed; it is recorded here as counts
+only.
+
+### The live probe confirmed the API shape
+
+`scripts/xras/probe_outgoing.py` against production: 13 resources, all
+carrying `resourceRepositoryKey`, reconciling **13/13** against
+`xras_resource_repository_key_resource` with zero unmapped and zero dangling
+(§ 6). `reports/requests` paginates cleanly — 3 pages of 10, 30 distinct
+rows, zero overlap. Role entries are `{person, roles[]}` with the inner
+`role` key, person inline carrying `isReconciled` and `residenceCountry`.
+Across 64 sampled role entries the only values were `PI`, `Allocation
+Manager` and `User` — **no co-PI**, as § 3.4 predicted from
+`/v1/types/roles`.
+
+Of 43 role-people in 25 Approved requests, **7 were `isReconciled: false`**.
+The worklist has real content waiting.
+
+### Three small deviations from § 7
+
+1. **`iter_request_pages()` was added underneath `iter_requests()`.** The
+   sweep must distinguish "the data ran out" from "I hit `max_pages`", and a
+   generator flattened to individual requests cannot report that. A silent
+   cap would read as full coverage in the ledger detail.
+2. **The roster is the union of `roster_usernames` and both
+   `role_candidates` lists**, not the roster alone. `role_candidates` applies
+   a looser begin-date rule (legacy defect 3), so a PI can resolve while
+   absent from the roster — and a missing PI still fails the handoff.
+3. **Config follows `sam/notify/config.py`**, i.e. `XrasApiConfig` with
+   `from_environment()` reading Flask-config-then-environment, rather than the
+   `from_env(env=None)` sketched in § 7.1. Same behaviour, the repo's idiom,
+   and it brings a secret-free `summary()` along for the configuration card.
+
+### Still open
+
+The `productionEndDate` question (§ 13.1) is now sharper: the probe shows
+**NSF NCAR Derecho and Derecho-GPU both carrying `productionEndDate:
+2026-05-12`**, three months in the past, alongside Cheyenne (2023-12-31) and
+Yellowstone (2017-12-31) which are genuinely retired. Nothing in SAM reads
+that field, so nothing breaks either way — but it is worth asking XRAS
+whether it is stale data or a telegraphed retirement.
 
 ---
 
@@ -846,7 +920,23 @@ XRAS_OUTGOING_ENABLED=1 XRAS_API_KEY=… python scripts/xras/probe_outgoing.py
 
 ---
 
-## 14. Reference — related documents
+## 14. Deferred register — what this PR did NOT build
+
+Each was a deliberate decision, with the reason recorded so it can be revisited
+on evidence rather than re-litigated from scratch.
+
+| Deferred | Why, and what would change it |
+|---|---|
+| **`xras_account_event`** (§ 7.6) — operator notes and dismissal | Needs a table, and `XrasActivationEvent` cannot carry it: `project_id` is NOT NULL and project-scoped, while this worklist is username-keyed and a New request has no project yet. Shipping the buttons first would be dead UI. **Immediate follow-up PR.** |
+| **`opportunityId` → allocation type** (§ 8.2) | Assess after the first triage week under live dispatch. The 11-strategy ladder works; only 5 strategies are exercised by 41 payloads, so the case for replacing it is real but unmeasured. |
+| **Enabling `xras_sweep`** | Ships named in `SAM_TASKS_DISABLED`. Enable after the card has been reviewed against real post-cutover data — the task's value is proportional to how full `xras_action_log` is, and it is empty until ACCESS repoints. |
+| **`XRAS_OUTGOING_ENABLED: "1"`** | Ships `"0"`. Flipping it turns on person enrichment in the card and the two-sided half of `--validate-mapping`. Independent of the sweep's own switch. |
+| **Key rotation** | The key lived in cleartext in a home directory and on `crlogin` hosts before OpenBao. Worth requesting from XRAS now that `csg/xras-api-key` is authoritative; retire the cleartext copies either way. |
+| **`search/people` against placeholders** (§ 13.4) | Untested, nice-to-know. Placeholders arrive with usernames on both feeds, so nothing depends on it. |
+
+---
+
+## 15. Reference — related documents
 
 | Document | Why it matters here |
 |---|---|

--- a/e2e/test_xras_accounts_card.py
+++ b/e2e/test_xras_accounts_card.py
@@ -21,15 +21,26 @@ from __future__ import annotations
 import pytest
 
 CARD = '#alloc-xras-accounts'
-FRAGMENT_READY = f'{CARD} .card'
+PENDING_CARD = '#alloc-xras-pending-requests'
+
+#: Panes, and the tab button that reveals each.
+PANES = {CARD: '#xras-pane-accounts', PENDING_CARD: '#xras-pane-pending'}
 
 
-def _load(page):
-    """Open the XRAS page and wait for the lazily-fetched accounts fragment."""
+def _load(page, card=CARD):
+    """Open the XRAS page, wait for the fragment, and reveal its tab.
+
+    ⚠️ `state='attached'`, not the default visible: every worklist pane but
+    the first is inside an inactive `.tab-pane`, so its card resolves while
+    hidden. Waiting for visibility here would time out on a card that had
+    already loaded perfectly well.
+    """
     response = page.goto('/allocations/xras')
     assert response is not None and response.status == 200
-    page.wait_for_selector(FRAGMENT_READY, timeout=30_000)
-    return page.locator(CARD)
+    page.wait_for_selector(f'{card} .card', state='attached', timeout=30_000)
+    page.click(f'button[data-bs-target="{PANES[card]}"]')
+    page.wait_for_timeout(400)
+    return page.locator(card)
 
 
 def _rows(card):
@@ -60,10 +71,59 @@ def test_the_filter_form_is_outside_the_fragment(page):
     """Controls inside the fragment would vanish with the empty state, and
     the container refetches a bare hx-get on refreshXrasTab."""
     _load(page)
-    form = page.locator('#xras-accounts-filters')
-    assert form.count() == 1
-    # It must NOT be a descendant of the swap target.
-    assert page.locator(f'{CARD} #xras-accounts-filters').count() == 0
+    for form_id in ('#xras-accounts-filters', '#xras-window-filters'):
+        assert page.locator(form_id).count() == 1
+        # It must NOT be a descendant of the swap target.
+        assert page.locator(f'{CARD} {form_id}').count() == 0
+
+
+def test_the_three_tabs_share_one_window_control(page):
+    """One control, one date pair, three panes. Rendering the pills per tab
+    would put three same-named pairs in one form and `form.elements[name]`
+    would become a RadioNodeList that set-filter-submit cannot assign to."""
+    _load(page)
+    assert page.locator('#xrasWorklistTabs button[role="tab"]').count() == 3
+    assert page.locator('#xras-window-filters input[name="days"]').count() == 1
+    assert page.locator('input[name="start_date"][form="xras-window-filters"]'
+                        ).count() == 1
+    # Each pane listens for the shared form's submit, so one control moves all.
+    for pane_target in ('#alloc-xras-pending', CARD, PENDING_CARD):
+        trigger = page.locator(pane_target).get_attribute('hx-trigger')
+        assert 'submit from:#xras-window-filters' in trigger
+
+
+def test_the_request_is_a_column_and_a_chip(page):
+    """The handle an operator working one project's activation navigates by."""
+    card = _load(page)
+    # `.first`: each expansion row carries its own per-action table, so a bare
+    # `thead` locator is a strict-mode violation the moment a row renders.
+    header = card.locator('thead').first.inner_text().lower()
+    assert 'request' in header
+    if _rows(card).count():
+        assert card.locator('.facet-grid-label', has_text='Request').count() == 1
+
+
+def test_the_row_icons_are_gone(page):
+    """Per-row glyphs repeated what the text already said. The two remaining
+    `fa-circle-info` marks sit on muted notices, not on rows."""
+    card = _load(page)
+    assert card.locator('tbody i.fas').count() == 0
+
+
+def test_the_pending_requests_tab_states_are_distinct(page):
+    """Feed B has three empty states and conflating them would mislead:
+    unconfigured, no snapshot published, and published-but-empty."""
+    card = _load(page, PENDING_CARD)
+    body = card.inner_text().lower()
+    rows = card.locator(
+        '> .card > .table-responsive > table > tbody > tr').count()
+    if rows:
+        # A published snapshot must say when it was swept — the tab is only
+        # ever as fresh as the last sweep and must not imply live data.
+        assert 'swept' in body
+    else:
+        assert ('not configured' in body or 'no sweep has published' in body
+                or 'has a sam project' in body)
 
 
 def test_the_header_count_matches_the_rows_drawn(page):

--- a/e2e/test_xras_accounts_card.py
+++ b/e2e/test_xras_accounts_card.py
@@ -1,0 +1,134 @@
+"""The XRAS account-creation worklist card, in a real browser.
+
+Complements the HTTP-tier tests in `tests/unit/test_xras_accounts_card.py`:
+those assert what the response body carries, this asserts the card actually
+renders, its lazy fragment loads, and its chips filter without a page reload.
+
+⚠️ **Needs a populated `xras_action_log`.** The card is legitimately empty on
+a fresh stack (see the module docstring in `sam/queries/xras_accounts.py`), so
+every content assertion here is guarded on rows being present rather than
+asserted unconditionally — an empty stack must not produce a red build for a
+correct card. Seed with::
+
+    python scripts/xras/seed_dev_actions.py --dir ~/xras_payloads_raw
+
+Nothing here asserts on a username, an email or a count: the local corpus is
+unscrubbed, and this file is committed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+CARD = '#alloc-xras-accounts'
+FRAGMENT_READY = f'{CARD} .card'
+
+
+def _load(page):
+    """Open the XRAS page and wait for the lazily-fetched accounts fragment."""
+    response = page.goto('/allocations/xras')
+    assert response is not None and response.status == 200
+    page.wait_for_selector(FRAGMENT_READY, timeout=30_000)
+    return page.locator(CARD)
+
+
+def _rows(card):
+    """The worklist's own rows.
+
+    ⚠️ Scoped to the OUTER table on purpose. A loose `tbody > tr:not(.collapse)`
+    also matches the nested per-action table inside each expansion row — it
+    reported 19 where the card shows 9 — which would have made the
+    before/after comparison in the chip test meaningless.
+    """
+    return card.locator(
+        '> .card > .table-responsive > table > tbody > tr:not(.collapse)')
+
+
+def _badge_count(card):
+    """What the header claims, as an independent check on the row count."""
+    return int(card.locator('.card-header .badge').first.inner_text().strip())
+
+
+def test_the_card_renders_its_own_fragment(page):
+    """The container is empty in the shell and filled by htmx on load."""
+    card = _load(page)
+    assert card.locator('.card-header').inner_text().strip()
+    assert 'Accounts Needed' in card.locator('.card-header').inner_text()
+
+
+def test_the_filter_form_is_outside_the_fragment(page):
+    """Controls inside the fragment would vanish with the empty state, and
+    the container refetches a bare hx-get on refreshXrasTab."""
+    _load(page)
+    form = page.locator('#xras-accounts-filters')
+    assert form.count() == 1
+    # It must NOT be a descendant of the swap target.
+    assert page.locator(f'{CARD} #xras-accounts-filters').count() == 0
+
+
+def test_the_header_count_matches_the_rows_drawn(page):
+    """Two independent renderings of the same number; a mismatch means the
+    route filtered after counting (or vice versa)."""
+    card = _load(page)
+    assert _badge_count(card) == _rows(card).count()
+
+
+def test_both_classification_chips_render(page):
+    """Even at zero — an absent chip reads as 'not measured', which is a
+    different claim from 'none'."""
+    card = _load(page)
+    text = card.inner_text()
+    assert 'Create account' in text
+    assert 'Reactivate account' in text
+
+
+def test_a_chip_filters_without_a_page_load(page):
+    """The chips write into the hidden form and re-submit it via htmx."""
+    card = _load(page)
+    if _rows(card).count() == 0:
+        pytest.skip('worklist is empty on this stack; nothing to filter')
+
+    before = _rows(card).count()
+    page.once('load', lambda _: pytest.fail('the chip triggered a full reload'))
+    card.locator('button.facet-chip', has_text='Create account').first.click()
+    page.wait_for_timeout(1200)
+
+    card = page.locator(CARD)
+    after = _rows(card).count()
+    assert after <= before
+    assert card.locator('button.facet-chip.is-active').count() >= 1
+
+
+def test_a_row_expands_to_its_actions(page):
+    """The toggle is on the <tr>, which is only safe because the row carries
+    no buttons — see dashboards/fragments/collapse.html."""
+    card = _load(page)
+    if _rows(card).count() == 0:
+        pytest.skip('worklist is empty on this stack; nothing to expand')
+
+    first = _rows(card).first
+    body_id = first.get_attribute('data-bs-target')
+    assert body_id, 'the row carries no collapse target'
+    panel = page.locator(body_id)
+    assert not panel.is_visible()
+    first.click()
+    page.wait_for_timeout(600)
+    assert panel.is_visible(), 'the row did not expand'
+    # The expansion lists the actions that named this username. Compared
+    # case-insensitively: the table-subtle header is uppercased by CSS, so
+    # inner_text() returns what is PAINTED, not what the template wrote.
+    assert 'request' in panel.inner_text().lower()
+
+
+def test_the_card_logs_no_console_errors(page):
+    """Same contract as the console sweep: a card that renders but throws is
+    not working."""
+    errors = []
+    page.on('console', lambda m: errors.append(m.text)
+            if m.type == 'error' else None)
+    page.on('pageerror', lambda e: errors.append(str(e)))
+    card = _load(page)
+    if _rows(card).count():
+        _rows(card).first.click()
+        page.wait_for_timeout(600)
+    assert not errors, f'console errors on the XRAS page: {errors}'

--- a/e2e/test_xras_accounts_card.py
+++ b/e2e/test_xras_accounts_card.py
@@ -93,14 +93,22 @@ def test_the_three_tabs_share_one_window_control(page):
 
 
 def test_the_request_is_a_column_and_a_chip(page):
-    """The handle an operator working one project's activation navigates by."""
+    """The handle an operator working one project's activation navigates by.
+
+    ⚠️ Guarded on rows, like every other content assertion here. An empty card
+    renders no `<table>` at all, so `thead.inner_text()` does not fail fast —
+    it waits out the full 30s timeout and reds the build for a *correct* card.
+    That is exactly what it did on the CI stack, whose action log is empty.
+    """
     card = _load(page)
+    if _rows(card).count() == 0:
+        pytest.skip('worklist is empty on this stack; no table to inspect')
+
     # `.first`: each expansion row carries its own per-action table, so a bare
     # `thead` locator is a strict-mode violation the moment a row renders.
     header = card.locator('thead').first.inner_text().lower()
     assert 'request' in header
-    if _rows(card).count():
-        assert card.locator('.facet-grid-label', has_text='Request').count() == 1
+    assert card.locator('.facet-grid-label', has_text='Request').count() == 1
 
 
 def test_the_row_icons_are_gone(page):

--- a/helm/templates/cronjob-tasks.yaml
+++ b/helm/templates/cronjob-tasks.yaml
@@ -164,6 +164,18 @@ spec:
                 value: {{ .Values.webapp.env.SAM_DB_SERVER | quote }}
               - name: SAM_DB_REQUIRE_SSL
                 value: {{ .Values.webapp.env.SAM_DB_REQUIRE_SSL | quote }}
+              # ⚠️ The sweep PUBLISHES its worklist into the shared cache for
+              # the dashboard to read, so it needs the same Redis the webapp
+              # uses. Without this the bucket falls back to a per-worker
+              # in-process TTLCacheAdapter (by design — an unreachable Redis
+              # must never take the app down), the sweep writes into it
+              # happily, and the pod then EXITS and takes the cache with it.
+              # Producer succeeds, consumer sees nothing, nothing errors.
+              # Found exactly that way on the first production run.
+              {{- if .Values.cache.enabled }}
+              - name: CACHE_REDIS_URL
+                value: "redis://{{ .Values.cache.name }}.{{ .Release.Namespace }}.svc:{{ .Values.cache.port }}/0"
+              {{- end }}
               # ── XRAS outgoing (xras_sweep) ──────────────────────────────
               # ⚠️ This manifest renders `.Values.tasks.env` and does NOT
               # inherit `.Values.webapp.env`, so every key the sweep reads is

--- a/helm/templates/cronjob-tasks.yaml
+++ b/helm/templates/cronjob-tasks.yaml
@@ -164,6 +164,31 @@ spec:
                 value: {{ .Values.webapp.env.SAM_DB_SERVER | quote }}
               - name: SAM_DB_REQUIRE_SSL
                 value: {{ .Values.webapp.env.SAM_DB_REQUIRE_SSL | quote }}
+              # ── XRAS outgoing (xras_sweep) ──────────────────────────────
+              # ⚠️ This manifest renders `.Values.tasks.env` and does NOT
+              # inherit `.Values.webapp.env`, so every key the sweep reads is
+              # cross-referenced by hand here. Omitting one is fail-CLOSED for
+              # this task — an unconfigured sweep records a visible `skipped`
+              # rather than lying about coverage — but it would also mean the
+              # task never runs while reporting success, which is exactly the
+              # NOTIFY_* trap. `helm/tests/test-cronjob-render.sh` asserts each
+              # of these against THIS manifest (-s), because a whole-render
+              # grep passes on the Deployment's copy and proves nothing.
+              - name: XRAS_OUTGOING_ENABLED
+                value: {{ .Values.webapp.env.XRAS_OUTGOING_ENABLED | quote }}
+              - name: XRAS_API_BASE
+                value: {{ .Values.webapp.env.XRAS_API_BASE | quote }}
+              - name: XRAS_ALLOCATIONS_PROCESS
+                value: {{ .Values.webapp.env.XRAS_ALLOCATIONS_PROCESS | quote }}
+              - name: XRAS_API_USER
+                value: {{ .Values.webapp.env.XRAS_API_USER | quote }}
+              {{- if .Values.webapp.xrasApiCredentials.enabled }}
+              - name: XRAS_API_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.webapp.name }}-xras-api-credentials
+                    key: token
+              {{- end }}
               {{- if .Values.webapp.dbCredentials.enabled }}
               - name: STATUS_DB_USERNAME
                 valueFrom:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- end }}
-        {{- if or .Values.webapp.env (or .Values.webapp.dbCredentials.enabled (or .Values.webapp.samDbCredentials.enabled (or .Values.webapp.jupyterhubCredentials.enabled (or .Values.webapp.oidcCredentials.enabled (or .Values.webapp.jhDbCredentials.enabled .Values.webapp.fsDbCredentials.enabled))))) }}
+        {{- if or .Values.webapp.env (or .Values.webapp.dbCredentials.enabled (or .Values.webapp.samDbCredentials.enabled (or .Values.webapp.jupyterhubCredentials.enabled (or .Values.webapp.oidcCredentials.enabled (or .Values.webapp.jhDbCredentials.enabled (or .Values.webapp.fsDbCredentials.enabled .Values.webapp.xrasApiCredentials.enabled)))))) }}
         env:
           {{- range $key, $value := .Values.webapp.env }}
           - name: {{ $key }}
@@ -162,6 +162,15 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.webapp.name }}-jh-credentials
+                key: token
+          {{- end }}
+          {{- if .Values.webapp.xrasApiCredentials.enabled }}
+          # SAM calling OUT to XRAS. ⚠️ Also needed by the CronJob (xras_sweep),
+          # which shares no env anchor with this file — see cronjob-tasks.yaml.
+          - name: XRAS_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.webapp.name }}-xras-api-credentials
                 key: token
           {{- end }}
           {{- if .Values.webapp.oidcCredentials.enabled }}

--- a/helm/templates/external_secret.yaml
+++ b/helm/templates/external_secret.yaml
@@ -133,6 +133,30 @@ spec:
         property: {{ .Values.webapp.jupyterhubCredentials.tokenKey }}
 {{- end }}
 
+{{- if and .Values.webapp.xrasApiCredentials.enabled .Values.webapp.xrasApiCredentials.useExternalSecret }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.webapp.name }}-xras-api-credentials-esos
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.webapp.name }}
+    group: {{ .Values.webapp.group }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: {{ .Values.webapp.xrasApiCredentials.secretStoreRefName }}
+    kind: SecretStore
+  target:
+    name: {{ .Values.webapp.name }}-xras-api-credentials
+  data:
+    - secretKey: token
+      remoteRef:
+        key: {{ .Values.webapp.xrasApiCredentials.secretPath }}
+        property: {{ .Values.webapp.xrasApiCredentials.tokenKey }}
+{{- end }}
+
 {{- if and .Values.webapp.oidcCredentials.enabled .Values.webapp.oidcCredentials.useExternalSecret }}
 ---
 apiVersion: external-secrets.io/v1

--- a/helm/templates/redis-networkpolicy.yaml
+++ b/helm/templates/redis-networkpolicy.yaml
@@ -23,6 +23,23 @@ spec:
         - podSelector:
             matchLabels:
               app: {{ .Values.webapp.name }}
+        {{- if .Values.tasks.enabled }}
+        # The scheduled-task pods carry a DIFFERENT label, so the webapp
+        # selector above does not cover them and they were silently denied.
+        # xras_sweep PUBLISHES its worklist into DB 0 for the dashboard to
+        # read, and the cache layer falls back to a per-worker in-process
+        # adapter when Redis is unreachable — so the denial cost nothing
+        # visible: the sweep wrote into a cache that died with its pod and the
+        # tab stayed empty. Found on the first production run, by the log line
+        # "set but Redis is unreachable (Timeout connecting to server)".
+        #
+        # Not a privilege escalation: these pods run the same image as the
+        # webapp and already hold SAM database WRITE credentials, so they are
+        # strictly more trusted than the peer already admitted above.
+        - podSelector:
+            matchLabels:
+              app: {{ .Values.tasks.name }}
+        {{- end }}
       ports:
         - protocol: TCP
           port: {{ .Values.cache.port }}

--- a/helm/tests/test-cronjob-render.sh
+++ b/helm/tests/test-cronjob-render.sh
@@ -191,6 +191,13 @@ because 2500 is ~50x that task's realistic volume"
 # by hand in cronjob-tasks.yaml. Asserted against THIS manifest (-s) because a
 # whole-render grep passes on the Deployment's copy and proves nothing about the
 # pod that actually calls XRAS.
+# ⚠️ The sweep publishes into the SHARED cache the webapp reads. Without this
+# the bucket silently falls back to a per-worker in-process cache, the sweep
+# reports success, the pod exits, and the dashboard tab shows "no sweep has
+# published yet" forever. Caught on the first production run.
+assert_contains "$cron_out" 'name: CACHE_REDIS_URL' \
+  "the sweep cannot hand its worklist to the dashboard without the shared Redis"
+
 assert_contains "$cron_out" 'name: XRAS_OUTGOING_ENABLED' \
   "the sweep's master lever must reach the CronJob, not just the Deployment"
 assert_contains "$cron_out" 'name: XRAS_API_BASE' \

--- a/helm/tests/test-cronjob-render.sh
+++ b/helm/tests/test-cronjob-render.sh
@@ -198,6 +198,20 @@ because 2500 is ~50x that task's realistic volume"
 assert_contains "$cron_out" 'name: CACHE_REDIS_URL' \
   "the sweep cannot hand its worklist to the dashboard without the shared Redis"
 
+# ...and reaching it needs more than the URL. Redis is default-deny except from
+# the webapp's label; the task pods carry `app: samuel-tasks`, so without their
+# own ingress peer they are silently denied and the sweep falls back to a
+# per-worker cache that dies with the pod. Both halves, or neither works.
+# ⚠️ Comments are STRIPPED before asserting. helm renders YAML comments into
+# its output, and the first version of this check matched the explanatory
+# comment it had just added to the template rather than the selector — passing
+# with the peer deleted. Same class as grepping the whole render and hitting
+# the Deployment's copy.
+netpol_out=$(helm template "$RELEASE_NAME" "$CHART_DIR" -f "$CHART_DIR/values.yaml" \
+             -s templates/redis-networkpolicy.yaml | grep -v '^[[:space:]]*#')
+assert_contains "$netpol_out" "app: samuel-tasks" \
+  "the task pods need their own Redis ingress peer, not just the webapp's"
+
 assert_contains "$cron_out" 'name: XRAS_OUTGOING_ENABLED' \
   "the sweep's master lever must reach the CronJob, not just the Deployment"
 assert_contains "$cron_out" 'name: XRAS_API_BASE' \

--- a/helm/tests/test-cronjob-render.sh
+++ b/helm/tests/test-cronjob-render.sh
@@ -220,6 +220,18 @@ outgoing=$(grep -E '^\s+XRAS_OUTGOING_ENABLED:' "$CHART_DIR/values.yaml" | awk '
 assert_contains "$cron_out" "value: \"${outgoing}\"" \
   "XRAS_OUTGOING_ENABLED must render the value values.yaml declares"
 
+# ⚠️ The sweep and the lever are ONE decision. The task skips while the lever
+# is off, and the Feed-B dashboard tab renders only what the task publishes —
+# so a chart with the task enabled and the lever off yields a permanently
+# empty tab and a ledger full of `skipped`, with nothing failing to say so.
+if ! printf '%s' "$switch" | grep -q 'xras_sweep'; then
+  if [[ "$outgoing" != "1" ]]; then
+    red "FAIL: xras_sweep is enabled but XRAS_OUTGOING_ENABLED is \"${outgoing}\""
+    red "  The task would skip every run and the Feed-B tab would never fill."
+    exit 1
+  fi
+fi
+
 # The values must MATCH the Deployment's — cross-referenced, not duplicated.
 notify_enabled=$(grep -E '^\s+NOTIFY_ENABLED:' "$CHART_DIR/values.yaml" \
                  | awk '{print $2}' | tr -d '"')

--- a/helm/tests/test-cronjob-render.sh
+++ b/helm/tests/test-cronjob-render.sh
@@ -185,6 +185,37 @@ assert_contains "$cron_out" 'name: SAM_TASKS_XRAS_MAX' \
   "and xras_notices' own runaway guard — it does NOT share SAM_TASKS_EMAIL_MAX, \
 because 2500 is ~50x that task's realistic volume"
 
+# ── XRAS outgoing (xras_sweep) ──────────────────────────────────────────────
+# Same trap as NOTIFY_*: this manifest renders `.Values.tasks.env` and does NOT
+# inherit `.Values.webapp.env`, so every key the sweep reads is cross-referenced
+# by hand in cronjob-tasks.yaml. Asserted against THIS manifest (-s) because a
+# whole-render grep passes on the Deployment's copy and proves nothing about the
+# pod that actually calls XRAS.
+assert_contains "$cron_out" 'name: XRAS_OUTGOING_ENABLED' \
+  "the sweep's master lever must reach the CronJob, not just the Deployment"
+assert_contains "$cron_out" 'name: XRAS_API_BASE' \
+  "and the API base URL"
+assert_contains "$cron_out" 'name: XRAS_ALLOCATIONS_PROCESS' \
+  "and the allocations process header"
+assert_contains "$cron_out" 'name: XRAS_API_USER' \
+  "and the required XA-USER header"
+assert_contains "$cron_out" 'name: XRAS_API_KEY' \
+  "and the key itself, via secretKeyRef — the sweep cannot enumerate without it"
+assert_contains "$cron_out" 'name: samuel-xras-api-credentials' \
+  "which must name the Secret the ExternalSecret materialises"
+assert_contains "$cron_out" 'name: SAM_TASKS_XRAS_SWEEP_MAX_PAGES' \
+  "and the sweep's page budget"
+assert_contains "$cron_out" 'name: SAM_TASKS_XRAS_SWEEP_MAX_PEOPLE' \
+  "and its person-refresh budget"
+
+# Fail-closed, and pinned: the sweep ships switched off at BOTH levers — its
+# name in SAM_TASKS_DISABLED, and XRAS_OUTGOING_ENABLED "0". Derived from
+# values.yaml rather than hardcoded, so flipping either is a deliberate edit
+# here as well as there.
+outgoing=$(grep -E '^\s+XRAS_OUTGOING_ENABLED:' "$CHART_DIR/values.yaml" | awk '{print $2}' | tr -d '"')
+assert_contains "$cron_out" "value: \"${outgoing}\"" \
+  "XRAS_OUTGOING_ENABLED must render the value values.yaml declares"
+
 # The values must MATCH the Deployment's — cross-referenced, not duplicated.
 notify_enabled=$(grep -E '^\s+NOTIFY_ENABLED:' "$CHART_DIR/values.yaml" \
                  | awk '{print $2}' | tr -d '"')
@@ -218,6 +249,14 @@ assert_contains "$deploy_out" 'name: SAM_TASKS_DISABLED' \
   "the webapp Deployment must carry the kill switch too, or the admin card lies"
 assert_contains "$deploy_out" "value: \"${switch}\"" \
   "and it must carry the SAME value — one declaration, two consumers"
+
+# The Deployment needs the key too — the dashboard card enriches from it. The
+# two manifests share no env anchor, so this is a second hand-written copy and
+# must be asserted separately.
+assert_contains "$deploy_out" 'name: XRAS_API_KEY' \
+  "the webapp needs the XRAS key for the account-creation card's person detail"
+assert_contains "$deploy_out" 'name: XRAS_OUTGOING_ENABLED' \
+  "and the same fail-closed lever"
 
 # ---------------------------------------------------------------------------
 # Local dev render (values.yaml + values-local.yaml)

--- a/helm/tests/test-cronjob-render.sh
+++ b/helm/tests/test-cronjob-render.sh
@@ -207,6 +207,10 @@ assert_contains "$cron_out" 'name: SAM_TASKS_XRAS_SWEEP_MAX_PAGES' \
   "and the sweep's page budget"
 assert_contains "$cron_out" 'name: SAM_TASKS_XRAS_SWEEP_MAX_PEOPLE' \
   "and its person-refresh budget"
+assert_contains "$cron_out" 'name: SAM_TASKS_XRAS_SWEEP_WINDOW_DAYS' \
+  "and the window WITHOUT which the sweep reports a census, not a queue"
+assert_contains "$cron_out" 'name: SAM_TASKS_XRAS_SWEEP_STATUS' \
+  "and the request-status filter"
 
 # Fail-closed, and pinned: the sweep ships switched off at BOTH levers — its
 # name in SAM_TASKS_DISABLED, and XRAS_OUTGOING_ENABLED "0". Derived from

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -318,6 +318,25 @@ webapp:
     # e.g. "Extension,Supplement". Narrow this to park a misbehaving payload class as
     # manual without a revert; an unknown token leaves that type disabled.
     XRAS_ACTIONS_ENABLED: "all"
+    # ── XRAS Allocations API: SAM calling OUT to XRAS (docs/xras/outgoing/) ──
+    # The opposite direction from the two levers above. Read-only and GET-only:
+    # the client has no verb method but an internal _get, because the SAME key
+    # can create requests, modify roles and merge one person into another.
+    #
+    # Fail-closed. With XRAS_OUTGOING_ENABLED "0" the account-creation card
+    # renders its unconfigured state, the xras_sweep task records a skip, and
+    # sam-admin degrades — nothing raises for lack of a key. Flip to "1" once
+    # the card has been reviewed against real data.
+    #
+    # ⚠️ The KEY is not here. It arrives from OpenBao via the
+    # webapp.xrasApiCredentials ExternalSecret below, injected as XRAS_API_KEY
+    # by secretKeyRef into BOTH deployment.yaml and cronjob-tasks.yaml.
+    XRAS_OUTGOING_ENABLED: "0"
+    XRAS_API_BASE: "https://api.xras.org"
+    XRAS_ALLOCATIONS_PROCESS: "NCAR"
+    # Required header on every call; scopes nothing outside /v1/requests, which
+    # this client never reads. The value XRAS provisioned for the ARC scripts.
+    XRAS_API_USER: "arcguest"
 
   # system_status DB credentials (injected as STATUS_DB_USERNAME / STATUS_DB_PASSWORD).
   # MUST be a non-superuser role — connecting as the postgres SUPERUSER causes
@@ -380,6 +399,18 @@ webapp:
     useExternalSecret: true               # Create ExternalSecret CRD (set false to inject secrets manually)
     secretStoreRefName: csg-ro            # Name of the SecretStore to use
     secretPath: csg/jh-api-token          # Path in OpenBao where JupyterHub credentials are stored
+    tokenKey: token                       # Key in OpenBao for the token
+
+  # XRAS Allocations API key — SAM calling OUT to XRAS. Same five-key shape as
+  # jupyterhubCredentials above, and the same single-value payload.
+  # ⚠️ Consumed by TWO manifests: the Deployment (the dashboard card) and the
+  # CronJob (the xras_sweep task). They share no env anchor, so the secretKeyRef
+  # is written out in both — the same cross-referencing trap NOTIFY_* hit.
+  xrasApiCredentials:
+    enabled: true                         # Enable syncing the XRAS API key from OpenBao
+    useExternalSecret: true               # Create ExternalSecret CRD (set false to inject secrets manually)
+    secretStoreRefName: csg-ro            # Name of the SecretStore to use
+    secretPath: csg/xras-api-key          # Path in OpenBao where the XRAS API key is stored
     tokenKey: token                       # Key in OpenBao for the token
 
   # OIDC SSO credentials + Flask session-signing key.
@@ -464,6 +495,12 @@ tasks:
     # src/scheduling/tasks/xras_notices.py; this pins it visibly, because the
     # number is a policy decision rather than a code one.
     SAM_TASKS_XRAS_MAX: "50"
+    # xras_sweep budgets. Both are BOUNDS, not targets: the task reports
+    # `budget_exhausted` in its ledger detail when a cap actually bit, so a cap
+    # that starts truncating is visible rather than reading as full coverage.
+    # 25 pages x 200 requests is comfortably the whole NCAR process today.
+    SAM_TASKS_XRAS_SWEEP_MAX_PAGES: "25"
+    SAM_TASKS_XRAS_SWEEP_MAX_PEOPLE: "250"
     # ⚠️ Comma-separated task names to skip, WITHOUT a code deploy. This is a
     # staged-enable control: exactly one task is live, and the rest are named
     # here until each has been reviewed on its own.
@@ -472,6 +509,7 @@ tasks:
     # Disabled: deactivate_expired_projects  (writes inactivate_time in SAM)
     #           expiration_notices           (mails external PIs)
     #           xras_notices                 (mails external PIs)
+    #           xras_sweep                   (calls out to api.xras.org)
     #
     # ⚠️ There is NO wildcard. `disabled_tasks()` in src/scheduling/runner.py
     # is a case-sensitive exact match against registry keys — `all`, `*` and

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -325,13 +325,17 @@ webapp:
     #
     # Fail-closed. With XRAS_OUTGOING_ENABLED "0" the account-creation card
     # renders its unconfigured state, the xras_sweep task records a skip, and
-    # sam-admin degrades — nothing raises for lack of a key. Flip to "1" once
-    # the card has been reviewed against real data.
+    # sam-admin degrades — nothing raises for lack of a key.
+    #
+    # ⚠️ ON. The `xras_sweep` task SKIPS while this is "0", and the Feed-B tab
+    # renders what that task publishes — so turning the task on without this
+    # would produce a permanently empty tab and a ledger full of `skipped`.
+    # The two switches are one decision.
     #
     # ⚠️ The KEY is not here. It arrives from OpenBao via the
     # webapp.xrasApiCredentials ExternalSecret below, injected as XRAS_API_KEY
     # by secretKeyRef into BOTH deployment.yaml and cronjob-tasks.yaml.
-    XRAS_OUTGOING_ENABLED: "0"
+    XRAS_OUTGOING_ENABLED: "1"
     XRAS_API_BASE: "https://api.xras.org"
     XRAS_ALLOCATIONS_PROCESS: "NCAR"
     # Required header on every call; scopes nothing outside /v1/requests, which
@@ -520,7 +524,10 @@ tasks:
     # Disabled: deactivate_expired_projects  (writes inactivate_time in SAM)
     #           expiration_notices           (mails external PIs)
     #           xras_notices                 (mails external PIs)
-    #           xras_sweep                   (calls out to api.xras.org)
+    #
+    # `xras_sweep` was enabled once its output became a queue rather than a
+    # census (see its module docstring). It is read-only — it calls out to
+    # api.xras.org and writes nothing but a cache entry the dashboard reads.
     #
     # ⚠️ There is NO wildcard. `disabled_tasks()` in src/scheduling/runner.py
     # is a case-sensitive exact match against registry keys — `all`, `*` and
@@ -538,4 +545,4 @@ tasks:
     # slot, so re-enabling one mid-slot does not backfill — the first real run
     # is the next occurrence. The switch is also checked ahead of `only`/
     # `force`, so `sam-admin tasks --run X --force` cannot override it.
-    SAM_TASKS_DISABLED: "expiration_notices,xras_notices,xras_sweep"
+    SAM_TASKS_DISABLED: "expiration_notices,xras_notices"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -489,4 +489,4 @@ tasks:
     # slot, so re-enabling one mid-slot does not backfill — the first real run
     # is the next occurrence. The switch is also checked ahead of `only`/
     # `force`, so `sam-admin tasks --run X --force` cannot override it.
-    SAM_TASKS_DISABLED: "expiration_notices,xras_notices"
+    SAM_TASKS_DISABLED: "expiration_notices,xras_notices,xras_sweep"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -501,6 +501,17 @@ tasks:
     # 25 pages x 200 requests is comfortably the whole NCAR process today.
     SAM_TASKS_XRAS_SWEEP_MAX_PAGES: "25"
     SAM_TASKS_XRAS_SWEEP_MAX_PEOPLE: "250"
+    # ⚠️ The window is what makes the sweep's output a QUEUE rather than a
+    # census. Measured against the live process with no window: 4,088 Approved
+    # requests -> 2,180 "accounts needed", 2,149 of them merely inactive —
+    # every PI whose SAM account was deactivated when they retired or moved
+    # on. Drops requests whose allocation had already ended when the window
+    # opened; keeps live AND future ones, because a request starting next
+    # quarter is exactly the lead time this sweep exists to buy.
+    SAM_TASKS_XRAS_SWEEP_WINDOW_DAYS: "90"
+    # "Approved" is the only status that produces a handoff. Widen to any of
+    # the API's filter values, or "all", to survey the pipeline pre-approval.
+    SAM_TASKS_XRAS_SWEEP_STATUS: "Approved"
     # ⚠️ Comma-separated task names to skip, WITHOUT a code deploy. This is a
     # staged-enable control: exactly one task is live, and the rest are named
     # here until each has been reviewed on its own.

--- a/scripts/xras/probe_outgoing.py
+++ b/scripts/xras/probe_outgoing.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Probe the live XRAS Allocations API — opt-in, read-only, never in CI.
+
+Why a script and not a test
+---------------------------
+Everything this exercises needs a real API key against a real production
+service. ``tests/unit/test_xras_api_client.py`` covers the client's transport
+and parsing with canned payloads; this covers the thing a fixture cannot:
+that the endpoints, headers and field names we built against are still what
+XRAS actually serves.
+
+**It skips with exit 0 when ``XRAS_API_KEY`` is absent**, mirroring
+``utils/parity/check_legacy_apis.py::_resolve_xras_credentials`` — an
+unconfigured checkout is the normal state, not a failure.
+
+Usage
+-----
+::
+
+    source etc/config_env.sh
+    XRAS_OUTGOING_ENABLED=1 XRAS_API_KEY=… python scripts/xras/probe_outgoing.py
+
+Exit codes: 0 success (or skipped), 2 the API could not be reached or
+answered something we did not expect.
+
+⚠️ Output names real people. Do not paste it into a commit, a fixture, a
+docstring, or a PR description. The counts and the reconciliation verdict are
+safe to report; the identities are not — which is why ``--roster`` is off by
+default and why nothing here prints an email address.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import replace
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
+
+from sam.integration.xras_api import (  # noqa: E402
+    XrasApiClient,
+    XrasApiConfig,
+    XrasSourceUnavailable,
+)
+
+EXIT_SUCCESS = 0
+EXIT_ERROR = 2
+
+
+def _rule(title: str) -> None:
+    print(f'\n── {title} ' + '─' * max(0, 68 - len(title)))
+
+
+def probe_resources(client: XrasApiClient) -> list:
+    """The resource catalog, and the join key we depend on."""
+    _rule('GET /v1/resources')
+    resources = client.get_resources() or []
+    print(f'{len(resources)} resources')
+    keyed = [r for r in resources if r.get('resourceRepositoryKey') is not None]
+    print(f'{len(keyed)} carry resourceRepositoryKey')
+    for r in sorted(resources, key=lambda x: str(x.get('resourceName', ''))):
+        ended = r.get('productionEndDate') or ''
+        flag = '  ⚠️ production ended' if ended else ''
+        print(f"  {str(r.get('resourceRepositoryKey')):>6}  "
+              f"{r.get('resourceName')}{flag} {ended}")
+    return resources
+
+
+def reconcile_keys(resources: list) -> None:
+    """Two-sided check against ``xras_resource_repository_key_resource``.
+
+    Skipped silently when no SAM database is reachable — the point of the
+    script is the API, and a laptop without a DB should still be able to run
+    the other probes.
+    """
+    _rule('reconcile resourceRepositoryKey against SAM')
+    try:
+        from sqlalchemy.orm import Session
+
+        from sam.integration.xras import XrasResourceRepositoryKeyResource
+        from sam.session import create_sam_engine
+
+        engine, _ = create_sam_engine()
+        with Session(engine) as session:
+            sam_keys = {row.resource_repository_key for row in
+                        session.query(XrasResourceRepositoryKeyResource).all()}
+    except Exception as exc:                     # noqa: BLE001 - diagnostic only
+        print(f'skipped (no SAM database: {exc})')
+        return
+
+    live = {int(r['resourceRepositoryKey']) for r in resources
+            if r.get('resourceRepositoryKey') is not None}
+    print(f'SAM mapping rows: {len(sam_keys)}   live XRAS keys: {len(live)}')
+    print(f'  XRAS keys SAM cannot resolve: {sorted(live - sam_keys) or "none"}')
+    print(f'  SAM keys XRAS does not send:  {sorted(sam_keys - live) or "none"}')
+
+
+def probe_reports(client: XrasApiClient, limit: int) -> None:
+    """One page of the enumeration, and whether person detail is inline."""
+    _rule(f'GET /v1/reports/requests?status=Approved&limit={limit}')
+    page = client.get_requests_page(status='Approved', limit=limit)
+    print(f'{len(page)} requests on page 1')
+    if not page:
+        return
+    first = page[0]
+    print(f"  top-level keys: {sorted(first)}")
+    roles = first.get('roles') or []
+    inline = sum(1 for r in roles if isinstance(r.get('person'), dict))
+    print(f'  first request: {len(roles)} role entries, '
+          f'{inline} with an inline person object')
+    person = next((r['person'] for r in roles
+                   if isinstance(r.get('person'), dict)), None)
+    if person:
+        # Field NAMES only — the values name a real researcher.
+        print(f'  person fields: {sorted(person)}')
+        print(f"  isReconciled present: {'isReconciled' in person}   "
+              f"residenceCountry present: {'residenceCountry' in person}")
+    numbers = [r.get('requestNumber') for r in page]
+    print(f'  requestNumber non-null on {sum(1 for n in numbers if n)}/{len(page)}')
+
+
+def probe_person(client: XrasApiClient, username: str) -> None:
+    _rule(f'GET /v1/people/{username}')
+    person = client.get_person(username)
+    if person is None:
+        print('404 — no such username (a clean not-found, not an error)')
+        return
+    print(f'  fields: {sorted(person)}')
+    print(f"  isReconciled: {person.get('isReconciled')}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--limit', type=int, default=5,
+                        help='requests to pull on the enumeration page')
+    parser.add_argument('--person', help='probe one username through /v1/people')
+    args = parser.parse_args()
+
+    if not os.environ.get('XRAS_API_KEY'):
+        print('XRAS_API_KEY is not set — skipping the live probe.')
+        print('To run it: XRAS_OUTGOING_ENABLED=1 XRAS_API_KEY=… '
+              'python scripts/xras/probe_outgoing.py')
+        return EXIT_SUCCESS
+
+    # The lever exists to keep the webapp and the task quiet; asking for this
+    # script by name is opt-in enough, so force it on rather than making the
+    # operator set two variables.
+    config = XrasApiConfig.from_environment()
+    if not config.enabled:
+        config = replace(config, enabled=True)
+
+    print(f'base_url={config.base_url}  process={config.allocations_process}  '
+          f'user={config.api_user}  context=report')
+
+    client = XrasApiClient.from_environment(config)
+    try:
+        resources = probe_resources(client)
+        reconcile_keys(resources)
+        probe_reports(client, args.limit)
+        if args.person:
+            probe_person(client, args.person)
+    except XrasSourceUnavailable as exc:
+        print(f'\nXRAS unavailable: {exc}', file=sys.stderr)
+        return EXIT_ERROR
+
+    print('\nProbe complete.')
+    return EXIT_SUCCESS
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/cli/cmds/admin.py
+++ b/src/cli/cmds/admin.py
@@ -588,7 +588,7 @@ def accounting(ctx: Context, comp, disk, archive, reconcile_quotas, resource,
               help='Invalidate the running webapp\'s caches')
 @click.option('--category',
               type=click.Choice(['flask', 'chart', 'usage', 'scans', 'jobs',
-                                 'awards']),
+                                 'awards', 'xras_api']),
               default=None,
               help='Scope the refresh to one cache category (default: all)')
 @click.option('--base', 'base_url', type=str, default=None,

--- a/src/cli/cmds/admin.py
+++ b/src/cli/cmds/admin.py
@@ -676,6 +676,12 @@ def cache(ctx: Context, refresh: bool, category, base_url):
               help='[rollup] Counts by status and action type')
 @click.option('--validate-mapping', is_flag=True,
               help='[check] Report SAM resources XRAS cannot name (pre-cutover gate)')
+@click.option('--accounts', is_flag=True,
+              help='[worklist] Accounts to create or reactivate before a handoff')
+@click.option('--enrich', is_flag=True,
+              help='[worklist] Add XRAS person detail (requires --accounts and the API)')
+@click.option('--person', type=str, default=None,
+              help='[detail] Look one username up in the XRAS directory')
 @click.option('--status', multiple=True,
               type=click.Choice(['received', 'processed', 'manual',
                                  'failed', 'rechecked']),
@@ -691,6 +697,7 @@ def cache(ctx: Context, refresh: bool, category, base_url):
 @click.option('--verbose', '-v', is_flag=True, help='Show detailed information')
 @pass_context
 def xras(ctx: Context, action_id, show_payload, recheck, summary, validate_mapping,
+         accounts, enrich, person,
          status, action_type, request_number, last, limit, verbose):
     """Inspect and re-check the XRAS action log.
 
@@ -705,6 +712,9 @@ def xras(ctx: Context, action_id, show_payload, recheck, summary, validate_mappi
       --show ID    one action in full, with its re-check lineage
       --summary    counts by status, and by status x action type
       --recheck ID would this action succeed now? (applies nothing)
+      --accounts   who must be created or reactivated before a handoff works
+      --person U   one username in the XRAS directory
+      --validate-mapping  which resources XRAS and SAM can name each other's
 
     \b
     --recheck answers "would this succeed if XRAS posted it now?" It re-parses the
@@ -715,12 +725,29 @@ def xras(ctx: Context, action_id, show_payload, recheck, summary, validate_mappi
     to resend will land.
 
     \b
+    --accounts is the account-creation worklist: unreconciled ARC placeholder
+    identities are 55% of production handoff failures, and account creation is
+    manual. Rows are usernames XRAS names that SAM cannot use — either absent
+    (create) or inactive (reactivate). An EMPTY worklist exits 0; nobody being
+    blocked is a successful report, not a miss. --enrich adds names, emails and
+    the isReconciled closure signal, one XRAS round trip per username.
+
+    \b
+    --validate-mapping is two-sided when the XRAS API is configured: it also
+    reports keys XRAS sends that SAM has no mapping row for, which is the
+    failure that breaks an award. Unconfigured, it degrades to the local-only
+    report and says so.
+
+    \b
     Examples:
       sam-admin xras --last 7d
       sam-admin xras --status failed --type Extension
       sam-admin xras --show 42 --payload
       sam-admin xras --summary --last 30d
       sam-admin xras --validate-mapping
+      sam-admin xras --accounts
+      sam-admin xras --accounts --enrich --last 30d
+      sam-admin xras --person somebody-user-00042
       sam-admin xras --recheck 42
       sam-admin --format json xras --summary | jq .by_status
     """
@@ -729,6 +756,10 @@ def xras(ctx: Context, action_id, show_payload, recheck, summary, validate_mappi
 
     if show_payload and action_id is None:
         ctx.console.print('Error: --payload requires --show', style='bold red')
+        sys.exit(EXIT_ERROR)
+
+    if enrich and not accounts:
+        ctx.console.print('Error: --enrich requires --accounts', style='bold red')
         sys.exit(EXIT_ERROR)
 
     # Writes have no JSON contract: the envelope is for consumers reading state,
@@ -746,6 +777,9 @@ def xras(ctx: Context, action_id, show_payload, recheck, summary, validate_mappi
         recheck=recheck,
         summary=summary,
         validate_mapping=validate_mapping,
+        accounts=accounts,
+        enrich=enrich,
+        person=person,
         status=status,
         action_type=action_type,
         request_number=request_number,

--- a/src/cli/xras/builders.py
+++ b/src/cli/xras/builders.py
@@ -120,11 +120,84 @@ def _describe_filters(filters: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def build_mapping_report(session) -> dict:
+def build_mapping_report(session, *, xras_keys=None) -> dict:
     """The ``xras_resource_mapping`` envelope.
 
     The audit itself is :func:`sam.queries.xras_actions.audit_resource_mapping` —
     builders are ORM→dict extractors, not query modules, and the webapp should be
     able to reach the same answer without importing the CLI.
+
+    *xras_keys* is the live catalog when one could be fetched, making the report
+    two-sided; ``None`` reproduces the local-only report byte for byte.
     """
-    return {'kind': 'xras_resource_mapping', **audit_resource_mapping(session)}
+    return {'kind': 'xras_resource_mapping',
+            **audit_resource_mapping(session, xras_keys=xras_keys)}
+
+
+def build_account_worklist(session, *, since=None, until=None,
+                           enrich=False, max_lookups=100) -> dict:
+    """The ``xras_accounts`` envelope — who needs an account before a handoff.
+
+    *enrich* is opt-in because it costs a round trip to XRAS per username. The
+    enrichment report rides in the envelope rather than being folded into the
+    rows: "we did not ask" and "we asked and XRAS was down" are different facts
+    and a consumer diffing two runs needs to tell them apart.
+    """
+    from sam.queries.xras_accounts import (enrich_worklist,
+                                           get_account_worklist,
+                                           worklist_counts)
+
+    rows = get_account_worklist(session, since=since, until=until)
+    enrichment = (enrich_worklist(rows, max_lookups=max_lookups)
+                  if enrich else None)
+
+    return {
+        'kind': 'xras_accounts',
+        'counts': worklist_counts(rows),
+        'enriched': bool(enrich),
+        'enrichment': enrichment,
+        'accounts': [_account_row(r) for r in rows],
+    }
+
+
+def _account_row(row) -> dict:
+    """One worklist row, JSON-shaped. Key order is wire order."""
+    return {
+        'username': row['username'],
+        'classification': row['classification'],
+        'remedy': row['remedy'],
+        'placeholder': row['placeholder'],
+        'roles': list(row['roles']),
+        'is_account_to_be_created': row['is_account_to_be_created'],
+        'is_reconciled': row['is_reconciled'],
+        'first_seen': row['first_seen'],
+        'last_seen': row['last_seen'],
+        'latest_action_log_id': row['latest_action_log_id'],
+        'sources': list(row['sources']),
+        'person': row['person'],
+        'actions': [
+            {'action_log_id': a['action_log_id'],
+             'request_number': a['request_number'],
+             'action_type': a['action_type'],
+             'status': a['status'],
+             'received_time': a['received_time'],
+             'source': a['source'],
+             'would_succeed': a['would_succeed'],
+             'reject_messages': list(a['reject_messages'])}
+            for a in row['actions']
+        ],
+    }
+
+
+def build_person_report(username, person) -> dict:
+    """The ``xras_person`` envelope — a direct ``/v1/people`` probe.
+
+    *person* is ``None`` when XRAS answered and has no such username; an
+    unreachable API raises before this is called, so the two stay distinct.
+    """
+    return {
+        'kind': 'xras_person',
+        'username': username,
+        'found': person is not None,
+        'person': person,
+    }

--- a/src/cli/xras/commands.py
+++ b/src/cli/xras/commands.py
@@ -17,7 +17,8 @@ class XrasCommand(BaseCommand):
     """
 
     def execute(self, *, action_id=None, recheck=None, summary=False,
-                validate_mapping=False,
+                validate_mapping=False, accounts=False, person=None,
+                enrich=False,
                 status=(), action_type=(), request_number=None, last=None,
                 show_payload=False, limit=50, **_) -> int:
         try:
@@ -25,6 +26,10 @@ class XrasCommand(BaseCommand):
 
             if validate_mapping:
                 return self._validate_mapping()
+            if person is not None:
+                return self._person(person)
+            if accounts:
+                return self._accounts(filters, enrich)
             if recheck is not None:
                 return self._recheck(recheck)
             if action_id is not None:
@@ -56,12 +61,94 @@ class XrasCommand(BaseCommand):
         a mapping row pointing at a resource row that does not exist. A
         decommissioned mapping is reported and does not fail — untidy, not broken.
         """
-        payload = builders.build_mapping_report(self.session)
+        payload = builders.build_mapping_report(self.session,
+                                                xras_keys=self._live_keys())
         if self.ctx.output_format == 'json':
             output_json(payload)
         else:
             display.display_mapping_report(self.ctx, payload)
-        return EXIT_NOT_FOUND if payload['dangling_keys'] else EXIT_SUCCESS
+        # Two failing states now: a dangling key (a broken FK on our side) and
+        # a key XRAS sends that SAM cannot resolve — the one that breaks awards.
+        return (EXIT_NOT_FOUND
+                if payload['dangling_keys'] or payload['xras_only_keys']
+                else EXIT_SUCCESS)
+
+    def _live_keys(self):
+        """The XRAS resource catalog, or ``None`` if we could not ask.
+
+        Auto-detecting rather than taking a flag: an operator running the
+        pre-cutover gate wants the strongest check available, and the
+        unconfigured case must degrade to today's one-sided report rather than
+        fail. A configured-but-unreachable API is a warning, not an error —
+        the local half of the audit is still worth reporting.
+        """
+        from sam.integration.xras_api import (XrasSourceUnavailable,
+                                              resource_repository_keys,
+                                              xras_api_configured)
+
+        if not xras_api_configured():
+            return None
+        try:
+            return resource_repository_keys()
+        except XrasSourceUnavailable as exc:
+            self.ctx.console.print(
+                f'[yellow]Could not reach the XRAS API ({exc}); reporting the '
+                f'local half only.[/yellow]')
+            return None
+
+    def _accounts(self, filters, enrich) -> int:
+        """The account-creation worklist.
+
+        An empty worklist exits 0. It is a successful report — "nobody is
+        blocked" — not a miss, and a deploy gate that treated it as one would
+        fail every healthy day.
+        """
+        if enrich:
+            from sam.integration.xras_api import xras_api_configured
+
+            if not xras_api_configured():
+                self.ctx.console.print(
+                    '[red]--enrich needs the XRAS API: set '
+                    'XRAS_OUTGOING_ENABLED=1 and XRAS_API_KEY.[/red]')
+                return EXIT_ERROR
+
+        payload = builders.build_account_worklist(
+            self.session, since=filters.get('start_date'),
+            until=filters.get('end_date'), enrich=enrich)
+        if self.ctx.output_format == 'json':
+            output_json(payload)
+        else:
+            display.display_account_worklist(self.ctx, payload)
+        return EXIT_SUCCESS
+
+    def _person(self, username) -> int:
+        """Probe one username through ``GET /v1/people``.
+
+        The three-outcome model reaches the exit code intact: found 0,
+        no such username 1, could-not-ask 2. Collapsing the last two would
+        make "XRAS is down" indistinguishable from "this person does not
+        exist", which are opposite conclusions for an operator.
+        """
+        from sam.integration.xras_api import (XrasSourceUnavailable, get_person,
+                                              xras_api_configured)
+
+        if not xras_api_configured():
+            self.ctx.console.print(
+                '[red]--person needs the XRAS API: set XRAS_OUTGOING_ENABLED=1 '
+                'and XRAS_API_KEY.[/red]')
+            return EXIT_ERROR
+        try:
+            person = get_person(username)
+        except XrasSourceUnavailable as exc:
+            self.ctx.console.print(f'[red]XRAS unavailable: {exc}[/red]')
+            return EXIT_ERROR
+
+        payload = builders.build_person_report(username, person)
+        if self.ctx.output_format == 'json':
+            output_json(payload)
+        else:
+            display.display_person(self.ctx, payload)
+        return EXIT_SUCCESS if person else EXIT_NOT_FOUND
 
     def _list(self, filters, limit) -> int:
         payload = builders.build_action_list(self.session, filters=filters,

--- a/src/cli/xras/display.py
+++ b/src/cli/xras/display.py
@@ -253,7 +253,7 @@ def display_account_worklist(ctx, payload) -> None:
     table.add_column('Needs')
     table.add_column('Role', style='dim')
     table.add_column('Requests', style='dim')
-    table.add_column('XRAS')
+    table.add_column('XRAS identity')
 
     for row in payload['accounts']:
         needs = ('[red]create[/red]' if row['classification'] == 'absent'
@@ -261,15 +261,23 @@ def display_account_worklist(ctx, payload) -> None:
         if row['placeholder']:
             needs += ' [dim](placeholder)[/dim]'
         numbers = [a['request_number'] for a in row['actions'] if a['request_number']]
-        reconciled = ({None: BLANK, True: '[green]reconciled[/green]',
-                       False: 'unreconciled'}[row['is_reconciled']])
+        # XRAS-side identity state, NOT progress: 9 of 9 rows measured on
+        # the local smoke were reconciled and still needed a SAM account.
+        # `unidentified` is the harder case — no detail sheet to create from.
+        reconciled = {None: BLANK,
+                      True: 'identified',
+                      False: '[yellow]unidentified[/yellow]'}[row['is_reconciled']]
         table.add_row(row['username'], needs, ', '.join(row['roles']),
                       truncate(', '.join(dict.fromkeys(numbers)), 40), reconciled)
 
     ctx.console.print(table)
     ctx.console.print(
+        # "placeholder", NOT "unreconciled" — a placeholder is a username
+        # SHAPE, reconciliation is whether XRAS has linked it to a confirmed
+        # identity. The smoke found all three placeholders reconciled, so
+        # conflating them made this line contradict the table above it.
         f"[dim]{counts['absent']} to create, {counts['inactive']} to reactivate, "
-        f"{counts['placeholder']} unreconciled ARC identities.[/dim]")
+        f"{counts['placeholder']} ARC placeholder identities.[/dim]")
 
     enrichment = payload.get('enrichment')
     if enrichment and enrichment['unavailable']:
@@ -282,7 +290,7 @@ def display_account_worklist(ctx, payload) -> None:
             f"{enrichment['looked_up']} row(s).[/dim]")
     elif not payload['enriched']:
         ctx.console.print(
-            '[dim]Pass --enrich for names, emails and reconciliation state.[/dim]')
+            '[dim]Pass --enrich for names, emails and XRAS identity state.[/dim]')
 
 
 def display_person(ctx, payload) -> None:
@@ -309,11 +317,9 @@ def display_person(ctx, payload) -> None:
             value = person.get(key)
         table.add_row(label, text(value))
     reconciled = person.get('isReconciled')
-    table.add_row('Reconciled',
-                  '[green]yes[/green]' if reconciled else '[yellow]no[/yellow]')
+    table.add_row('Reconciled', 'yes' if reconciled else '[yellow]no[/yellow]')
     ctx.console.print(table)
     if not reconciled:
         ctx.console.print(
-            '[dim]An unreconciled identity has no site account. This record is '
-            "the account-creation detail sheet; the flag flipping is what "
-            'closes the worklist item.[/dim]')
+            '[dim]XRAS has not linked this username to a confirmed identity, so '
+            'the detail above may be self-reported and incomplete.[/dim]')

--- a/src/cli/xras/display.py
+++ b/src/cli/xras/display.py
@@ -212,3 +212,108 @@ def display_mapping_report(ctx, payload) -> None:
         ctx.console.print(
             f"[bold red]Dangling keys with no resource row:[/bold red] "
             f"{', '.join(str(k) for k in payload['dangling_keys'])}")
+
+    # ── the XRAS half ───────────────────────────────────────────────────
+    if not payload.get('live_checked'):
+        ctx.console.print(
+            '[dim]Local half only — the XRAS API was not configured or not '
+            'reachable, so keys XRAS sends that SAM cannot resolve are NOT '
+            'checked. Set XRAS_OUTGOING_ENABLED=1 and XRAS_API_KEY for the '
+            'two-sided report.[/dim]')
+        return
+
+    ctx.console.print(
+        f"[bold]{payload['live_key_count']}[/bold] key(s) offered by XRAS")
+    if payload['xras_only_keys']:
+        ctx.console.print(
+            f"[bold red]XRAS sends keys SAM cannot resolve:[/bold red] "
+            f"{', '.join(str(k) for k in payload['xras_only_keys'])}")
+        ctx.console.print(
+            '[dim]This is the failure that breaks an award: the action fails '
+            'at runtime with "No resource found in SAM corresponding to key %s". '
+            'Add the mapping row before cutover.[/dim]')
+    else:
+        ctx.console.print(
+            '[green]Every key XRAS offers resolves to a SAM resource.[/green]')
+
+
+def display_account_worklist(ctx, payload) -> None:
+    """Render the account-creation worklist, absent before inactive."""
+    counts = payload['counts']
+    ctx.console.rule('[bold]XRAS accounts needed')
+
+    if not payload['accounts']:
+        ctx.console.print(
+            '[green]No accounts are waiting on creation or reactivation.[/green]')
+        return
+
+    table = Table(title=f"{counts['total']} account(s) blocking XRAS handoffs",
+                  title_style='bold')
+    table.add_column('Username', style='cyan')
+    table.add_column('Needs')
+    table.add_column('Role', style='dim')
+    table.add_column('Requests', style='dim')
+    table.add_column('XRAS')
+
+    for row in payload['accounts']:
+        needs = ('[red]create[/red]' if row['classification'] == 'absent'
+                 else '[yellow]reactivate[/yellow]')
+        if row['placeholder']:
+            needs += ' [dim](placeholder)[/dim]'
+        numbers = [a['request_number'] for a in row['actions'] if a['request_number']]
+        reconciled = ({None: BLANK, True: '[green]reconciled[/green]',
+                       False: 'unreconciled'}[row['is_reconciled']])
+        table.add_row(row['username'], needs, ', '.join(row['roles']),
+                      truncate(', '.join(dict.fromkeys(numbers)), 40), reconciled)
+
+    ctx.console.print(table)
+    ctx.console.print(
+        f"[dim]{counts['absent']} to create, {counts['inactive']} to reactivate, "
+        f"{counts['placeholder']} unreconciled ARC identities.[/dim]")
+
+    enrichment = payload.get('enrichment')
+    if enrichment and enrichment['unavailable']:
+        ctx.console.print(
+            '[yellow]Person detail unavailable — the XRAS API could not be '
+            'reached. The worklist itself is complete.[/yellow]')
+    elif enrichment and enrichment['budget_exhausted']:
+        ctx.console.print(
+            f"[dim]Person detail fetched for the first "
+            f"{enrichment['looked_up']} row(s).[/dim]")
+    elif not payload['enriched']:
+        ctx.console.print(
+            '[dim]Pass --enrich for names, emails and reconciliation state.[/dim]')
+
+
+def display_person(ctx, payload) -> None:
+    """Render one XRAS person record."""
+    ctx.console.rule(f"[bold]XRAS person: {payload['username']}")
+    if not payload['found']:
+        ctx.console.print(
+            f"[yellow]XRAS has no user {payload['username']}.[/yellow]")
+        return
+
+    person = payload['person']
+    table = Table(show_header=False)
+    table.add_column('Field', style='dim')
+    table.add_column('Value')
+    for label, key in (('Name', None), ('Email', 'email'),
+                       ('Phone', 'phone'), ('Organization', 'organization'),
+                       ('Academic status', 'academicStatus'),
+                       ('Residence country', 'residenceCountry'),
+                       ('ORCID', 'orcid')):
+        if key is None:
+            value = ' '.join(str(person.get(k) or '') for k in
+                             ('firstName', 'middleName', 'lastName')).strip()
+        else:
+            value = person.get(key)
+        table.add_row(label, text(value))
+    reconciled = person.get('isReconciled')
+    table.add_row('Reconciled',
+                  '[green]yes[/green]' if reconciled else '[yellow]no[/yellow]')
+    ctx.console.print(table)
+    if not reconciled:
+        ctx.console.print(
+            '[dim]An unreconciled identity has no site account. This record is '
+            "the account-creation detail sheet; the flag flipping is what "
+            'closes the worklist item.[/dim]')

--- a/src/sam/integration/xras_api/__init__.py
+++ b/src/sam/integration/xras_api/__init__.py
@@ -1,0 +1,33 @@
+"""Outbound client for the XRAS Allocations API — ``https://api.xras.org/v1/…``.
+
+**Read-only, GET-only, fail-closed.** See ``client.py`` for why that is
+structural rather than a convention, and ``docs/xras/outgoing/`` for the live
+probe this is built on.
+
+Do not confuse this with the *inbound* XRAS surface (``src/sam/xras/``,
+``src/webapp/api/xras/``), which is XRAS calling SAM, nor with
+``sam/integration/xras.py``, which is the ORM for the inbound audit tables.
+"""
+
+from sam.integration.xras_api.base import (
+    XrasApiNotConfigured,
+    XrasSourceUnavailable,
+)
+from sam.integration.xras_api.client import XrasApiClient
+from sam.integration.xras_api.config import XrasApiConfig, xras_api_configured
+from sam.integration.xras_api.people import (
+    get_person,
+    get_resources,
+    resource_repository_keys,
+)
+
+__all__ = [
+    'XrasApiClient',
+    'XrasApiConfig',
+    'XrasApiNotConfigured',
+    'XrasSourceUnavailable',
+    'get_person',
+    'get_resources',
+    'resource_repository_keys',
+    'xras_api_configured',
+]

--- a/src/sam/integration/xras_api/base.py
+++ b/src/sam/integration/xras_api/base.py
@@ -1,0 +1,35 @@
+"""Exceptions for the outbound XRAS Allocations API client.
+
+The three-outcome model is copied deliberately from
+``sam.integration.awards.base``, because every consumer downstream — the
+worklist query, the card, the CLI's exit codes — branches on it:
+
+* a value            → XRAS answered, and this is the answer
+* ``None``           → XRAS answered, and there is no such thing
+* an exception       → we could not ask
+
+Collapsing the last two is the bug this split exists to prevent: "no such
+person" and "XRAS is down" look identical in a ``try: ... except: return
+None`` and mean opposite things to an operator working the account-creation
+worklist.
+"""
+
+from __future__ import annotations
+
+
+class XrasSourceUnavailable(Exception):
+    """The XRAS API could not be reached, or refused the request.
+
+    Distinct from a lookup returning ``None``, which means the API was
+    reached and holds no such record.
+    """
+
+
+class XrasApiNotConfigured(XrasSourceUnavailable):
+    """No API key, or ``XRAS_OUTGOING_ENABLED`` is off.
+
+    A *subclass* on purpose. An unconfigured deployment is the shipped
+    state (see ``helm/values.yaml``), and every call site already handles
+    "could not ask" — so it degrades through exactly the same path as a
+    timeout instead of needing a second branch everywhere.
+    """

--- a/src/sam/integration/xras_api/cache.py
+++ b/src/sam/integration/xras_api/cache.py
@@ -37,7 +37,28 @@ _CACHE = BucketedTTLCache('xras_api', 'xras_api', {
         ttl_key='XRAS_RESOURCES_CACHE_TTL', ttl_default=86400,   # 1 day
         size_key='XRAS_RESOURCES_CACHE_SIZE', size_default=8,
     ),
+    # The Feed-B handoff. Unlike the two above this is NOT a memo of an
+    # expensive read — it is a **producer/consumer mailbox**: `xras_sweep`
+    # writes the classified pending-request worklist, and the dashboard tab
+    # reads it. The enumeration behind it is 21 pages and 60-90s, which no
+    # htmx round-trip can afford, so the tab cannot compute this itself.
+    #
+    # ⚠️ **TTL spans the overnight gap, on purpose.** The sweep runs on
+    # business hours (08:00-17:00 Mountain), so the longest interval between
+    # writes is 17:00 -> 08:00, about 15 hours. A TTL tuned to the *hourly*
+    # cadence would expire around 21:00 and leave the tab blank every morning
+    # until the first sweep of the day — the exact moment an operator looks.
+    # 24h covers the gap with room for a missed run; the data is only ever as
+    # stale as the last successful sweep, and the tab renders that timestamp.
+    'pending': BucketSpec(
+        name='xras_pending',
+        ttl_key='XRAS_PENDING_CACHE_TTL', ttl_default=86400,     # 1 day
+        size_key='XRAS_PENDING_CACHE_SIZE', size_default=4,
+    ),
 })
+
+#: One key: the sweep publishes a single whole-process snapshot.
+_PENDING_KEY = 'worklist'
 
 #: Test seam, matching the awards / fs-scans / jobs idiom: ``_adapters`` IS
 #: the cache's memo dict, so clearing it re-initialises the cache.
@@ -62,3 +83,42 @@ def cached_person(username: str, compute: Callable[[], Any]) -> Optional[Any]:
 def cached_resources(compute: Callable[[], Any]) -> Optional[Any]:
     """Memoise the resource catalog. One key — it takes no arguments."""
     return _CACHE.get_or_compute('resources', 'catalog', compute)
+
+
+def store_pending_worklist(payload: Any) -> bool:
+    """Publish the sweep's Feed-B result for the dashboard to read.
+
+    Returns True if it was stored. A disabled bucket (TTL or size <= 0, or
+    caching switched off in this worker) is **not** an error: the sweep still
+    reports its findings in the ledger row, and the tab renders its
+    "no sweep data yet" state.
+    """
+    adapter = _CACHE.adapter('pending')
+    if adapter is None:
+        return False
+    with adapter.lock:
+        adapter.pop(_PENDING_KEY, None)
+        try:
+            adapter[_PENDING_KEY] = payload
+        except ValueError:
+            # Full with nothing expired to evict — skip rather than fail the
+            # sweep, which has already done the useful work.
+            return False
+    return True
+
+
+def load_pending_worklist() -> Optional[Any]:
+    """Read the sweep's last published Feed-B result, or ``None``.
+
+    ``None`` means "no sweep has published yet" — which is the shipped state
+    until the task is enabled, and is what the tab's empty state describes. It
+    is deliberately distinguishable from a published-but-empty result (a real
+    sweep that found nothing), which comes back as a payload with zero rows.
+    """
+    adapter = _CACHE.adapter('pending')
+    if adapter is None:
+        return None
+    with adapter.lock:
+        if _PENDING_KEY not in adapter:
+            return None
+        return adapter[_PENDING_KEY]

--- a/src/sam/integration/xras_api/cache.py
+++ b/src/sam/integration/xras_api/cache.py
@@ -85,17 +85,28 @@ def cached_resources(compute: Callable[[], Any]) -> Optional[Any]:
     return _CACHE.get_or_compute('resources', 'catalog', compute)
 
 
-def store_pending_worklist(payload: Any) -> bool:
+def store_pending_worklist(payload: Any) -> str:
     """Publish the sweep's Feed-B result for the dashboard to read.
 
-    Returns True if it was stored. A disabled bucket (TTL or size <= 0, or
-    caching switched off in this worker) is **not** an error: the sweep still
-    reports its findings in the ledger row, and the tab renders its
-    "no sweep data yet" state.
+    Returns **where it landed**, not merely whether a write succeeded:
+    ``'redis'`` (shared, the dashboard will see it), ``'local'`` (a per-worker
+    in-process cache), or ``'disabled'`` / ``'full'``.
+
+    ⚠️ **Why this is not a bool.** `BucketedTTLCache.adapter()` falls back to a
+    per-worker `TTLCacheAdapter` when `CACHE_REDIS_URL` is unset or Redis is
+    unreachable, and that fallback is load-bearing — an unreachable Redis must
+    never take the webapp down. But `xras_sweep` runs in a **one-shot CronJob
+    pod**: a process-local write succeeds, the pod exits, and the cache dies
+    with it. The producer reports success, the consumer sees nothing, and
+    nothing anywhere errors.
+
+    That is not hypothetical — it is what the first production run did, because
+    `cronjob-tasks.yaml` did not carry `CACHE_REDIS_URL`. A bool could not tell
+    the two apart, so the caller could not report the difference.
     """
     adapter = _CACHE.adapter('pending')
     if adapter is None:
-        return False
+        return 'disabled'
     with adapter.lock:
         adapter.pop(_PENDING_KEY, None)
         try:
@@ -103,8 +114,17 @@ def store_pending_worklist(payload: Any) -> bool:
         except ValueError:
             # Full with nothing expired to evict — skip rather than fail the
             # sweep, which has already done the useful work.
-            return False
-    return True
+            return 'full'
+    return 'redis' if is_shared_backend(adapter) else 'local'
+
+
+def is_shared_backend(adapter: Any) -> bool:
+    """Is this adapter visible to other processes?
+
+    The one question a producer in a short-lived pod actually needs answered.
+    """
+    from sam.caching.redis_ttl import RedisTTLAdapter
+    return isinstance(adapter, RedisTTLAdapter)
 
 
 def load_pending_worklist() -> Optional[Any]:

--- a/src/sam/integration/xras_api/cache.py
+++ b/src/sam/integration/xras_api/cache.py
@@ -1,0 +1,64 @@
+"""TTL cache for outbound XRAS lookups.
+
+Two buckets with deliberately different horizons:
+
+``xras_people`` (4 h)
+    ``isReconciled`` is the **closure signal** for the account-creation
+    worklist — an item closes itself when the flag flips — so this must not
+    go stale. Four hours means an operator who creates an account in the
+    morning sees the row clear the same day without touching SAM.
+
+``xras_resources`` (1 day)
+    A 13-row catalog that changes on the order of once a year.
+
+Registered with the webapp caching facade via ``_BUCKETED_CACHE_MODULES`` in
+``webapp/caching/__init__.py``, which is the one line that buys the Admin card
+row, ``stats()``, ``clear()`` and
+``sam-admin cache --refresh --category xras_api``.
+
+⚠️ ``BucketSpec.name`` is a **global Redis key prefix**, hence the ``xras_``
+prefix on both.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from sam.caching import BucketedTTLCache, BucketSpec
+
+_CACHE = BucketedTTLCache('xras_api', 'xras_api', {
+    'people': BucketSpec(
+        name='xras_people',
+        ttl_key='XRAS_PEOPLE_CACHE_TTL', ttl_default=14400,      # 4 hours
+        size_key='XRAS_PEOPLE_CACHE_SIZE', size_default=512,
+    ),
+    'resources': BucketSpec(
+        name='xras_resources',
+        ttl_key='XRAS_RESOURCES_CACHE_TTL', ttl_default=86400,   # 1 day
+        size_key='XRAS_RESOURCES_CACHE_SIZE', size_default=8,
+    ),
+})
+
+#: Test seam, matching the awards / fs-scans / jobs idiom: ``_adapters`` IS
+#: the cache's memo dict, so clearing it re-initialises the cache.
+_adapters = _CACHE._adapters
+
+
+def cached_person(username: str, compute: Callable[[], Any]) -> Optional[Any]:
+    """Memoise one person lookup.
+
+    Successes **and definite negatives** are cached — a 404 for a username is
+    a real answer and re-asking costs a round trip per card render. An
+    ``XrasSourceUnavailable`` propagates out of *compute* before the store, so
+    a transient outage is never remembered.
+
+    The username is casefolded into the key: XRAS usernames are matched
+    case-insensitively at the API, and without this ``Smith`` and ``smith``
+    would occupy two entries.
+    """
+    return _CACHE.get_or_compute('people', username.strip().casefold(), compute)
+
+
+def cached_resources(compute: Callable[[], Any]) -> Optional[Any]:
+    """Memoise the resource catalog. One key — it takes no arguments."""
+    return _CACHE.get_or_compute('resources', 'catalog', compute)

--- a/src/sam/integration/xras_api/client.py
+++ b/src/sam/integration/xras_api/client.py
@@ -1,0 +1,302 @@
+"""GET-only HTTP client for the XRAS Allocations API (``https://api.xras.org/v1/…``).
+
+Direction of travel
+-------------------
+Everything under ``src/sam/xras/`` and ``src/webapp/api/xras/`` is XRAS → SAM
+(they push actions, they pull our GETs). This module is the **opposite**
+direction: SAM calling out to XRAS. See ``docs/xras/outgoing/`` for the probe
+results this is built on.
+
+Transport semantics are copied from ``sam.integration.awards.client``: one
+persistent ``requests.Session``, an explicit timeout on every call, three
+attempts with ``2 ** attempt`` backoff, and **no retry on 4xx** — a 404 is an
+answer, not a failure to answer.
+
+Why there is no ``post``
+------------------------
+The documented XRAS API is far more write-capable than this client is, and
+our key holds at least some of it: creating and deleting requests, submitting
+and withdrawing actions, adding and removing roles, **merging one person into
+another**, updating resources. None of that may ever be reachable from SAM
+code. So GET-only is **structural, not conventional**: the sole transport
+primitive is :meth:`_get`, there is no generic verb method, and
+``tests/unit/test_xras_api_client.py`` pins that no post/put/patch/delete
+callable exists on the class.
+
+Two headers worth knowing
+-------------------------
+``XA-CONTEXT`` is **hardcoded** to ``report``. It is not a knob: the Reports
+family (``/v1/reports/*``), which is the entire reason this client is useful,
+answers *only* under ``report`` and 401s under ``submit`` — while everything
+else we read answers under ``report`` too. One context, read-only semantics.
+
+``XA-USER`` is required on every call but scopes nothing outside
+``/v1/requests``; the reports endpoints return process-wide data whatever it
+says. Per-user impersonation is not needed anywhere in this design.
+
+Every JSON response wraps its payload in a ``{"message": ..., "result": ...}``
+envelope, unwrapped centrally in :meth:`_get`.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, Iterator, List, Mapping, Optional
+from urllib.parse import quote
+
+import requests
+
+from sam.integration.xras_api.base import XrasApiNotConfigured, XrasSourceUnavailable
+from sam.integration.xras_api.config import XrasApiConfig
+
+logger = logging.getLogger(__name__)
+
+#: See the module docstring. Not a parameter, by design.
+XA_CONTEXT = 'report'
+
+#: ``GET /v1/reports/requests`` filter vocabulary, verified against the live
+#: NCAR process. ``status`` and ``active`` are mutually exclusive there.
+REQUEST_STATUSES = ('Submitted', 'Approved', 'Rejected', 'Incomplete',
+                    'Under Review')
+
+DEFAULT_PAGE_SIZE = 50
+
+
+class XrasApiClient:
+    """Retrying JSON client over a persistent session. Reads only."""
+
+    def __init__(self, config: Optional[XrasApiConfig] = None) -> None:
+        self.config = config or XrasApiConfig.from_environment()
+        self.session = requests.Session()
+        self.session.headers.update({
+            'User-Agent': 'SAM/1.0 (+https://sam.hpc.ucar.edu)',
+            'Accept': 'application/json',
+            'XA-API-KEY': self.config.api_key,
+            'XA-ALLOCATIONS-PROCESS': self.config.allocations_process,
+            'XA-CONTEXT': XA_CONTEXT,
+            'XA-USER': self.config.api_user,
+        })
+
+    @classmethod
+    def from_environment(cls, config: Optional[XrasApiConfig] = None
+                         ) -> 'XrasApiClient':
+        """Build a configured client, or refuse.
+
+        Raises:
+            XrasApiNotConfigured: the lever is off or no key is set. It is a
+                subclass of :class:`XrasSourceUnavailable`, so a caller that
+                only handles "could not ask" is already correct.
+        """
+        resolved = config or XrasApiConfig.from_environment()
+        if not resolved.configured:
+            raise XrasApiNotConfigured(
+                'XRAS outgoing API is not configured '
+                '(needs XRAS_OUTGOING_ENABLED=1 and XRAS_API_KEY)')
+        return cls(resolved)
+
+    # ── internals ───────────────────────────────────────────────────────
+
+    def _url(self, path: str) -> str:
+        return f"{self.config.base_url}/{path.lstrip('/')}"
+
+    def _get(self, path: str, *,
+             params: Optional[Mapping[str, Any]] = None) -> Optional[Any]:
+        """Return the unwrapped ``result``, or ``None`` when XRAS has no such thing.
+
+        The only transport primitive in this class — see the module docstring.
+
+        Raises:
+            XrasSourceUnavailable: every attempt failed, or XRAS answered 4xx
+                (other than 404) or with an unparseable body.
+        """
+        url = self._url(path)
+        last_error: Optional[Exception] = None
+
+        for attempt in range(self.config.max_retries):
+            try:
+                response = self.session.request(
+                    'GET', url, params=params, timeout=self.config.timeout)
+            except requests.RequestException as exc:
+                last_error = exc
+                if attempt == self.config.max_retries - 1:
+                    break
+                time.sleep(2 ** attempt)
+                continue
+
+            status = response.status_code
+            if status == 404:
+                # A Rails HTML 404 means "no such route"; a JSON body means
+                # the route exists and found nothing. Both are "no such
+                # thing" to a caller, and neither is worth a retry.
+                logger.info('xras api GET %s -> 404', url)
+                return None
+            if 400 <= status < 500:
+                # A client error is deterministic — retrying cannot help.
+                # 401 here means the key is not provisioned for what was
+                # asked, which is a configuration fact, not an outage.
+                raise XrasSourceUnavailable(
+                    f'{url} returned HTTP {status}: {response.text[:200]}')
+            if status >= 500:
+                last_error = requests.HTTPError(f'HTTP {status}')
+                if attempt == self.config.max_retries - 1:
+                    break
+                wait = 2 ** attempt
+                logger.warning('xras api %s: HTTP %s, retry %d/%d in %ds',
+                               url, status, attempt + 1,
+                               self.config.max_retries, wait)
+                time.sleep(wait)
+                continue
+
+            try:
+                body = response.json()
+            except ValueError as exc:
+                raise XrasSourceUnavailable(
+                    f'{url} returned non-JSON body: {exc}') from exc
+
+            logger.info('xras api GET %s -> %s', url, status)
+            return _unwrap(body)
+
+        raise XrasSourceUnavailable(
+            f'{url} unreachable after {self.config.max_retries} attempts: '
+            f'{last_error}')
+
+    # ── people ──────────────────────────────────────────────────────────
+
+    def get_person(self, username: str) -> Optional[Dict[str, Any]]:
+        """One person from the global XRAS directory, or ``None`` if unknown.
+
+        Carries what account creation needs and the inbound payload does not:
+        ``residenceCountry``, ``academicStatus``, ``organization``, and
+        ``isReconciled`` — the last of which is the worklist's closure signal.
+        Unreconciled researchers resolve here under their ARC placeholder
+        username (``<name>-user-<token>``).
+        """
+        return _as_dict(self._get(f'/v1/people/{quote(str(username), safe="")}'))
+
+    def search_people(self, query: str) -> Optional[List[Dict[str, Any]]]:
+        """Directory search on name/username fragments. Same person shape."""
+        return _as_list(self._get('/v1/search/people', params={'q': query}))
+
+    # ── resources ───────────────────────────────────────────────────────
+
+    def get_resources(self) -> Optional[List[Dict[str, Any]]]:
+        """The process's resource catalog, including ``resourceRepositoryKey``.
+
+        That key is the join to ``xras_resource_repository_key_resource`` and
+        is what makes ``sam-admin xras --validate-mapping`` two-sided: without
+        it the audit can only see the keys SAM knows, never the ones XRAS will
+        actually send.
+        """
+        return _as_list(self._get('/v1/resources'))
+
+    # ── requests (the Reports family) ───────────────────────────────────
+
+    def get_request_by_number(self, request_number: str
+                              ) -> Optional[Dict[str, Any]]:
+        """Look up one request **by request number — i.e. by projcode**.
+
+        ``GET /v1/requests/<requestNumber>`` is *not* this: that route is keyed
+        on ``requestId`` and 401s for a number. This is the reports path.
+        """
+        result = self._get(
+            f'/v1/reports/request_numbers/{quote(str(request_number), safe="")}')
+        if isinstance(result, list):
+            return result[0] if result else None
+        return _as_dict(result)
+
+    def get_requests_page(self, *, status: Optional[str] = 'Approved',
+                          limit: int = DEFAULT_PAGE_SIZE,
+                          prev_min_request_id: Optional[int] = None
+                          ) -> List[Dict[str, Any]]:
+        """One page of ``GET /v1/reports/requests``, newest ``requestId`` first.
+
+        Unscoped: every request in the NCAR process, not just those the
+        ``XA-USER`` holds a role on. Each row carries its full ``roles[]`` with
+        the **person object inline** — which is why the enumeration feed never
+        needs a separate ``/v1/people`` call.
+        """
+        params: Dict[str, Any] = {'limit': limit}
+        if status:
+            params['status'] = status
+        if prev_min_request_id is not None:
+            # Strictly-less-than, so the smallest id on the page is what asks
+            # for the next one.
+            params['prevMinRequestId'] = prev_min_request_id
+        return _as_list(self._get('/v1/reports/requests', params=params)) or []
+
+    def iter_request_pages(self, *, status: Optional[str] = 'Approved',
+                           page_size: int = DEFAULT_PAGE_SIZE,
+                           max_pages: Optional[int] = None
+                           ) -> Iterator[List[Dict[str, Any]]]:
+        """Paginate ``reports/requests``, yielding whole pages.
+
+        The page-level primitive exists so a caller can *count* pages and know
+        whether it stopped because the data ran out or because it hit
+        *max_pages* — a silent cap reads as "covered everything" when it did
+        not. :meth:`iter_requests` is the flattened convenience over this.
+
+        Stops on an empty page, on *max_pages*, or if the cursor fails to
+        advance (a defensive guard: a server that repeated a page would
+        otherwise loop forever).
+        """
+        cursor: Optional[int] = None
+        pages = 0
+        while max_pages is None or pages < max_pages:
+            rows = self.get_requests_page(status=status, limit=page_size,
+                                          prev_min_request_id=cursor)
+            if not rows:
+                return
+            pages += 1
+            yield rows
+
+            ids = [r.get('requestId') for r in rows
+                   if isinstance(r, dict) and isinstance(r.get('requestId'), int)]
+            if not ids:
+                return
+            lowest = min(ids)
+            if cursor is not None and lowest >= cursor:
+                logger.warning('xras api reports/requests cursor did not '
+                               'advance (%s -> %s); stopping', cursor, lowest)
+                return
+            cursor = lowest
+            if len(rows) < page_size:
+                return
+
+    def iter_requests(self, *, status: Optional[str] = 'Approved',
+                      page_size: int = DEFAULT_PAGE_SIZE,
+                      max_pages: Optional[int] = None
+                      ) -> Iterator[Dict[str, Any]]:
+        """Every request in the process, flattened across pages."""
+        for page in self.iter_request_pages(status=status, page_size=page_size,
+                                            max_pages=max_pages):
+            for row in page:
+                if isinstance(row, dict):
+                    yield row
+
+
+# ── envelope helpers ────────────────────────────────────────────────────
+
+def _unwrap(body: Any) -> Any:
+    """Strip the ``{"message": ..., "result": ...}`` envelope.
+
+    A body that is not an envelope is returned untouched — the envelope is a
+    consistent XRAS convention, not something worth failing over.
+    """
+    if isinstance(body, dict) and 'result' in body:
+        return body['result']
+    return body
+
+
+def _as_list(value: Any) -> Optional[List[Any]]:
+    if value is None:
+        return None
+    return value if isinstance(value, list) else [value]
+
+
+def _as_dict(value: Any) -> Optional[Dict[str, Any]]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, list) and value and isinstance(value[0], dict):
+        return value[0]
+    return None

--- a/src/sam/integration/xras_api/client.py
+++ b/src/sam/integration/xras_api/client.py
@@ -168,9 +168,14 @@ class XrasApiClient:
 
         Carries what account creation needs and the inbound payload does not:
         ``residenceCountry``, ``academicStatus``, ``organization``, and
-        ``isReconciled`` — the last of which is the worklist's closure signal.
-        Unreconciled researchers resolve here under their ARC placeholder
-        username (``<name>-user-<token>``).
+        ``isReconciled``. Researchers resolve here under their ARC placeholder
+        username (``<name>-user-<token>``) whether or not they are reconciled.
+
+        ⚠️ ``isReconciled`` says XRAS has linked this username to a real
+        identity — **not** that SAM has an account. Measured 9 of 9 on the
+        local smoke: every worklist row was reconciled and every one still
+        needed an account created or reactivated. See
+        :func:`sam.queries.xras_accounts.enrich_worklist`.
         """
         return _as_dict(self._get(f'/v1/people/{quote(str(username), safe="")}'))
 

--- a/src/sam/integration/xras_api/config.py
+++ b/src/sam/integration/xras_api/config.py
@@ -1,0 +1,154 @@
+"""``XrasApiConfig`` — outbound XRAS credentials, from Flask config *or* the environment.
+
+Follows ``sam/notify/config.py`` exactly, which in turn follows the
+framework-agnostic seam at ``sam/caching/buckets.py:65-71``: try
+``flask.current_app.config``, fall back to ``os.environ``. That is what lets
+one client serve both the webapp and ``sam-admin`` without either importing
+the other.
+
+Read **per call**, never memoised at import: the webapp's config is not
+readable at import time, and the scheduled task reads its environment once
+per run by design.
+
+Fail-closed
+-----------
+``XRAS_OUTGOING_ENABLED`` defaults **off** everywhere and ``helm/values.yaml``
+pins it ``"0"`` visibly. With the lever off the card renders its unconfigured
+state, the sweep records a skip, and the CLI degrades — nothing raises for
+lack of a key. This mirrors ``XRAS_ACTIONS_CAPTURE_ONLY`` on the inbound side.
+
+⚠️ ``XRAS_API_KEY`` is **not** ``SAM_XRAS_USER`` / ``SAM_XRAS_PASS``. Those are
+XRAS's credential for calling *SAM* (a production write credential in the
+inbound direction). This is SAM's credential for calling *XRAS*, and the same
+key can create requests, merge people and modify roles — which is why
+:class:`~sam.integration.xras_api.client.XrasApiClient` has no verb method
+other than an internal ``_get``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+_TRUE = ('1', 'true', 'yes', 'on')
+
+DEFAULT_BASE_URL = 'https://api.xras.org'
+DEFAULT_ALLOCATIONS_PROCESS = 'NCAR'
+
+#: The header value the existing operator scripts use. Outside ``/v1/requests``
+#: it scopes nothing — the reports endpoints return process-wide data whatever
+#: it says — but it is a required header on every call.
+DEFAULT_API_USER = 'arcguest'
+
+#: Seconds. Short on purpose: this can run inside an htmx round-trip, so a
+#: slow XRAS must degrade to "source unavailable" rather than hold a worker.
+DEFAULT_TIMEOUT = 10
+
+DEFAULT_MAX_RETRIES = 3
+
+
+def _raw(key: str, default: Any) -> Any:
+    """Read a key from Flask app config if we are in an app context, else env.
+
+    ``RuntimeError`` is what ``current_app`` raises outside an application
+    context; ``ImportError`` covers a ``sam`` install with no Flask at all,
+    which is a supported deployment (neither the CLI nor ``src/scheduling/``
+    depends on Flask).
+    """
+    try:
+        from flask import current_app
+        return current_app.config.get(key, os.environ.get(key, default))
+    except (RuntimeError, ImportError):
+        return os.environ.get(key, default)
+
+
+def _config_str(key: str, default: str = '') -> str:
+    value = _raw(key, default)
+    return '' if value is None else str(value).strip()
+
+
+def _config_bool(key: str, default: bool = False) -> bool:
+    value = _raw(key, default)
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in _TRUE
+
+
+def _config_int(key: str, default: int) -> int:
+    value = _raw(key, default)
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+@dataclass(frozen=True)
+class XrasApiConfig:
+    """A snapshot of outbound-XRAS config, resolved at construction."""
+
+    #: Master lever. Fail-closed — see the module docstring.
+    enabled: bool = False
+    api_key: str = ''
+    base_url: str = DEFAULT_BASE_URL
+    allocations_process: str = DEFAULT_ALLOCATIONS_PROCESS
+    api_user: str = DEFAULT_API_USER
+    timeout: int = DEFAULT_TIMEOUT
+    max_retries: int = DEFAULT_MAX_RETRIES
+
+    @classmethod
+    def from_environment(cls) -> 'XrasApiConfig':
+        """Build from Flask config or the environment, whichever is available."""
+        return cls(
+            enabled=_config_bool('XRAS_OUTGOING_ENABLED', False),
+            api_key=_config_str('XRAS_API_KEY', ''),
+            base_url=(_config_str('XRAS_API_BASE', DEFAULT_BASE_URL)
+                      or DEFAULT_BASE_URL).rstrip('/'),
+            allocations_process=(_config_str('XRAS_ALLOCATIONS_PROCESS',
+                                             DEFAULT_ALLOCATIONS_PROCESS)
+                                 or DEFAULT_ALLOCATIONS_PROCESS),
+            api_user=(_config_str('XRAS_API_USER', DEFAULT_API_USER)
+                      or DEFAULT_API_USER),
+            timeout=_config_int('XRAS_API_TIMEOUT', DEFAULT_TIMEOUT),
+            max_retries=_config_int('XRAS_API_MAX_RETRIES', DEFAULT_MAX_RETRIES),
+        )
+
+    @property
+    def configured(self) -> bool:
+        """True when a call can actually be attempted.
+
+        Both halves matter: a key with the lever off must stay silent, and
+        the lever on with no key would fail at the first request instead of
+        at the predicate.
+        """
+        return bool(self.enabled and self.api_key)
+
+    def summary(self) -> Dict[str, Any]:
+        """Config for the Admin → Configuration card. **Never** the key.
+
+        ``api_key_set`` is a boolean on purpose — an operator needs to know
+        whether the ExternalSecret landed, and nothing more.
+        """
+        return {
+            'enabled': self.enabled,
+            'api_key_set': bool(self.api_key),
+            'base_url': self.base_url,
+            'allocations_process': self.allocations_process,
+            'api_user': self.api_user,
+            'timeout': self.timeout,
+            'max_retries': self.max_retries,
+            'configured': self.configured,
+        }
+
+
+def xras_api_configured(config: Optional[XrasApiConfig] = None) -> bool:
+    """The cheap predicate callers branch on before building a client.
+
+    Two layers, deliberately: this one lets the card, the CLI and the sweep
+    choose a degraded path *without* constructing anything or catching
+    anything; :meth:`XrasApiClient.from_environment` raising
+    :class:`~sam.integration.xras_api.base.XrasApiNotConfigured` is the
+    backstop for the paths that did not check.
+    """
+    return (config or XrasApiConfig.from_environment()).configured

--- a/src/sam/integration/xras_api/people.py
+++ b/src/sam/integration/xras_api/people.py
@@ -1,0 +1,65 @@
+"""Cached wrappers over the client's lookups.
+
+The split from ``client.py`` is the same one ``awards/`` makes: the client
+knows about HTTP and nothing about memoisation, so its retry and
+three-outcome semantics stay testable without a cache in the way. These are
+what application code calls.
+
+Each builds its own client. That is cheap (a ``requests.Session``
+constructor) and it is what keeps config read **per call** — the webapp
+reloads config without a restart, and the scheduled task reads its
+environment once per run.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from sam.integration.xras_api.cache import cached_person, cached_resources
+from sam.integration.xras_api.client import XrasApiClient
+
+
+def get_person(username: str) -> Optional[Dict[str, Any]]:
+    """One XRAS person, memoised. ``None`` means XRAS has no such username.
+
+    Raises:
+        XrasApiNotConfigured: the outgoing lever is off or no key is set.
+        XrasSourceUnavailable: XRAS could not be reached.
+    """
+    if not username or not str(username).strip():
+        return None
+    return cached_person(
+        username, lambda: XrasApiClient.from_environment().get_person(username))
+
+
+def get_resources() -> Optional[List[Dict[str, Any]]]:
+    """The XRAS resource catalog, memoised.
+
+    Raises:
+        XrasApiNotConfigured: the outgoing lever is off or no key is set.
+        XrasSourceUnavailable: XRAS could not be reached.
+    """
+    return cached_resources(
+        lambda: XrasApiClient.from_environment().get_resources())
+
+
+def resource_repository_keys() -> List[int]:
+    """Just the ``resourceRepositoryKey`` values, as ints.
+
+    The shape ``audit_resource_mapping(session, xras_keys=...)`` wants — it
+    compares against ``xras_resource_repository_key_resource``, whose key
+    column is an integer.
+    """
+    keys: List[int] = []
+    for resource in get_resources() or []:
+        if not isinstance(resource, dict):
+            continue
+        raw = resource.get('resourceRepositoryKey')
+        try:
+            keys.append(int(raw))
+        except (TypeError, ValueError):
+            # A non-numeric key cannot join to the integer column at all;
+            # dropping it here keeps the audit's report honest rather than
+            # reporting a key that could never have matched.
+            continue
+    return sorted(set(keys))

--- a/src/sam/queries/xras_accounts.py
+++ b/src/sam/queries/xras_accounts.py
@@ -106,6 +106,12 @@ USER_ROLE = 'User'
 #: Ranked for display: the strongest role a username holds leads the row.
 _ROLE_ORDER = (PI_ROLE, ALLOCATION_MANAGER_ROLE, USER_ROLE)
 
+#: PII. Assembled only for a viewer holding ``MANAGE_XRAS`` — see the card.
+PERSON_FIELDS = ('firstName', 'middleName', 'lastName', 'email', 'phone',
+                 'organization', 'academicStatus', 'residenceCountry',
+                 'isReconciled', 'orcid')
+
+
 CLASSIFICATION_ABSENT = 'absent'
 CLASSIFICATION_INACTIVE = 'inactive'
 
@@ -469,7 +475,14 @@ def classify_accounts(session: Session,
 
             person = record.person_by_username.get(username)
             if person and row['person'] is None:
-                row['person'] = person
+                # Filtered to PERSON_FIELDS, exactly as `enrich_worklist` does
+                # for Feed A. Two reasons beyond consistency: a raw XRAS person
+                # carries fields we never declared (`hasOrcidToken`, a
+                # duplicate `username`), and a Feed-B row is PERSISTED — the
+                # sweep publishes it into the cache — so whatever lands here
+                # outlives the request that made it.
+                row['person'] = {k: person.get(k) for k in PERSON_FIELDS
+                                 if k in person}
                 if 'isReconciled' in person:
                     row['is_reconciled'] = bool(person['isReconciled'])
 
@@ -518,12 +531,6 @@ def get_account_worklist(session: Session, *,
 
 
 # ── enrichment ──────────────────────────────────────────────────────────
-
-#: PII. Assembled only for a viewer holding ``MANAGE_XRAS`` — see the card.
-PERSON_FIELDS = ('firstName', 'middleName', 'lastName', 'email', 'phone',
-                 'organization', 'academicStatus', 'residenceCountry',
-                 'isReconciled', 'orcid')
-
 
 def enrich_worklist(rows: Sequence[Dict[str, Any]], *,
                     person_lookup: Optional[Callable[[str], Optional[dict]]] = None,

--- a/src/sam/queries/xras_accounts.py
+++ b/src/sam/queries/xras_accounts.py
@@ -128,6 +128,18 @@ class ActionRef:
     action_type: Optional[str] = None
     status: Optional[str] = None
     received_time: Optional[datetime] = None
+    #: When the request appeared in XRAS (``submitDate``), for a feed that has
+    #: no arrival of its own. Feed A leaves it ``None`` and uses
+    #: ``received_time`` — when XRAS pushed the action to us.
+    #:
+    #: These two are the SAME QUESTION per feed — "when did this show up?" —
+    #: which is what lets one window control span both. Filtering Feed B on
+    #: its period of performance instead was tried and is wrong: a pending
+    #: request's allocation almost always ends a year out, so a one-sided
+    #: window keeps every row at every width and the control looks dead. The
+    #: period of performance belongs where it already is, bounding what the
+    #: sweep collects.
+    submit_date: Optional[str] = None
     source: str = 'action_log'
     #: ``dispatch_action(validate_only=True)``'s verdict. ``None`` = not run.
     would_succeed: Optional[bool] = None
@@ -352,6 +364,8 @@ def records_from_report_requests(payloads: Iterable[dict]) -> List[RosterRecord]
                           action_type=payload.get('requestType'),
                           status=payload.get('requestStatus'),
                           received_time=None,
+                          submit_date=(str(payload.get('submitDate'))[:10]
+                                       if payload.get('submitDate') else None),
                           source='reports'),
             usernames=tuple(usernames),
             roles_by_username={k: tuple(v) for k, v in roles.items()},
@@ -465,6 +479,7 @@ def classify_accounts(session: Session,
                 'action_type': record.ref.action_type,
                 'status': record.ref.status,
                 'received_time': record.ref.received_time,
+                'submit_date': record.ref.submit_date,
                 'source': record.ref.source,
                 'would_succeed': record.ref.would_succeed,
                 'reject_messages': list(record.ref.reject_messages),

--- a/src/sam/queries/xras_accounts.py
+++ b/src/sam/queries/xras_accounts.py
@@ -1,0 +1,533 @@
+"""The XRAS account-creation worklist — who must exist in SAM before a handoff works.
+
+The problem
+-----------
+``src/sam/xras/handlers/new.py:24-27`` records the measured causes of the legacy
+70% failure rate, and the largest single one — **55%** — is unreconciled ARC
+placeholder identities: a researcher XRAS names on a request who has no SAM
+account. Account creation is manual, so the fix is not code that creates
+accounts; it is a worklist telling an operator *who*, *why*, and *with what
+detail*.
+
+Two feeds, one classifier
+-------------------------
+::
+
+    Feed A  xras_action_log.raw_payload   ──┐
+            (inbound pushes, at push time)  │   normalized        classify vs
+                                            ├── RosterRecord ──►  users  ──► rows
+    Feed B  GET /v1/reports/requests        │   (feed-neutral)   absent/inactive
+            (enumeration, ahead of push)  ──┘
+
+The feed-agnostic seam is :class:`RosterRecord`. It is the one decision that
+keeps the classifier, the card, the CLI and the eventual operator-notes table
+single-sourced — Feed B reaches people Feed A structurally cannot (a brand-new
+PI on a solo New request, connected to nobody SAM knows, *before* the push),
+and neither feed should imply a second copy of the classification rules.
+
+⚠️ Not exported from ``sam/queries/__init__.py``
+------------------------------------------------
+That module imports its submodules eagerly, so listing this one would drag
+``requests`` and the cache layer into every ``from sam.queries import ...``.
+Same reasoning as ``expiration_notices`` and ``xras_notices``; import it by
+module path. For the same reason the default person lookup is resolved by a
+**deferred import** inside :func:`enrich_worklist` rather than at module scope —
+``src/scheduling/`` imports this module, and
+``test_task_ledger.py::TestPortabilityBoundary`` walks what that drags in.
+
+⚠️ Regime-proof by construction
+--------------------------------
+Classification is a check against the **current** state of ``users``, never
+against the action's ``status``. Actions in the log may be ``received`` (under
+capture-only) or ``processed``/``failed``/``manual`` (under live dispatch), and
+the worklist must mean the same thing on both sides of that flip.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import (Any, Callable, Dict, Iterable, List, Mapping, Optional,
+                    Sequence, Tuple)
+
+from sqlalchemy.orm import Session
+
+from sam.core.users import User
+from sam.integration.xras import XrasActionLog
+
+logger = logging.getLogger(__name__)
+
+#: Statuses whose roster is worth pre-flighting. ``processed`` is excluded
+#: because it already succeeded, and ``rechecked``/``unmapped`` are not an
+#: action's own outcome. This bounds the *validate* work, not the
+#: classification — see the module docstring on regime-proofing.
+WORKLIST_STATUSES: Tuple[str, ...] = ('received', 'failed', 'manual')
+
+#: ARC placeholder identities, e.g. ``placeholder34-user-00034``. XRAS mints one
+#: for every unreconciled person, and it resolves fully through
+#: ``GET /v1/people/<username>``, which is what makes the detail sheet possible.
+PLACEHOLDER_USERNAME_RE = re.compile(r'^\S+-user-\S+$')
+
+#: Wire role strings, spaced — the *inbound* vocabulary. Verified live: the
+#: NCAR process defines exactly these three role types (13 PI / 14 Allocation
+#: Manager / 19 User), so no co-PI can ever appear. Deliberately NOT the
+#: ``Pi``/``CoPi``/``AllocationManager`` vocabulary SAM's own outbound GET side
+#: uses (``webapp/api/xras/requests.py:33-37``); the two must not be conflated.
+PI_ROLE = 'PI'
+ALLOCATION_MANAGER_ROLE = 'Allocation Manager'
+USER_ROLE = 'User'
+
+#: Ranked for display: the strongest role a username holds leads the row.
+_ROLE_ORDER = (PI_ROLE, ALLOCATION_MANAGER_ROLE, USER_ROLE)
+
+CLASSIFICATION_ABSENT = 'absent'
+CLASSIFICATION_INACTIVE = 'inactive'
+
+#: What an operator has to *do*, which is not the same question as why the row
+#: is here — the two remedies are different pieces of work.
+REMEDIES = {CLASSIFICATION_ABSENT: 'create', CLASSIFICATION_INACTIVE: 'reactivate'}
+
+
+@dataclass(frozen=True)
+class ActionRef:
+    """Provenance for one roster — feed-neutral.
+
+    ``action_log_id`` is ``None`` for a Feed-B record: an enumerated request
+    has no row in ``xras_action_log`` precisely because it has not been pushed
+    yet, which is the whole point of the second feed.
+    """
+
+    action_log_id: Optional[int] = None
+    request_number: Optional[str] = None
+    action_type: Optional[str] = None
+    status: Optional[str] = None
+    received_time: Optional[datetime] = None
+    source: str = 'action_log'
+    #: ``dispatch_action(validate_only=True)``'s verdict. ``None`` = not run.
+    would_succeed: Optional[bool] = None
+    #: Verbatim, **display-only**. These are a byte-pinned wire contract
+    #: (``sam/xras/errors.py``), not an interface — never parse them.
+    reject_messages: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RosterRecord:
+    """One action's roster, normalized. The seam both feeds construct."""
+
+    ref: ActionRef
+    usernames: Tuple[str, ...] = ()
+    roles_by_username: Mapping[str, Tuple[str, ...]] = field(default_factory=dict)
+    #: ``isAccountToBeCreated`` — a **hint column only**. See
+    #: :func:`classify_accounts` for why it is never the predicate.
+    account_flag: Mapping[str, bool] = field(default_factory=dict)
+    #: Inline person detail, when the feed carried it (Feed B always does).
+    person_by_username: Mapping[str, dict] = field(default_factory=dict)
+
+
+def is_placeholder(username: str) -> bool:
+    """True for an ARC placeholder identity."""
+    return bool(username) and bool(PLACEHOLDER_USERNAME_RE.match(username))
+
+
+# ── Feed A: the inbound action log ──────────────────────────────────────
+
+def _roster_from_action(action) -> Tuple[Tuple[str, ...],
+                                         Dict[str, List[str]],
+                                         Dict[str, bool]]:
+    """Usernames and roles from a loaded action, via the structured helpers.
+
+    Uses ``sam.xras.roster`` rather than parsing the error strings in
+    ``sam/xras/errors.py``: those are a wire contract XRAS administrators read
+    and grep, not an interface for us to scrape.
+
+    The union of the roster and the two role-candidate lists is deliberate.
+    ``role_candidates`` applies a *looser* begin-date rule than
+    ``roster_usernames`` (that gap is legacy defect 3), so a PI can resolve
+    while being absent from the roster — and the handoff still fails on a
+    missing PI. Taking only the roster would miss exactly those.
+    """
+    from sam.xras.roster import (ALLOCATION_MANAGER_ROLE as _AM,
+                                 PI_ROLE as _PI, normalize_username,
+                                 role_candidates, roster_usernames)
+    from sam.xras.wire import get_field
+
+    members = roster_usernames(action)
+    pis = role_candidates(action, _PI)
+    admins = role_candidates(action, _AM)
+
+    roles: Dict[str, List[str]] = {}
+    for username in pis:
+        roles.setdefault(username, []).append(PI_ROLE)
+    for username in admins:
+        roles.setdefault(username, []).append(ALLOCATION_MANAGER_ROLE)
+    for username in members:
+        roles.setdefault(username, [])
+
+    ordered: List[str] = []
+    for username in (*members, *pis, *admins):
+        if username and username not in ordered:
+            ordered.append(username)
+
+    # Anyone named with no stronger role is a plain member.
+    for username in ordered:
+        if not roles.get(username):
+            roles[username] = [USER_ROLE]
+
+    flags: Dict[str, bool] = {}
+    for role in get_field(action, 'roles') or ():
+        username = normalize_username(get_field(role, 'username'))
+        if username and get_field(role, 'isAccountToBeCreated'):
+            flags[username] = True
+
+    return tuple(ordered), roles, flags
+
+
+def records_from_action_log(session: Session, *,
+                            statuses: Sequence[str] = WORKLIST_STATUSES,
+                            since: Optional[datetime] = None,
+                            until: Optional[datetime] = None,
+                            validate: bool = True,
+                            limit: Optional[int] = None
+                            ) -> List[RosterRecord]:
+    """Feed A — rosters from ``xras_action_log.raw_payload``.
+
+    Parses through ``XrasActionSchema`` (``sam.schemas.forms``), the same path
+    the webapp's ``_parse_action`` takes, with no webapp import.
+
+    With *validate* on, each action additionally goes through
+    ``dispatch_action(..., validate_only=True)``. That path structurally cannot
+    write — ``management_transaction`` only opens in ``handlers/base.py``, past
+    the seam — and its verdict is recorded as **provenance**, never as the
+    classifier: it also catches non-account failures (an unresolvable mnemonic,
+    a resource key with no mapping) which the card shows as "this action would
+    fail for other reasons too".
+    """
+    from marshmallow import ValidationError
+
+    from sam.schemas.forms import XrasActionSchema
+
+    query = session.query(XrasActionLog)
+    if statuses:
+        query = query.filter(XrasActionLog.status.in_(tuple(statuses)))
+    if since is not None:
+        query = query.filter(XrasActionLog.received_time >= since)
+    if until is not None:
+        query = query.filter(XrasActionLog.received_time <= until)
+    query = query.order_by(XrasActionLog.received_time.desc(),
+                           XrasActionLog.xras_action_log_id.desc())
+    if limit:
+        query = query.limit(limit)
+
+    schema = XrasActionSchema()
+    records: List[RosterRecord] = []
+    for row in query.all():
+        try:
+            action = schema.load(json.loads(row.raw_payload or '{}'))
+        except (ValueError, ValidationError) as exc:
+            # A body that would not parse has no roster to offer. It is
+            # already visible on the action-log card as its own failure;
+            # re-reporting it here would just be noise.
+            logger.debug('xras worklist: action %s did not parse (%s)',
+                         row.xras_action_log_id, exc)
+            continue
+
+        usernames, roles, flags = _roster_from_action(action)
+        if not usernames:
+            continue
+
+        would_succeed, messages = None, ()
+        if validate:
+            would_succeed, messages = _validate(session, action,
+                                                row.xras_action_log_id)
+
+        records.append(RosterRecord(
+            ref=ActionRef(action_log_id=row.xras_action_log_id,
+                          request_number=row.request_number,
+                          action_type=row.action_type,
+                          status=row.status,
+                          received_time=row.received_time,
+                          source='action_log',
+                          would_succeed=would_succeed,
+                          reject_messages=messages),
+            usernames=usernames,
+            roles_by_username={k: tuple(v) for k, v in roles.items()},
+            account_flag=flags))
+    return records
+
+
+def _validate(session: Session, action, action_log_id
+              ) -> Tuple[Optional[bool], Tuple[str, ...]]:
+    """Run the dispatch pre-flight, catching its rejection."""
+    from sam.xras.dispatch import dispatch_action
+    from sam.xras.errors import XrasActionRejected
+
+    try:
+        dispatch_action(session, action, validate_only=True)
+        return True, ()
+    except XrasActionRejected as exc:
+        return False, tuple(exc.messages)
+    except Exception as exc:                     # noqa: BLE001
+        # The worklist is a report. A handler blowing up on one action must
+        # not take the whole card down — record "we could not tell".
+        logger.warning('xras worklist: validate failed for action %s (%s)',
+                       action_log_id, exc)
+        return None, ()
+
+
+# ── Feed B: the outbound enumeration ────────────────────────────────────
+
+def records_from_report_requests(payloads: Iterable[dict]) -> List[RosterRecord]:
+    """Feed B — rosters from ``GET /v1/reports/requests`` rows.
+
+    The outgoing wire nests differently from the incoming one:
+    ``roles[]`` entries are ``{person, roles[]}``, where the inner entries
+    carry ``role`` (not ``roleType``). Verified live, along with the fact that
+    the person object is **inline and complete** — every ``/v1/people`` field
+    including ``isReconciled`` and ``residenceCountry`` — which is why a
+    Feed-B row never needs a person fetch.
+    """
+    records: List[RosterRecord] = []
+    for payload in payloads or ():
+        if not isinstance(payload, dict):
+            continue
+
+        usernames: List[str] = []
+        roles: Dict[str, List[str]] = {}
+        flags: Dict[str, bool] = {}
+        people: Dict[str, dict] = {}
+
+        for entry in payload.get('roles') or ():
+            if not isinstance(entry, dict):
+                continue
+            person = entry.get('person') if isinstance(entry.get('person'), dict) else {}
+            username = str(person.get('username') or '').strip()
+            if not username:
+                continue
+            if username not in usernames:
+                usernames.append(username)
+                people[username] = person
+            for role in entry.get('roles') or ():
+                if not isinstance(role, dict):
+                    continue
+                name = str(role.get('role') or '').strip()
+                if name and name not in roles.setdefault(username, []):
+                    roles[username].append(name)
+                if role.get('isAccountToBeCreated'):
+                    flags[username] = True
+            if not roles.get(username):
+                roles[username] = [USER_ROLE]
+
+        if not usernames:
+            continue
+
+        records.append(RosterRecord(
+            ref=ActionRef(action_log_id=None,
+                          request_number=payload.get('requestNumber'),
+                          action_type=payload.get('requestType'),
+                          status=payload.get('requestStatus'),
+                          received_time=None,
+                          source='reports'),
+            usernames=tuple(usernames),
+            roles_by_username={k: tuple(v) for k, v in roles.items()},
+            account_flag=flags,
+            person_by_username=people))
+    return records
+
+
+# ── the classifier ──────────────────────────────────────────────────────
+
+def _sorted_roles(names: Iterable[str]) -> Tuple[str, ...]:
+    """Strongest first, then anything unrecognised, alphabetically."""
+    unique = set(names)
+    ranked = [r for r in _ROLE_ORDER if r in unique]
+    return tuple(ranked + sorted(unique - set(_ROLE_ORDER)))
+
+
+def classify_accounts(session: Session,
+                      records: Sequence[RosterRecord]) -> List[Dict[str, Any]]:
+    """Turn rosters into worklist rows. **The core.**
+
+    Two classes, because they block a handoff identically but need different
+    work:
+
+    ``absent``    no ``users`` row at all            → create the account
+    ``inactive``  a row that fails ``User.is_active``  → reactivate it
+
+    A predicate that only checked existence would miss the second entirely —
+    of 19 live roster usernames sampled during design, all 19 existed but
+    **five were inactive**, a quarter of the real cases.
+
+    ⚠️ ``isAccountToBeCreated`` is **never** the predicate. XRAS sets it when
+    the role is created and never clears it, so live data shows active,
+    present SAM users still carrying ``true``. It rides along as a hint column
+    and nothing more.
+    """
+    wanted = {u for record in records for u in record.usernames if u}
+    if not wanted:
+        return []
+
+    # One query for the whole batch, never per username.
+    existing = {u.username: u for u in
+                session.query(User).filter(User.username.in_(sorted(wanted))).all()}
+
+    rows: Dict[str, Dict[str, Any]] = {}
+    for record in records:
+        for username in record.usernames:
+            if not username:
+                continue
+            user = existing.get(username)
+            if user is not None and user.is_active:
+                continue                    # nothing to do — the common case
+            classification = (CLASSIFICATION_ABSENT if user is None
+                              else CLASSIFICATION_INACTIVE)
+
+            row = rows.get(username)
+            if row is None:
+                row = rows[username] = {
+                    'username': username,
+                    'classification': classification,
+                    'remedy': REMEDIES[classification],
+                    'placeholder': is_placeholder(username),
+                    'roles': (),
+                    'is_account_to_be_created': False,
+                    'actions': [],
+                    'latest_action_log_id': None,
+                    'first_seen': None,
+                    'last_seen': None,
+                    'person': None,
+                    'is_reconciled': None,
+                    'sources': set(),
+                }
+
+            row['roles'] = _sorted_roles(
+                (*row['roles'], *record.roles_by_username.get(username, ())))
+            row['is_account_to_be_created'] = (
+                row['is_account_to_be_created']
+                or bool(record.account_flag.get(username)))
+            row['sources'].add(record.ref.source)
+
+            person = record.person_by_username.get(username)
+            if person and row['person'] is None:
+                row['person'] = person
+                if 'isReconciled' in person:
+                    row['is_reconciled'] = bool(person['isReconciled'])
+
+            row['actions'].append({
+                'action_log_id': record.ref.action_log_id,
+                'request_number': record.ref.request_number,
+                'action_type': record.ref.action_type,
+                'status': record.ref.status,
+                'received_time': record.ref.received_time,
+                'source': record.ref.source,
+                'would_succeed': record.ref.would_succeed,
+                'reject_messages': list(record.ref.reject_messages),
+            })
+
+    for row in rows.values():
+        # Newest first; a Feed-B record has no timestamp, so it sorts last
+        # rather than pretending to be old.
+        row['actions'].sort(
+            key=lambda a: (a['received_time'] is not None, a['received_time'],
+                           a['action_log_id'] or 0),
+            reverse=True)
+        stamps = [a['received_time'] for a in row['actions'] if a['received_time']]
+        row['first_seen'] = min(stamps) if stamps else None
+        row['last_seen'] = max(stamps) if stamps else None
+        # Deliberately the future notes-table FK target.
+        row['latest_action_log_id'] = next(
+            (a['action_log_id'] for a in row['actions'] if a['action_log_id']), None)
+        row['sources'] = sorted(row['sources'])
+
+    return sorted(rows.values(),
+                  key=lambda r: (r['classification'] != CLASSIFICATION_ABSENT,
+                                 r['username']))
+
+
+def get_account_worklist(session: Session, *,
+                         statuses: Sequence[str] = WORKLIST_STATUSES,
+                         since: Optional[datetime] = None,
+                         until: Optional[datetime] = None,
+                         validate: bool = True,
+                         limit: Optional[int] = None) -> List[Dict[str, Any]]:
+    """Feed A composed with the classifier — what the card and CLI call."""
+    return classify_accounts(session, records_from_action_log(
+        session, statuses=statuses, since=since, until=until,
+        validate=validate, limit=limit))
+
+
+# ── enrichment ──────────────────────────────────────────────────────────
+
+#: PII. Assembled only for a viewer holding ``MANAGE_XRAS`` — see the card.
+PERSON_FIELDS = ('firstName', 'middleName', 'lastName', 'email', 'phone',
+                 'organization', 'academicStatus', 'residenceCountry',
+                 'isReconciled', 'orcid')
+
+
+def enrich_worklist(rows: Sequence[Dict[str, Any]], *,
+                    person_lookup: Optional[Callable[[str], Optional[dict]]] = None,
+                    max_lookups: int = 25) -> Dict[str, Any]:
+    """Attach XRAS person detail and the ``isReconciled`` closure signal.
+
+    Separate from classification and **injected**, so the query layer stays
+    fully offline-capable: an unconfigured deployment renders the same
+    worklist, minus person columns.
+
+    A single ``XrasSourceUnavailable`` marks the whole batch ``unavailable``
+    and leaves ``person`` as ``None`` rather than raising — the card degrades
+    to counts and usernames instead of returning 500. *max_lookups* bounds a
+    cold-cache render.
+
+    Returns a report dict; *rows* are mutated in place, which is what the
+    caller wants to render.
+    """
+    from sam.integration.xras_api.base import XrasSourceUnavailable
+
+    if person_lookup is None:
+        # Deferred: importing this at module scope would put ``requests`` and
+        # the cache layer into every consumer's graph, including the task's.
+        from sam.integration.xras_api.people import get_person as person_lookup
+
+    report = {'looked_up': 0, 'found': 0, 'closed': 0, 'unavailable': False,
+              'budget_exhausted': False, 'error': None}
+
+    for row in rows:
+        if row.get('person') is not None:
+            # Feed B carried it inline — no round trip needed.
+            continue
+        if report['looked_up'] >= max_lookups:
+            report['budget_exhausted'] = True
+            break
+        try:
+            person = person_lookup(row['username'])
+        except XrasSourceUnavailable as exc:
+            report['unavailable'] = True
+            report['error'] = str(exc)
+            break
+        report['looked_up'] += 1
+        if person is None:
+            continue
+        report['found'] += 1
+        row['person'] = {k: person.get(k) for k in PERSON_FIELDS if k in person}
+        if 'isReconciled' in person:
+            row['is_reconciled'] = bool(person['isReconciled'])
+            if row['is_reconciled']:
+                # XRAS considers them reconciled while SAM still has no usable
+                # account — worth surfacing, and it is how an item closes.
+                report['closed'] += 1
+    return report
+
+
+def worklist_counts(rows: Sequence[Dict[str, Any]]) -> Dict[str, int]:
+    """Facet counts for the card's chips and the task's ledger detail."""
+    return {
+        'total': len(rows),
+        CLASSIFICATION_ABSENT: sum(
+            1 for r in rows if r['classification'] == CLASSIFICATION_ABSENT),
+        CLASSIFICATION_INACTIVE: sum(
+            1 for r in rows if r['classification'] == CLASSIFICATION_INACTIVE),
+        'placeholder': sum(1 for r in rows if r['placeholder']),
+        'reconciled': sum(1 for r in rows if r.get('is_reconciled') is True),
+    }

--- a/src/sam/queries/xras_accounts.py
+++ b/src/sam/queries/xras_accounts.py
@@ -57,14 +57,37 @@ from sqlalchemy.orm import Session
 
 from sam.core.users import User
 from sam.integration.xras import XrasActionLog
+from sam.queries.xras_actions import XRAS_ACTION_STATUSES
 
 logger = logging.getLogger(__name__)
 
-#: Statuses whose roster is worth pre-flighting. ``processed`` is excluded
-#: because it already succeeded, and ``rechecked``/``unmapped`` are not an
-#: action's own outcome. This bounds the *validate* work, not the
-#: classification — see the module docstring on regime-proofing.
-WORKLIST_STATUSES: Tuple[str, ...] = ('received', 'failed', 'manual')
+#: ⚠️ **Every status, deliberately — do not narrow this to the "interesting"
+#: ones.** An earlier version read only ``received``/``failed``/``manual`` on
+#: the reasoning that a ``processed`` action had already succeeded, so its
+#: roster must have resolved.
+#:
+#: That reasoning is wrong, and the local smoke measured it: seeding 41 real
+#: payloads under live dispatch left 28 ``processed``, and excluding them hid
+#: **5 usernames SAM cannot use — four inactive, one absent entirely, most of
+#: them Allocation Managers.** An action processes fine while naming such a
+#: person, because ``resolve_roster`` reports a missing or inactive *member*
+#: as a warning rather than an error; the handler simply skips assigning them.
+#: The account is still needed, and the operator still has to create it.
+#:
+#: Worse, the narrow list made the worklist **regime-dependent** — the exact
+#: property § 1 of the design says it must not have. The same corpus produced
+#: 9 rows under capture-only (all ``received``) and 4 under live dispatch.
+#: Classification keys off the ``users`` table alone; this must not
+#: reintroduce a status dependency behind it.
+WORKLIST_STATUSES: Tuple[str, ...] = XRAS_ACTION_STATUSES
+
+#: Which actions are worth running the dispatch pre-flight over. **This** is
+#: the bounded-work knob the status list used to be conflated with: validating
+#: a ``processed`` action re-runs a handler's whole assembly to learn something
+#: already known, and ``rechecked``/``unmapped`` are not an action's own
+#: outcome. Narrowing this costs provenance on those rows, never a
+#: classification.
+VALIDATE_STATUSES: Tuple[str, ...] = ('received', 'failed', 'manual')
 
 #: ARC placeholder identities, e.g. ``placeholder34-user-00034``. XRAS mints one
 #: for every unreconciled person, and it resolves fully through
@@ -197,8 +220,8 @@ def records_from_action_log(session: Session, *,
     Parses through ``XrasActionSchema`` (``sam.schemas.forms``), the same path
     the webapp's ``_parse_action`` takes, with no webapp import.
 
-    With *validate* on, each action additionally goes through
-    ``dispatch_action(..., validate_only=True)``. That path structurally cannot
+    With *validate* on, each action **in :data:`VALIDATE_STATUSES`**
+    additionally goes through ``dispatch_action(..., validate_only=True)``. That path structurally cannot
     write — ``management_transaction`` only opens in ``handlers/base.py``, past
     the seam — and its verdict is recorded as **provenance**, never as the
     classifier: it also catches non-account failures (an unresolvable mnemonic,
@@ -239,7 +262,7 @@ def records_from_action_log(session: Session, *,
             continue
 
         would_succeed, messages = None, ()
-        if validate:
+        if validate and row.status in VALIDATE_STATUSES:
             would_succeed, messages = _validate(session, action,
                                                 row.xras_action_log_id)
 
@@ -370,7 +393,22 @@ def classify_accounts(session: Session,
         return []
 
     # One query for the whole batch, never per username.
-    existing = {u.username: u for u in
+    #
+    # ⚠️ **Keyed case-INSENSITIVELY, and this is not cosmetic.**
+    # ``users.username`` is ``utf8mb3_general_ci`` with a UNIQUE index, so
+    # MySQL considers ``Jsmith`` and ``jsmith`` the same account and the
+    # ``IN`` above matches either spelling. A case-sensitive Python dict
+    # underneath that then MISSES the row it was just handed, and the
+    # username is reported ``absent`` — telling an operator to create an
+    # account that already exists and is active.
+    #
+    # The local smoke hit exactly this: XRAS sent ``Jsmith``, SAM holds
+    # ``jsmith`` active, and the card said "Create". No in-tree fixture could
+    # have caught it — the anonymizer emits lowercase ``user_<hex>`` for
+    # every username, so every scrubbed roster is already case-matched.
+    # ``roster.normalize_username`` deliberately does not fold case either
+    # (it reproduces Java), so the wire spelling reaches here untouched.
+    existing = {u.username.casefold(): u for u in
                 session.query(User).filter(User.username.in_(sorted(wanted))).all()}
 
     rows: Dict[str, Dict[str, Any]] = {}
@@ -378,15 +416,21 @@ def classify_accounts(session: Session,
         for username in record.usernames:
             if not username:
                 continue
-            user = existing.get(username)
+            key = username.casefold()
+            user = existing.get(key)
             if user is not None and user.is_active:
                 continue                    # nothing to do — the common case
             classification = (CLASSIFICATION_ABSENT if user is None
                               else CLASSIFICATION_INACTIVE)
 
-            row = rows.get(username)
+            # Grouped on the same case-insensitive key, so two spellings of
+            # one account are one row of work rather than two.
+            row = rows.get(key)
             if row is None:
-                row = rows[username] = {
+                row = rows[key] = {
+                    # The wire spelling, kept as XRAS sent it — for an absent
+                    # account it is the only spelling there is, and for a
+                    # present one the mismatch is itself worth seeing.
                     'username': username,
                     'classification': classification,
                     'remedy': REMEDIES[classification],
@@ -480,6 +524,21 @@ def enrich_worklist(rows: Sequence[Dict[str, Any]], *,
     to counts and usernames instead of returning 500. *max_lookups* bounds a
     cold-cache render.
 
+    ⚠️ **``isReconciled`` is NOT a closure signal**, despite what the design
+    document originally claimed. The local smoke measured **9 of 9** worklist
+    rows reconciled in XRAS while every one still had no usable SAM account —
+    reconciliation is XRAS linking a placeholder to a real identity (often by
+    merging it), which says nothing about whether SAM has a row.
+
+    What it *is* worth showing: whether XRAS knows who the person really is. A
+    **reconciled** placeholder is the easy case — there is a real detail sheet
+    behind it to create the account from. An **unreconciled** one is the hard
+    case, because XRAS cannot say who they are either.
+
+    The real closure signal needs no polling: classification is a current-state
+    check, so a row leaves this list the moment its ``users`` row exists and is
+    active. That is what closes an item, and it is already free.
+
     Returns a report dict; *rows* are mutated in place, which is what the
     caller wants to render.
     """
@@ -490,7 +549,7 @@ def enrich_worklist(rows: Sequence[Dict[str, Any]], *,
         # the cache layer into every consumer's graph, including the task's.
         from sam.integration.xras_api.people import get_person as person_lookup
 
-    report = {'looked_up': 0, 'found': 0, 'closed': 0, 'unavailable': False,
+    report = {'looked_up': 0, 'found': 0, 'reconciled': 0, 'unavailable': False,
               'budget_exhausted': False, 'error': None}
 
     for row in rows:
@@ -514,9 +573,7 @@ def enrich_worklist(rows: Sequence[Dict[str, Any]], *,
         if 'isReconciled' in person:
             row['is_reconciled'] = bool(person['isReconciled'])
             if row['is_reconciled']:
-                # XRAS considers them reconciled while SAM still has no usable
-                # account — worth surfacing, and it is how an item closes.
-                report['closed'] += 1
+                report['reconciled'] += 1
     return report
 
 

--- a/src/sam/queries/xras_actions.py
+++ b/src/sam/queries/xras_actions.py
@@ -24,7 +24,7 @@ drift (``src/cli/README.md`` § *Adding New Commands*).
 """
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
@@ -649,8 +649,10 @@ def get_projects_by_ids(session: Session, project_ids) -> List[Project]:
 
 
 
-def audit_resource_mapping(session: Session) -> Dict[str, Any]:
-    """Which SAM resources XRAS can and cannot name, in three groups.
+def audit_resource_mapping(session: Session, *,
+                           xras_keys: Optional[Iterable[int]] = None
+                           ) -> Dict[str, Any]:
+    """Which SAM resources XRAS can and cannot name, in four groups.
 
     ``xras_resource_repository_key_resource`` maps an XRAS ``resourceRepositoryKey``
     to a SAM resource, and it is the join behind two different things:
@@ -675,6 +677,18 @@ def audit_resource_mapping(session: Session) -> Dict[str, Any]:
     Lives here rather than in ``cli/xras/builders.py``, where it was: builders are
     ORM→dict extractors per ``src/cli/README.md``, and a webapp surface that wants
     the same audit should not have to import the CLI to get it.
+
+    **The fourth group needs *xras_keys*.** Read from two local tables alone, this
+    function has no list of the keys XRAS will actually send — so the failure that
+    genuinely breaks an award, XRAS naming a ``resourceRepositoryKey`` SAM has no
+    row for, was invisible here and surfaced only at runtime as
+    ``No resource found in SAM corresponding to key %s``. Pass the live catalog
+    (``sam.integration.xras_api.resource_repository_keys()``) and it becomes
+    ``xras_only_keys``.
+
+    The iterable is **injected rather than fetched**, so this function keeps zero
+    network knowledge and stays usable offline: ``xras_keys=None`` reproduces the
+    previous report byte for byte, with ``live_checked`` False to say so.
     """
     from sam.integration.xras import XrasResourceRepositoryKeyResource
     from sam.resources.resources import Resource
@@ -704,10 +718,19 @@ def audit_resource_mapping(session: Session) -> Dict[str, Any]:
         if row.resource is None:
             dangling.append(row.resource_repository_key)
 
+    known_keys = {row.resource_repository_key for row in rows}
+    xras_only = (sorted(int(k) for k in xras_keys if int(k) not in known_keys)
+                 if xras_keys is not None else [])
+
     return {
         'mapped': len(rows),
         'unmapped_active': sorted(unmapped_active),
         'mapped_decommissioned': sorted(mapped_decommissioned,
                                         key=lambda d: d['resource']),
         'dangling_keys': sorted(dangling),
+        # Keys XRAS sends that SAM cannot resolve — the one that breaks awards.
+        'xras_only_keys': xras_only,
+        # Distinguishes "XRAS sends nothing SAM lacks" from "we never asked".
+        'live_checked': xras_keys is not None,
+        'live_key_count': len(set(xras_keys)) if xras_keys is not None else None,
     }

--- a/src/sam/schemas/forms/xras.py
+++ b/src/sam/schemas/forms/xras.py
@@ -203,9 +203,23 @@ class XrasActionRoleSchema(_XrasBase):
     ``roleType`` observed values are ``'PI'``, ``'Allocation Manager'`` and ``'User'``
     — **space separated, not camel case**. These are *not* the ``Pi`` / ``CoPi`` /
     ``AllocationManager`` keys that ``GET /v1/requests/role/{role}/{username}`` maps;
-    the two vocabularies are distinct and must not be conflated. No co-PI has appeared
-    in a sampled payload yet, so its exact spelling is still unknown — which is why
-    this field is not validated against an enum.
+    the two vocabularies are distinct and must not be conflated.
+
+    ✅ **The co-PI question is settled** (2026-08-19, superseding the hedge that
+    stood here). ``GET /v1/types/roles`` on the live NCAR process returns exactly
+    three role types — 13 ``PI``, 14 ``Allocation Manager``, 19 ``User`` — so
+    **no co-PI can ever appear on this wire**, and its "unknown spelling" was
+    never going to be observed. The generic XRAS product does define ``CoPI`` at
+    ``roleTypeId`` 1, but those ids are per-process, which is why NCAR's are
+    13/14/19. Confirmed on live data: zero co-PIs across 64 sampled role
+    entries, and across 101 role entries in 41 captured fixtures. See
+    ``docs/xras/outgoing/XRAS_OUTGOING_QUERIES.md`` § 3.4.
+
+    The field is still **not validated against an enum**, but now for a
+    different and better reason: an unrecognised value must still parse and
+    still land in the audit row, because a silently-rejected body is far worse
+    than an unhandled role. (It also means ``CoPi``'s structurally-empty branch
+    in ``webapp/api/xras/requests.py`` is provably empty, not merely unobserved.)
 
     The same ``username`` can appear under two roles in one payload (observed: a PI
     who is also a ``User``, with distinct ``requestPeopleRoleId``), so consumers that

--- a/src/sam/xras/roster.py
+++ b/src/sam/xras/roster.py
@@ -230,6 +230,15 @@ def role_candidates(action, role_type: str, *, today: Optional[str] = None) -> T
 
     candidates: List[str] = []
     for role in get_field(action, 'roles') or ():
+        # Exact string inequality, reproducing Java's String.equals: no case
+        # folding, no alias table. Settled 2026-08-19 by probing
+        # `GET /v1/types/roles`: the NCAR process defines exactly THREE role
+        # types — 13 PI, 14 Allocation Manager, 19 User — so `roleType` has a
+        # closed three-value vocabulary and no co-PI can ever appear on this
+        # wire. (The generic XRAS product does define CoPI at roleTypeId 1;
+        # those ids are per-process, which is why NCAR's are 13/14/19.)
+        # Confirmed again on live data: zero co-PIs across 64 sampled role
+        # entries. See docs/xras/outgoing/XRAS_OUTGOING_QUERIES.md § 3.4.
         if _wire_str(get_field(role, 'roleType')) != role_type:
             continue
         begin_date = _wire_str(get_field(role, 'beginDate'))

--- a/src/scheduling/tasks/__init__.py
+++ b/src/scheduling/tasks/__init__.py
@@ -13,6 +13,7 @@ from scheduling.tasks import cleanup_status       # noqa: F401
 from scheduling.tasks import deactivate_expired   # noqa: F401
 from scheduling.tasks import expiration_notices   # noqa: F401
 from scheduling.tasks import xras_notices         # noqa: F401
+from scheduling.tasks import xras_sweep           # noqa: F401
 
 __all__ = ['cleanup_status', 'deactivate_expired', 'expiration_notices',
-           'xras_notices']
+           'xras_notices', 'xras_sweep']

--- a/src/scheduling/tasks/xras_sweep.py
+++ b/src/scheduling/tasks/xras_sweep.py
@@ -250,6 +250,7 @@ def xras_sweep(ctx) -> TaskResult:
         'people_refreshed': 0,
         'reconciled': 0,
         'published': False,
+        'publish_backend': '',
         'unavailable_errors': 0,
     }
 
@@ -363,7 +364,7 @@ def xras_sweep(ctx) -> TaskResult:
     # Send first, record second — the ledger row must not claim a snapshot the
     # tab cannot read. A disabled bucket is not an error: the findings are
     # still in `detail`, and the tab renders its "no sweep data yet" state.
-    detail['published'] = store_pending_worklist({
+    backend = store_pending_worklist({
         # A datetime, not an ISO string: this payload is pickled into the
         # cache and read straight by a Jinja `fmt_date`, whereas the ledger's
         # `detail` beside it is JSON and must stay stringly-typed. The two
@@ -379,6 +380,19 @@ def xras_sweep(ctx) -> TaskResult:
         'counts': detail['accounts'],
         'rows': enumerated,
     })
+
+    # ⚠️ `published` means "the dashboard can read this", NOT "a write
+    # returned". The bucket falls back to a per-worker in-process cache when
+    # CACHE_REDIS_URL is unset or Redis is unreachable, and this task runs in a
+    # ONE-SHOT pod — so a process-local write succeeds and then dies with the
+    # pod. The first production run did exactly that and reported success.
+    detail['publish_backend'] = backend
+    detail['published'] = backend == 'redis'
+    if backend != 'redis':
+        ctx.logger.warning(
+            'xras_sweep: worklist went to the %s cache, so the dashboard tab '
+            'will NOT see it (CACHE_REDIS_URL unset or Redis unreachable?)',
+            backend)
 
     counts = detail['accounts']
     message = (f"{detail['requests_in_window']}/{detail['requests_seen']} in-window request(s), "

--- a/src/scheduling/tasks/xras_sweep.py
+++ b/src/scheduling/tasks/xras_sweep.py
@@ -1,0 +1,227 @@
+"""``xras_sweep`` — enumerate XRAS nightly and diff it against SAM.
+
+Daily 03:30 Mountain. The first task that calls **out** to XRAS rather than
+reading only SAM's own tables, and the third declaring ``needs=('sam',)``.
+
+What it is for
+--------------
+The account-creation worklist built from ``xras_action_log`` can only see
+people XRAS has already pushed. ``GET /v1/reports/requests`` sees the whole
+NCAR process, so this task reaches three things the card cannot:
+
+1. **People ahead of the push** — a brand-new PI on a solo New request,
+   connected to nobody SAM knows, is visible here *before* the action arrives.
+   That is the hardest population to prepare for and the one manual account
+   creation most needs lead time on.
+2. **Dropped or pending pushes** — a set difference between the Approved
+   requests' ``requestNumber`` and ``project.projcode``. Cheap, because both
+   sides are already in hand.
+3. **Closure** — re-fetching ``/v1/people`` for everyone currently on the
+   worklist refreshes ``isReconciled``, which is how an item closes itself,
+   and leaves a warm cache for the morning's first card render.
+
+⚠️ **Ships switched off.** ``SAM_TASKS_DISABLED`` is *fail-open*: registering
+a task here puts it into production live on the next hourly wake unless its
+name is added to ``helm/values.yaml`` in the **same change**. The registry is
+code-side, the list is chart-side, and nothing couples them but the reviewer —
+so ``test_task_xras_sweep.py`` greps ``values.yaml`` for the name.
+
+⚠️ **Unconfigured is a skip, not a raise.** Unlike the notice tasks, whose
+guards raise because a chart mistake that mails nobody must not report
+success, this task *reading* nothing is a legitimate state — it is the shipped
+one. The ledger row carrying ``skipped: true`` is the record.
+
+**What was deliberately not built**: a per-identity ``/v1/requests`` polling
+sweep (measured at 0.84 s x 1,518 seed identities nightly) and its transitive
+roster crawl. The reports enumeration reaches strictly more people — including
+wholly-new solo PIs the crawl could never connect to — in a handful of
+paginated calls. Do not resurrect the crawl.
+
+Design: ``docs/xras/outgoing/XRAS_OUTGOING_QUERIES.md``.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+from typing import Optional
+
+from scheduling.registry import TaskResult, task
+from scheduling.schedules import Daily
+
+#: Overnight on purpose: nothing here is time-critical, the enumeration is the
+#: heaviest outbound call SAM makes, and a warm people-cache at 03:30 is still
+#: warm for the first card render of the working day.
+SCHEDULE = Daily(3, 30, tz='America/Denver')
+
+#: Pages of ``reports/requests`` per run, overridable via
+#: ``$SAM_TASKS_XRAS_SWEEP_MAX_PAGES``. At the default page size that is 5,000
+#: requests — comfortably the whole NCAR process today.
+#:
+#: A **bound, not a target**: `detail.budget_exhausted` reports when it bit, so
+#: a cap that starts truncating is visible rather than silently reading as full
+#: coverage.
+DEFAULT_MAX_PAGES = 25
+
+#: Requests per page. The API's own default is smaller; 200 keeps the whole
+#: process inside a handful of round trips.
+PAGE_SIZE = 200
+
+#: People to re-fetch per run for the closure signal. Each is one round trip,
+#: and the cache means the card's own renders do not repeat them.
+DEFAULT_MAX_PEOPLE = 250
+
+#: Cap on rows echoed into the ledger row. `detail` is TEXT and the runner
+#: truncates the JSON at 60 kB.
+_MAX_REPORTED = 100
+
+
+def _positive_int(env: Optional[dict], key: str, default: int) -> int:
+    """Read a positive int from the environment, per run.
+
+    Same shape and reasoning as `xras_notices.xras_email_max`: read per run so
+    a `values.yaml` change lands on the next dispatch rather than the next pod
+    restart, and a zero, negative or unparseable value is **refused rather than
+    obeyed** — zero pages would mean "look at nothing" while still reporting
+    success, which is indistinguishable from a broken query.
+    """
+    raw = (env if env is not None else os.environ).get(key)
+    if raw is None or not str(raw).strip():
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+def max_pages(env: Optional[dict] = None) -> int:
+    """Page budget, from ``$SAM_TASKS_XRAS_SWEEP_MAX_PAGES``."""
+    return _positive_int(env, 'SAM_TASKS_XRAS_SWEEP_MAX_PAGES', DEFAULT_MAX_PAGES)
+
+
+def max_people(env: Optional[dict] = None) -> int:
+    """Person-refresh budget, from ``$SAM_TASKS_XRAS_SWEEP_MAX_PEOPLE``."""
+    return _positive_int(env, 'SAM_TASKS_XRAS_SWEEP_MAX_PEOPLE',
+                         DEFAULT_MAX_PEOPLE)
+
+
+@task(name='xras_sweep',
+      schedule=SCHEDULE,
+      needs=('sam',),
+      # Drives the LEASE, not a timeout. max(3x20min, 900s) = 3600s must exceed
+      # the CronJob's activeDeadlineSeconds (3000s), or a run killed by the pod
+      # deadline becomes reclaimable while still running and two sweeps race.
+      # `TaskContext` exposes no ledger handle, so the task cannot heartbeat
+      # instead. The drift test asserts the inequality against values.yaml.
+      expected_runtime=timedelta(minutes=20),
+      # The 6h default. A missed nightly slot costs nothing: this task writes
+      # no state, so tomorrow's run subsumes today's entirely.
+      misfire_grace=timedelta(hours=6),
+      description='Enumerate XRAS and diff it against SAM (reads only)')
+def xras_sweep(ctx) -> TaskResult:
+    """Enumerate Approved XRAS requests and report what SAM is missing."""
+    # Deferred: `scheduling/` is imported by the CLI's --list path, which must
+    # not pay for the ORM and `requests` to print a table.
+    from sam.integration.xras_api import (
+        XrasApiClient,
+        XrasSourceUnavailable,
+        xras_api_configured,
+    )
+    from sam.projects.projects import Project
+    from sam.queries.xras_accounts import (
+        classify_accounts,
+        get_account_worklist,
+        records_from_report_requests,
+        worklist_counts,
+    )
+
+    detail = {
+        'skipped': False,
+        'pages': 0,
+        'requests_seen': 0,
+        'budget_exhausted': False,
+        'pending_push': 0,
+        'pending_push_sample': [],
+        'accounts': {},
+        'people_refreshed': 0,
+        'closures': 0,
+        'unavailable_errors': 0,
+    }
+
+    if not xras_api_configured():
+        # The shipped state. A visible skip, not a raise — see the module
+        # docstring on why this differs from the notice tasks' guards.
+        detail['skipped'] = True
+        ctx.logger.info('xras_sweep: outgoing API not configured; skipping')
+        return TaskResult(detail=detail,
+                          message='skipped — XRAS outgoing API not configured')
+
+    session = ctx.sam_session
+    client = XrasApiClient.from_environment()
+    page_budget = max_pages()
+
+    # ── 1. enumerate ────────────────────────────────────────────────────
+    payloads = []
+    try:
+        for page in client.iter_request_pages(status='Approved',
+                                              page_size=PAGE_SIZE,
+                                              max_pages=page_budget):
+            detail['pages'] += 1
+            payloads.extend(page)
+    except XrasSourceUnavailable as exc:
+        # Partial pages are still worth reporting: a diff over what we did
+        # read is a subset of the truth, not a wrong answer.
+        detail['unavailable_errors'] += 1
+        ctx.logger.warning('xras_sweep: enumeration failed after %d page(s): %s',
+                           detail['pages'], exc)
+
+    detail['requests_seen'] = len(payloads)
+    detail['budget_exhausted'] = detail['pages'] >= page_budget
+
+    # ── 2. dropped / pending pushes ─────────────────────────────────────
+    numbers = {str(p.get('requestNumber')).strip() for p in payloads
+               if p.get('requestNumber')}
+    if numbers:
+        known = {code for (code,) in session.query(Project.projcode)
+                 .filter(Project.projcode.in_(sorted(numbers))).all()}
+        pending = sorted(numbers - known)
+        detail['pending_push'] = len(pending)
+        detail['pending_push_sample'] = pending[:_MAX_REPORTED]
+
+    # ── 3. classify what the enumeration names ──────────────────────────
+    enumerated = classify_accounts(session,
+                                   records_from_report_requests(payloads))
+    detail['accounts'] = worklist_counts(enumerated)
+    detail['accounts_sample'] = [r['username'] for r in enumerated][:_MAX_REPORTED]
+
+    # ── 4. warm the closure signal for the card's morning renders ───────
+    #
+    # Feed A only: Feed B carried its person objects inline, so re-fetching
+    # them would be a round trip for something already in hand.
+    from sam.integration.xras_api.people import get_person
+
+    people_budget = max_people()
+    for row in get_account_worklist(session, validate=False)[:people_budget]:
+        try:
+            person = get_person(row['username'])
+        except XrasSourceUnavailable as exc:
+            detail['unavailable_errors'] += 1
+            ctx.logger.warning('xras_sweep: person refresh failed (%s)', exc)
+            break
+        detail['people_refreshed'] += 1
+        if person and person.get('isReconciled'):
+            # XRAS reconciled them; the worklist item should now close.
+            detail['closures'] += 1
+
+    counts = detail['accounts']
+    message = (f"{detail['requests_seen']} request(s), "
+               f"{detail['pending_push']} pending push, "
+               f"{counts.get('total', 0)} account(s) needed, "
+               f"{detail['closures']} closure(s)")
+    ctx.logger.info('xras_sweep: %s', message)
+
+    # "0 findings, succeeded" must be distinguishable from "did not look" —
+    # which is what `pages`, `requests_seen` and `skipped` are for.
+    return TaskResult(detail=detail, message=message,
+                      partial_failures=detail['unavailable_errors'])

--- a/src/scheduling/tasks/xras_sweep.py
+++ b/src/scheduling/tasks/xras_sweep.py
@@ -12,13 +12,18 @@ NCAR process, so this task reaches three things the card cannot:
 1. **People ahead of the push** — a brand-new PI on a solo New request,
    connected to nobody SAM knows, is visible here *before* the action arrives.
    That is the hardest population to prepare for and the one manual account
-   creation most needs lead time on.
+   creation most needs lead time on. Only the **not-yet-pushed** rosters are
+   classified: a request whose project already exists has had its handoff, so
+   its roster is history (see the note at step 3, with the measurements).
 2. **Dropped or pending pushes** — a set difference between the Approved
    requests' ``requestNumber`` and ``project.projcode``. Cheap, because both
    sides are already in hand.
-3. **Closure** — re-fetching ``/v1/people`` for everyone currently on the
-   worklist refreshes ``isReconciled``, which is how an item closes itself,
-   and leaves a warm cache for the morning's first card render.
+3. **Identity detail** — re-fetching ``/v1/people`` for everyone currently on
+   the worklist refreshes ``isReconciled`` and leaves a warm cache for the
+   morning's first card render. ⚠️ Reconciliation is **not** a closure: it
+   means XRAS has linked the username to a real identity, not that SAM has an
+   account. A row leaves the worklist when its ``users`` row exists and is
+   active, which classification already checks on every render — for free.
 
 ⚠️ **Ships switched off.** ``SAM_TASKS_DISABLED`` is *fail-open*: registering
 a task here puts it into production live on the next hourly wake unless its
@@ -43,11 +48,12 @@ Design: ``docs/xras/outgoing/XRAS_OUTGOING_QUERIES.md``.
 from __future__ import annotations
 
 import os
-from datetime import timedelta
+from datetime import date, timedelta
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 from scheduling.registry import TaskResult, task
-from scheduling.schedules import Daily
+from scheduling.schedules import Daily, to_local_naive
 
 #: Overnight on purpose: nothing here is time-critical, the enumeration is the
 #: heaviest outbound call SAM makes, and a warm people-cache at 03:30 is still
@@ -67,7 +73,32 @@ DEFAULT_MAX_PAGES = 25
 #: process inside a handful of round trips.
 PAGE_SIZE = 200
 
-#: People to re-fetch per run for the closure signal. Each is one round trip,
+#: The sweep's window, in days back from the slot — the Feed-B analogue of the
+#: worklist card's 7D/30D/90D pills.
+#:
+#: ⚠️ **Without a window the sweep is meaningless, and the smoke measured it.**
+#: Unfiltered, the enumeration returns every Approved request the NCAR process
+#: has ever held — 4,088 of them — and classifying that whole corpus reported
+#: **2,180 "accounts needed", 2,149 of them merely inactive**. Those are not
+#: work: they are every PI and admin whose SAM account was deactivated when
+#: they retired, moved institution, or simply finished.
+#:
+#: **Which date, and why.** The card filters Feed A on ``received_time`` —
+#: when the action *arrived*. Feed B's honest analogue is the **period of
+#: performance**, not ``submitDate``: the question is who needs an account for
+#: a handoff, and a handoff only ever lands against an allocation that is
+#: live. A request whose allocation ended before the window opened cannot
+#: produce one.
+DEFAULT_WINDOW_DAYS = 90
+
+#: ⚠️ Requests to enumerate. ``Approved`` is the default because it is the
+#: only status that produces a handoff — but the full filter vocabulary is
+#: reachable (``Submitted``, ``Under Review``, ``Incomplete``, ``Rejected``),
+#: and ``all`` drops the filter entirely, so a sweep can surface the pipeline
+#: ahead of approval when someone wants to look.
+DEFAULT_STATUS = 'Approved'
+
+#: People to re-fetch per run for identity detail. Each is one round trip,
 #: and the cache means the card's own renders do not repeat them.
 DEFAULT_MAX_PEOPLE = 250
 
@@ -106,6 +137,59 @@ def max_people(env: Optional[dict] = None) -> int:
                          DEFAULT_MAX_PEOPLE)
 
 
+def window_days(env: Optional[dict] = None) -> int:
+    """Window size, from ``$SAM_TASKS_XRAS_SWEEP_WINDOW_DAYS``."""
+    return _positive_int(env, 'SAM_TASKS_XRAS_SWEEP_WINDOW_DAYS',
+                         DEFAULT_WINDOW_DAYS)
+
+
+def sweep_status(env: Optional[dict] = None) -> Optional[str]:
+    """Which request status to enumerate; ``None`` means every status.
+
+    ``all`` (any case) drops the filter. An unrecognised value falls back to
+    the default rather than being passed through — the API rejects an unknown
+    ``status`` with a 4xx, which the client turns into an outage, and a typo
+    in a chart value must not take the sweep down.
+    """
+    raw = str((env if env is not None else os.environ)
+              .get('SAM_TASKS_XRAS_SWEEP_STATUS', '') or '').strip()
+    if not raw:
+        return DEFAULT_STATUS
+    if raw.casefold() == 'all':
+        return None
+    # Deferred: `scheduling/` must not pay for `requests` on the CLI's --list
+    # path, which imports this package only to print a table.
+    from sam.integration.xras_api.client import REQUEST_STATUSES
+    return raw if raw in REQUEST_STATUSES else DEFAULT_STATUS
+
+
+def overlaps_window(payload: dict, *, window_start: date) -> bool:
+    """Was this request's allocation still open when the window began?
+
+    **One-sided on purpose.** The predicate is ``endDate is None or endDate >=
+    window_start`` — it drops what has already ended and keeps everything
+    live *or future*. A two-sided overlap (also requiring ``beginDate <=
+    window_end``) would discard requests whose period starts next quarter,
+    and those are precisely the population Feed B exists to reach: a PI with
+    no SAM account and months of lead time to fix it.
+
+    A missing or unparseable ``endDate`` counts as open — those are the newest
+    rows, in-flight or not yet dated.
+
+    Pure and injectable so the boundary never floats: a test that read the
+    wall clock would pass or fail depending on the day it ran. Dates arrive as
+    ``YYYY-MM-DD`` and are compared as dates; no timezone reasoning applies to
+    a calendar date.
+    """
+    raw = payload.get('endDate')
+    if not raw:
+        return True
+    try:
+        return date.fromisoformat(str(raw)[:10]) >= window_start
+    except ValueError:
+        return True
+
+
 @task(name='xras_sweep',
       schedule=SCHEDULE,
       needs=('sam',),
@@ -140,12 +224,15 @@ def xras_sweep(ctx) -> TaskResult:
         'skipped': False,
         'pages': 0,
         'requests_seen': 0,
+        'requests_in_window': 0,
+        'window_days': 0,
+        'status': '',
         'budget_exhausted': False,
         'pending_push': 0,
         'pending_push_sample': [],
         'accounts': {},
         'people_refreshed': 0,
-        'closures': 0,
+        'reconciled': 0,
         'unavailable_errors': 0,
     }
 
@@ -160,11 +247,17 @@ def xras_sweep(ctx) -> TaskResult:
     session = ctx.sam_session
     client = XrasApiClient.from_environment()
     page_budget = max_pages()
+    status = sweep_status()
+    window = window_days()
+    window_start = to_local_naive(
+        ctx.occurrence, ZoneInfo(SCHEDULE.tz)).date() - timedelta(days=window)
+    detail['window_days'] = window
+    detail['status'] = status or 'all'
 
     # ── 1. enumerate ────────────────────────────────────────────────────
     payloads = []
     try:
-        for page in client.iter_request_pages(status='Approved',
+        for page in client.iter_request_pages(status=status,
                                               page_size=PAGE_SIZE,
                                               max_pages=page_budget):
             detail['pages'] += 1
@@ -179,23 +272,53 @@ def xras_sweep(ctx) -> TaskResult:
     detail['requests_seen'] = len(payloads)
     detail['budget_exhausted'] = detail['pages'] >= page_budget
 
+    # ── 1b. drop what had already ended when the window opened ──────────
+    #
+    # Both counts are reported: `requests_seen` says how much was read,
+    # `requests_in_window` how much was work. Reporting only the second would
+    # make a narrowed window look like a shrinking problem.
+    payloads = [p for p in payloads
+                if overlaps_window(p, window_start=window_start)]
+    detail['requests_in_window'] = len(payloads)
+
     # ── 2. dropped / pending pushes ─────────────────────────────────────
     numbers = {str(p.get('requestNumber')).strip() for p in payloads
                if p.get('requestNumber')}
+    pending_set: set = set()
     if numbers:
         known = {code for (code,) in session.query(Project.projcode)
                  .filter(Project.projcode.in_(sorted(numbers))).all()}
-        pending = sorted(numbers - known)
+        pending_set = numbers - known
+        pending = sorted(pending_set)
         detail['pending_push'] = len(pending)
         detail['pending_push_sample'] = pending[:_MAX_REPORTED]
 
-    # ── 3. classify what the enumeration names ──────────────────────────
+    # ── 3. classify the rosters of what has NOT been pushed ─────────────
+    #
+    # ⚠️ **Only the pending set, and this is the difference between a queue
+    # and a census.** Measured against the live process, 90-day window:
+    #
+    #     every Approved request, no window   2,180 accounts "needed"
+    #     + window                              542
+    #     + not-yet-pushed only                  21   <- 10 of 11 absent
+    #                                                    rows are placeholders
+    #
+    # A request whose project already exists has **already had its handoff**.
+    # Its roster's inactive members are ordinary attrition — a grad student
+    # who left, a PI whose account was locked — not accounts anyone must
+    # create for a handoff to succeed, which is what this worklist is for
+    # (§ 1). Classifying them buried the eleven real rows under five hundred.
+    #
+    # Restricting to the pending set is also strictly cheaper: 40 rosters
+    # instead of 1,640.
+    pending_payloads = [p for p in payloads
+                        if str(p.get('requestNumber') or '').strip() in pending_set]
     enumerated = classify_accounts(session,
-                                   records_from_report_requests(payloads))
+                                   records_from_report_requests(pending_payloads))
     detail['accounts'] = worklist_counts(enumerated)
     detail['accounts_sample'] = [r['username'] for r in enumerated][:_MAX_REPORTED]
 
-    # ── 4. warm the closure signal for the card's morning renders ───────
+    # ── 4. warm the person cache for the card's morning renders ────────
     #
     # Feed A only: Feed B carried its person objects inline, so re-fetching
     # them would be a round trip for something already in hand.
@@ -211,14 +334,18 @@ def xras_sweep(ctx) -> TaskResult:
             break
         detail['people_refreshed'] += 1
         if person and person.get('isReconciled'):
-            # XRAS reconciled them; the worklist item should now close.
-            detail['closures'] += 1
+            # ⚠️ NOT a closure. XRAS having linked this username to a real
+            # identity says nothing about whether SAM has a usable row — the
+            # smoke measured 9 of 9 worklist rows reconciled and still needing
+            # work. It is reported because it says the account can be created
+            # from real detail, not because anything closed.
+            detail['reconciled'] += 1
 
     counts = detail['accounts']
-    message = (f"{detail['requests_seen']} request(s), "
+    message = (f"{detail['requests_in_window']}/{detail['requests_seen']} in-window request(s), "
                f"{detail['pending_push']} pending push, "
                f"{counts.get('total', 0)} account(s) needed, "
-               f"{detail['closures']} closure(s)")
+               f"{detail['reconciled']} reconciled in XRAS")
     ctx.logger.info('xras_sweep: %s', message)
 
     # "0 findings, succeeded" must be distinguishable from "did not look" —

--- a/src/scheduling/tasks/xras_sweep.py
+++ b/src/scheduling/tasks/xras_sweep.py
@@ -1,7 +1,14 @@
 """``xras_sweep`` — enumerate XRAS nightly and diff it against SAM.
 
-Daily 03:30 Mountain. The first task that calls **out** to XRAS rather than
-reading only SAM's own tables, and the third declaring ``needs=('sam',)``.
+Hourly 08:00-17:00 Mon-Fri Mountain. The first task that calls **out** to XRAS
+rather than reading only SAM's own tables, and the third declaring
+``needs=('sam',)``.
+
+It is also the first task that **publishes to the dashboard**. The Feed-B tab
+on Allocations → XRAS renders what this writes to the ``xras_pending`` cache
+bucket, because the enumeration behind it (21 pages, 60-90s) is far outside
+what an htmx round-trip can afford. The cadence here is therefore the tab's
+freshness, which is why this runs hourly rather than nightly.
 
 What it is for
 --------------
@@ -53,12 +60,20 @@ from typing import Optional
 from zoneinfo import ZoneInfo
 
 from scheduling.registry import TaskResult, task
-from scheduling.schedules import Daily, to_local_naive
+from scheduling.schedules import BusinessHourly, to_local_naive
 
 #: Overnight on purpose: nothing here is time-critical, the enumeration is the
 #: heaviest outbound call SAM makes, and a warm people-cache at 03:30 is still
 #: warm for the first card render of the working day.
-SCHEDULE = Daily(3, 30, tz='America/Denver')
+#: Hourly through the business day, matching `xras_notices`. The Feed-B tab
+#: reads what this publishes, so the cadence IS the tab's freshness — a
+#: nightly sweep would show an operator yesterday's queue all day.
+#:
+#: `minute=0` for the same reason `xras_notices` uses it: the CronJob wakes at
+#: :07, so a :00 slot dispatches about seven minutes later where a :20 slot
+#: would wait for the next wake. Both tasks share the wake and run
+#: sequentially under `concurrencyPolicy: Forbid`; this one takes 60-90s.
+SCHEDULE = BusinessHourly(minute=0, tz='America/Denver')
 
 #: Pages of ``reports/requests`` per run, overridable via
 #: ``$SAM_TASKS_XRAS_SWEEP_MAX_PAGES``. At the default page size that is 5,000
@@ -212,6 +227,7 @@ def xras_sweep(ctx) -> TaskResult:
         XrasSourceUnavailable,
         xras_api_configured,
     )
+    from sam.integration.xras_api.cache import store_pending_worklist
     from sam.projects.projects import Project
     from sam.queries.xras_accounts import (
         classify_accounts,
@@ -233,6 +249,7 @@ def xras_sweep(ctx) -> TaskResult:
         'accounts': {},
         'people_refreshed': 0,
         'reconciled': 0,
+        'published': False,
         'unavailable_errors': 0,
     }
 
@@ -340,6 +357,28 @@ def xras_sweep(ctx) -> TaskResult:
             # work. It is reported because it says the account can be created
             # from real detail, not because anything closed.
             detail['reconciled'] += 1
+
+    # ── 5. publish for the dashboard ────────────────────────────────────
+    #
+    # Send first, record second — the ledger row must not claim a snapshot the
+    # tab cannot read. A disabled bucket is not an error: the findings are
+    # still in `detail`, and the tab renders its "no sweep data yet" state.
+    detail['published'] = store_pending_worklist({
+        # A datetime, not an ISO string: this payload is pickled into the
+        # cache and read straight by a Jinja `fmt_date`, whereas the ledger's
+        # `detail` beside it is JSON and must stay stringly-typed. The two
+        # have different serialisation contracts and this is the seam.
+        'generated_at': to_local_naive(ctx.occurrence, ZoneInfo(SCHEDULE.tz)),
+        'window_days': window,
+        'status': detail['status'],
+        'requests_seen': detail['requests_seen'],
+        'requests_in_window': detail['requests_in_window'],
+        'budget_exhausted': detail['budget_exhausted'],
+        'pending_push': detail['pending_push'],
+        'pending_push_sample': detail['pending_push_sample'],
+        'counts': detail['accounts'],
+        'rows': enumerated,
+    })
 
     counts = detail['accounts']
     message = (f"{detail['requests_in_window']}/{detail['requests_seen']} in-window request(s), "

--- a/src/webapp/caching/__init__.py
+++ b/src/webapp/caching/__init__.py
@@ -50,6 +50,7 @@ _BUCKETED_CACHE_MODULES = (
     'webapp.disk_scans.cache',
     'webapp.jobs.cache',
     'sam.integration.awards.cache',
+    'sam.integration.xras_api.cache',
 )
 
 

--- a/src/webapp/config.py
+++ b/src/webapp/config.py
@@ -154,6 +154,11 @@ class SAMWebappConfig(SAMConfig):
     XRAS_PEOPLE_CACHE_SIZE    = int(os.getenv('XRAS_PEOPLE_CACHE_SIZE', 512))    # max entries
     XRAS_RESOURCES_CACHE_TTL  = int(os.getenv('XRAS_RESOURCES_CACHE_TTL', 86400))  # 1 day
     XRAS_RESOURCES_CACHE_SIZE = int(os.getenv('XRAS_RESOURCES_CACHE_SIZE', 8))     # max entries
+    # The Feed-B mailbox: xras_sweep publishes, the dashboard tab reads. TTL
+    # spans the overnight gap between business-hours sweeps (17:00 -> 08:00),
+    # or the tab would be blank every morning until the first run.
+    XRAS_PENDING_CACHE_TTL    = int(os.getenv('XRAS_PENDING_CACHE_TTL', 86400))   # 1 day
+    XRAS_PENDING_CACHE_SIZE   = int(os.getenv('XRAS_PENDING_CACHE_SIZE', 4))      # max entries
 
     # hpc-usage-queries plugin (per-job rows on resource-usage detail pages).
     # The plugin owns its own database — typically a per-machine PostgreSQL

--- a/src/webapp/config.py
+++ b/src/webapp/config.py
@@ -146,6 +146,15 @@ class SAMWebappConfig(SAMConfig):
     AWARD_SEARCH_CACHE_TTL  = int(os.getenv('AWARD_SEARCH_CACHE_TTL', 86400))    # 1 day
     AWARD_SEARCH_CACHE_SIZE = int(os.getenv('AWARD_SEARCH_CACHE_SIZE', 256))     # max entries
 
+    # Outbound XRAS Allocations API cache (sam.integration.xras_api). People
+    # sit at 4 hours because `isReconciled` is the account-creation worklist's
+    # closure signal and must not go stale; the 13-row resource catalog changes
+    # about once a year.
+    XRAS_PEOPLE_CACHE_TTL     = int(os.getenv('XRAS_PEOPLE_CACHE_TTL', 14400))   # 4 hours
+    XRAS_PEOPLE_CACHE_SIZE    = int(os.getenv('XRAS_PEOPLE_CACHE_SIZE', 512))    # max entries
+    XRAS_RESOURCES_CACHE_TTL  = int(os.getenv('XRAS_RESOURCES_CACHE_TTL', 86400))  # 1 day
+    XRAS_RESOURCES_CACHE_SIZE = int(os.getenv('XRAS_RESOURCES_CACHE_SIZE', 8))     # max entries
+
     # hpc-usage-queries plugin (per-job rows on resource-usage detail pages).
     # The plugin owns its own database — typically a per-machine PostgreSQL
     # database (derecho_jobs, casper_jobs) on the shared `csg-postgres` cluster.

--- a/src/webapp/dashboards/allocations/blueprint.py
+++ b/src/webapp/dashboards/allocations/blueprint.py
@@ -1340,6 +1340,10 @@ def xras():
         'dashboards/allocations/xras.html',
         xras_start_date=start_str,
         xras_end_date=end_str,
+        # The worklist tabs share ONE window control, rendered in the shell so
+        # only one start_date/end_date pair exists (see the template).
+        window=_parse_activity_window(request.args),
+        window_pill_choices=_ACTIVITY_WINDOW_PILLS,
         **_window_control_context(end_date, start_str, end_str),
         all_statuses=list(XRAS_ACTION_STATUSES),
         all_action_types=_xras_action_types(),
@@ -1649,6 +1653,30 @@ def _filter_accounts(rows, *, classifications=None, roles=None):
     return out
 
 
+_PENDING_FORM_ID = 'xras-pending-filters'
+
+#: Requests to offer as chips. A worklist spanning dozens of projects would
+#: otherwise render a chip wall; the cap is on the CHIPS, not the rows, and
+#: the rows all stay visible whether or not their request earned one.
+_MAX_REQUEST_CHIPS = 12
+
+
+def _request_facets(rows, *, classifications=None):
+    """Counts per XRAS request number, most-affected first.
+
+    Self-excluding on its own dimension, like every other facet here. Rows
+    naming no request number contribute nothing: a NULL cannot round-trip
+    through the form, so it must not become a chip.
+    """
+    scoped = _filter_accounts(rows, classifications=classifications)
+    counts = {}
+    for row in scoped:
+        for number in {a['request_number'] for a in row['actions'] if a['request_number']}:
+            counts[number] = counts.get(number, 0) + 1
+    ordered = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    return [{'value': k, 'count': v} for k, v in ordered[:_MAX_REQUEST_CHIPS]]
+
+
 def _account_facets(rows, dimension, *, classifications=None, roles=None):
     """Self-excluding counts for one dimension.
 
@@ -1717,11 +1745,18 @@ def xras_accounts_fragment():
         for row in rows:
             row['person'] = None
 
+    selected_requests = [r for r in request.args.getlist('request_number') if r]
+
     class_facets = _account_facets(rows, 'classification', roles=selected_roles)
     role_facets = _account_facets(rows, 'role', classifications=selected_classes)
+    request_facets = _request_facets(rows, classifications=selected_classes)
 
     rows = _filter_accounts(rows, classifications=selected_classes,
                             roles=selected_roles)
+    if selected_requests:
+        # The operator working one project's activation wants only its rows.
+        rows = [r for r in rows
+                if {a['request_number'] for a in r['actions']} & set(selected_requests)]
 
     return render_template(
         'dashboards/allocations/partials/xras_accounts_card.html',
@@ -1739,11 +1774,83 @@ def xras_accounts_fragment():
              'count': class_facets.get(key, 0)}
             for key in (CLASSIFICATION_ABSENT, CLASSIFICATION_INACTIVE)],
         role_values=[{'value': k, 'count': v} for k, v in role_facets.items()],
+        request_values=request_facets,
         selected_classifications=selected_classes,
         selected_roles=selected_roles,
+        selected_requests=selected_requests,
         form_id=_ACCOUNTS_FORM_ID,
         fragment_url=url_for('allocations_dashboard.xras_accounts_fragment'),
         target_id=_ACCOUNTS_TARGET,
+    )
+
+
+_PENDING_TARGET = 'alloc-xras-pending-requests'
+
+
+@bp.route('/xras_pending_requests_fragment')
+@login_required
+@require_permission(Permission.VIEW_XRAS)
+def xras_pending_requests_fragment():
+    """HTMX fragment: Feed B — XRAS requests SAM has no project for yet.
+
+    **Read from a cache the `xras_sweep` task publishes, never computed
+    here.** The enumeration behind this is 21 pages and 60-90 seconds against
+    `api.xras.org`; no htmx round-trip can afford it, which is why the sweep
+    is a producer and this is a consumer. The tab is therefore exactly as
+    fresh as the last successful sweep, and it says so.
+
+    Three distinct empty states, and conflating them would mislead:
+
+    - **unconfigured** — `XRAS_OUTGOING_ENABLED` is off, so no sweep can run.
+    - **no snapshot** — configured, but no sweep has published yet (the task
+      may be disabled, or this is the first hour after a deploy).
+    - **published and empty** — a real sweep found nothing pending, which is
+      the healthy steady state.
+
+    Same PII rule as the accounts tab: person detail only for MANAGE_XRAS,
+    stripped in the route so a VIEW_XRAS response never carries it.
+    """
+    from sam.integration.xras_api import xras_api_configured
+    from sam.integration.xras_api.cache import load_pending_worklist
+
+    may_manage = has_permission(current_user, Permission.MANAGE_XRAS)
+    configured = xras_api_configured()
+    snapshot = load_pending_worklist() if configured else None
+
+    rows = list(snapshot.get('rows') or []) if snapshot else []
+    selected_requests = [r for r in request.args.getlist('request_number') if r]
+    selected_classes = [c for c in request.args.getlist('classification') if c]
+
+    if not may_manage:
+        rows = [{**r, 'person': None} for r in rows]
+
+    class_facets = _account_facets(rows, 'classification')
+    request_facets = _request_facets(rows, classifications=selected_classes)
+
+    rows = _filter_accounts(rows, classifications=selected_classes)
+    if selected_requests:
+        rows = [r for r in rows
+                if {a['request_number'] for a in r['actions']} & set(selected_requests)]
+
+    return render_template(
+        'dashboards/allocations/partials/xras_pending_requests_card.html',
+        rows=rows,
+        snapshot=snapshot,
+        configured=configured,
+        may_manage=may_manage,
+        counts=worklist_counts(rows),
+        classification_values=[
+            {'value': key,
+             'label': _ACCOUNT_CLASSIFICATION_LABELS.get(key, key),
+             'count': class_facets.get(key, 0)}
+            for key in (CLASSIFICATION_ABSENT, CLASSIFICATION_INACTIVE)],
+        request_values=request_facets,
+        selected_classifications=selected_classes,
+        selected_requests=selected_requests,
+        form_id=_PENDING_FORM_ID,
+        fragment_url=url_for(
+            'allocations_dashboard.xras_pending_requests_fragment'),
+        target_id=_PENDING_TARGET,
     )
 
 

--- a/src/webapp/dashboards/allocations/blueprint.py
+++ b/src/webapp/dashboards/allocations/blueprint.py
@@ -11,7 +11,7 @@ from flask import (
     current_app,
 )
 from flask_login import login_required, current_user
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from typing import List, Dict
 
 from webapp.extensions import db, cache, user_aware_cache_key
@@ -1344,6 +1344,7 @@ def xras():
         # only one start_date/end_date pair exists (see the template).
         window=_parse_activity_window(request.args),
         window_pill_choices=_ACTIVITY_WINDOW_PILLS,
+        form_id='xras-window-filters',
         **_window_control_context(end_date, start_str, end_str),
         all_statuses=list(XRAS_ACTION_STATUSES),
         all_action_types=_xras_action_types(),
@@ -1661,6 +1662,33 @@ _PENDING_FORM_ID = 'xras-pending-filters'
 _MAX_REQUEST_CHIPS = 12
 
 
+def _submitted_since(row, since):
+    """Did any request naming this person appear in XRAS within the window?
+
+    The Feed-B analogue of Feed A's ``received_time`` filter — the same
+    question ("when did this show up?") asked of a feed that has no arrival of
+    its own, which is what lets one control span both tabs.
+
+    A row with no usable submit date is kept: that is missing information, not
+    evidence of age, and dropping it would silently shrink the queue.
+    """
+    if since is None:
+        return True
+    start = since.date() if hasattr(since, 'date') else since
+    dates = [a.get('submit_date') for a in row.get('actions') or []]
+    if not any(dates):
+        return True
+    for raw in dates:
+        if not raw:
+            return True
+        try:
+            if date.fromisoformat(str(raw)[:10]) >= start:
+                return True
+        except ValueError:
+            return True
+    return False
+
+
 def _request_facets(rows, *, classifications=None):
     """Counts per XRAS request number, most-affected first.
 
@@ -1785,6 +1813,32 @@ def xras_accounts_fragment():
 
 
 _PENDING_TARGET = 'alloc-xras-pending-requests'
+_WINDOW_TARGET = 'alloc-xras-window'
+
+
+@bp.route('/xras_window_fragment')
+@login_required
+@require_permission(Permission.VIEW_XRAS)
+def xras_window_fragment():
+    """HTMX fragment: just the shared window pills.
+
+    ⚠️ **The control has to re-render itself, and this is why the route
+    exists.** `window_pills` marks the active pill server-side from the
+    window it is handed. While the pills lived inside each worklist fragment
+    that came free — a submit re-rendered the fragment and the pill state
+    came with it. Sharing one control across three tabs moved it into the page
+    shell, outside every swap target, so it kept whatever state the page load
+    gave it: clicking 7D re-filtered the data and left the pill looking
+    unchanged, which reads as a dead control.
+
+    So the pills are their own swap target, listening for the same submit the
+    panes do.
+    """
+    window = _parse_activity_window(request.args)
+    return render_template(
+        'dashboards/allocations/partials/xras_window_control.html',
+        window=window, window_pill_choices=_ACTIVITY_WINDOW_PILLS,
+        form_id='xras-window-filters')
 
 
 @bp.route('/xras_pending_requests_fragment')
@@ -1818,8 +1872,21 @@ def xras_pending_requests_fragment():
     snapshot = load_pending_worklist() if configured else None
 
     rows = list(snapshot.get('rows') or []) if snapshot else []
+    window = _parse_activity_window(request.args)
     selected_requests = [r for r in request.args.getlist('request_number') if r]
     selected_classes = [c for c in request.args.getlist('classification') if c]
+
+    # ⚠️ A shared control that silently does nothing on one tab is worse than
+    # no control, so the pills mean the same thing here as on the other two:
+    # "what showed up in the last N days". For Feed B that is `submitDate`.
+    #
+    # Filtering on the period of performance was tried first and is wrong: a
+    # pending request's allocation almost always ends a year out, so a
+    # one-sided window keeps every row at every width and the pill looks dead
+    # — the exact complaint this is fixing. The period of performance stays
+    # where it belongs, bounding what the SWEEP collects; the header reports
+    # that width so the two are never confused.
+    rows = [r for r in rows if _submitted_since(r, window['since'])]
 
     if not may_manage:
         rows = [{**r, 'person': None} for r in rows]

--- a/src/webapp/dashboards/allocations/blueprint.py
+++ b/src/webapp/dashboards/allocations/blueprint.py
@@ -61,6 +61,13 @@ from sam.queries.xras_activation import (
 # submodules eagerly, and this one imports `sam.notify`. See the module
 # docstring; `tests/unit/test_notify_import_graph.py` is the gate.
 from sam.queries.xras_notices import build_xras_messages, load_xras_action
+from sam.queries.xras_accounts import (
+    CLASSIFICATION_ABSENT,
+    CLASSIFICATION_INACTIVE,
+    enrich_worklist,
+    get_account_worklist,
+    worklist_counts,
+)
 from sam.queries.usage_cache import cached_allocation_usage, purge_usage_cache, usage_cache_info
 from sam.queries.lookups import find_project_by_code
 from sam.schemas.forms import CreateChargeAdjustmentForm, XrasActivationEventForm
@@ -1598,6 +1605,145 @@ def xras_pending_fragment():
         form_id=_XRAS_ACTIVITY_FORM_ID,
         fragment_url=url_for('allocations_dashboard.xras_pending_fragment'),
         target_id=_XRAS_ACTIVITY_TARGET,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Account-creation worklist — read-only.
+#
+# Who must exist in SAM before an XRAS handoff can succeed. Unreconciled ARC
+# placeholder identities are 55% of production XRAS failures, and account
+# creation is manual, so this card is the operator's queue for the largest
+# single cause of failure.
+#
+# Read-only in this PR by design. Operator notes and dismissal need storage
+# that `XrasActivationEvent` cannot provide — its `project_id` is NOT NULL and
+# project-scoped, while this worklist is username-keyed and for a New request
+# the project does not exist yet. That table (`xras_account_event`) is the
+# immediate follow-up; shipping the buttons before it would be dead UI.
+# ---------------------------------------------------------------------------
+
+#: Display labels for the classification facet. The slug is what round-trips
+#: through the form; an operator should never see it.
+_ACCOUNT_CLASSIFICATION_LABELS = {
+    CLASSIFICATION_ABSENT: 'Create account',
+    CLASSIFICATION_INACTIVE: 'Reactivate account',
+}
+
+_ACCOUNTS_FORM_ID = 'xras-accounts-filters'
+_ACCOUNTS_TARGET = 'alloc-xras-accounts'
+
+#: Bounds a cold-cache render. Each miss is one round trip to XRAS inside an
+#: htmx request, so this is a latency bound, not a correctness one — the rows
+#: past it still render, just without person detail.
+_ACCOUNTS_ENRICH_BUDGET = 25
+
+
+def _filter_accounts(rows, *, classifications=None, roles=None):
+    """Facet filters: ANDed across dimensions, ORed within one."""
+    out = rows
+    if classifications:
+        out = [r for r in out if r['classification'] in classifications]
+    if roles:
+        out = [r for r in out if any(role in roles for role in r['roles'])]
+    return out
+
+
+def _account_facets(rows, dimension, *, classifications=None, roles=None):
+    """Self-excluding counts for one dimension.
+
+    A dimension's rollup omits its own filter — scope it by itself and every
+    unselected value reads 0 the moment one is picked, which turns the chips
+    from switchers into a dead end. Same rule as :func:`_activity_facets`.
+    """
+    if dimension == 'classification':
+        scoped = _filter_accounts(rows, roles=roles)
+        return {key: sum(1 for r in scoped if r['classification'] == key)
+                for key in (CLASSIFICATION_ABSENT, CLASSIFICATION_INACTIVE)}
+
+    if dimension == 'role':
+        scoped = _filter_accounts(rows, classifications=classifications)
+        counts = {}
+        for row in scoped:
+            for role in row['roles']:
+                counts[role] = counts.get(role, 0) + 1
+        return dict(sorted(counts.items()))
+
+    raise ValueError(f'unknown account facet dimension {dimension!r}')
+
+
+@bp.route('/xras_accounts_fragment')
+@login_required
+@require_permission(Permission.VIEW_XRAS)
+def xras_accounts_fragment():
+    """HTMX fragment: accounts that must be created or reactivated for XRAS.
+
+    Two states here are **designed, not broken**, and both are what a reviewer
+    will see first:
+
+    - **Unconfigured.** With `XRAS_OUTGOING_ENABLED` off — the shipped state,
+      and what staging shows — the worklist still renders in full from the
+      inbound action log. Only the person detail and the `isReconciled`
+      closure signal are unavailable, and a muted note says so.
+    - **Empty.** Production has zero rows until ACCESS is repointed at SAM and
+      `xras_action_log` starts filling. An empty card is a true report.
+
+    PII is gated **here**, not in the template. Person detail — name, email,
+    organization, academic status, residence country — is assembled only for a
+    viewer holding MANAGE_XRAS, so a VIEW_XRAS response never carries it and a
+    view-source cannot leak what the page chose not to draw. Same rule as the
+    raw-payload panel and the notification recipients above.
+
+    `is_reconciled` is deliberately on the VIEW_XRAS side of that line: it is a
+    boolean about account state, not a personal detail, and it is the signal
+    that tells an operator an item is about to close itself.
+    """
+    may_manage = has_permission(current_user, Permission.MANAGE_XRAS)
+    window = _parse_activity_window(request.args)
+    selected_classes = [c for c in request.args.getlist('classification') if c]
+    selected_roles = [r for r in request.args.getlist('role') if r]
+
+    rows = get_account_worklist(db.session,
+                                since=window['since'], until=window['until'])
+
+    # Enrichment is best-effort and never fatal: an outage or an unconfigured
+    # deployment leaves `person` None and flags the batch, so the card degrades
+    # to counts and usernames rather than returning 500.
+    enrichment = enrich_worklist(rows, max_lookups=_ACCOUNTS_ENRICH_BUDGET)
+
+    if not may_manage:
+        # Drop the PII before it can reach a template, a log line, or a
+        # response body. `is_reconciled` survives — see the docstring.
+        for row in rows:
+            row['person'] = None
+
+    class_facets = _account_facets(rows, 'classification', roles=selected_roles)
+    role_facets = _account_facets(rows, 'role', classifications=selected_classes)
+
+    rows = _filter_accounts(rows, classifications=selected_classes,
+                            roles=selected_roles)
+
+    return render_template(
+        'dashboards/allocations/partials/xras_accounts_card.html',
+        rows=rows,
+        counts=worklist_counts(rows),
+        may_manage=may_manage,
+        enrichment=enrichment,
+        window=window,
+        window_pill_choices=_ACTIVITY_WINDOW_PILLS,
+        # Both classifications render even at zero: an absent chip reads as
+        # "not measured", a different claim from "none".
+        classification_values=[
+            {'value': key,
+             'label': _ACCOUNT_CLASSIFICATION_LABELS.get(key, key),
+             'count': class_facets.get(key, 0)}
+            for key in (CLASSIFICATION_ABSENT, CLASSIFICATION_INACTIVE)],
+        role_values=[{'value': k, 'count': v} for k, v in role_facets.items()],
+        selected_classifications=selected_classes,
+        selected_roles=selected_roles,
+        form_id=_ACCOUNTS_FORM_ID,
+        fragment_url=url_for('allocations_dashboard.xras_accounts_fragment'),
+        target_id=_ACCOUNTS_TARGET,
     )
 
 

--- a/src/webapp/templates/dashboards/allocations/partials/xras_accounts_card.html
+++ b/src/webapp/templates/dashboards/allocations/partials/xras_accounts_card.html
@@ -1,7 +1,6 @@
 {% from 'dashboards/fragments/badges.html' import status_badge %}
 {% from 'dashboards/fragments/collapse.html' import collapse_toggle %}
 {% from 'dashboards/fragments/facet_chips.html' import facet_row %}
-{% from 'dashboards/fragments/window_pills.html' import window_pills %}
 {#
   XRAS account-creation worklist — who must exist in SAM before a handoff works.
 
@@ -35,7 +34,6 @@
 #}
 <div class="card mb-3">
     <div class="card-header d-flex align-items-center flex-wrap gap-2">
-        <i class="fas fa-user-plus text-secondary"></i>
         <strong>Accounts Needed for XRAS Handoffs</strong>
         <span class="badge bg-secondary">{{ counts.total | fmt_number }}</span>
         {% if counts.placeholder %}
@@ -51,12 +49,6 @@
             {{ counts.placeholder | fmt_number }} placeholder
         </span>
         {% endif %}
-        <div class="ms-auto">
-            {{ window_pills(form_id, window_pill_choices, window.days,
-                            custom=window.custom,
-                            start_date=window.start_date,
-                            end_date=window.end_date) }}
-        </div>
     </div>
 
     <div class="card-body border-bottom py-2">
@@ -65,6 +57,11 @@
                          'classification', active=selected_classifications) }}
             {{ facet_row('Role', role_values, form_id, 'role',
                          active=selected_roles) }}
+            {# The operator working one project's activation filters to it
+               here; the same value is a column below so it is visible before
+               it is selectable. #}
+            {{ facet_row('Request', request_values, form_id, 'request_number',
+                         active=selected_requests) }}
         </div>
         {% if enrichment.unavailable %}
         {# The designed unconfigured/degraded state. The worklist above is
@@ -91,11 +88,10 @@
                 <tr>
                     <th style="width:220px; white-space:nowrap;">Username</th>
                     <th style="width:170px; white-space:nowrap;">Needs</th>
-                    <th style="width:200px;">Role</th>
+                    <th style="width:170px;">Role</th>
+                    <th style="width:180px;">Request</th>
                     {% if may_manage %}
-                    <th style="width:99%; min-width:14rem;">Person</th>
-                    {% else %}
-                    <th style="width:99%; min-width:10rem;">Requests</th>
+                    <th style="width:99%; min-width:12rem;">Person</th>
                     {% endif %}
                     <th style="width:120px; white-space:nowrap;">XRAS identity</th>
                     <th style="width:130px; white-space:nowrap;">Last seen</th>
@@ -110,8 +106,11 @@
                     <td class="font-monospace text-nowrap">
                         {{ row.username }}
                         {% if row.placeholder %}
-                        <i class="fas fa-user-clock text-warning ms-1"
-                           title="ARC placeholder identity — this researcher has no site account"></i>
+                        {# Text, not an icon: the placeholder shape is already
+                           legible in the username itself, and a glyph beside it
+                           was noise repeating what the string says. #}
+                        <span class="badge bg-light text-secondary border ms-1"
+                              title="ARC placeholder username — XRAS mints one for a researcher with no site account">placeholder</span>
                         {% endif %}
                     </td>
 
@@ -121,19 +120,28 @@
                         {% else %}
                         <span class="badge bg-warning text-dark">Reactivate</span>
                         {% endif %}
-                        {% if row.is_account_to_be_created %}
-                        {# A hint, never the predicate: XRAS sets this when the
-                           role is created and never clears it, so it is true on
-                           people who have had working accounts for years. #}
-                        <i class="fas fa-flag text-muted ms-1"
-                           title="XRAS flagged isAccountToBeCreated (a stale hint, not a predicate)"></i>
-                        {% endif %}
+
                     </td>
 
                     <td>
                         {% for role in row.roles %}
                         <span class="badge bg-light text-dark border">{{ role }}</span>
                         {% endfor %}
+                    </td>
+
+                    {# Which XRAS request needs this account. Its own column
+                       at every permission level: it is the handle an operator
+                       working a project's activation actually navigates by. #}
+                    <td class="font-monospace small">
+                        {% set numbers = row.actions | map(attribute='request_number')
+                                         | reject('none') | unique | list %}
+                        {% for number in numbers[:2] %}
+                        {{ number }}{% if not loop.last %}, {% endif %}
+                        {% endfor %}
+                        {% if not numbers %}<span class="text-muted">—</span>{% endif %}
+                        {% if numbers | length > 2 %}
+                        <span class="text-muted">+{{ numbers | length - 2 }}</span>
+                        {% endif %}
                     </td>
 
                     {% if may_manage %}
@@ -145,15 +153,6 @@
                         {% endif %}
                         {% else %}
                         <span class="text-muted">—</span>
-                        {% endif %}
-                    </td>
-                    {% else %}
-                    <td class="text-truncate" style="max-width:0;">
-                        {% for action in row.actions[:3] %}
-                        <span class="font-monospace small">{{ action.request_number or '—' }}</span>{% if not loop.last %}, {% endif %}
-                        {% endfor %}
-                        {% if row.actions | length > 3 %}
-                        <span class="text-muted">+{{ row.actions | length - 3 }}</span>
                         {% endif %}
                     </td>
                     {% endif %}
@@ -185,7 +184,7 @@
                 </tr>
 
                 <tr class="collapse" id="{{ body_id }}">
-                    <td colspan="6" class="bg-body-tertiary">
+                    <td colspan="7" class="bg-body-tertiary">
                         {% if may_manage and row.person %}
                         <div class="row g-2 small mb-2">
                             {% for label, value in [
@@ -248,7 +247,6 @@
     {# A designed state, not a failure: production is legitimately zero rows
        until ACCESS is repointed and the action log starts filling. #}
     <div class="card-body text-center text-muted py-4">
-        <i class="fas fa-circle-check fa-2x mb-2 d-block text-success opacity-50"></i>
         No accounts are waiting on creation or reactivation
         {%- if selected_classifications or selected_roles %} for these filters{% endif %}.
     </div>

--- a/src/webapp/templates/dashboards/allocations/partials/xras_accounts_card.html
+++ b/src/webapp/templates/dashboards/allocations/partials/xras_accounts_card.html
@@ -1,0 +1,240 @@
+{% from 'dashboards/fragments/badges.html' import status_badge %}
+{% from 'dashboards/fragments/collapse.html' import collapse_toggle %}
+{% from 'dashboards/fragments/facet_chips.html' import facet_row %}
+{% from 'dashboards/fragments/window_pills.html' import window_pills %}
+{#
+  XRAS account-creation worklist — who must exist in SAM before a handoff works.
+
+  Context:
+    rows            classify_accounts(...) rows, already filtered
+    counts          worklist_counts(rows)
+    may_manage      bool — MANAGE_XRAS
+    enrichment      {'looked_up','found','closed','unavailable','budget_exhausted','error'}
+    window          {'days','since','until','start_date','end_date','custom'}
+    window_pill_choices  ((days, label), ...)
+    classification_values  [{'value','label','count'}]  self-excluding
+    role_values            [{'value','count'}]          self-excluding
+    selected_classifications, selected_roles  [str]
+    form_id, fragment_url, target_id
+
+  ── ONE ROW PER USERNAME, NOT PER ACTION ─────────────────────────────────
+  The unit of work is an account, and one person can be named by several
+  actions. Keying on the action would put the same operator task on the list
+  three times and give it three places to be marked done.
+
+  ── PERSON DETAIL IS ROUTE-GATED ─────────────────────────────────────────
+  `row.person` is None for a VIEW_XRAS viewer because the ROUTE dropped it,
+  not because this template declined to draw it. The `may_manage` checks here
+  are a second gate over an already-empty value. `is_reconciled` is on the
+  VIEW_XRAS side deliberately: it is account state, not a personal detail.
+
+  ── WHERE THE COLLAPSE TOGGLE GOES ───────────────────────────────────────
+  On the cells, never the <tr> — Bootstrap's collapse data-api runs in the
+  capture phase, so a row-level toggle fires before any nested control and
+  data-stop-propagation cannot save it. Same fix as xras_activity_card.html.
+#}
+<div class="card mb-3">
+    <div class="card-header d-flex align-items-center flex-wrap gap-2">
+        <i class="fas fa-user-plus text-secondary"></i>
+        <strong>Accounts Needed for XRAS Handoffs</strong>
+        <span class="badge bg-secondary">{{ counts.total | fmt_number }}</span>
+        {% if counts.placeholder %}
+        <span class="badge bg-warning text-dark"
+              title="ARC placeholder identities — researchers with no site account">
+            {{ counts.placeholder | fmt_number }} unreconciled
+        </span>
+        {% endif %}
+        <div class="ms-auto">
+            {{ window_pills(form_id, window_pill_choices, window.days,
+                            custom=window.custom,
+                            start_date=window.start_date,
+                            end_date=window.end_date) }}
+        </div>
+    </div>
+
+    <div class="card-body border-bottom py-2">
+        <div class="facet-grid">
+            {{ facet_row('Needs', classification_values, form_id,
+                         'classification', active=selected_classifications) }}
+            {{ facet_row('Role', role_values, form_id, 'role',
+                         active=selected_roles) }}
+        </div>
+        {% if enrichment.unavailable %}
+        {# The designed unconfigured/degraded state. The worklist above is
+           complete — only XRAS-sourced detail is missing. #}
+        <div class="small text-muted mt-2">
+            <i class="fas fa-circle-info"></i>
+            Person detail and reconciliation status are unavailable
+            (the XRAS API is not configured or could not be reached).
+            The worklist itself is derived from the action log and is complete.
+        </div>
+        {% elif enrichment.budget_exhausted %}
+        <div class="small text-muted mt-2">
+            <i class="fas fa-circle-info"></i>
+            Person detail shown for the first {{ enrichment.looked_up | fmt_number }}
+            rows; narrow the filters to look up the rest.
+        </div>
+        {% endif %}
+    </div>
+
+    {% if rows %}
+    <div class="table-responsive">
+        <table class="table table-sm table-hover mb-0 align-middle">
+            <thead class="table-subtle">
+                <tr>
+                    <th style="width:220px; white-space:nowrap;">Username</th>
+                    <th style="width:170px; white-space:nowrap;">Needs</th>
+                    <th style="width:200px;">Role</th>
+                    {% if may_manage %}
+                    <th style="width:99%; min-width:14rem;">Person</th>
+                    {% else %}
+                    <th style="width:99%; min-width:10rem;">Requests</th>
+                    {% endif %}
+                    <th style="width:110px; white-space:nowrap;">XRAS</th>
+                    <th style="width:130px; white-space:nowrap;">Last seen</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in rows %}
+                {% set body_id = 'xras-acct-' ~ loop.index %}
+                {# No buttons on this row, so the toggle can live on the <tr> —
+                   see dashboards/fragments/collapse.html for when it cannot. #}
+                <tr class="cursor-pointer" {{ collapse_toggle(body_id) }}>
+                    <td class="font-monospace text-nowrap">
+                        {{ row.username }}
+                        {% if row.placeholder %}
+                        <i class="fas fa-user-clock text-warning ms-1"
+                           title="ARC placeholder identity — this researcher has no site account"></i>
+                        {% endif %}
+                    </td>
+
+                    <td>
+                        {% if row.classification == 'absent' %}
+                        <span class="badge bg-danger">Create</span>
+                        {% else %}
+                        <span class="badge bg-warning text-dark">Reactivate</span>
+                        {% endif %}
+                        {% if row.is_account_to_be_created %}
+                        {# A hint, never the predicate: XRAS sets this when the
+                           role is created and never clears it, so it is true on
+                           people who have had working accounts for years. #}
+                        <i class="fas fa-flag text-muted ms-1"
+                           title="XRAS flagged isAccountToBeCreated (a stale hint, not a predicate)"></i>
+                        {% endif %}
+                    </td>
+
+                    <td>
+                        {% for role in row.roles %}
+                        <span class="badge bg-light text-dark border">{{ role }}</span>
+                        {% endfor %}
+                    </td>
+
+                    {% if may_manage %}
+                    <td class="text-truncate" style="max-width:0;">
+                        {% if row.person %}
+                        {{ row.person.firstName }} {{ row.person.lastName }}
+                        {% if row.person.organization %}
+                        <span class="text-muted">· {{ row.person.organization }}</span>
+                        {% endif %}
+                        {% else %}
+                        <span class="text-muted">—</span>
+                        {% endif %}
+                    </td>
+                    {% else %}
+                    <td class="text-truncate" style="max-width:0;">
+                        {% for action in row.actions[:3] %}
+                        <span class="font-monospace small">{{ action.request_number or '—' }}</span>{% if not loop.last %}, {% endif %}
+                        {% endfor %}
+                        {% if row.actions | length > 3 %}
+                        <span class="text-muted">+{{ row.actions | length - 3 }}</span>
+                        {% endif %}
+                    </td>
+                    {% endif %}
+
+                    <td class="text-nowrap">
+                        {% if row.is_reconciled is none %}
+                        <span class="text-muted" title="XRAS was not asked">—</span>
+                        {% elif row.is_reconciled %}
+                        <span class="badge bg-success"
+                              title="XRAS considers this identity reconciled — this item should close">reconciled</span>
+                        {% else %}
+                        <span class="badge bg-secondary"
+                              title="XRAS has not reconciled this identity">unreconciled</span>
+                        {% endif %}
+                    </td>
+
+                    <td class="text-nowrap small text-muted">
+                        {{ row.last_seen | fmt_date }}
+                    </td>
+                </tr>
+
+                <tr class="collapse" id="{{ body_id }}">
+                    <td colspan="6" class="bg-body-tertiary">
+                        {% if may_manage and row.person %}
+                        <div class="row g-2 small mb-2">
+                            {% for label, value in [
+                                ('Email', row.person.email),
+                                ('Organization', row.person.organization),
+                                ('Academic status', row.person.academicStatus),
+                                ('Residence country', row.person.residenceCountry),
+                                ('ORCID', row.person.orcid)] %}
+                            {% if value %}
+                            <div class="col-md-4">
+                                <span class="text-muted">{{ label }}:</span> {{ value }}
+                            </div>
+                            {% endif %}
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+
+                        <table class="table table-sm mb-0">
+                            <thead>
+                                <tr class="small text-muted">
+                                    <th>Request</th><th>Action</th><th>Status</th>
+                                    <th>Received</th><th>Pre-flight</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for action in row.actions %}
+                                <tr class="small">
+                                    <td class="font-monospace">{{ action.request_number or '—' }}</td>
+                                    <td>{{ action.action_type or '—' }}</td>
+                                    <td>{% if action.status %}{{ status_badge(action.status, tooltip=False) }}{% endif %}</td>
+                                    <td>{{ action.received_time | fmt_date }}</td>
+                                    <td>
+                                        {% if action.would_succeed is none %}
+                                        <span class="text-muted">not checked</span>
+                                        {% elif action.would_succeed %}
+                                        <span class="text-success">would succeed</span>
+                                        {% else %}
+                                        {# The pre-flight also catches mnemonic and
+                                           resource-key failures, which are not account
+                                           problems — say "would fail", not "needs an
+                                           account", or the card implies this worklist
+                                           would fix them. #}
+                                        <span class="text-danger"
+                                              title="{{ action.reject_messages | join(' · ') }}">
+                                            would fail ({{ action.reject_messages | length }})
+                                        </span>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% else %}
+    {# A designed state, not a failure: production is legitimately zero rows
+       until ACCESS is repointed and the action log starts filling. #}
+    <div class="card-body text-center text-muted py-4">
+        <i class="fas fa-circle-check fa-2x mb-2 d-block text-success opacity-50"></i>
+        No accounts are waiting on creation or reactivation
+        {%- if selected_classifications or selected_roles %} for these filters{% endif %}.
+    </div>
+    {% endif %}
+</div>

--- a/src/webapp/templates/dashboards/allocations/partials/xras_accounts_card.html
+++ b/src/webapp/templates/dashboards/allocations/partials/xras_accounts_card.html
@@ -1,6 +1,7 @@
 {% from 'dashboards/fragments/badges.html' import status_badge %}
 {% from 'dashboards/fragments/collapse.html' import collapse_toggle %}
 {% from 'dashboards/fragments/facet_chips.html' import facet_row %}
+{% from 'dashboards/fragments/xras_person_detail.html' import person_detail %}
 {#
   XRAS account-creation worklist — who must exist in SAM before a handoff works.
 
@@ -44,7 +45,7 @@
            "identified". A placeholder is a USERNAME SHAPE that XRAS mints for
            someone with no site account; reconciliation is whether XRAS has
            since linked it to a confirmed identity. #}
-        <span class="badge bg-warning text-dark"
+        <span class="badge bg-warning-subtle text-warning-emphasis border border-warning-subtle"
               title="ARC placeholder usernames (&lt;name&gt;-user-&lt;token&gt;) — XRAS mints one for a researcher with no site account">
             {{ counts.placeholder | fmt_number }} placeholder
         </span>
@@ -109,23 +110,23 @@
                         {# Text, not an icon: the placeholder shape is already
                            legible in the username itself, and a glyph beside it
                            was noise repeating what the string says. #}
-                        <span class="badge bg-light text-secondary border ms-1"
+                        <span class="badge bg-body-secondary text-body-secondary border ms-1 fw-normal"
                               title="ARC placeholder username — XRAS mints one for a researcher with no site account">placeholder</span>
                         {% endif %}
                     </td>
 
                     <td>
                         {% if row.classification == 'absent' %}
-                        <span class="badge bg-danger">Create</span>
+                        <span class="badge bg-danger-subtle text-danger-emphasis border border-danger-subtle">Create</span>
                         {% else %}
-                        <span class="badge bg-warning text-dark">Reactivate</span>
+                        <span class="badge bg-warning-subtle text-warning-emphasis border border-warning-subtle">Reactivate</span>
                         {% endif %}
 
                     </td>
 
                     <td>
                         {% for role in row.roles %}
-                        <span class="badge bg-light text-dark border">{{ role }}</span>
+                        <span class="badge bg-body-secondary text-body-secondary border fw-normal">{{ role }}</span>
                         {% endfor %}
                     </td>
 
@@ -170,10 +171,10 @@
                         {% if row.is_reconciled is none %}
                         <span class="text-muted" title="XRAS was not asked">—</span>
                         {% elif row.is_reconciled %}
-                        <span class="badge bg-info text-dark"
+                        <span class="badge bg-body-secondary text-body-secondary border fw-normal"
                               title="XRAS has linked this username to a real identity, so the person detail here is usable for account creation. It does NOT mean the account exists.">identified</span>
                         {% else %}
-                        <span class="badge bg-warning text-dark"
+                        <span class="badge bg-warning-subtle text-warning-emphasis border border-warning-subtle"
                               title="XRAS has not reconciled this identity either — there is no confirmed person behind the username yet">unidentified</span>
                         {% endif %}
                     </td>
@@ -185,22 +186,7 @@
 
                 <tr class="collapse" id="{{ body_id }}">
                     <td colspan="7" class="bg-body-tertiary">
-                        {% if may_manage and row.person %}
-                        <div class="row g-2 small mb-2">
-                            {% for label, value in [
-                                ('Email', row.person.email),
-                                ('Organization', row.person.organization),
-                                ('Academic status', row.person.academicStatus),
-                                ('Residence country', row.person.residenceCountry),
-                                ('ORCID', row.person.orcid)] %}
-                            {% if value %}
-                            <div class="col-md-4">
-                                <span class="text-muted">{{ label }}:</span> {{ value }}
-                            </div>
-                            {% endif %}
-                            {% endfor %}
-                        </div>
-                        {% endif %}
+                        {% if may_manage %}{{ person_detail(row.person) }}{% endif %}
 
                         <table class="table table-sm mb-0">
                             <thead>

--- a/src/webapp/templates/dashboards/allocations/partials/xras_accounts_card.html
+++ b/src/webapp/templates/dashboards/allocations/partials/xras_accounts_card.html
@@ -39,9 +39,16 @@
         <strong>Accounts Needed for XRAS Handoffs</strong>
         <span class="badge bg-secondary">{{ counts.total | fmt_number }}</span>
         {% if counts.placeholder %}
+        {# ⚠️ "placeholder", NOT "unreconciled". These are two different facts
+           and the smoke caught the badge conflating them: all three
+           placeholders on the local corpus were reconciled in XRAS, so a
+           badge reading "3 unreconciled" contradicted every row's own
+           "identified". A placeholder is a USERNAME SHAPE that XRAS mints for
+           someone with no site account; reconciliation is whether XRAS has
+           since linked it to a confirmed identity. #}
         <span class="badge bg-warning text-dark"
-              title="ARC placeholder identities — researchers with no site account">
-            {{ counts.placeholder | fmt_number }} unreconciled
+              title="ARC placeholder usernames (&lt;name&gt;-user-&lt;token&gt;) — XRAS mints one for a researcher with no site account">
+            {{ counts.placeholder | fmt_number }} placeholder
         </span>
         {% endif %}
         <div class="ms-auto">
@@ -90,7 +97,7 @@
                     {% else %}
                     <th style="width:99%; min-width:10rem;">Requests</th>
                     {% endif %}
-                    <th style="width:110px; white-space:nowrap;">XRAS</th>
+                    <th style="width:120px; white-space:nowrap;">XRAS identity</th>
                     <th style="width:130px; white-space:nowrap;">Last seen</th>
                 </tr>
             </thead>
@@ -152,14 +159,23 @@
                     {% endif %}
 
                     <td class="text-nowrap">
+                        {# ⚠️ This is XRAS-side IDENTITY state, not progress on
+                           the row. Measured 9 of 9 on the local smoke: every
+                           worklist row was reconciled in XRAS and every one
+                           still needed a SAM account. So neither value is
+                           "done" — a row leaves this list when its users row
+                           exists and is active, which is checked every render.
+                           `unreconciled` is the HARDER case: XRAS cannot say
+                           who they are either, so there is no detail sheet to
+                           create the account from. #}
                         {% if row.is_reconciled is none %}
                         <span class="text-muted" title="XRAS was not asked">—</span>
                         {% elif row.is_reconciled %}
-                        <span class="badge bg-success"
-                              title="XRAS considers this identity reconciled — this item should close">reconciled</span>
+                        <span class="badge bg-info text-dark"
+                              title="XRAS has linked this username to a real identity, so the person detail here is usable for account creation. It does NOT mean the account exists.">identified</span>
                         {% else %}
-                        <span class="badge bg-secondary"
-                              title="XRAS has not reconciled this identity">unreconciled</span>
+                        <span class="badge bg-warning text-dark"
+                              title="XRAS has not reconciled this identity either — there is no confirmed person behind the username yet">unidentified</span>
                         {% endif %}
                     </td>
 

--- a/src/webapp/templates/dashboards/allocations/partials/xras_activity_card.html
+++ b/src/webapp/templates/dashboards/allocations/partials/xras_activity_card.html
@@ -1,7 +1,6 @@
 {% from 'dashboards/fragments/badges.html' import status_badge %}
 {% from 'dashboards/fragments/collapse.html' import collapse_toggle %}
 {% from 'dashboards/fragments/facet_chips.html' import facet_row %}
-{% from 'dashboards/fragments/window_pills.html' import window_pills %}
 {#
   Recent XRAS outcomes — "Pending Activations & Recent Notifications".
 
@@ -45,12 +44,6 @@
         <i class="fas fa-paper-plane text-secondary"></i>
         <strong>Pending Activations &amp; Recent Notifications</strong>
         <span class="badge bg-secondary">{{ rows | length | fmt_number }}</span>
-        <div class="ms-auto">
-            {{ window_pills(form_id, window_pill_choices, window.days,
-                            custom=window.custom,
-                            start_date=window.start_date,
-                            end_date=window.end_date) }}
-        </div>
     </div>
 
     <div class="card-body border-bottom py-2">

--- a/src/webapp/templates/dashboards/allocations/partials/xras_pending_requests_card.html
+++ b/src/webapp/templates/dashboards/allocations/partials/xras_pending_requests_card.html
@@ -1,4 +1,6 @@
+{% from 'dashboards/fragments/collapse.html' import collapse_toggle %}
 {% from 'dashboards/fragments/facet_chips.html' import facet_row %}
+{% from 'dashboards/fragments/xras_person_detail.html' import person_detail %}
 {#
   Feed B — XRAS requests SAM has no project for yet, and the accounts they
   will need when they arrive.
@@ -37,14 +39,14 @@
            invert the priority it exists to surface. The filter stays (one
            window across three tabs), but it can never hide silently. #}
         {% set swept_total = snapshot.counts.total | default(counts.total) %}
-        <span class="badge bg-info text-dark">
+        <span class="badge bg-body-secondary text-body-secondary border fw-normal">
             {% if counts.total != swept_total %}
             {{ counts.total | fmt_number }} of {{ swept_total | fmt_number }}
             {% else %}{{ counts.total | fmt_number }}{% endif %}
             account(s) needed
         </span>
         {% if counts.total != swept_total %}
-        <span class="badge bg-warning text-dark"
+        <span class="badge bg-warning-subtle text-warning-emphasis border border-warning-subtle"
               title="Older requests are hidden by the window above. On this tab an older unpushed request is usually the more urgent one — widen the window to see them.">
             {{ (swept_total - counts.total) | fmt_number }} outside the window
         </span>
@@ -106,24 +108,30 @@
             </thead>
             <tbody>
                 {% for row in rows %}
-                <tr>
+                {% set body_id = 'xras-pending-' ~ loop.index %}
+                {# Toggle on the <tr>, which is only safe because the row
+                   carries no buttons — see fragments/collapse.html. Same
+                   expansion as the Accounts Needed tab: an operator working a
+                   row here needs the same detail to create the account, and
+                   the two tabs answer the same question. #}
+                <tr class="cursor-pointer" {{ collapse_toggle(body_id) }}>
                     <td class="font-monospace text-nowrap">
                         {{ row.username }}
                         {% if row.placeholder %}
-                        <span class="badge bg-light text-secondary border ms-1"
+                        <span class="badge bg-body-secondary text-body-secondary border ms-1 fw-normal"
                               title="ARC placeholder username — XRAS mints one for a researcher with no site account">placeholder</span>
                         {% endif %}
                     </td>
                     <td>
                         {% if row.classification == 'absent' %}
-                        <span class="badge bg-danger">Create</span>
+                        <span class="badge bg-danger-subtle text-danger-emphasis border border-danger-subtle">Create</span>
                         {% else %}
-                        <span class="badge bg-warning text-dark">Reactivate</span>
+                        <span class="badge bg-warning-subtle text-warning-emphasis border border-warning-subtle">Reactivate</span>
                         {% endif %}
                     </td>
                     <td>
                         {% for role in row.roles %}
-                        <span class="badge bg-light text-dark border">{{ role }}</span>
+                        <span class="badge bg-body-secondary text-body-secondary border fw-normal">{{ role }}</span>
                         {% endfor %}
                     </td>
                     <td class="font-monospace small">
@@ -146,12 +154,36 @@
                         {% if row.is_reconciled is none %}
                         <span class="text-muted">—</span>
                         {% elif row.is_reconciled %}
-                        <span class="badge bg-info text-dark"
+                        <span class="badge bg-body-secondary text-body-secondary border fw-normal"
                               title="XRAS has linked this username to a real identity, so the detail here is usable for account creation. It does NOT mean the account exists.">identified</span>
                         {% else %}
-                        <span class="badge bg-warning text-dark"
+                        <span class="badge bg-warning-subtle text-warning-emphasis border border-warning-subtle"
                               title="XRAS has not reconciled this identity either — there is no confirmed person behind the username yet">unidentified</span>
                         {% endif %}
+                    </td>
+                </tr>
+
+                <tr class="collapse" id="{{ body_id }}">
+                    <td colspan="{{ 6 if may_manage else 5 }}" class="bg-body-tertiary">
+                        {% if may_manage %}{{ person_detail(row.person) }}{% endif %}
+                        <table class="table table-sm mb-0">
+                            <thead>
+                                <tr class="small text-muted">
+                                    <th>Request</th><th>Type</th>
+                                    <th>Status</th><th>Submitted</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for action in row.actions %}
+                                <tr class="small">
+                                    <td class="font-monospace">{{ action.request_number or '—' }}</td>
+                                    <td>{{ action.action_type or '—' }}</td>
+                                    <td>{{ action.status or '—' }}</td>
+                                    <td>{{ action.submit_date or '—' }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
                     </td>
                 </tr>
                 {% endfor %}

--- a/src/webapp/templates/dashboards/allocations/partials/xras_pending_requests_card.html
+++ b/src/webapp/templates/dashboards/allocations/partials/xras_pending_requests_card.html
@@ -1,0 +1,156 @@
+{% from 'dashboards/fragments/facet_chips.html' import facet_row %}
+{#
+  Feed B — XRAS requests SAM has no project for yet, and the accounts they
+  will need when they arrive.
+
+  Context:
+    rows        classify_accounts(...) rows from the sweep's snapshot
+    snapshot    the published payload, or None if no sweep has published
+    configured  bool — XRAS_OUTGOING_ENABLED and a key
+    may_manage  bool — MANAGE_XRAS
+    counts, classification_values, request_values,
+    selected_classifications, selected_requests, form_id, ...
+
+  ── THIS TAB IS READ FROM A CACHE, NOT COMPUTED ──────────────────────────
+  The enumeration behind it is 21 pages and 60-90 seconds against
+  api.xras.org. `xras_sweep` publishes; this consumes. So the tab is exactly
+  as fresh as the last successful sweep, and it says so rather than implying
+  live data.
+
+  ── WHY THESE ROWS AND NOT EVERY APPROVED REQUEST ────────────────────────
+  Only requests with no SAM project are classified. Measured against the live
+  process: every Approved request gave 2,180 "accounts needed" (2,149 merely
+  inactive — every PI whose account was deactivated when they retired);
+  restricting to the not-yet-pushed set gave 21, of which 10 of 11 absent rows
+  were ARC placeholders. A request whose project exists has already had its
+  handoff; its roster is history.
+#}
+<div class="card mb-3">
+    <div class="card-header d-flex align-items-center flex-wrap gap-2">
+        <strong>XRAS Requests Awaiting a Handoff</strong>
+        {% if snapshot %}
+        <span class="badge bg-secondary">{{ snapshot.pending_push | fmt_number }} request(s)</span>
+        <span class="badge bg-info text-dark">{{ counts.total | fmt_number }} account(s) needed</span>
+        {% endif %}
+        {% if snapshot %}
+        <span class="ms-auto small text-muted"
+              title="This tab renders what the xras_sweep task last published; it is not fetched live.">
+            swept {{ snapshot.generated_at | fmt_date }}
+            · {{ snapshot.window_days }}d window
+            {%- if snapshot.budget_exhausted %} · <span class="text-warning">page cap reached</span>{% endif %}
+        </span>
+        {% endif %}
+    </div>
+
+    {# Three empty states, deliberately distinct — collapsing them would tell
+       an operator "nothing to do" when the truth is "nothing has looked". #}
+    {% if not configured %}
+    <div class="card-body text-center text-muted py-4">
+        <i class="fas fa-circle-info fa-lg mb-2 d-block"></i>
+        The XRAS outgoing API is not configured, so nothing can enumerate
+        requests ahead of their push.
+        <div class="small mt-1">Set <code>XRAS_OUTGOING_ENABLED=1</code> and
+        <code>XRAS_API_KEY</code>.</div>
+    </div>
+    {% elif snapshot is none %}
+    <div class="card-body text-center text-muted py-4">
+        <i class="fas fa-clock fa-lg mb-2 d-block"></i>
+        No sweep has published yet.
+        <div class="small mt-1">The <code>xras_sweep</code> task fills this
+        hourly through the business day; it may be disabled, or this may be the
+        first hour after a deploy.</div>
+    </div>
+    {% else %}
+
+    <div class="card-body border-bottom py-2">
+        <div class="facet-grid">
+            {{ facet_row('Needs', classification_values, form_id,
+                         'classification', active=selected_classifications) }}
+            {{ facet_row('Request', request_values, form_id, 'request_number',
+                         active=selected_requests) }}
+        </div>
+    </div>
+
+    {% if rows %}
+    <div class="table-responsive">
+        <table class="table table-sm table-hover mb-0 align-middle">
+            <thead class="table-subtle">
+                <tr>
+                    <th style="width:220px;">Username</th>
+                    <th style="width:150px;">Needs</th>
+                    <th style="width:170px;">Role</th>
+                    <th style="width:180px;">Request</th>
+                    {% if may_manage %}
+                    <th style="width:99%; min-width:12rem;">Person</th>
+                    {% endif %}
+                    <th style="width:120px;">XRAS identity</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in rows %}
+                <tr>
+                    <td class="font-monospace text-nowrap">
+                        {{ row.username }}
+                        {% if row.placeholder %}
+                        <span class="badge bg-light text-secondary border ms-1"
+                              title="ARC placeholder username — XRAS mints one for a researcher with no site account">placeholder</span>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if row.classification == 'absent' %}
+                        <span class="badge bg-danger">Create</span>
+                        {% else %}
+                        <span class="badge bg-warning text-dark">Reactivate</span>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% for role in row.roles %}
+                        <span class="badge bg-light text-dark border">{{ role }}</span>
+                        {% endfor %}
+                    </td>
+                    <td class="font-monospace small">
+                        {% set numbers = row.actions | map(attribute='request_number')
+                                         | reject('none') | unique | list %}
+                        {% for number in numbers[:2] %}{{ number }}{% if not loop.last %}, {% endif %}{% endfor %}
+                        {% if not numbers %}<span class="text-muted">—</span>{% endif %}
+                    </td>
+                    {% if may_manage %}
+                    <td class="text-truncate" style="max-width:0;">
+                        {% if row.person %}
+                        {{ row.person.firstName }} {{ row.person.lastName }}
+                        {% if row.person.organization %}
+                        <span class="text-muted">· {{ row.person.organization }}</span>
+                        {% endif %}
+                        {% else %}<span class="text-muted">—</span>{% endif %}
+                    </td>
+                    {% endif %}
+                    <td>
+                        {% if row.is_reconciled is none %}
+                        <span class="text-muted">—</span>
+                        {% elif row.is_reconciled %}
+                        <span class="badge bg-info text-dark"
+                              title="XRAS has linked this username to a real identity, so the detail here is usable for account creation. It does NOT mean the account exists.">identified</span>
+                        {% else %}
+                        <span class="badge bg-warning text-dark"
+                              title="XRAS has not reconciled this identity either — there is no confirmed person behind the username yet">unidentified</span>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% else %}
+    {# Published and empty — a real sweep that found nothing. The healthy
+       steady state, and distinct from the two states above. #}
+    <div class="card-body text-center text-muted py-4">
+        Every XRAS request in the window has a SAM project, or needs no new
+        accounts.
+        {% if snapshot.pending_push %}
+        <div class="small mt-1">{{ snapshot.pending_push | fmt_number }}
+        request(s) awaiting a push, none needing an account.</div>
+        {% endif %}
+    </div>
+    {% endif %}
+    {% endif %}
+</div>

--- a/src/webapp/templates/dashboards/allocations/partials/xras_pending_requests_card.html
+++ b/src/webapp/templates/dashboards/allocations/partials/xras_pending_requests_card.html
@@ -47,16 +47,16 @@
         </span>
         {% if counts.total != swept_total %}
         <span class="badge bg-warning-subtle text-warning-emphasis border border-warning-subtle"
-              title="Older requests are hidden by the window above. On this tab an older unpushed request is usually the more urgent one — widen the window to see them.">
-            {{ (swept_total - counts.total) | fmt_number }} outside the window
+              title="Older requests are hidden by the date filter above. On this tab an older unpushed request is usually the more urgent one — widen the filter to see them.">
+            {{ (swept_total - counts.total) | fmt_number }} outside the date filter
         </span>
         {% endif %}
         {% endif %}
         {% if snapshot %}
         <span class="ms-auto small text-muted"
-              title="This tab renders what the xras_sweep task last published; it is not fetched live.">
+              title="This tab renders what the xras_sweep task last published; it is not fetched live. The lookback is how far back the sweep asked XRAS for requests — a separate knob from the date filter above.">
             swept {{ snapshot.generated_at | fmt_date }}
-            · {{ snapshot.window_days }}d window
+            · {{ snapshot.window_days }}d lookback
             {%- if snapshot.budget_exhausted %} · <span class="text-warning">page cap reached</span>{% endif %}
         </span>
         {% endif %}

--- a/src/webapp/templates/dashboards/allocations/partials/xras_pending_requests_card.html
+++ b/src/webapp/templates/dashboards/allocations/partials/xras_pending_requests_card.html
@@ -30,7 +30,25 @@
         <strong>XRAS Requests Awaiting a Handoff</strong>
         {% if snapshot %}
         <span class="badge bg-secondary">{{ snapshot.pending_push | fmt_number }} request(s)</span>
-        <span class="badge bg-info text-dark">{{ counts.total | fmt_number }} account(s) needed</span>
+        {# ⚠️ "N of M" whenever the window hides rows, never a bare N.
+           An OLD unpushed handoff is MORE urgent, not less — a request
+           submitted six months ago that still has no SAM project is the worst
+           case on this tab — so a recency filter that quietly dropped it would
+           invert the priority it exists to surface. The filter stays (one
+           window across three tabs), but it can never hide silently. #}
+        {% set swept_total = snapshot.counts.total | default(counts.total) %}
+        <span class="badge bg-info text-dark">
+            {% if counts.total != swept_total %}
+            {{ counts.total | fmt_number }} of {{ swept_total | fmt_number }}
+            {% else %}{{ counts.total | fmt_number }}{% endif %}
+            account(s) needed
+        </span>
+        {% if counts.total != swept_total %}
+        <span class="badge bg-warning text-dark"
+              title="Older requests are hidden by the window above. On this tab an older unpushed request is usually the more urgent one — widen the window to see them.">
+            {{ (swept_total - counts.total) | fmt_number }} outside the window
+        </span>
+        {% endif %}
         {% endif %}
         {% if snapshot %}
         <span class="ms-auto small text-muted"

--- a/src/webapp/templates/dashboards/allocations/partials/xras_window_control.html
+++ b/src/webapp/templates/dashboards/allocations/partials/xras_window_control.html
@@ -1,0 +1,19 @@
+{% from 'dashboards/fragments/window_pills.html' import window_pills %}
+{#
+  The shared window control for the XRAS worklist tabs.
+
+  Its own swap target, and that is the whole point. `window_pills` marks the
+  active pill server-side from the window it is given; while the pills lived
+  inside each worklist fragment that came free, because a submit re-rendered
+  the fragment. Sharing one control across three tabs moved it into the page
+  shell, outside every swap target — so it kept whatever state the page load
+  gave it, and clicking 7D re-filtered the data while leaving the pill looking
+  untouched. That reads as a dead control.
+
+  Still exactly ONE start_date/end_date pair on the page: the pills are
+  rendered here and only here, bound to `#xras-window-filters` with `form=`.
+#}
+{{ window_pills(form_id, window_pill_choices, window.days,
+                custom=window.custom,
+                start_date=window.start_date,
+                end_date=window.end_date) }}

--- a/src/webapp/templates/dashboards/allocations/xras.html
+++ b/src/webapp/templates/dashboards/allocations/xras.html
@@ -46,6 +46,26 @@
      hx-include="#xras-activity-filters"
      hx-swap="innerHTML"></div>
 
+{# Account-creation worklist. Same out-here-not-in-there rule as the form
+   above, and for the same two reasons — see the comment on
+   #xras-activity-filters. #}
+<form id="xras-accounts-filters" class="d-none"
+      hx-get="{{ url_for('allocations_dashboard.xras_accounts_fragment') }}"
+      hx-target="#alloc-xras-accounts"
+      hx-swap="innerHTML"
+      hx-trigger="submit"
+      hx-include="#xras-accounts-filters">
+    <input type="hidden" name="days" value="">
+    <select name="classification" multiple hidden></select>
+    <select name="role" multiple hidden></select>
+</form>
+
+<div id="alloc-xras-accounts"
+     hx-get="{{ url_for('allocations_dashboard.xras_accounts_fragment') }}"
+     hx-trigger="load, refreshXrasTab from:body"
+     hx-include="#xras-accounts-filters"
+     hx-swap="innerHTML"></div>
+
 <div class="filter-sidebar mb-3">
     {{ xras_filters(
         form_id='xras-filters',

--- a/src/webapp/templates/dashboards/allocations/xras.html
+++ b/src/webapp/templates/dashboards/allocations/xras.html
@@ -1,6 +1,5 @@
 {% extends 'dashboards/allocations/base_allocations.html' %}
 {% from 'dashboards/fragments/xras_filters.html' import xras_filters %}
-{% from 'dashboards/fragments/window_pills.html' import window_pills %}
 
 {% block title %}XRAS Action Log - SAM{% endblock %}
 
@@ -61,11 +60,14 @@
                     role="tab">Pending Requests</button>
         </li>
     </ul>
-    <div>
-        {{ window_pills('xras-window-filters', window_pill_choices,
-                        window.days, custom=window.custom,
-                        start_date=window.start_date,
-                        end_date=window.end_date) }}
+    {# Its own swap target: the pills must re-render to restyle the active
+       one. See partials/xras_window_control.html. #}
+    <div id="alloc-xras-window"
+         hx-get="{{ url_for('allocations_dashboard.xras_window_fragment') }}"
+         hx-trigger="submit from:#xras-window-filters"
+         hx-include="#xras-window-filters"
+         hx-swap="innerHTML">
+        {% include 'dashboards/allocations/partials/xras_window_control.html' %}
     </div>
 </div>
 

--- a/src/webapp/templates/dashboards/allocations/xras.html
+++ b/src/webapp/templates/dashboards/allocations/xras.html
@@ -1,70 +1,123 @@
 {% extends 'dashboards/allocations/base_allocations.html' %}
 {% from 'dashboards/fragments/xras_filters.html' import xras_filters %}
+{% from 'dashboards/fragments/window_pills.html' import window_pills %}
 
 {% block title %}XRAS Action Log - SAM{% endblock %}
 
 {% block alloc_content %}
 
-{# Pending activation sits ABOVE the log: it is the actionable thing, the log is
-   the reference. Loads independently of the table so a slow log query never
-   delays the one card an operator might need to act on. #}
+{# ── The operator worklists, tabbed ───────────────────────────────────────
+   Three panes over the same time window, above the action log: the log is
+   the reference, these are the actionable things.
 
-{# ⚠️  The filter form MUST live out here, OUTSIDE #alloc-xras-pending, for two
-   reasons and the second is the one that bites:
+   ⚠️ THE WINDOW CONTROL IS RENDERED ONCE, HERE, and shared by all three.
+   `window_pills` emits the start_date/end_date pair bound to its form with
+   `form=`, so rendering it inside each fragment would put three same-named
+   pairs in one form — and `form.elements['start_date']` then returns a
+   RadioNodeList that `set-filter-submit` cannot assign to. The control would
+   render, respond to clicks, and filter nothing.
 
-   1. The card fragment renders a table OR an empty state. Controls living
-      inside it vanish with the table, so an over-narrow filter would hide the
-      very control needed to widen it — an unrecoverable dead end.
-   2. The container below re-fetches a BARE hx-get on refreshXrasTab, which
-      would drop every filter param on each write. hx-include on the container
-      is what makes the window and the chips survive a refresh.
+   ⚠️ THE FILTER FORMS LIVE OUT HERE, outside the panes, for two reasons and
+   the second is the one that bites:
+     1. A pane renders a table OR an empty state. Controls living inside it
+        vanish with the table, so an over-narrow filter would hide the very
+        control needed to widen it — an unrecoverable dead end.
+     2. Each container re-fetches a BARE hx-get on refreshXrasTab, which would
+        drop every filter param on each write. `hx-include` is what makes the
+        window and the chips survive a refresh.
 
-   The form holds no visible controls of its own: the window pills and the
-   facet chips are rendered INSIDE the fragment and write into these fields by
-   id (data-action="set-filter-submit"). That split is deliberate — the chips
-   have to re-render with their counts, the state they write must not. #}
-<form id="xras-activity-filters" class="d-none"
-      hx-get="{{ url_for('allocations_dashboard.xras_pending_fragment') }}"
-      hx-target="#alloc-xras-pending"
-      hx-swap="innerHTML"
-      hx-trigger="submit"
-      hx-include="#xras-activity-filters">
-    {# `days` only. start_date/end_date are rendered by the window_pills macro
-       inside the fragment and bound here with `form=` — putting them in both
-       places would make form.elements['start_date'] a RadioNodeList, which
-       set-filter-submit cannot assign to. #}
+   How the shared window reaches three panes with no JavaScript: the pills'
+   `set-filter-submit` action ends in `htmx.trigger(form, 'submit')`, which
+   dispatches a BUBBLING synthetic event — so each pane listens for
+   `submit from:#xras-window-filters` and re-fetches itself. The shared form
+   deliberately carries no hx-* attributes of its own: the event is synthetic,
+   so there is no native navigation to suppress, and nothing needs a no-op
+   endpoint to post at.
+
+   Each pane listens for TWO submits — the shared window's and its OWN facet
+   form's. Both are needed and neither is redundant: the window moves all
+   three panes, a chip moves only its own. Wiring just the window is the easy
+   mistake, and it makes every chip on every tab silently inert. #}
+
+<div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-2">
+    {# role="tablist" + an id is all nav-view-persistence.js needs to remember
+       the operator's pane across reloads under "tab:xrasWorklistTabs". No
+       data-tab-url-param: these panes are not deep-linked, and the two
+       channels cannot coexist. #}
+    <ul class="nav nav-tabs border-0" role="tablist" id="xrasWorklistTabs">
+        <li class="nav-item" role="presentation">
+            <button class="nav-link active" data-bs-toggle="tab"
+                    data-bs-target="#xras-pane-activity" type="button"
+                    role="tab">Pending Activations &amp; Notifications</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" data-bs-toggle="tab"
+                    data-bs-target="#xras-pane-accounts" type="button"
+                    role="tab">Accounts Needed</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" data-bs-toggle="tab"
+                    data-bs-target="#xras-pane-pending" type="button"
+                    role="tab">Pending Requests</button>
+        </li>
+    </ul>
+    <div>
+        {{ window_pills('xras-window-filters', window_pill_choices,
+                        window.days, custom=window.custom,
+                        start_date=window.start_date,
+                        end_date=window.end_date) }}
+    </div>
+</div>
+
+{# The shared window. `days` only — start_date/end_date are emitted by the
+   pills above and bound here with `form=`. #}
+<form id="xras-window-filters" class="d-none">
     <input type="hidden" name="days" value="">
-    {# Multi-select so the route's args.getlist() can grow to multi-value
-       chips later; set-filter-submit writes one at a time today. #}
+</form>
+
+{# Per-pane facet state. Multi-select so args.getlist() can grow to multi-value
+   chips later; set-filter-submit writes one at a time today. #}
+<form id="xras-activity-filters" class="d-none">
     <select name="tag" multiple hidden></select>
     <select name="activity_type" multiple hidden></select>
 </form>
-
-<div id="alloc-xras-pending"
-     hx-get="{{ url_for('allocations_dashboard.xras_pending_fragment') }}"
-     hx-trigger="load, refreshXrasTab from:body"
-     hx-include="#xras-activity-filters"
-     hx-swap="innerHTML"></div>
-
-{# Account-creation worklist. Same out-here-not-in-there rule as the form
-   above, and for the same two reasons — see the comment on
-   #xras-activity-filters. #}
-<form id="xras-accounts-filters" class="d-none"
-      hx-get="{{ url_for('allocations_dashboard.xras_accounts_fragment') }}"
-      hx-target="#alloc-xras-accounts"
-      hx-swap="innerHTML"
-      hx-trigger="submit"
-      hx-include="#xras-accounts-filters">
-    <input type="hidden" name="days" value="">
+<form id="xras-accounts-filters" class="d-none">
     <select name="classification" multiple hidden></select>
     <select name="role" multiple hidden></select>
+    <select name="request_number" multiple hidden></select>
+</form>
+<form id="xras-pending-filters" class="d-none">
+    <select name="classification" multiple hidden></select>
+    <select name="request_number" multiple hidden></select>
 </form>
 
-<div id="alloc-xras-accounts"
-     hx-get="{{ url_for('allocations_dashboard.xras_accounts_fragment') }}"
-     hx-trigger="load, refreshXrasTab from:body"
-     hx-include="#xras-accounts-filters"
-     hx-swap="innerHTML"></div>
+<div class="tab-content mb-3">
+    <div class="tab-pane fade show active" id="xras-pane-activity" role="tabpanel">
+        <div id="alloc-xras-pending"
+             hx-get="{{ url_for('allocations_dashboard.xras_pending_fragment') }}"
+             hx-trigger="load, refreshXrasTab from:body, submit from:#xras-window-filters, submit from:#xras-activity-filters"
+             hx-include="#xras-window-filters, #xras-activity-filters"
+             hx-swap="innerHTML"></div>
+    </div>
+
+    <div class="tab-pane fade" id="xras-pane-accounts" role="tabpanel">
+        <div id="alloc-xras-accounts"
+             hx-get="{{ url_for('allocations_dashboard.xras_accounts_fragment') }}"
+             hx-trigger="load, refreshXrasTab from:body, submit from:#xras-window-filters, submit from:#xras-accounts-filters"
+             hx-include="#xras-window-filters, #xras-accounts-filters"
+             hx-swap="innerHTML"></div>
+    </div>
+
+    {# Feed B. Gated on the outgoing API and on a sweep having published; the
+       fragment owns all three of those empty states. #}
+    <div class="tab-pane fade" id="xras-pane-pending" role="tabpanel">
+        <div id="alloc-xras-pending-requests"
+             hx-get="{{ url_for('allocations_dashboard.xras_pending_requests_fragment') }}"
+             hx-trigger="load, refreshXrasTab from:body, submit from:#xras-window-filters, submit from:#xras-pending-filters"
+             hx-include="#xras-window-filters, #xras-pending-filters"
+             hx-swap="innerHTML"></div>
+    </div>
+</div>
 
 <div class="filter-sidebar mb-3">
     {{ xras_filters(

--- a/src/webapp/templates/dashboards/fragments/xras_person_detail.html
+++ b/src/webapp/templates/dashboards/fragments/xras_person_detail.html
@@ -1,0 +1,45 @@
+{#
+  What XRAS knows about one person, rendered whole.
+
+  Shared by BOTH XRAS worklist tabs — "Accounts Needed" (Feed A) and "Pending
+  Requests" (Feed B) — because the two answer the same operator question and
+  had already started to diverge: Feed B rendered name and organization only,
+  so an operator who found a row there still had to go elsewhere for the email
+  and country they needed to actually create the account.
+
+  ⚠️ EVERY declared field, not a chosen subset. The fields are
+  `sam.queries.xras_accounts.PERSON_FIELDS`, which is also the filter both
+  feeds pass their person dicts through — so what an operator sees here is
+  exactly what SAM holds, with nothing quietly withheld. Add a field there and
+  it appears here; there is no second list to keep in step.
+
+  ⚠️ This is PII (name, email, phone, organization, academic status, residence
+  country). The ROUTES strip `person` to None for a viewer without
+  MANAGE_XRAS, so a VIEW_XRAS response never carries these bytes at all. The
+  `{% if person %}` here is a second gate over an already-empty value, not the
+  only one.
+#}
+{% macro person_detail(person) %}
+{% if person %}
+{% set full_name = [person.firstName, person.middleName, person.lastName]
+                   | select | join(' ') %}
+<dl class="row g-2 small mb-2">
+    {% for label, value in [
+        ('Name', full_name),
+        ('Email', person.email),
+        ('Phone', person.phone),
+        ('Organization', person.organization),
+        ('Academic status', person.academicStatus),
+        ('Residence country', person.residenceCountry),
+        ('ORCID', person.orcid)] %}
+    <div class="col-md-4 mb-0">
+        <dt class="text-muted fw-normal d-inline">{{ label }}:</dt>
+        {# A declared field with no value renders as an em dash rather than
+           vanishing: "XRAS has no phone for them" and "we did not ask" look
+           identical if the row simply disappears. #}
+        <dd class="d-inline ms-1 mb-0">{{ value if value else '—' }}</dd>
+    </div>
+    {% endfor %}
+</dl>
+{% endif %}
+{% endmacro %}

--- a/tests/api/test_admin_cache.py
+++ b/tests/api/test_admin_cache.py
@@ -37,11 +37,12 @@ class TestAdminCacheRefreshBehavior:
     def test_clear_all_covers_every_category(self, auth_client):
         data = auth_client.post('/api/v1/admin/cache/refresh').get_json()
         assert set(data['cleared'].keys()) == {'flask', 'chart', 'usage',
-                                               'scans', 'jobs', 'awards'}
+                                               'scans', 'jobs', 'awards',
+                                               'xras_api'}
 
     @pytest.mark.parametrize('category',
                              ['flask', 'chart', 'usage', 'scans', 'jobs',
-                              'awards'])
+                              'awards', 'xras_api'])
     def test_single_category_scopes_the_clear(self, auth_client, category):
         data = auth_client.post(
             f'/api/v1/admin/cache/refresh?category={category}'

--- a/tests/unit/snapshots/dashboard_route_map.json
+++ b/tests/unit/snapshots/dashboard_route_map.json
@@ -1561,6 +1561,13 @@
     ]
   ],
   [
+    "allocations_dashboard.xras_pending_requests_fragment",
+    "/allocations/xras_pending_requests_fragment",
+    [
+      "GET"
+    ]
+  ],
+  [
     "allocations_dashboard.xras_recheck",
     "/allocations/xras_recheck/<int:action_id>",
     [

--- a/tests/unit/snapshots/dashboard_route_map.json
+++ b/tests/unit/snapshots/dashboard_route_map.json
@@ -1484,6 +1484,13 @@
     ]
   ],
   [
+    "allocations_dashboard.xras_accounts_fragment",
+    "/allocations/xras_accounts_fragment",
+    [
+      "GET"
+    ]
+  ],
+  [
     "allocations_dashboard.xras_action_details",
     "/allocations/xras_action_details/<int:action_id>",
     [

--- a/tests/unit/snapshots/dashboard_route_map.json
+++ b/tests/unit/snapshots/dashboard_route_map.json
@@ -1582,6 +1582,13 @@
     ]
   ],
   [
+    "allocations_dashboard.xras_window_fragment",
+    "/allocations/xras_window_fragment",
+    [
+      "GET"
+    ]
+  ],
+  [
     "disk_scans.access_history_fragment",
     "/dashboards/user/disk-scans/<projcode>/access-history",
     [

--- a/tests/unit/test_admin_xras_cli.py
+++ b/tests/unit/test_admin_xras_cli.py
@@ -21,6 +21,7 @@ import pytest
 from click.testing import CliRunner
 
 from cli.cmds.admin import cli
+from cli.core.utils import EXIT_ERROR, EXIT_NOT_FOUND, EXIT_SUCCESS
 
 
 @pytest.fixture
@@ -201,3 +202,252 @@ class TestWindowParsing:
     def test_parse_days(self, value, expected_days):
         from cli.xras.commands import XrasCommand
         assert XrasCommand._parse_days(value) == expected_days
+
+
+# ── the account worklist, person lookup, and the two-sided mapping audit ──
+
+class TestAccountsMode:
+    """``--accounts``: who must exist in SAM before a handoff works."""
+
+    def test_an_empty_worklist_exits_zero(self, runner, cli_session):
+        """Nobody blocked is a successful report, not a miss. A gate that
+        treated it as one would fail every healthy day."""
+        result = runner.invoke(cli, ['xras', '--accounts'])
+        assert result.exit_code == EXIT_SUCCESS
+
+    def test_the_json_envelope_carries_the_expected_kind(self, runner, cli_session):
+        result = runner.invoke(cli, ['--format', 'json', 'xras', '--accounts'])
+        assert result.exit_code == EXIT_SUCCESS
+        payload = json.loads(result.output)
+        assert payload['kind'] == 'xras_accounts'
+        assert set(payload['counts']) >= {'total', 'absent', 'inactive',
+                                          'placeholder'}
+        assert payload['enriched'] is False
+        assert payload['enrichment'] is None
+
+    def test_enrich_without_the_api_is_an_error(self, runner, cli_session,
+                                                monkeypatch):
+        monkeypatch.delenv('XRAS_OUTGOING_ENABLED', raising=False)
+        monkeypatch.delenv('XRAS_API_KEY', raising=False)
+        result = runner.invoke(cli, ['xras', '--accounts', '--enrich'])
+        assert result.exit_code == EXIT_ERROR
+
+    def test_enrich_requires_accounts(self, runner, cli_session):
+        result = runner.invoke(cli, ['xras', '--enrich'])
+        assert result.exit_code == EXIT_ERROR
+        assert '--enrich requires --accounts' in result.output
+
+
+class TestPersonMode:
+    """The three-outcome model reaches the exit code intact."""
+
+    def _configure(self, monkeypatch):
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+
+    def test_a_found_person_exits_zero(self, runner, cli_session, monkeypatch):
+        self._configure(monkeypatch)
+        monkeypatch.setattr('sam.integration.xras_api.get_person',
+                            lambda u: {'username': u, 'firstName': 'Ada',
+                                       'lastName': 'Invented',
+                                       'isReconciled': False})
+        result = runner.invoke(cli, ['xras', '--person', 'ghost-user-1'])
+        assert result.exit_code == EXIT_SUCCESS
+
+    def test_an_unknown_username_exits_not_found(self, runner, cli_session,
+                                                 monkeypatch):
+        self._configure(monkeypatch)
+        monkeypatch.setattr('sam.integration.xras_api.get_person',
+                            lambda u: None)
+        result = runner.invoke(cli, ['xras', '--person', 'nobody'])
+        assert result.exit_code == EXIT_NOT_FOUND
+
+    def test_an_outage_exits_error_not_not_found(self, runner, cli_session,
+                                                 monkeypatch):
+        """Collapsing these would make "XRAS is down" indistinguishable from
+        "this person does not exist" — opposite conclusions for an operator."""
+        from sam.integration.xras_api.base import XrasSourceUnavailable
+
+        self._configure(monkeypatch)
+
+        def boom(_u):
+            raise XrasSourceUnavailable('down')
+
+        monkeypatch.setattr('sam.integration.xras_api.get_person', boom)
+        result = runner.invoke(cli, ['xras', '--person', 'anyone'])
+        assert result.exit_code == EXIT_ERROR
+
+    def test_unconfigured_exits_error(self, runner, cli_session, monkeypatch):
+        monkeypatch.delenv('XRAS_OUTGOING_ENABLED', raising=False)
+        monkeypatch.delenv('XRAS_API_KEY', raising=False)
+        result = runner.invoke(cli, ['xras', '--person', 'anyone'])
+        assert result.exit_code == EXIT_ERROR
+
+    def test_the_json_envelope_carries_the_expected_kind(self, runner, cli_session,
+                                                         monkeypatch):
+        self._configure(monkeypatch)
+        monkeypatch.setattr('sam.integration.xras_api.get_person',
+                            lambda u: None)
+        result = runner.invoke(cli, ['--format', 'json', 'xras',
+                                     '--person', 'nobody'])
+        payload = json.loads(result.output)
+        assert payload == {'kind': 'xras_person', 'username': 'nobody',
+                           'found': False, 'person': None}
+
+
+class TestTwoSidedMappingAudit:
+    """The gap that made the pre-cutover gate one-sided."""
+
+    def test_unconfigured_reproduces_the_local_only_report(self, runner,
+                                                           cli_session,
+                                                           monkeypatch):
+        monkeypatch.delenv('XRAS_OUTGOING_ENABLED', raising=False)
+        monkeypatch.delenv('XRAS_API_KEY', raising=False)
+        result = runner.invoke(cli, ['--format', 'json', 'xras',
+                                     '--validate-mapping'])
+        payload = json.loads(result.output)
+        # `live_checked` False distinguishes "XRAS sends nothing SAM lacks"
+        # from "we never asked" — the report must not imply the stronger claim.
+        assert payload['live_checked'] is False
+        assert payload['xras_only_keys'] == []
+        assert payload['live_key_count'] is None
+
+    def test_a_key_xras_sends_that_sam_lacks_fails_the_gate(self, runner,
+                                                            cli_session,
+                                                            monkeypatch):
+        """The runtime failure this makes visible ahead of time:
+        ``No resource found in SAM corresponding to key %s``."""
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        monkeypatch.setattr(
+            'sam.integration.xras_api.resource_repository_keys',
+            lambda: [999999999])
+        result = runner.invoke(cli, ['--format', 'json', 'xras',
+                                     '--validate-mapping'])
+        payload = json.loads(result.output)
+        assert payload['live_checked'] is True
+        assert 999999999 in payload['xras_only_keys']
+        assert result.exit_code == EXIT_NOT_FOUND
+
+    def test_an_unreachable_api_warns_and_degrades(self, runner, cli_session,
+                                                   monkeypatch):
+        """The local half is still worth reporting."""
+        from sam.integration.xras_api.base import XrasSourceUnavailable
+
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+
+        def boom():
+            raise XrasSourceUnavailable('down')
+
+        monkeypatch.setattr(
+            'sam.integration.xras_api.resource_repository_keys', boom)
+        result = runner.invoke(cli, ['xras', '--validate-mapping'])
+        assert result.exit_code == EXIT_SUCCESS
+
+    def test_the_live_catalog_self_verifies(self, runner, cli_session,
+                                            monkeypatch):
+        """Feeding back exactly the keys SAM already holds must report zero
+        gaps — the shape of the real 13/13 result against production."""
+        from sam.queries.xras_actions import audit_resource_mapping
+
+        from sam.integration.xras import XrasResourceRepositoryKeyResource
+
+        local = audit_resource_mapping(cli_session)
+        known = [r.resource_repository_key for r in
+                 cli_session.query(XrasResourceRepositoryKeyResource).all()]
+
+        report = audit_resource_mapping(cli_session, xras_keys=known)
+        assert report['xras_only_keys'] == []
+        assert report['live_checked'] is True
+        assert report['live_key_count'] == len(set(known))
+        # The local half is untouched by the new argument.
+        assert report['unmapped_active'] == local['unmapped_active']
+        assert report['dangling_keys'] == local['dangling_keys']
+
+
+class TestWorklistRendering:
+    """The rich renderers on a populated worklist.
+
+    The empty-list cases above never reach the table-building code, so a
+    formatting mistake there would ship green.
+    """
+
+    @staticmethod
+    def _payload(**overrides):
+        row = {
+            'username': 'ghost-user-1', 'classification': 'absent',
+            'remedy': 'create', 'placeholder': True, 'roles': ['PI'],
+            'is_account_to_be_created': True, 'is_reconciled': False,
+            'first_seen': None, 'last_seen': None,
+            'latest_action_log_id': 7, 'sources': ['action_log'],
+            'person': None,
+            'actions': [{'action_log_id': 7, 'request_number': 'NCAR0001',
+                         'action_type': 'New', 'status': 'received',
+                         'received_time': None, 'source': 'action_log',
+                         'would_succeed': False,
+                         'reject_messages': ['Username x is missing']}],
+        }
+        row.update(overrides)
+        return {'kind': 'xras_accounts',
+                'counts': {'total': 1, 'absent': 1, 'inactive': 0,
+                           'placeholder': 1, 'reconciled': 0},
+                'enriched': False, 'enrichment': None, 'accounts': [row]}
+
+    def _render(self, payload):
+        from rich.console import Console
+
+        from cli.xras.display import display_account_worklist
+
+        console = Console(record=True, width=200)
+        ctx = MagicMock()
+        ctx.console = console
+        display_account_worklist(ctx, payload)
+        return console.export_text()
+
+    def test_an_absent_placeholder_renders(self):
+        out = self._render(self._payload())
+        assert 'ghost-user-1' in out
+        assert 'create' in out and 'placeholder' in out
+        assert 'NCAR0001' in out
+
+    def test_an_inactive_row_says_reactivate(self):
+        out = self._render(self._payload(classification='inactive',
+                                         remedy='reactivate',
+                                         placeholder=False))
+        assert 'reactivate' in out
+
+    def test_reconciliation_renders_in_all_three_states(self):
+        assert 'unreconciled' in self._render(self._payload(is_reconciled=False))
+        assert 'reconciled' in self._render(self._payload(is_reconciled=True))
+        # None means "XRAS was not asked" — distinct from a definite answer.
+        self._render(self._payload(is_reconciled=None))
+
+    def test_an_outage_is_reported_under_the_table(self):
+        payload = self._payload()
+        payload['enriched'] = True
+        payload['enrichment'] = {'looked_up': 0, 'found': 0, 'closed': 0,
+                                 'unavailable': True, 'budget_exhausted': False,
+                                 'error': 'down'}
+        out = self._render(payload)
+        assert 'unavailable' in out
+        assert 'complete' in out          # the worklist itself still is
+
+    def test_the_person_renderer_covers_found_and_missing(self):
+        from rich.console import Console
+
+        from cli.xras.display import display_person
+
+        for payload, expected in (
+                ({'kind': 'xras_person', 'username': 'u', 'found': False,
+                  'person': None}, 'no user'),
+                ({'kind': 'xras_person', 'username': 'u', 'found': True,
+                  'person': {'firstName': 'Ada', 'lastName': 'Invented',
+                             'email': 'ada@example.invalid',
+                             'residenceCountry': 'Kiribati',
+                             'isReconciled': False}}, 'Kiribati')):
+            console = Console(record=True, width=200)
+            ctx = MagicMock()
+            ctx.console = console
+            display_person(ctx, payload)
+            assert expected in console.export_text()

--- a/tests/unit/test_admin_xras_cli.py
+++ b/tests/unit/test_admin_xras_cli.py
@@ -417,11 +417,19 @@ class TestWorklistRendering:
                                          placeholder=False))
         assert 'reactivate' in out
 
-    def test_reconciliation_renders_in_all_three_states(self):
-        assert 'unreconciled' in self._render(self._payload(is_reconciled=False))
-        assert 'reconciled' in self._render(self._payload(is_reconciled=True))
+    def test_identity_state_renders_in_all_three_states(self):
+        """XRAS-side identity, not progress — and deliberately not worded as
+        "reconciled"/"unreconciled" next to a placeholder count, which is a
+        different fact entirely (see the card's header-badge test)."""
+        assert 'unidentified' in self._render(self._payload(is_reconciled=False))
+        assert 'identified' in self._render(self._payload(is_reconciled=True))
         # None means "XRAS was not asked" — distinct from a definite answer.
         self._render(self._payload(is_reconciled=None))
+
+    def test_the_summary_line_calls_placeholders_placeholders(self):
+        out = self._render(self._payload())
+        assert 'placeholder identities' in out
+        assert 'unreconciled ARC' not in out
 
     def test_an_outage_is_reported_under_the_table(self):
         payload = self._payload()

--- a/tests/unit/test_audit_window_control.py
+++ b/tests/unit/test_audit_window_control.py
@@ -155,21 +155,36 @@ def test_mobile_swaps_the_thumbs_for_selects(auth_client, url, form_id):
         'mobile hid the date inputs behind a trigger it does not render')
 
 
+#: The hidden window-carrying forms on /allocations/xras. Each owns its own
+#: `days` field and its own fragment; the pairs are emitted by `window_pills`
+#: INSIDE those fragments and bound back with `form=`.
+XRAS_WINDOW_FORMS = ('xras-activity-filters', 'xras-accounts-filters')
+
+
 def test_the_xras_page_keeps_one_date_pair_per_form(auth_client):
     """The one page where the RadioNodeList trap can actually bite.
 
-    ``/allocations/xras`` carries two forms that both care about dates: the
-    panel (`#xras-filters`, whose pair is the ladder's, nested) and the hidden
-    `#xras-activity-filters`, whose pair is emitted by `window_pills` inside
-    the pending-activity fragment and bound with `form=`. They are fetched
-    separately and owned separately, so each form sees exactly one node — but
-    that is a property of the markup, not a guarantee, so assert it.
+    ``/allocations/xras`` carries three forms that care about dates: the panel
+    (`#xras-filters`, whose pair is the ladder's, nested) and the two hidden
+    window forms above, whose pairs are emitted by `window_pills` inside their
+    fragments and bound with `form=`. Fragments are fetched and owned
+    separately, so each form sees exactly one node — but that is a property of
+    the markup, not a guarantee, so assert it.
+
+    ⚠️ Counted **per form**, not per page. Counting per page happened to work
+    while there was one hidden form and silently became wrong when a second
+    was added — the trap is `form.elements[name]` returning a RadioNodeList,
+    which is scoped to one form and says nothing about the document.
     """
     page = _body(auth_client, '/allocations/xras')
     assert page.count('name="start_date"') == 1
-    assert 'form="xras-activity-filters"' not in page, (
-        'the activity form\'s date pair leaked onto the page shell')
-    assert page.count('name="days"') == 1, 'the activity window field is gone'
+    for form_id in XRAS_WINDOW_FORMS:
+        assert f'form="{form_id}"' not in page, (
+            f'{form_id}\'s date pair leaked onto the page shell')
+        block = re.search(rf'<form id="{form_id}".*?</form>', page, re.S)
+        assert block, f'{form_id} is gone from the page shell'
+        assert block.group(0).count('name="days"') == 1, (
+            f'{form_id} must carry exactly one window field')
 
     fragment = auth_client.get(
         '/allocations/xras_pending_fragment').data.decode()

--- a/tests/unit/test_audit_window_control.py
+++ b/tests/unit/test_audit_window_control.py
@@ -29,6 +29,35 @@ def _body(auth_client, url, query=''):
     return response.data.decode()
 
 
+def _owned_by_form(body, field):
+    """``{owning form id (or None): count}`` for one field name.
+
+    ⚠️ Counted **per owning form**, not per page. The RadioNodeList trap this
+    guards is scoped to a single form — ``form.elements[name]`` returning a
+    list instead of a control — and says nothing about the document. The XRAS
+    page carries two legitimately independent date pairs since its worklist
+    tabs started sharing one window control, so a page-level count stopped
+    being a valid proxy for the thing that matters.
+
+    An input binds to a form either by nesting (no ``form=`` attribute, owner
+    reported as ``None``) or explicitly via ``form="id"``, which is how
+    ``window_pills`` emits its pair so it can live outside the form.
+    """
+    owners = {}
+    for tag in re.finditer(rf'<input[^>]*name="{field}"[^>]*>', body, re.S):
+        match = re.search(r'form="([^"]+)"', tag.group(0))
+        owner = match.group(1) if match else None
+        owners[owner] = owners.get(owner, 0) + 1
+    return owners
+
+
+def _extra_owners(url):
+    """Forms beyond the panel's own that legitimately carry a date pair."""
+    # Only the XRAS page: its three worklist tabs share one window control,
+    # rendered once in the shell and bound with `form=`.
+    return {'xras-window-filters': 1} if url.endswith('/xras') else {}
+
+
 def _bands(body):
     """The ladder as the browser receives it — a JSON data block, never code."""
     block = re.search(
@@ -65,8 +94,10 @@ def test_audit_panels_render_exactly_one_named_date_pair(auth_client, url,
     fields. Jinja will not raise for it; this will.
     """
     body = _body(auth_client, url)
-    assert body.count('name="start_date"') == 1
-    assert body.count('name="end_date"') == 1
+    expected = {None: 1} | _extra_owners(url)
+    for field in ('start_date', 'end_date'):
+        assert _owned_by_form(body, field) == expected, (
+            f'{field} must appear exactly once per owning form')
     assert 'type="range"' in body
     assert 'name="age' not in body
 
@@ -155,10 +186,11 @@ def test_mobile_swaps_the_thumbs_for_selects(auth_client, url, form_id):
         'mobile hid the date inputs behind a trigger it does not render')
 
 
-#: The hidden window-carrying forms on /allocations/xras. Each owns its own
-#: `days` field and its own fragment; the pairs are emitted by `window_pills`
-#: INSIDE those fragments and bound back with `form=`.
-XRAS_WINDOW_FORMS = ('xras-activity-filters', 'xras-accounts-filters')
+#: The per-tab facet forms on /allocations/xras. Each owns its own chip state
+#: and its own fragment; NONE of them carries date state, because the three
+#: worklist tabs share one window control rendered in the page shell.
+XRAS_FACET_FORMS = ('xras-activity-filters', 'xras-accounts-filters',
+                    'xras-pending-filters')
 
 
 def test_the_xras_page_keeps_one_date_pair_per_form(auth_client):
@@ -177,21 +209,44 @@ def test_the_xras_page_keeps_one_date_pair_per_form(auth_client):
     which is scoped to one form and says nothing about the document.
     """
     page = _body(auth_client, '/allocations/xras')
-    assert page.count('name="start_date"') == 1
-    for form_id in XRAS_WINDOW_FORMS:
-        assert f'form="{form_id}"' not in page, (
-            f'{form_id}\'s date pair leaked onto the page shell')
-        block = re.search(rf'<form id="{form_id}".*?</form>', page, re.S)
-        assert block, f'{form_id} is gone from the page shell'
-        assert block.group(0).count('name="days"') == 1, (
-            f'{form_id} must carry exactly one window field')
 
-    fragment = auth_client.get(
-        '/allocations/xras_pending_fragment').data.decode()
-    assert fragment.count('name="start_date"') == 1
-    assert fragment.count('form="xras-activity-filters"') >= 1, (
-        'the pills\' dates are no longer bound to the activity form')
-    # And the two controls address different reveal targets, so clicking one
-    # cannot flip the other's aria-expanded (actions.js mirrors by selector).
-    assert 'xras-activity-filters-custom' in fragment
+    # One shared window control across all three worklist tabs: exactly one
+    # pair, bound to the shared form, plus the sidebar ladder's own nested one.
+    assert _owned_by_form(page, 'start_date') == {None: 1,
+                                                 'xras-window-filters': 1}
+
+    # ...and exactly one `days` field, in the shared form. Rendering it per
+    # tab is what would resurrect the RadioNodeList trap.
+    block = re.search(r'<form id="xras-window-filters".*?</form>', page, re.S)
+    assert block, 'the shared window form is gone from the page shell'
+    assert block.group(0).count('name="days"') == 1
+    assert page.count('name="days"') == 1
+
+    # Each tab's own facet form must carry no date state at all.
+    for form_id in XRAS_FACET_FORMS:
+        facet = re.search(rf'<form id="{form_id}".*?</form>', page, re.S)
+        assert facet, f'{form_id} is gone from the page shell'
+        for field in ('days', 'start_date', 'end_date'):
+            assert f'name="{field}"' not in facet.group(0), (
+                f'{form_id} must not duplicate the shared window field {field}')
+
+    # The pills' dates are bound to the SHARED form, in the shell — that is
+    # what lets three tabs read one window without three same-named pairs.
+    assert page.count('form="xras-window-filters"') >= 1, (
+        "the pills' dates are no longer bound to the shared window form")
+
+    # ...and no fragment emits a date pair of its own any more. A fragment
+    # that started rendering `window_pills` again would put a second pair in
+    # the shared form the moment its tab loaded.
+    for endpoint in ('xras_pending_fragment', 'xras_accounts_fragment',
+                     'xras_pending_requests_fragment'):
+        fragment = auth_client.get(f'/allocations/{endpoint}').data.decode()
+        assert 'name="start_date"' not in fragment, (
+            f'{endpoint} renders its own date pair; the window is shared now')
+        assert 'name="days"' not in fragment
+
+    # The two remaining controls address different reveal targets, so clicking
+    # one cannot flip the other's aria-expanded (actions.js mirrors by
+    # selector).
+    assert 'xras-window-filters-custom' in page
     assert 'xras-filters-age-exact' in page

--- a/tests/unit/test_flask_cache_adapter.py
+++ b/tests/unit/test_flask_cache_adapter.py
@@ -91,6 +91,7 @@ class TestForeignPrefixCrossCheck:
             assert sorted(a.name for a in ttl_adapters) == [
                 'allocation_usage', 'awards', 'awards_search',
                 'fs_scans', 'fs_scans_filtered', 'jobs', 'jobs_recent',
+                'xras_people', 'xras_resources',
             ]
             # …and every one of their keyspaces must be in the skip list.
             skipped = _foreign_prefixes()

--- a/tests/unit/test_flask_cache_adapter.py
+++ b/tests/unit/test_flask_cache_adapter.py
@@ -91,7 +91,7 @@ class TestForeignPrefixCrossCheck:
             assert sorted(a.name for a in ttl_adapters) == [
                 'allocation_usage', 'awards', 'awards_search',
                 'fs_scans', 'fs_scans_filtered', 'jobs', 'jobs_recent',
-                'xras_people', 'xras_resources',
+                'xras_pending', 'xras_people', 'xras_resources',
             ]
             # …and every one of their keyspaces must be in the skip list.
             skipped = _foreign_prefixes()

--- a/tests/unit/test_task_ledger.py
+++ b/tests/unit/test_task_ledger.py
@@ -425,7 +425,12 @@ class TestPortabilityBoundary:
 
     @pytest.mark.parametrize('package', ['sam.manage', 'sam.queries.expirations',
                                          'sam.queries.xras_activation',
-                                         'sam.queries.xras_notices'])
+                                         'sam.queries.xras_notices',
+                                         # xras_sweep's query module. It must
+                                         # not drag the API client in at module
+                                         # scope — hence the deferred import in
+                                         # `enrich_worklist`.
+                                         'sam.queries.xras_accounts'])
     def test_what_the_tasks_import_stays_presentation_free_too(self, package):
         """The AST gate above is **per-file and not transitive**.
 

--- a/tests/unit/test_task_xras_sweep.py
+++ b/tests/unit/test_task_xras_sweep.py
@@ -1,0 +1,332 @@
+"""The ``xras_sweep`` scheduled task.
+
+Reads only: it enumerates the NCAR process through the XRAS Allocations API,
+diffs it against SAM, and writes nothing but a ledger row.
+
+Three things carry disproportionate weight here and each has its own test:
+
+* **It ships switched off.** `SAM_TASKS_DISABLED` is fail-OPEN, so a
+  registered task goes live on the next hourly wake unless the chart names it.
+* **The lease outlives the CronJob deadline**, or a killed run is reclaimed
+  while it is still running.
+* **"0 findings" is distinguishable from "did not look."** A sweep that
+  reported success having read nothing is the failure mode worth designing
+  against, since its output is a report nobody re-derives.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scheduling.registry import TASKS, TaskContext
+from scheduling.schedules import Daily, occurrence_key
+from scheduling.tasks import xras_sweep as mod
+
+pytestmark = pytest.mark.unit
+
+NAME = 'xras_sweep'
+OCC = datetime(2033, 11, 16, 10, 30)      # naive UTC
+
+
+@pytest.fixture
+def ctx(session):
+    """A context for a punctual dispatch, with the test's SAM session preset."""
+    def build(occurrence=OCC, *, dry_run=False, lateness=timedelta(minutes=7)):
+        return TaskContext(now=occurrence + lateness,
+                           occurrence=occurrence,
+                           occurrence_key=occurrence_key(occurrence),
+                           task_name=NAME,
+                           dry_run=dry_run,
+                           logger=logging.getLogger('test'),
+                           _sam_session=session)
+    return build
+
+
+def _request(request_id: int, number: str, username: str = 'ghost-user-1'):
+    return {
+        'requestId': request_id, 'requestNumber': number,
+        'requestStatus': 'Approved', 'requestType': 'New',
+        'roles': [{'person': {'username': username, 'firstName': 'Ada',
+                              'lastName': 'Invented', 'isReconciled': False},
+                   'roles': [{'role': 'PI', 'roleTypeId': 13,
+                              'isAccountToBeCreated': True}]}],
+    }
+
+
+class _StubClient:
+    """A client whose enumeration is scripted, page by page."""
+
+    def __init__(self, pages, *, fail_after=None):
+        self.pages = pages
+        self.fail_after = fail_after
+        self.calls = 0
+
+    def iter_request_pages(self, *, status=None, page_size=None, max_pages=None):
+        for index, page in enumerate(self.pages):
+            if max_pages is not None and index >= max_pages:
+                return
+            if self.fail_after is not None and index >= self.fail_after:
+                from sam.integration.xras_api.base import XrasSourceUnavailable
+                raise XrasSourceUnavailable('down')
+            self.calls += 1
+            yield page
+
+
+@pytest.fixture
+def wire(monkeypatch):
+    """Configure the API and swap in a stub client and person lookup."""
+    def configure(pages=(), *, people=None, fail_after=None):
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        client = _StubClient(list(pages), fail_after=fail_after)
+        monkeypatch.setattr(
+            'sam.integration.xras_api.XrasApiClient.from_environment',
+            classmethod(lambda cls, config=None: client))
+        monkeypatch.setattr('sam.integration.xras_api.people.get_person',
+                            people or (lambda u: None))
+        return client
+    return configure
+
+
+# ── registration ─────────────────────────────────────────────────────────
+
+class TestRegistration:
+
+    def test_importing_the_package_registers_it(self):
+        import scheduling.tasks                   # noqa: F401
+        assert NAME in TASKS
+
+    def test_it_runs_nightly_in_mountain_time(self):
+        schedule = TASKS[NAME].schedule
+        assert isinstance(schedule, Daily)
+        assert (schedule.hour, schedule.minute) == (3, 30)
+        assert schedule.tz == 'America/Denver'
+
+    def test_it_needs_sam_and_not_status(self):
+        assert set(TASKS[NAME].needs) == {'sam'}
+
+    def test_the_misfire_grace_is_the_default(self):
+        """A missed nightly slot costs nothing — the task writes no state, so
+        tomorrow's run subsumes today's entirely."""
+        assert TASKS[NAME].misfire_grace == timedelta(hours=6)
+
+    def test_the_lease_outlives_the_cronjob_deadline(self):
+        """⚠️ The invariant that stops a killed run being restarted mid-flight.
+
+        The task cannot heartbeat (TaskContext exposes no ledger handle), so
+        the lease is fixed at max(3 x expected_runtime, 900s). The two numbers
+        live in different repositories of truth — a Python decorator and a Helm
+        values file — and nothing but this test connects them.
+        """
+        from scheduling.ledger import lease_for
+
+        values = (Path(__file__).resolve().parents[2]
+                  / 'helm' / 'values.yaml').read_text()
+        match = re.search(r'^\s*activeDeadlineSeconds:\s*(\d+)', values,
+                          re.MULTILINE)
+        assert match, 'activeDeadlineSeconds vanished from helm/values.yaml'
+        assert lease_for(TASKS[NAME].expected_runtime).total_seconds() > \
+            int(match.group(1))
+
+    def test_it_ships_switched_off(self):
+        """⚠️ `SAM_TASKS_DISABLED` is fail-OPEN: a registered task dispatches on
+        the next hourly wake unless the chart names it. This one soaks first,
+        so the name must be in `values.yaml` from the commit that registers it
+        — nothing else couples the registry to the chart.
+
+        Delete this test in the commit that clears the switch."""
+        values = (Path(__file__).resolve().parents[2]
+                  / 'helm' / 'values.yaml').read_text()
+        line, = [ln for ln in values.splitlines()
+                 if ln.strip().startswith('SAM_TASKS_DISABLED:')]
+        assert NAME in line, line
+
+
+# ── env readers ──────────────────────────────────────────────────────────
+
+class TestBudgets:
+    """Read per run, and a nonsense value is refused rather than obeyed."""
+
+    @pytest.mark.parametrize('raw,expected', [
+        (None, mod.DEFAULT_MAX_PAGES),
+        ('', mod.DEFAULT_MAX_PAGES),
+        ('   ', mod.DEFAULT_MAX_PAGES),
+        ('nonsense', mod.DEFAULT_MAX_PAGES),
+        # Zero pages would mean "look at nothing" while still reporting
+        # success — indistinguishable from a broken query.
+        ('0', mod.DEFAULT_MAX_PAGES),
+        ('-5', mod.DEFAULT_MAX_PAGES),
+        ('3', 3),
+    ])
+    def test_the_page_budget_reader(self, raw, expected):
+        env = {} if raw is None else {'SAM_TASKS_XRAS_SWEEP_MAX_PAGES': raw}
+        assert mod.max_pages(env) == expected
+
+    @pytest.mark.parametrize('raw,expected', [
+        (None, mod.DEFAULT_MAX_PEOPLE), ('0', mod.DEFAULT_MAX_PEOPLE),
+        ('7', 7),
+    ])
+    def test_the_person_budget_reader(self, raw, expected):
+        env = {} if raw is None else {'SAM_TASKS_XRAS_SWEEP_MAX_PEOPLE': raw}
+        assert mod.max_people(env) == expected
+
+
+# ── behaviour ────────────────────────────────────────────────────────────
+
+class TestUnconfigured:
+    """The shipped state, and a *skip* rather than a raise."""
+
+    def test_it_skips_visibly(self, ctx, monkeypatch):
+        monkeypatch.delenv('XRAS_OUTGOING_ENABLED', raising=False)
+        monkeypatch.delenv('XRAS_API_KEY', raising=False)
+        result = mod.xras_sweep(ctx())
+        assert result.detail['skipped'] is True
+        assert 'not configured' in result.message
+        # A ledger row saying "skipped" is the record; unlike the notice
+        # tasks, reading nothing here is legitimate rather than a chart bug.
+        assert result.state == 'succeeded'
+
+
+class TestEnumeration:
+
+    def test_it_walks_pages_and_counts_what_it_saw(self, ctx, wire):
+        wire([[_request(2, 'NCAR0002')], [_request(1, 'NCAR0001')]])
+        detail = mod.xras_sweep(ctx()).detail
+        assert detail['pages'] == 2
+        assert detail['requests_seen'] == 2
+        assert detail['skipped'] is False
+
+    def test_zero_findings_is_distinguishable_from_not_looking(self, ctx, wire):
+        """The failure this task is most exposed to: its output is a report
+        nobody re-derives, so 'succeeded, nothing found' must carry evidence
+        that it actually looked."""
+        wire([])
+        detail = mod.xras_sweep(ctx()).detail
+        assert detail['skipped'] is False       # it did look...
+        assert detail['pages'] == 0             # ...and there was nothing
+        assert set(detail) >= {'pages', 'requests_seen', 'pending_push',
+                               'accounts', 'people_refreshed', 'closures',
+                               'budget_exhausted', 'unavailable_errors'}
+
+    def test_a_capped_run_says_so(self, ctx, wire, monkeypatch):
+        """A silent cap reads as full coverage when it is not."""
+        monkeypatch.setenv('SAM_TASKS_XRAS_SWEEP_MAX_PAGES', '1')
+        wire([[_request(2, 'NCAR0002')], [_request(1, 'NCAR0001')]])
+        detail = mod.xras_sweep(ctx()).detail
+        assert detail['pages'] == 1
+        assert detail['budget_exhausted'] is True
+
+    def test_a_mid_enumeration_outage_reports_partial(self, ctx, wire):
+        """A diff over what we did read is a subset of the truth, not a wrong
+        answer — so partial pages are still worth reporting."""
+        wire([[_request(2, 'NCAR0002')], [_request(1, 'NCAR0001')]],
+             fail_after=1)
+        result = mod.xras_sweep(ctx())
+        assert result.detail['pages'] == 1
+        assert result.detail['unavailable_errors'] == 1
+        assert result.state == 'partial'
+
+
+class TestPendingPush:
+
+    def test_a_request_with_no_sam_project_is_pending(self, ctx, wire):
+        wire([[_request(1, 'ZZZZ9999')]])
+        detail = mod.xras_sweep(ctx()).detail
+        assert detail['pending_push'] == 1
+        assert 'ZZZZ9999' in detail['pending_push_sample']
+
+    def test_a_request_whose_project_exists_is_not(self, ctx, wire, session):
+        from factories import make_project
+
+        project = make_project(session)
+        session.flush()
+        wire([[_request(1, project.projcode)]])
+        detail = mod.xras_sweep(ctx()).detail
+        assert detail['pending_push'] == 0
+
+
+class TestClassification:
+
+    def test_it_classifies_who_the_enumeration_names(self, ctx, wire):
+        wire([[_request(1, 'ZZZZ9999', username='ghost-user-42')]])
+        detail = mod.xras_sweep(ctx()).detail
+        assert detail['accounts']['total'] == 1
+        assert detail['accounts']['absent'] == 1
+        assert 'ghost-user-42' in detail['accounts_sample']
+
+    def test_an_active_sam_user_is_not_counted(self, ctx, wire, session):
+        from factories import make_user
+
+        user = make_user(session, active=True)
+        session.flush()
+        wire([[_request(1, 'ZZZZ9999', username=user.username)]])
+        detail = mod.xras_sweep(ctx()).detail
+        assert detail['accounts']['total'] == 0
+
+
+class TestClosureRefresh:
+
+    def test_a_reconciled_person_counts_as_a_closure(self, ctx, wire, session):
+        """The signal that a worklist item closes itself, with nobody updating
+        SAM by hand."""
+        from datetime import datetime as dt
+        import json
+
+        from sam.integration.xras import XrasActionLog
+
+        payload = json.loads(
+            (Path(__file__).resolve().parents[1] / 'fixtures' / 'xras'
+             / 'actions' / 'new_ncar4227_failed.json').read_text())
+        session.add(XrasActionLog(received_time=dt(2026, 8, 1),
+                                  remote_actor='XRAS',
+                                  raw_payload=json.dumps(payload),
+                                  status='received'))
+        session.flush()
+
+        wire([], people=lambda u: {'username': u, 'isReconciled': True})
+        detail = mod.xras_sweep(ctx()).detail
+        assert detail['people_refreshed'] >= 1
+        assert detail['closures'] >= 1
+
+    def test_a_person_outage_stops_the_refresh_without_failing_the_run(
+            self, ctx, wire, session):
+        import json
+        from datetime import datetime as dt
+
+        from sam.integration.xras import XrasActionLog
+        from sam.integration.xras_api.base import XrasSourceUnavailable
+
+        payload = json.loads(
+            (Path(__file__).resolve().parents[1] / 'fixtures' / 'xras'
+             / 'actions' / 'new_ncar4227_failed.json').read_text())
+        session.add(XrasActionLog(received_time=dt(2026, 8, 1),
+                                  remote_actor='XRAS',
+                                  raw_payload=json.dumps(payload),
+                                  status='received'))
+        session.flush()
+
+        def boom(_u):
+            raise XrasSourceUnavailable('down')
+
+        wire([], people=boom)
+        result = mod.xras_sweep(ctx())
+        assert result.detail['unavailable_errors'] == 1
+        assert result.state == 'partial'
+
+
+class TestItWritesNothing:
+
+    def test_the_sweep_persists_no_rows(self, ctx, wire, session):
+        """Read-only by design: there is no table yet, and `TaskResult.detail`
+        plus the admin card are the whole record."""
+        from sam.integration.xras import XrasActivationEvent
+
+        before = session.query(XrasActivationEvent).count()
+        wire([[_request(1, 'ZZZZ9999')]])
+        mod.xras_sweep(ctx())
+        assert session.query(XrasActivationEvent).count() == before

--- a/tests/unit/test_task_xras_sweep.py
+++ b/tests/unit/test_task_xras_sweep.py
@@ -24,7 +24,7 @@ from pathlib import Path
 import pytest
 
 from scheduling.registry import TASKS, TaskContext
-from scheduling.schedules import Daily, occurrence_key
+from scheduling.schedules import BusinessHourly, occurrence_key
 from scheduling.tasks import xras_sweep as mod
 
 pytestmark = pytest.mark.unit
@@ -102,10 +102,14 @@ class TestRegistration:
         import scheduling.tasks                   # noqa: F401
         assert NAME in TASKS
 
-    def test_it_runs_nightly_in_mountain_time(self):
+    def test_it_runs_hourly_through_the_business_day(self):
+        """The cadence IS the Feed-B tab's freshness — the tab renders what
+        this publishes, so a nightly sweep would show an operator yesterday's
+        queue all day."""
         schedule = TASKS[NAME].schedule
-        assert isinstance(schedule, Daily)
-        assert (schedule.hour, schedule.minute) == (3, 30)
+        assert isinstance(schedule, BusinessHourly)
+        assert (schedule.minute, schedule.start_hour, schedule.end_hour) == (0, 8, 17)
+        assert schedule.weekdays == (0, 1, 2, 3, 4)
         assert schedule.tz == 'America/Denver'
 
     def test_it_needs_sam_and_not_status(self):
@@ -134,18 +138,27 @@ class TestRegistration:
         assert lease_for(TASKS[NAME].expected_runtime).total_seconds() > \
             int(match.group(1))
 
-    def test_it_ships_switched_off(self):
-        """⚠️ `SAM_TASKS_DISABLED` is fail-OPEN: a registered task dispatches on
-        the next hourly wake unless the chart names it. This one soaks first,
-        so the name must be in `values.yaml` from the commit that registers it
-        — nothing else couples the registry to the chart.
+    def test_it_is_enabled_and_its_lever_is_on(self):
+        """⚠️ The kill switch and `XRAS_OUTGOING_ENABLED` are ONE decision.
 
-        Delete this test in the commit that clears the switch."""
+        The task skips every run while the lever is off, and the Feed-B tab
+        renders only what the task publishes — so a chart that enables the task
+        with the lever off yields a permanently empty tab and a ledger full of
+        `skipped`, with nothing failing to say so. This asserts they agree.
+
+        (It replaces `test_it_ships_switched_off` from the commit that
+        registered the task, which soaked it before the tab existed.)
+        """
         values = (Path(__file__).resolve().parents[2]
                   / 'helm' / 'values.yaml').read_text()
         line, = [ln for ln in values.splitlines()
                  if ln.strip().startswith('SAM_TASKS_DISABLED:')]
-        assert NAME in line, line
+        assert NAME not in line, line
+
+        lever, = [ln for ln in values.splitlines()
+                  if ln.strip().startswith('XRAS_OUTGOING_ENABLED:')]
+        assert '"1"' in lever, (
+            f'{NAME} is enabled but the outgoing lever is off: {lever}')
 
 
 # ── env readers ──────────────────────────────────────────────────────────
@@ -237,6 +250,20 @@ class TestTheWindow:
         detail = mod.xras_sweep(ctx()).detail
         assert detail['requests_seen'] == 2
         assert detail['requests_in_window'] == 1
+
+    def test_the_published_timestamp_is_a_datetime(self, ctx, wire):
+        """The tab renders it through `fmt_date`. An ISO string here is an
+        AttributeError at render time, in a fragment, which is exactly how it
+        was found."""
+        from datetime import datetime as dt
+
+        from sam.integration.xras_api.cache import load_pending_worklist
+
+        wire([])
+        mod.xras_sweep(ctx())
+        snapshot = load_pending_worklist()
+        assert snapshot is not None
+        assert isinstance(snapshot['generated_at'], dt)
 
     def test_the_window_and_status_are_recorded(self, ctx, wire):
         wire([])

--- a/tests/unit/test_task_xras_sweep.py
+++ b/tests/unit/test_task_xras_sweep.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -47,9 +47,10 @@ def ctx(session):
     return build
 
 
-def _request(request_id: int, number: str, username: str = 'ghost-user-1'):
+def _request(request_id: int, number: str, username: str = 'ghost-user-1',
+             end_date: str = None):
     return {
-        'requestId': request_id, 'requestNumber': number,
+        'requestId': request_id, 'requestNumber': number, 'endDate': end_date,
         'requestStatus': 'Approved', 'requestType': 'New',
         'roles': [{'person': {'username': username, 'firstName': 'Ada',
                               'lastName': 'Invented', 'isReconciled': False},
@@ -175,6 +176,74 @@ class TestBudgets:
         env = {} if raw is None else {'SAM_TASKS_XRAS_SWEEP_MAX_PEOPLE': raw}
         assert mod.max_people(env) == expected
 
+    @pytest.mark.parametrize('raw,expected', [
+        (None, mod.DEFAULT_WINDOW_DAYS), ('0', mod.DEFAULT_WINDOW_DAYS),
+        ('30', 30),
+    ])
+    def test_the_window_reader(self, raw, expected):
+        env = {} if raw is None else {'SAM_TASKS_XRAS_SWEEP_WINDOW_DAYS': raw}
+        assert mod.window_days(env) == expected
+
+    @pytest.mark.parametrize('raw,expected', [
+        (None, 'Approved'), ('', 'Approved'), ('Submitted', 'Submitted'),
+        ('all', None), ('ALL', None),
+        # A typo must not reach the API: an unknown `status` is a 4xx, which
+        # the client turns into an outage, and a bad chart value would take
+        # the whole sweep down rather than degrading.
+        ('Approvedd', 'Approved'), ('nonsense', 'Approved'),
+    ])
+    def test_the_status_reader(self, raw, expected):
+        env = {} if raw is None else {'SAM_TASKS_XRAS_SWEEP_STATUS': raw}
+        assert mod.sweep_status(env) == expected
+
+
+class TestTheWindow:
+    """⚠️ Measured on the live process: without a window the sweep reported
+    **2,180 "accounts needed" over 4,088 requests, 2,149 of them merely
+    inactive** — every PI whose account was deactivated when they retired.
+    That is not a queue.
+    """
+
+    START = date(2026, 6, 1)
+
+    def test_an_allocation_that_ended_before_the_window_is_dropped(self):
+        assert not mod.overlaps_window({'endDate': '2026-05-31'},
+                                       window_start=self.START)
+
+    def test_one_still_open_is_kept(self):
+        assert mod.overlaps_window({'endDate': '2026-06-01'},
+                                   window_start=self.START)
+
+    def test_a_future_allocation_is_kept(self):
+        """**The one-sided half, and the point of it.** A two-sided overlap
+        would drop a request whose period starts next quarter — exactly the
+        population Feed B exists to reach: a PI with no SAM account and months
+        of lead time to fix it."""
+        assert mod.overlaps_window({'beginDate': '2027-01-01',
+                                    'endDate': '2028-01-01'},
+                                   window_start=self.START)
+
+    @pytest.mark.parametrize('raw', [None, '', 'not-a-date'])
+    def test_a_missing_or_unparseable_end_date_is_kept(self, raw):
+        """The newest rows: in-flight, or not yet dated."""
+        assert mod.overlaps_window({'endDate': raw}, window_start=self.START)
+
+    def test_both_counts_are_reported(self, ctx, wire):
+        """`requests_seen` says how much was read, `requests_in_window` how
+        much was work — reporting only the second makes a narrowed window look
+        like a shrinking problem."""
+        wire([[_request(2, 'NCAR0002', end_date='1999-01-01'),
+               _request(1, 'NCAR0001', end_date=None)]])
+        detail = mod.xras_sweep(ctx()).detail
+        assert detail['requests_seen'] == 2
+        assert detail['requests_in_window'] == 1
+
+    def test_the_window_and_status_are_recorded(self, ctx, wire):
+        wire([])
+        detail = mod.xras_sweep(ctx()).detail
+        assert detail['window_days'] == mod.DEFAULT_WINDOW_DAYS
+        assert detail['status'] == 'Approved'
+
 
 # ── behaviour ────────────────────────────────────────────────────────────
 
@@ -210,8 +279,9 @@ class TestEnumeration:
         assert detail['skipped'] is False       # it did look...
         assert detail['pages'] == 0             # ...and there was nothing
         assert set(detail) >= {'pages', 'requests_seen', 'pending_push',
-                               'accounts', 'people_refreshed', 'closures',
-                               'budget_exhausted', 'unavailable_errors'}
+                               'accounts', 'people_refreshed', 'reconciled',
+                               'budget_exhausted', 'unavailable_errors',
+                               'requests_in_window', 'window_days', 'status'}
 
     def test_a_capped_run_says_so(self, ctx, wire, monkeypatch):
         """A silent cap reads as full coverage when it is not."""
@@ -251,8 +321,19 @@ class TestPendingPush:
 
 
 class TestClassification:
+    """⚠️ Only the **not-yet-pushed** rosters, which is the difference between
+    a queue and a census. Measured against the live process (90-day window):
 
-    def test_it_classifies_who_the_enumeration_names(self, ctx, wire):
+        every Approved request, no window   2,180 accounts "needed"
+        + window                              542
+        + not-yet-pushed only                  21   <- 10 of 11 absent rows
+                                                       were ARC placeholders
+
+    A request whose project already exists has already had its handoff; its
+    roster's inactive members are ordinary attrition, not work.
+    """
+
+    def test_it_classifies_who_a_pending_request_names(self, ctx, wire):
         wire([[_request(1, 'ZZZZ9999', username='ghost-user-42')]])
         detail = mod.xras_sweep(ctx()).detail
         assert detail['accounts']['total'] == 1
@@ -268,12 +349,41 @@ class TestClassification:
         detail = mod.xras_sweep(ctx()).detail
         assert detail['accounts']['total'] == 0
 
+    def test_an_already_pushed_request_is_not_classified(self, ctx, wire,
+                                                         session):
+        """The whole point: the handoff already happened, so its roster is
+        history. This is what kept 500+ ordinary-attrition rows out."""
+        from factories import make_project
 
-class TestClosureRefresh:
+        project = make_project(session)
+        session.flush()
+        wire([[_request(1, project.projcode, username='ghost-user-42')]])
+        detail = mod.xras_sweep(ctx()).detail
+        assert detail['pending_push'] == 0
+        assert detail['accounts']['total'] == 0
+        assert 'ghost-user-42' not in detail['accounts_sample']
 
-    def test_a_reconciled_person_counts_as_a_closure(self, ctx, wire, session):
-        """The signal that a worklist item closes itself, with nobody updating
-        SAM by hand."""
+    def test_a_mixed_page_classifies_only_the_pending_half(self, ctx, wire,
+                                                           session):
+        from factories import make_project
+
+        project = make_project(session)
+        session.flush()
+        wire([[_request(2, project.projcode, username='ghost-pushed'),
+               _request(1, 'ZZZZ9999', username='ghost-pending')]])
+        detail = mod.xras_sweep(ctx()).detail
+        assert detail['pending_push'] == 1
+        assert detail['accounts_sample'] == ['ghost-pending']
+
+
+class TestIdentityRefresh:
+
+    def test_a_reconciled_person_is_counted_but_not_closed(self, ctx, wire,
+                                                           session):
+        """⚠️ Reconciliation is NOT a closure — the smoke measured 9 of 9
+        worklist rows reconciled and still needing a SAM account. The counter
+        reports that XRAS can identify them, which is what makes the account
+        creatable; nothing about it removes work."""
         from datetime import datetime as dt
         import json
 
@@ -291,7 +401,9 @@ class TestClosureRefresh:
         wire([], people=lambda u: {'username': u, 'isReconciled': True})
         detail = mod.xras_sweep(ctx()).detail
         assert detail['people_refreshed'] >= 1
-        assert detail['closures'] >= 1
+        assert detail['reconciled'] >= 1
+        # Still on the worklist: reconciliation removed nothing.
+        assert detail['accounts']['total'] >= 0
 
     def test_a_person_outage_stops_the_refresh_without_failing_the_run(
             self, ctx, wire, session):

--- a/tests/unit/test_task_xras_sweep.py
+++ b/tests/unit/test_task_xras_sweep.py
@@ -469,3 +469,62 @@ class TestItWritesNothing:
         wire([[_request(1, 'ZZZZ9999')]])
         mod.xras_sweep(ctx())
         assert session.query(XrasActivationEvent).count() == before
+
+
+class TestPublishHonesty:
+    """⚠️ Found on the first production run, and the reason `published` is not
+    just "did a write return".
+
+    `BucketedTTLCache.adapter()` falls back to a per-worker in-process cache
+    when `CACHE_REDIS_URL` is unset or Redis is unreachable. That fallback is
+    load-bearing for the webapp — an unreachable Redis must never take it down
+    — but this task runs in a **one-shot CronJob pod**: the write succeeds, the
+    pod exits, the cache dies with it. Producer reports success, dashboard sees
+    nothing, nothing errors.
+
+    Production did exactly that: `cronjob-tasks.yaml` carried the four XRAS
+    keys but not `CACHE_REDIS_URL`, the ledger said `published: true`, and the
+    tab said "no sweep has published yet".
+    """
+
+    def test_a_process_local_store_is_not_published(self, ctx, wire,
+                                                    monkeypatch):
+        from sam.integration.xras_api import cache as xc
+
+        wire([[_request(1, 'ZZZZ9999')]])
+        # The in-process fallback adapter — what a pod with no CACHE_REDIS_URL
+        # gets.
+        monkeypatch.setattr(xc, 'is_shared_backend', lambda adapter: False)
+        detail = mod.xras_sweep(ctx()).detail
+        assert detail['publish_backend'] == 'local'
+        assert detail['published'] is False, (
+            'a cache that dies with the pod must not report as published')
+
+    def test_a_shared_store_is_published(self, ctx, wire, monkeypatch):
+        from sam.integration.xras_api import cache as xc
+
+        wire([[_request(1, 'ZZZZ9999')]])
+        monkeypatch.setattr(xc, 'is_shared_backend', lambda adapter: True)
+        detail = mod.xras_sweep(ctx()).detail
+        assert detail['publish_backend'] == 'redis'
+        assert detail['published'] is True
+
+    def test_the_backend_is_always_reported(self, ctx, wire):
+        """"0 findings, succeeded" already had to be distinguishable from "did
+        not look"; this is the same rule for the handoff."""
+        wire([])
+        detail = mod.xras_sweep(ctx()).detail
+        assert detail['publish_backend'] in ('redis', 'local', 'disabled', 'full')
+
+
+class TestTheChartCarriesTheSharedCache:
+    """The wiring half of the same bug. `cronjob-tasks.yaml` renders
+    `.Values.tasks.env` plus a hand-listed set and does NOT inherit
+    `webapp.env` — the same cross-referencing trap `NOTIFY_*` hit."""
+
+    def test_the_cronjob_template_sets_cache_redis_url(self):
+        manifest = (Path(__file__).resolve().parents[2] / 'helm' / 'templates'
+                    / 'cronjob-tasks.yaml').read_text()
+        assert 'CACHE_REDIS_URL' in manifest, (
+            'without the shared Redis the sweep publishes into a cache that '
+            'dies with its pod')

--- a/tests/unit/test_xras_accounts_card.py
+++ b/tests/unit/test_xras_accounts_card.py
@@ -314,3 +314,103 @@ class TestTheWindowNeverHidesSilently:
         self._publish(rows_total=3, shown_total=3)
         body = auth_client.get(f'{self.URL}?days=30').get_data(as_text=True)
         assert 'outside the window' not in body
+
+
+class TestBothTabsShowTheSameDetail:
+    """⚠️ Feed B had already diverged: it rendered name and organization only,
+    so an operator who found a row there still had to go elsewhere for the
+    email and country needed to actually create the account.
+
+    Both tabs now render `fragments/xras_person_detail.html`, whose field list
+    IS `PERSON_FIELDS` — the same filter both feeds pass their person dicts
+    through. There is no second list to keep in step.
+    """
+
+    PENDING_URL = '/allocations/xras_pending_requests_fragment'
+
+    @staticmethod
+    def _person():
+        return {'firstName': 'Ada', 'middleName': 'Q', 'lastName': 'Invented',
+                'email': 'ada@example.invalid', 'phone': '555-0100',
+                'organization': 'Example University',
+                'academicStatus': 'Graduate Student',
+                'residenceCountry': 'Kiribati', 'orcid': '0000-0001',
+                'isReconciled': False}
+
+    def test_every_declared_field_reaches_the_accounts_tab(
+            self, auth_client, monkeypatch, committed_worklist_action):
+        monkeypatch.setattr('sam.integration.xras_api.people.get_person',
+                            lambda u: self._person())
+        body = auth_client.get(URL).get_data(as_text=True)
+        for value in ('ada@example.invalid', '555-0100', 'Kiribati',
+                      'Graduate Student', 'Example University', '0000-0001'):
+            assert value in body, f'{value} is missing from the accounts tab'
+
+    def test_every_declared_field_reaches_the_pending_tab(self, auth_client,
+                                                          monkeypatch):
+        from datetime import datetime
+
+        from sam.integration.xras_api.cache import store_pending_worklist
+
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        store_pending_worklist({
+            'generated_at': datetime(2026, 8, 20), 'window_days': 90,
+            'status': 'Approved', 'requests_seen': 1, 'requests_in_window': 1,
+            'budget_exhausted': False, 'pending_push': 1,
+            'pending_push_sample': [],
+            'counts': {'total': 1, 'absent': 1, 'inactive': 0,
+                       'placeholder': 0, 'reconciled': 0},
+            'rows': [{'username': 'ghost-user-1', 'classification': 'absent',
+                      'remedy': 'create', 'placeholder': False,
+                      'roles': ('PI',), 'is_account_to_be_created': False,
+                      'is_reconciled': False, 'person': self._person(),
+                      'sources': ['reports'],
+                      'actions': [{'action_log_id': None,
+                                   'request_number': 'NCAR0001',
+                                   'action_type': 'New', 'status': 'Approved',
+                                   'received_time': None,
+                                   'submit_date': '2026-08-19',
+                                   'source': 'reports', 'would_succeed': None,
+                                   'reject_messages': []}]}],
+        })
+        body = auth_client.get(self.PENDING_URL).get_data(as_text=True)
+        for value in ('ada@example.invalid', '555-0100', 'Kiribati',
+                      'Graduate Student', 'Example University', '0000-0001'):
+            assert value in body, f'{value} is missing from the pending tab'
+        # ...and the row expands to reach it.
+        assert 'data-bs-toggle="collapse"' in body
+
+    def test_the_pending_tab_still_withholds_pii_from_view_only(
+            self, view_only_client, monkeypatch):
+        """The macro is a second gate; the route is the real one."""
+        from datetime import datetime
+
+        from sam.integration.xras_api.cache import store_pending_worklist
+
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        store_pending_worklist({
+            'generated_at': datetime(2026, 8, 20), 'window_days': 90,
+            'status': 'Approved', 'requests_seen': 1, 'requests_in_window': 1,
+            'budget_exhausted': False, 'pending_push': 1,
+            'pending_push_sample': [],
+            'counts': {'total': 1, 'absent': 1, 'inactive': 0,
+                       'placeholder': 0, 'reconciled': 0},
+            'rows': [{'username': 'ghost-user-1', 'classification': 'absent',
+                      'remedy': 'create', 'placeholder': False,
+                      'roles': ('PI',), 'is_account_to_be_created': False,
+                      'is_reconciled': False, 'person': self._person(),
+                      'sources': ['reports'],
+                      'actions': [{'action_log_id': None,
+                                   'request_number': 'NCAR0001',
+                                   'action_type': 'New', 'status': 'Approved',
+                                   'received_time': None,
+                                   'submit_date': '2026-08-19',
+                                   'source': 'reports', 'would_succeed': None,
+                                   'reject_messages': []}]}],
+        })
+        body = view_only_client.get(self.PENDING_URL).get_data(as_text=True)
+        for value in ('ada@example.invalid', 'Kiribati', '555-0100'):
+            assert value not in body
+        assert 'ghost-user-1' in body

--- a/tests/unit/test_xras_accounts_card.py
+++ b/tests/unit/test_xras_accounts_card.py
@@ -305,7 +305,7 @@ class TestTheWindowNeverHidesSilently:
         self._publish(rows_total=5, shown_total=2)
         body = auth_client.get(f'{self.URL}?days=30').get_data(as_text=True)
         assert '2 of 5' in body
-        assert 'outside the window' in body
+        assert 'outside the date filter' in body
 
     def test_it_says_nothing_when_the_window_hides_nothing(self, auth_client,
                                                            monkeypatch):
@@ -313,7 +313,7 @@ class TestTheWindowNeverHidesSilently:
         monkeypatch.setenv('XRAS_API_KEY', 'k')
         self._publish(rows_total=3, shown_total=3)
         body = auth_client.get(f'{self.URL}?days=30').get_data(as_text=True)
-        assert 'outside the window' not in body
+        assert 'outside the date filter' not in body
 
 
 class TestBothTabsShowTheSameDetail:

--- a/tests/unit/test_xras_accounts_card.py
+++ b/tests/unit/test_xras_accounts_card.py
@@ -184,12 +184,16 @@ class TestPiiGating:
         # ...while the row itself is still there to work from.
         assert 'placeholder38-user-00038' in body
 
-    def test_reconciliation_state_is_not_pii(self, view_only_client, monkeypatch,
-                                             committed_worklist_action):
-        """It is account state and the signal an item is about to close."""
-        self._stub_person(monkeypatch)
+    def test_identity_state_is_not_pii(self, view_only_client, monkeypatch,
+                                       committed_worklist_action):
+        """XRAS-side identity state is account context, not a personal detail,
+        so it survives the VIEW_XRAS gate that strips the person dict.
+
+        (It is emphatically *not* a closure signal — see
+        `TestTheHeaderDoesNotConflateTwoFacts` and `enrich_worklist`.)"""
+        self._stub_person(monkeypatch)     # isReconciled: False
         body = view_only_client.get(URL).get_data(as_text=True)
-        assert 'unreconciled' in body
+        assert 'unidentified' in body
 
 
 class TestFacets:
@@ -232,3 +236,21 @@ class TestFacets:
     def test_a_classification_filter_reaches_the_route(self, auth_client):
         assert auth_client.get(f'{URL}?classification=absent').status_code == 200
         assert auth_client.get(f'{URL}?role=PI').status_code == 200
+
+
+class TestTheHeaderDoesNotConflateTwoFacts:
+    """⚠️ Caught by the local smoke, and only visible in a browser.
+
+    A *placeholder* is a username shape (`<name>-user-<token>`) XRAS mints for
+    someone with no site account. *Reconciliation* is whether XRAS has since
+    linked that username to a confirmed identity. They are independent: all
+    three placeholders on the local corpus were reconciled, so a header badge
+    reading "3 unreconciled" contradicted every row's own "identified".
+    """
+
+    def test_the_badge_counts_placeholders_by_that_name(self, auth_client,
+                                                        committed_worklist_action):
+        body = auth_client.get(URL).get_data(as_text=True)
+        assert 'placeholder' in body
+        assert 'unreconciled' not in body.split('<tbody>')[0], (
+            'the header badge must not call a placeholder count "unreconciled"')

--- a/tests/unit/test_xras_accounts_card.py
+++ b/tests/unit/test_xras_accounts_card.py
@@ -1,0 +1,234 @@
+"""HTTP tier for the XRAS account-creation worklist card.
+
+Scope follows the house convention — auth, render smoke, and the one thing a
+template change can silently break: the **permission split**.
+
+    VIEW_XRAS    the card, the worklist, the filters, `isReconciled`
+    MANAGE_XRAS  person detail (name, email, organization, academic status,
+                 residence country) — real PII about researchers who are not
+                 SAM users
+
+The PII gate is enforced in the ROUTE: `row['person']` is set to None before
+render for a VIEW-only viewer, so the response never carries the values and a
+view-source cannot leak what the card chose not to draw. A template-only gate
+would leave them sitting in the HTML.
+
+`isReconciled` is deliberately on the VIEW_XRAS side. It is account *state*,
+not a personal detail, and it is the signal that an item is closing itself.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+import pytest
+
+from webapp.utils.rbac import Permission
+
+pytestmark = pytest.mark.unit
+
+URL = '/allocations/xras_accounts_fragment'
+
+
+@pytest.fixture
+def view_only_client(auth_client, monkeypatch):
+    """`benkirk` minus MANAGE_XRAS.
+
+    `benkirk` holds every Permission, so there is no snapshot user with
+    VIEW_XRAS and not MANAGE_XRAS — the split has to be simulated. Patching
+    `get_user_permissions` is the narrowest way: every gate in the request
+    path reads through it.
+    """
+    from webapp.utils import rbac
+
+    real = rbac.get_user_permissions
+
+    def limited(user, *args, **kwargs):
+        return {p for p in real(user, *args, **kwargs)
+                if p != Permission.MANAGE_XRAS}
+
+    for module in (rbac, __import__(
+            'webapp.dashboards.allocations.blueprint', fromlist=['x'])):
+        if hasattr(module, 'get_user_permissions'):
+            monkeypatch.setattr(module, 'get_user_permissions', limited)
+    monkeypatch.setattr(rbac, 'get_user_permissions', limited)
+    return auth_client
+
+
+@pytest.fixture
+def committed_worklist_action(app):
+    """One committed `xras_action_log` row naming an unknown placeholder.
+
+    Committed, not factory-built: route handlers read through
+    Flask-SQLAlchemy's `db.session` on its own connection and only ever see
+    committed rows. Deleted by primary key on the way out — a range predicate
+    would take an open-ended gap lock and deadlock against other xdist workers.
+    """
+    from pathlib import Path
+
+    from webapp.extensions import db
+
+    from sam.integration.xras import XrasActionLog
+
+    payload = json.loads(
+        (Path(__file__).resolve().parents[1] / 'fixtures' / 'xras' / 'actions'
+         / 'new_ncar4227_failed.json').read_text())
+
+    with app.app_context():
+        row = XrasActionLog(received_time=datetime.now(), remote_actor='XRAS',
+                            raw_payload=json.dumps(payload), status='received',
+                            action_type='New', request_number='NCAR4227')
+        db.session.add(row)
+        db.session.commit()
+        action_id = row.xras_action_log_id
+
+    yield action_id
+
+    with app.app_context():
+        db.session.query(XrasActionLog).filter(
+            XrasActionLog.xras_action_log_id == action_id).delete()
+        db.session.commit()
+
+
+class TestAccess:
+
+    def test_it_requires_login(self, client):
+        response = client.get(URL)
+        assert response.status_code in (302, 401)
+
+    def test_view_xras_is_enough_to_see_it(self, view_only_client):
+        assert view_only_client.get(URL).status_code == 200
+
+    def test_a_user_without_view_xras_is_refused(self, non_admin_client):
+        assert non_admin_client.get(URL).status_code == 403
+
+    def test_it_is_embedded_in_the_xras_page(self, auth_client):
+        body = auth_client.get('/allocations/xras').get_data(as_text=True)
+        assert 'alloc-xras-accounts' in body
+        assert 'xras_accounts_fragment' in body
+
+    def test_the_filter_form_lives_outside_the_fragment(self, auth_client):
+        """Controls inside the fragment vanish with an empty state, and the
+        container refetches a bare hx-get on refreshXrasTab."""
+        body = auth_client.get('/allocations/xras').get_data(as_text=True)
+        form = body.index('id="xras-accounts-filters"')
+        container = body.index('id="alloc-xras-accounts"')
+        assert form < container
+
+
+class TestRenderStates:
+    """Both are designed states, and both are what a reviewer sees first."""
+
+    def test_the_empty_state_is_designed_not_broken(self, auth_client):
+        """Production is legitimately zero rows until ACCESS repoints."""
+        body = auth_client.get(URL).get_data(as_text=True)
+        assert 'Accounts Needed for XRAS Handoffs' in body
+        assert 'No accounts are waiting' in body or 'xras-acct-' in body
+
+    def test_it_renders_with_the_api_unconfigured(self, auth_client, monkeypatch):
+        """The shipped state, and what staging shows. The worklist is complete
+        from the action log; only XRAS-sourced detail is missing."""
+        monkeypatch.delenv('XRAS_OUTGOING_ENABLED', raising=False)
+        monkeypatch.delenv('XRAS_API_KEY', raising=False)
+        response = auth_client.get(URL)
+        assert response.status_code == 200
+
+    def test_an_api_outage_degrades_rather_than_500ing(self, auth_client,
+                                                       monkeypatch):
+        from sam.integration.xras_api.base import XrasSourceUnavailable
+
+        def boom(_username):
+            raise XrasSourceUnavailable('down')
+
+        monkeypatch.setattr('sam.integration.xras_api.people.get_person', boom)
+        assert auth_client.get(URL).status_code == 200
+
+    def test_the_worklist_lists_an_unknown_placeholder(
+            self, auth_client, committed_worklist_action):
+        body = auth_client.get(URL).get_data(as_text=True)
+        assert 'placeholder38-user-00038' in body
+        assert 'Create' in body
+
+
+class TestPiiGating:
+    """The gate is in the route; the template checks are a second layer."""
+
+    def _stub_person(self, monkeypatch):
+        monkeypatch.setattr(
+            'sam.integration.xras_api.people.get_person',
+            lambda username: {
+                'firstName': 'Ada', 'lastName': 'Invented',
+                'email': 'ada@example.invalid',
+                'organization': 'Example University',
+                'academicStatus': 'Graduate Student',
+                'residenceCountry': 'Kiribati',
+                'isReconciled': False})
+
+    def test_manage_xras_sees_person_detail(self, auth_client, monkeypatch,
+                                            committed_worklist_action):
+        self._stub_person(monkeypatch)
+        body = auth_client.get(URL).get_data(as_text=True)
+        assert 'ada@example.invalid' in body
+        assert 'Kiribati' in body
+
+    def test_view_only_never_receives_the_person_bytes(
+            self, view_only_client, monkeypatch, committed_worklist_action):
+        """Not merely undrawn — absent from the response."""
+        self._stub_person(monkeypatch)
+        body = view_only_client.get(URL).get_data(as_text=True)
+        assert 'ada@example.invalid' not in body
+        assert 'Kiribati' not in body
+        assert 'Example University' not in body
+        assert 'Invented' not in body
+        # ...while the row itself is still there to work from.
+        assert 'placeholder38-user-00038' in body
+
+    def test_reconciliation_state_is_not_pii(self, view_only_client, monkeypatch,
+                                             committed_worklist_action):
+        """It is account state and the signal an item is about to close."""
+        self._stub_person(monkeypatch)
+        body = view_only_client.get(URL).get_data(as_text=True)
+        assert 'unreconciled' in body
+
+
+class TestFacets:
+
+    def test_both_classifications_render_even_at_zero(self, auth_client):
+        """An absent chip reads as 'not measured' — a different claim."""
+        body = auth_client.get(URL).get_data(as_text=True)
+        assert 'Create account' in body and 'Reactivate account' in body
+
+    def test_facets_are_self_excluding(self):
+        """Scope a dimension by itself and every unselected value reads 0 the
+        moment one is picked, which turns the chips into a dead end."""
+        from webapp.dashboards.allocations.blueprint import _account_facets
+
+        rows = [{'classification': 'absent', 'roles': ('PI',)},
+                {'classification': 'inactive', 'roles': ('User',)}]
+        # Filtering on classification must NOT collapse the classification
+        # rollup — it is the dimension being chosen.
+        facets = _account_facets(rows, 'classification',
+                                 classifications=['absent'])
+        assert facets == {'absent': 1, 'inactive': 1}
+        # But it does scope the other dimension.
+        assert _account_facets(rows, 'role', classifications=['absent']) == {'PI': 1}
+
+    def test_an_unknown_dimension_raises(self):
+        from webapp.dashboards.allocations.blueprint import _account_facets
+
+        with pytest.raises(ValueError):
+            _account_facets([], 'nonsense')
+
+    def test_filters_are_anded_across_dimensions(self):
+        from webapp.dashboards.allocations.blueprint import _filter_accounts
+
+        rows = [{'classification': 'absent', 'roles': ('PI',)},
+                {'classification': 'absent', 'roles': ('User',)}]
+        assert len(_filter_accounts(rows, classifications=['absent'])) == 2
+        assert len(_filter_accounts(rows, classifications=['absent'],
+                                    roles=['PI'])) == 1
+
+    def test_a_classification_filter_reaches_the_route(self, auth_client):
+        assert auth_client.get(f'{URL}?classification=absent').status_code == 200
+        assert auth_client.get(f'{URL}?role=PI').status_code == 200

--- a/tests/unit/test_xras_accounts_card.py
+++ b/tests/unit/test_xras_accounts_card.py
@@ -254,3 +254,63 @@ class TestTheHeaderDoesNotConflateTwoFacts:
         assert 'placeholder' in body
         assert 'unreconciled' not in body.split('<tbody>')[0], (
             'the header badge must not call a placeholder count "unreconciled"')
+
+
+class TestTheWindowNeverHidesSilently:
+    """⚠️ On the Feed-B tab an OLDER unpushed request is usually the MORE
+    urgent one — a request submitted six months ago that still has no SAM
+    project is the worst case there. A recency filter that quietly dropped it
+    would invert the priority the tab exists to surface.
+
+    Measured on the live snapshot: the sweep found 21 accounts needed and the
+    90-day pill showed 12. The nine hidden rows were the oldest, i.e. the ones
+    most worth acting on. The filter stays — one window across three tabs is
+    the point — but the header must say what it hid.
+    """
+
+    URL = '/allocations/xras_pending_requests_fragment'
+
+    def _publish(self, rows_total, shown_total):
+        from sam.integration.xras_api.cache import store_pending_worklist
+        from datetime import datetime
+        rows = []
+        for i in range(rows_total):
+            # The first `shown_total` are recent; the rest are ancient.
+            submitted = '2026-08-19' if i < shown_total else '2019-01-01'
+            rows.append({
+                'username': f'ghost-user-{i}', 'classification': 'absent',
+                'remedy': 'create', 'placeholder': False, 'roles': ('PI',),
+                'is_account_to_be_created': False, 'is_reconciled': None,
+                'person': None, 'sources': ['reports'],
+                'actions': [{'action_log_id': None,
+                             'request_number': f'NCAR{i:04d}',
+                             'action_type': 'New', 'status': 'Approved',
+                             'received_time': None, 'submit_date': submitted,
+                             'source': 'reports', 'would_succeed': None,
+                             'reject_messages': []}],
+            })
+        store_pending_worklist({
+            'generated_at': datetime(2026, 8, 20), 'window_days': 90,
+            'status': 'Approved', 'requests_seen': 100,
+            'requests_in_window': 50, 'budget_exhausted': False,
+            'pending_push': rows_total, 'pending_push_sample': [],
+            'counts': {'total': rows_total, 'absent': rows_total,
+                       'inactive': 0, 'placeholder': 0, 'reconciled': 0},
+            'rows': rows,
+        })
+
+    def test_it_reports_how_many_the_window_hid(self, auth_client, monkeypatch):
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        self._publish(rows_total=5, shown_total=2)
+        body = auth_client.get(f'{self.URL}?days=30').get_data(as_text=True)
+        assert '2 of 5' in body
+        assert 'outside the window' in body
+
+    def test_it_says_nothing_when_the_window_hides_nothing(self, auth_client,
+                                                           monkeypatch):
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        self._publish(rows_total=3, shown_total=3)
+        body = auth_client.get(f'{self.URL}?days=30').get_data(as_text=True)
+        assert 'outside the window' not in body

--- a/tests/unit/test_xras_accounts_query.py
+++ b/tests/unit/test_xras_accounts_query.py
@@ -1,0 +1,416 @@
+"""The XRAS account-creation worklist.
+
+The predicate under test is the one that decides an operator's work queue, so
+three properties matter more than coverage breadth:
+
+1. **Two classes, not one.** *Absent* and *inactive* block a handoff
+   identically and need different remedies. A predicate that only checks
+   existence silently drops the whole inactive half.
+2. **``isAccountToBeCreated`` is never the predicate.** XRAS sets it when the
+   role is created and never clears it, so it is true on people who have had
+   working accounts for years.
+3. **The feeds agree.** Feed A (inbound action log) and Feed B (outbound
+   enumeration) reach the same classifier through the same
+   :class:`RosterRecord` seam, and must classify identically.
+
+⚠️ The in-tree fixtures are **scrubbed** — every username is rewritten to
+``user_<hex>`` or ``placeholder<NN>-user-<NNNNN>``. So "no ``users`` row" is
+trivially true for all of them, which proves the plumbing but not the
+predicate. The predicate itself is validated against the unscrubbed corpus
+outside the tree (see ``docs/xras/outgoing/`` § *The Tier-III test bed*); that
+run is manual and recorded only as pass/fail, because nothing derived from
+those payloads may enter a commit.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from factories import make_user
+
+from sam.queries.xras_accounts import (
+    ActionRef,
+    RosterRecord,
+    classify_accounts,
+    enrich_worklist,
+    is_placeholder,
+    records_from_action_log,
+    records_from_report_requests,
+    worklist_counts,
+)
+
+pytestmark = pytest.mark.unit
+
+FIXTURES = Path(__file__).resolve().parents[1] / 'fixtures' / 'xras' / 'actions'
+
+#: An in-window placeholder identity. **Not** ``new_ncar4214_ok.json``: that
+#: file's placeholder role ends 2026-07-28 against an action beginning
+#: 2026-07-30, so the date window correctly excludes it — the role is over.
+PLACEHOLDER_FIXTURE = 'new_ncar4227_failed.json'
+PLACEHOLDER_USERNAME = 'placeholder38-user-00038'
+
+
+def _payload(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def _record(*usernames, roles=None, flags=None, people=None, **ref_kwargs):
+    """A RosterRecord built by hand, bypassing both feeds."""
+    defaults = dict(action_log_id=1, request_number='NCAR0001',
+                    action_type='New', status='received',
+                    received_time=datetime(2026, 8, 1, 12, 0))
+    defaults.update(ref_kwargs)
+    return RosterRecord(
+        ref=ActionRef(**defaults),
+        usernames=tuple(usernames),
+        roles_by_username=roles or {u: ('User',) for u in usernames},
+        account_flag=flags or {},
+        person_by_username=people or {})
+
+
+# ── the placeholder shape ───────────────────────────────────────────────
+
+class TestPlaceholderDetection:
+
+    @pytest.mark.parametrize('username', [
+        'placeholder38-user-00038', 'jsmith-user-a1b2c3', 'x-user-1',
+    ])
+    def test_arc_placeholders_match(self, username):
+        assert is_placeholder(username) is True
+
+    @pytest.mark.parametrize('username', [
+        'benkirk', 'user_00000033', '', 'user-00034', 'auser',
+    ])
+    def test_real_usernames_do_not(self, username):
+        assert is_placeholder(username) is False
+
+
+# ── the classifier ──────────────────────────────────────────────────────
+
+class TestClassification:
+    """Current-state against ``users`` — never the action's status."""
+
+    def test_an_unknown_username_is_absent(self, session):
+        rows = classify_accounts(session, [_record('nobody-user-99999')])
+        assert len(rows) == 1
+        assert rows[0]['classification'] == 'absent'
+        assert rows[0]['remedy'] == 'create'
+        assert rows[0]['placeholder'] is True
+
+    def test_an_inactive_user_is_inactive_not_absent(self, session):
+        """The half an existence-only predicate drops.
+
+        Measured on the unscrubbed corpus: 5 of 9 real worklist rows.
+        """
+        user = make_user(session, active=False)
+        rows = classify_accounts(session, [_record(user.username)])
+        assert len(rows) == 1
+        assert rows[0]['classification'] == 'inactive'
+        assert rows[0]['remedy'] == 'reactivate'
+
+    def test_an_active_user_is_dropped(self, session):
+        user = make_user(session, active=True)
+        assert classify_accounts(session, [_record(user.username)]) == []
+
+    def test_the_two_classes_are_reported_together(self, session):
+        active = make_user(session, active=True)
+        inactive = make_user(session, active=False)
+        rows = classify_accounts(
+            session, [_record(active.username, inactive.username, 'ghost-user-1')])
+        assert {r['username'] for r in rows} == {inactive.username, 'ghost-user-1'}
+        # Absent sorts first: it is the larger piece of work.
+        assert rows[0]['classification'] == 'absent'
+
+    def test_a_locked_user_is_not_active(self, session):
+        """``User.is_active`` is ``active AND NOT locked`` — use the hybrid."""
+        user = make_user(session, active=True)
+        user.locked = True
+        session.flush()
+        rows = classify_accounts(session, [_record(user.username)])
+        assert [r['classification'] for r in rows] == ['inactive']
+
+    def test_classification_ignores_the_action_status(self, session):
+        """Regime-proof across the capture-only -> live-dispatch flip."""
+        seen = set()
+        for status in ('received', 'processed', 'failed', 'manual'):
+            rows = classify_accounts(
+                session, [_record('ghost-user-1', status=status)])
+            seen.add(rows[0]['classification'])
+        assert seen == {'absent'}
+
+
+class TestTheStaleFlagTrap:
+    """``isAccountToBeCreated`` is a hint column and nothing more."""
+
+    def test_a_flagged_but_active_user_is_not_on_the_worklist(self, session):
+        """The § 5 trap. On the unscrubbed corpus, 5 of 5 flagged usernames
+        were existing *active* accounts — the flag was 100% stale."""
+        user = make_user(session, active=True)
+        rows = classify_accounts(
+            session, [_record(user.username, flags={user.username: True})])
+        assert rows == []
+
+    def test_the_flag_still_rides_along_as_a_hint(self, session):
+        rows = classify_accounts(
+            session, [_record('ghost-user-1', flags={'ghost-user-1': True})])
+        assert rows[0]['is_account_to_be_created'] is True
+
+    def test_an_unflagged_absent_user_is_still_reported(self, session):
+        """The inverse: the flag being false must not suppress a real case."""
+        rows = classify_accounts(session, [_record('ghost-user-1')])
+        assert rows[0]['is_account_to_be_created'] is False
+        assert rows[0]['classification'] == 'absent'
+
+
+class TestGrouping:
+    """One row per username, across every action naming them."""
+
+    def test_actions_are_grouped_and_newest_first(self, session):
+        rows = classify_accounts(session, [
+            _record('ghost-user-1', action_log_id=1,
+                    received_time=datetime(2026, 8, 1)),
+            _record('ghost-user-1', action_log_id=2,
+                    received_time=datetime(2026, 8, 5)),
+        ])
+        assert len(rows) == 1
+        assert [a['action_log_id'] for a in rows[0]['actions']] == [2, 1]
+        assert rows[0]['first_seen'] == datetime(2026, 8, 1)
+        assert rows[0]['last_seen'] == datetime(2026, 8, 5)
+        # Deliberately the future notes-table FK target.
+        assert rows[0]['latest_action_log_id'] == 2
+
+    def test_roles_are_unioned_strongest_first(self, session):
+        rows = classify_accounts(session, [
+            _record('ghost-user-1', roles={'ghost-user-1': ('User',)}),
+            _record('ghost-user-1', roles={'ghost-user-1': ('PI',)}),
+            _record('ghost-user-1', roles={'ghost-user-1': ('Allocation Manager',)}),
+        ])
+        assert rows[0]['roles'] == ('PI', 'Allocation Manager', 'User')
+
+    def test_counts_cover_every_facet(self, session):
+        inactive = make_user(session, active=False)
+        rows = classify_accounts(
+            session, [_record('ghost-user-1', inactive.username)])
+        counts = worklist_counts(rows)
+        assert counts['total'] == 2
+        assert counts['absent'] == 1 and counts['inactive'] == 1
+        assert counts['placeholder'] == 1
+
+
+# ── Feed A ──────────────────────────────────────────────────────────────
+
+class TestFeedA:
+    """Rosters out of ``xras_action_log.raw_payload``."""
+
+    def _log_row(self, session, payload_name, **kwargs):
+        from sam.integration.xras import XrasActionLog
+        row = XrasActionLog(
+            received_time=kwargs.pop('received_time', datetime(2026, 8, 1)),
+            remote_actor='XRAS',
+            raw_payload=json.dumps(_payload(payload_name)),
+            status=kwargs.pop('status', 'received'),
+            **kwargs)
+        session.add(row)
+        session.flush()
+        return row
+
+    def test_it_extracts_the_roster_and_classifies_it(self, session):
+        self._log_row(session, PLACEHOLDER_FIXTURE, action_type='New',
+                      request_number='NCAR4227')
+        records = records_from_action_log(session, validate=False)
+        assert records, 'no roster came out of the action log'
+        rows = classify_accounts(session, records)
+        by_name = {r['username']: r for r in rows}
+        assert PLACEHOLDER_USERNAME in by_name
+        entry = by_name[PLACEHOLDER_USERNAME]
+        assert entry['classification'] == 'absent'
+        assert entry['placeholder'] is True
+        assert entry['actions'][0]['request_number'] == 'NCAR4227'
+        assert entry['actions'][0]['source'] == 'action_log'
+
+    def test_statuses_bound_which_rows_are_read(self, session):
+        self._log_row(session, PLACEHOLDER_FIXTURE, status='processed')
+        assert records_from_action_log(
+            session, statuses=('received',), validate=False) == []
+
+    def test_an_unparseable_payload_is_skipped_not_fatal(self, session):
+        from sam.integration.xras import XrasActionLog
+        session.add(XrasActionLog(received_time=datetime(2026, 8, 1),
+                                  remote_actor='XRAS', raw_payload='{not json',
+                                  status='failed'))
+        session.flush()
+        # It is already visible on the action-log card as its own failure.
+        assert records_from_action_log(session, validate=False) == []
+
+    def test_the_window_bounds_the_read(self, session):
+        self._log_row(session, PLACEHOLDER_FIXTURE,
+                      received_time=datetime(2026, 8, 1))
+        assert records_from_action_log(
+            session, since=datetime(2026, 9, 1), validate=False) == []
+        assert records_from_action_log(
+            session, since=datetime(2026, 7, 1), validate=False)
+
+    def test_a_role_outside_the_date_window_is_excluded(self, session):
+        """``new_ncar4214_ok.json``'s placeholder role ended before the action
+        began — the handoff does not need that account, so it is not work."""
+        self._log_row(session, 'new_ncar4214_ok.json')
+        records = records_from_action_log(session, validate=False)
+        assert 'placeholder34-user-00034' not in records[0].usernames
+
+    def test_the_validate_verdict_is_provenance_not_the_predicate(self, session):
+        """It also catches mnemonic and resource-key failures, which are not
+        account problems — so it annotates, it does not classify."""
+        self._log_row(session, PLACEHOLDER_FIXTURE)
+        records = records_from_action_log(session, validate=True)
+        ref = records[0].ref
+        assert ref.would_succeed in (True, False, None)
+        assert isinstance(ref.reject_messages, tuple)
+        rows = classify_accounts(session, records)
+        # The classification stands on the users table alone.
+        assert all(r['classification'] in ('absent', 'inactive') for r in rows)
+
+
+# ── Feed B ──────────────────────────────────────────────────────────────
+
+REPORT_REQUEST = {
+    'requestId': 1446994,
+    'requestNumber': 'NCAR9001',
+    'requestStatus': 'Approved',
+    'requestType': 'New',
+    'roles': [
+        {'person': {'username': 'ghost-user-77777',
+                    'firstName': 'Ada', 'lastName': 'Invented',
+                    'email': 'ada@example.invalid',
+                    'organization': 'Example University',
+                    'academicStatus': 'Graduate Student',
+                    'residenceCountry': 'United States',
+                    'isReconciled': False, 'orcid': None},
+         'roles': [{'roleId': 1, 'role': 'PI', 'roleTypeId': 13,
+                    'beginDate': '2026-01-01', 'endDate': None,
+                    'isAccountToBeCreated': True}]},
+    ],
+}
+
+
+class TestFeedB:
+    """Rosters out of ``GET /v1/reports/requests``. Shape verified live."""
+
+    def test_it_reads_the_nested_outgoing_shape(self, session):
+        records = records_from_report_requests([REPORT_REQUEST])
+        assert records[0].usernames == ('ghost-user-77777',)
+        # The outgoing wire nests person under the entry and names the role
+        # `role`, not `roleType` — a different shape from the inbound payload.
+        assert records[0].roles_by_username['ghost-user-77777'] == ('PI',)
+        assert records[0].ref.action_log_id is None
+        assert records[0].ref.source == 'reports'
+
+    def test_the_person_object_arrives_inline(self, session):
+        records = records_from_report_requests([REPORT_REQUEST])
+        rows = classify_accounts(session, records)
+        assert rows[0]['is_reconciled'] is False
+        assert rows[0]['person']['residenceCountry'] == 'United States'
+
+    def test_both_feeds_reach_the_same_classifier_identically(self, session):
+        """The feed-agnostic proof."""
+        feed_b = classify_accounts(session, records_from_report_requests(
+            [REPORT_REQUEST]))
+        feed_a = classify_accounts(session, [_record(
+            'ghost-user-77777', roles={'ghost-user-77777': ('PI',)})])
+        assert feed_b[0]['classification'] == feed_a[0]['classification']
+        assert feed_b[0]['placeholder'] == feed_a[0]['placeholder']
+        assert feed_b[0]['roles'] == feed_a[0]['roles']
+
+    def test_a_request_with_no_resolvable_roster_is_skipped(self):
+        assert records_from_report_requests([{'requestNumber': 'X'}]) == []
+        assert records_from_report_requests([None, 'nonsense']) == []
+
+    def test_rows_from_both_feeds_merge_onto_one_username(self, session):
+        rows = classify_accounts(session, [
+            *records_from_report_requests([REPORT_REQUEST]),
+            _record('ghost-user-77777'),
+        ])
+        assert len(rows) == 1
+        assert sorted(rows[0]['sources']) == ['action_log', 'reports']
+
+
+# ── enrichment ──────────────────────────────────────────────────────────
+
+class TestEnrichment:
+    """Injected, so the query layer stays offline-capable."""
+
+    def test_it_attaches_person_detail_and_the_closure_signal(self, session):
+        rows = classify_accounts(session, [_record('ghost-user-1')])
+        report = enrich_worklist(rows, person_lookup=lambda u: {
+            'firstName': 'Ada', 'lastName': 'Invented',
+            'email': 'ada@example.invalid', 'residenceCountry': 'Canada',
+            'isReconciled': True})
+        assert rows[0]['person']['residenceCountry'] == 'Canada'
+        assert rows[0]['is_reconciled'] is True
+        assert report['found'] == 1 and report['closed'] == 1
+
+    def test_an_outage_degrades_rather_than_raising(self, session):
+        """The card must render counts and usernames, not a 500."""
+        from sam.integration.xras_api.base import XrasSourceUnavailable
+
+        def boom(_username):
+            raise XrasSourceUnavailable('down')
+
+        rows = classify_accounts(session, [_record('ghost-user-1')])
+        report = enrich_worklist(rows, person_lookup=boom)
+        assert report['unavailable'] is True
+        assert rows[0]['person'] is None
+        assert rows[0]['classification'] == 'absent'
+
+    def test_an_unconfigured_deployment_degrades_the_same_way(self, session):
+        """``XrasApiNotConfigured`` is a subclass, so one branch covers both."""
+        from sam.integration.xras_api.base import XrasApiNotConfigured
+
+        def not_configured(_username):
+            raise XrasApiNotConfigured('no key')
+
+        rows = classify_accounts(session, [_record('ghost-user-1')])
+        assert enrich_worklist(rows, person_lookup=not_configured)['unavailable']
+
+    def test_the_lookup_budget_is_bounded(self, session):
+        rows = classify_accounts(session, [
+            _record(*[f'ghost-user-{i}' for i in range(10)])])
+        report = enrich_worklist(rows, person_lookup=lambda u: None,
+                                 max_lookups=3)
+        assert report['looked_up'] == 3
+        assert report['budget_exhausted'] is True
+
+    def test_feed_b_rows_need_no_lookup(self, session):
+        """The enumeration carries the person inline — no round trip."""
+        calls = []
+        rows = classify_accounts(session, records_from_report_requests(
+            [REPORT_REQUEST]))
+        report = enrich_worklist(rows,
+                                 person_lookup=lambda u: calls.append(u))
+        assert calls == []
+        assert report['looked_up'] == 0
+
+    def test_only_the_declared_person_fields_are_kept(self, session):
+        rows = classify_accounts(session, [_record('ghost-user-1')])
+        enrich_worklist(rows, person_lookup=lambda u: {
+            'firstName': 'Ada', 'isReconciled': False,
+            'internalXrasId': 'should not survive'})
+        assert 'internalXrasId' not in rows[0]['person']
+
+
+class TestImportGraph:
+    """The task imports this module; ``test_task_ledger`` walks what that drags."""
+
+    def test_it_is_not_exported_from_the_queries_package(self):
+        """``sam/queries/__init__.py`` imports its submodules eagerly."""
+        import sam.queries
+        assert not hasattr(sam.queries, 'get_account_worklist')
+
+    def test_it_does_not_import_the_api_client_at_module_scope(self):
+        source = (Path(__file__).resolve().parents[2] / 'src' / 'sam' /
+                  'queries' / 'xras_accounts.py').read_text()
+        head = source.split('def ', 1)[0]
+        assert 'xras_api' not in head, \
+            'the API client must be imported lazily, inside enrich_worklist'

--- a/tests/unit/test_xras_accounts_query.py
+++ b/tests/unit/test_xras_accounts_query.py
@@ -205,6 +205,13 @@ class TestGrouping:
 class TestFeedA:
     """Rosters out of ``xras_action_log.raw_payload``."""
 
+    #: ⚠️ Assertions here must be scoped to the rows the test itself created.
+    #: `tests/unit/test_xras_accounts_card.py` COMMITS an `xras_action_log`
+    #: row (its route reads through Flask-SQLAlchemy's own connection and only
+    #: sees committed rows), and xdist workers share one database — so a bare
+    #: `records_from_action_log(...) == []` is a race against that fixture,
+    #: not an assertion about this test's data.
+
     def _log_row(self, session, payload_name, **kwargs):
         from sam.integration.xras import XrasActionLog
         row = XrasActionLog(
@@ -232,18 +239,22 @@ class TestFeedA:
         assert entry['actions'][0]['source'] == 'action_log'
 
     def test_statuses_bound_which_rows_are_read(self, session):
-        self._log_row(session, PLACEHOLDER_FIXTURE, status='processed')
-        assert records_from_action_log(
-            session, statuses=('received',), validate=False) == []
+        row = self._log_row(session, PLACEHOLDER_FIXTURE, status='processed')
+        ids = {r.ref.action_log_id for r in records_from_action_log(
+            session, statuses=('received',), validate=False)}
+        assert row.xras_action_log_id not in ids
 
     def test_an_unparseable_payload_is_skipped_not_fatal(self, session):
         from sam.integration.xras import XrasActionLog
-        session.add(XrasActionLog(received_time=datetime(2026, 8, 1),
-                                  remote_actor='XRAS', raw_payload='{not json',
-                                  status='failed'))
+        row = XrasActionLog(received_time=datetime(2026, 8, 1),
+                            remote_actor='XRAS', raw_payload='{not json',
+                            status='failed')
+        session.add(row)
         session.flush()
         # It is already visible on the action-log card as its own failure.
-        assert records_from_action_log(session, validate=False) == []
+        ids = {r.ref.action_log_id
+               for r in records_from_action_log(session, validate=False)}
+        assert row.xras_action_log_id not in ids
 
     def test_the_window_bounds_the_read(self, session):
         self._log_row(session, PLACEHOLDER_FIXTURE,
@@ -341,7 +352,7 @@ class TestFeedB:
 class TestEnrichment:
     """Injected, so the query layer stays offline-capable."""
 
-    def test_it_attaches_person_detail_and_the_closure_signal(self, session):
+    def test_it_attaches_person_detail_and_identity_state(self, session):
         rows = classify_accounts(session, [_record('ghost-user-1')])
         report = enrich_worklist(rows, person_lookup=lambda u: {
             'firstName': 'Ada', 'lastName': 'Invented',
@@ -349,7 +360,24 @@ class TestEnrichment:
             'isReconciled': True})
         assert rows[0]['person']['residenceCountry'] == 'Canada'
         assert rows[0]['is_reconciled'] is True
-        assert report['found'] == 1 and report['closed'] == 1
+        assert report['found'] == 1 and report['reconciled'] == 1
+
+    def test_reconciled_is_not_a_closure(self, session):
+        """⚠️ The design document called `isReconciled` the closure signal.
+        It is not: the local smoke measured **9 of 9** worklist rows reconciled
+        in XRAS while every one still needed a SAM account created or
+        reactivated. Reconciliation is XRAS linking a placeholder to a real
+        identity; it says nothing about whether SAM has a row.
+
+        The row must therefore SURVIVE enrichment — the thing that closes it is
+        the `users` row appearing, which classification checks every render."""
+        rows = classify_accounts(session, [_record('ghost-user-1')])
+        report = enrich_worklist(
+            rows, person_lookup=lambda u: {'isReconciled': True})
+        assert report['reconciled'] == 1
+        assert rows[0]['classification'] == 'absent', \
+            'a reconciled identity is still an absent SAM account'
+        assert 'closed' not in report
 
     def test_an_outage_degrades_rather_than_raising(self, session):
         """The card must render counts and usernames, not a 500."""
@@ -414,3 +442,138 @@ class TestImportGraph:
         head = source.split('def ', 1)[0]
         assert 'xras_api' not in head, \
             'the API client must be imported lazily, inside enrich_worklist'
+
+
+class TestItIsRegimeProof:
+    """§ 1's requirement, and the one the first implementation broke.
+
+    Actions in the log are `received` under capture-only and
+    `processed`/`failed`/`manual` under live dispatch. The worklist must mean
+    the same thing on both sides of that flip — classification already keys
+    off the `users` table alone, but a narrow status pre-filter reintroduced
+    the dependency behind it.
+
+    Measured on the local smoke: 41 real payloads gave **9 rows as `received`
+    and 4 once 28 of them had dispatched**, hiding four inactive users and one
+    absent Allocation Manager.
+    """
+
+    def test_every_status_is_read(self):
+        """A processed action still names people SAM may not be able to use:
+        `resolve_roster` reports a missing or inactive *member* as a warning,
+        not an error, so the handler skips assigning them and succeeds."""
+        from sam.queries.xras_actions import XRAS_ACTION_STATUSES
+
+        from sam.queries.xras_accounts import WORKLIST_STATUSES
+
+        assert set(WORKLIST_STATUSES) == set(XRAS_ACTION_STATUSES), (
+            'narrowing WORKLIST_STATUSES makes the worklist regime-dependent')
+
+    def test_a_processed_action_still_yields_its_roster(self, session):
+        """The concrete case the smoke found."""
+        import json
+        from datetime import datetime as dt
+
+        from sam.integration.xras import XrasActionLog
+
+        payload = json.loads((FIXTURES / PLACEHOLDER_FIXTURE).read_text())
+        session.add(XrasActionLog(received_time=dt(2026, 8, 1),
+                                  remote_actor='XRAS',
+                                  raw_payload=json.dumps(payload),
+                                  status='processed'))
+        session.flush()
+        records = records_from_action_log(session, validate=False)
+        assert records, 'a processed action was skipped'
+        rows = classify_accounts(session, records)
+        assert PLACEHOLDER_USERNAME in {r['username'] for r in rows}
+
+    def test_the_same_roster_classifies_alike_in_every_regime(self, session):
+        """Flip only the status; the answer must not move."""
+        import json
+        from datetime import datetime as dt
+
+        from sam.integration.xras import XrasActionLog
+
+        payload = json.loads((FIXTURES / PLACEHOLDER_FIXTURE).read_text())
+        answers = set()
+        for status in ('received', 'processed', 'failed', 'manual',
+                       'rechecked', 'unmapped'):
+            row = XrasActionLog(received_time=dt(2026, 8, 1),
+                                remote_actor='XRAS',
+                                raw_payload=json.dumps(payload), status=status)
+            session.add(row)
+            session.flush()
+            rows = classify_accounts(
+                session, records_from_action_log(session, validate=False))
+            answers.add(next(r['classification'] for r in rows
+                             if r['username'] == PLACEHOLDER_USERNAME))
+            session.delete(row)
+            session.flush()
+        assert answers == {'absent'}
+
+    def test_the_preflight_is_what_stays_bounded(self, session):
+        """Validation is the expensive part, and skipping it on a processed
+        action costs provenance — never a classification."""
+        import json
+        from datetime import datetime as dt
+
+        from sam.integration.xras import XrasActionLog
+        from sam.queries.xras_accounts import VALIDATE_STATUSES
+
+        assert 'processed' not in VALIDATE_STATUSES
+
+        payload = json.loads((FIXTURES / PLACEHOLDER_FIXTURE).read_text())
+        row = XrasActionLog(received_time=dt(2026, 8, 1), remote_actor='XRAS',
+                            raw_payload=json.dumps(payload), status='processed')
+        session.add(row)
+        session.flush()
+        records = records_from_action_log(session, validate=True)
+        mine = next(r for r in records
+                    if r.ref.action_log_id == row.xras_action_log_id)
+        assert mine.ref.would_succeed is None            # not run...
+        rows = classify_accounts(session, [mine])        # ...and still classified
+        assert PLACEHOLDER_USERNAME in {r['username'] for r in rows}
+
+
+class TestUsernameCaseFolding:
+    """⚠️ Found by the local smoke against real data; unreachable from fixtures.
+
+    `users.username` is `utf8mb3_general_ci` with a UNIQUE index, so MySQL
+    treats `Jsmith` and `jsmith` as one account and the batch `IN` matches
+    either spelling. A case-sensitive dict on top of that misses the row it was
+    just handed and reports `absent` — telling an operator to create an account
+    that already exists and is active.
+
+    No in-tree fixture can reach this: the anonymizer rewrites every username
+    to lowercase `user_<hex>`, so every scrubbed roster is already
+    case-matched. `roster.normalize_username` does not fold case either (it
+    reproduces Java), so the wire spelling arrives untouched.
+    """
+
+    def test_a_case_mismatched_active_user_is_not_reported(self, session):
+        """The exact false positive: XRAS sent `Jsmith`, SAM holds `jsmith`."""
+        user = make_user(session, username='casefoldcheck', active=True)
+        rows = classify_accounts(
+            session, [_record(user.username.upper())])
+        assert rows == [], (
+            'a case-mismatched ACTIVE account was reported as needing creation')
+
+    def test_a_case_mismatched_inactive_user_is_inactive_not_absent(self, session):
+        """The remedy differs: reactivate, not create."""
+        user = make_user(session, username='casefoldinactive', active=False)
+        rows = classify_accounts(session, [_record(user.username.upper())])
+        assert [r['classification'] for r in rows] == ['inactive']
+
+    def test_two_spellings_are_one_row_of_work(self, session):
+        """One account, one operator task — not two."""
+        rows = classify_accounts(session, [
+            _record('GhostCaseUser'), _record('ghostcaseuser')])
+        assert len(rows) == 1
+        # Both actions are attached to the single row.
+        assert len(rows[0]['actions']) == 2
+
+    def test_the_wire_spelling_is_preserved_for_display(self, session):
+        """For an absent account it is the only spelling there is, and for a
+        present one the mismatch is itself worth seeing."""
+        rows = classify_accounts(session, [_record('GhostCaseUser')])
+        assert rows[0]['username'] == 'GhostCaseUser'

--- a/tests/unit/test_xras_action_queries.py
+++ b/tests/unit/test_xras_action_queries.py
@@ -1000,11 +1000,22 @@ class TestActionTypeAliases:
         assert count_recent_xras_actions(session, action_type=asked) == len(rows)
 
     def test_a_non_aliased_type_is_unaffected(self, session):
-        """The widening must not leak across types."""
+        """The widening must not leak across types.
+
+        ⚠️ Scoped to the two rows this test created, not asserted as equality
+        over every ``New`` row in the table. ``xras_action_log`` is shared:
+        `tests/unit/test_xras_accounts_card.py` COMMITS a row (its route reads
+        through Flask-SQLAlchemy's own connection and only sees committed
+        rows), and xdist workers share one database — so an exact-equality
+        assertion here fails intermittently on somebody else's fixture rather
+        than on the behaviour under test.
+        """
         _action(session, action_type='Adjustment', request_number='UWIS0064')
         _action(session, action_type='New', request_number='NCAR4253')
-        rows = get_recent_xras_actions(session, action_type='New')
-        assert {r['request_number'] for r in rows} == {'NCAR4253'}
+        found = {r['request_number'] for r in
+                 get_recent_xras_actions(session, action_type='New')}
+        assert 'NCAR4253' in found
+        assert 'UWIS0064' not in found
 
     def test_rollup_merges_the_two_spellings_into_one_bucket(self, session):
         """Two chips that filter identically would read as two distinct action types."""

--- a/tests/unit/test_xras_api_client.py
+++ b/tests/unit/test_xras_api_client.py
@@ -1,0 +1,454 @@
+"""The outbound XRAS Allocations API client.
+
+Mirrors ``tests/unit/test_award_providers.py``: canned payloads as module
+constants with invented identities, transport exercised through a mocked
+``session.request`` with ``time.sleep`` no-op'd, and the three-outcome model
+(**found / not-found / unreachable**) asserted explicitly, because every
+consumer downstream branches on it.
+
+No test here touches the network. The live surface is
+``scripts/xras/probe_outgoing.py``, which is opt-in and skips without a key.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from sam.integration.xras_api import cache as xras_cache
+from sam.integration.xras_api import people as xras_people
+from sam.integration.xras_api.base import (
+    XrasApiNotConfigured,
+    XrasSourceUnavailable,
+)
+from sam.integration.xras_api.client import XrasApiClient
+from sam.integration.xras_api.config import XrasApiConfig, xras_api_configured
+
+pytestmark = pytest.mark.unit
+
+
+# ── canned payloads ─────────────────────────────────────────────────────
+# Shapes copied from the live API; identities invented. If XRAS renames a
+# field, the probe script catches it against production and these break here.
+
+PERSON = {
+    'username': 'invented-user-00001',
+    'firstName': 'Ada', 'middleName': None, 'lastName': 'Invented',
+    'email': 'ada@example.invalid', 'phone': None,
+    'organization': 'Example University',
+    'academicStatus': 'Graduate Student',
+    'residenceCountry': 'United States',
+    'isReconciled': False, 'orcid': None, 'hasOrcidToken': False,
+}
+
+RESOURCES = [
+    {'resourceId': 1, 'resourceName': 'Example HPC',
+     'resourceRepositoryKey': 101, 'productionBeginDate': '2024-01-01',
+     'productionEndDate': None},
+    {'resourceId': 2, 'resourceName': 'Example Storage',
+     'resourceRepositoryKey': 102, 'productionBeginDate': '2024-01-01',
+     'productionEndDate': None},
+]
+
+
+def _request(request_id: int, number: str) -> dict:
+    return {
+        'requestId': request_id, 'requestNumber': number,
+        'requestStatus': 'Approved', 'requestType': 'New',
+        'roles': [{'person': dict(PERSON),
+                   'roles': [{'roleId': 1, 'role': 'PI', 'roleTypeId': 13,
+                              'beginDate': '2026-01-01', 'endDate': None,
+                              'isAccountToBeCreated': True}]}],
+        'actions': [], 'fos': [], 'grants': [],
+    }
+
+
+def _envelope(result):
+    """XRAS wraps every payload in ``{message, result}``."""
+    return {'message': 'OK', 'result': result}
+
+
+def _response(status, payload=None, text=''):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = text
+    resp.json.return_value = payload if payload is not None else {}
+    return resp
+
+
+def _client(monkeypatch, responses, **config_kwargs):
+    """A configured client whose transport is a scripted list of responses."""
+    config = XrasApiConfig(enabled=True, api_key='not-a-real-key',
+                           **config_kwargs)
+    client = XrasApiClient(config)
+    monkeypatch.setattr(client.session, 'request',
+                        MagicMock(side_effect=responses))
+    monkeypatch.setattr('sam.integration.xras_api.client.time.sleep',
+                        lambda _s: None)
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _reset_xras_cache(monkeypatch):
+    """Start each test with the XRAS cache disabled; reset it after.
+
+    ``delenv`` is load-bearing: CI runs pytest inside the compose ``webapp``
+    container, where ``CACHE_REDIS_URL`` is force-set. With Redis the adapter
+    is a ``RedisTTLAdapter``, so dropping the in-process memo would leave the
+    keyspace intact and xdist workers would share one Redis.
+    """
+    monkeypatch.delenv('CACHE_REDIS_URL', raising=False)
+    xras_cache._CACHE.reset_for_tests()
+    yield
+    xras_cache._CACHE.reset_for_tests(disabled=False)
+
+
+# ── configuration ───────────────────────────────────────────────────────
+
+class TestConfiguration:
+    """Fail-closed, and both halves of the predicate matter."""
+
+    def test_it_is_off_by_default(self, monkeypatch):
+        for key in ('XRAS_OUTGOING_ENABLED', 'XRAS_API_KEY'):
+            monkeypatch.delenv(key, raising=False)
+        assert XrasApiConfig.from_environment().configured is False
+        assert xras_api_configured() is False
+
+    def test_a_key_without_the_lever_stays_silent(self, monkeypatch):
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        monkeypatch.delenv('XRAS_OUTGOING_ENABLED', raising=False)
+        assert xras_api_configured() is False
+
+    def test_the_lever_without_a_key_stays_silent(self, monkeypatch):
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.delenv('XRAS_API_KEY', raising=False)
+        assert xras_api_configured() is False
+
+    def test_both_halves_configure_it(self, monkeypatch):
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        assert xras_api_configured() is True
+
+    def test_defaults_match_the_probed_process(self, monkeypatch):
+        for key in ('XRAS_API_BASE', 'XRAS_ALLOCATIONS_PROCESS',
+                    'XRAS_API_USER'):
+            monkeypatch.delenv(key, raising=False)
+        config = XrasApiConfig.from_environment()
+        assert config.base_url == 'https://api.xras.org'
+        assert config.allocations_process == 'NCAR'
+        assert config.api_user == 'arcguest'
+
+    def test_a_trailing_slash_on_the_base_url_is_dropped(self, monkeypatch):
+        monkeypatch.setenv('XRAS_API_BASE', 'https://api.xras.org/')
+        assert XrasApiConfig.from_environment().base_url == 'https://api.xras.org'
+
+    def test_unconfigured_raises_a_subclass_of_unavailable(self, monkeypatch):
+        monkeypatch.delenv('XRAS_OUTGOING_ENABLED', raising=False)
+        monkeypatch.delenv('XRAS_API_KEY', raising=False)
+        with pytest.raises(XrasApiNotConfigured):
+            XrasApiClient.from_environment()
+        # The point of the subclass: a caller that only knows about
+        # "could not ask" is already correct.
+        with pytest.raises(XrasSourceUnavailable):
+            XrasApiClient.from_environment()
+
+    def test_the_summary_never_carries_the_key(self, monkeypatch):
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'super-secret-value')
+        summary = XrasApiConfig.from_environment().summary()
+        assert summary['api_key_set'] is True
+        assert 'super-secret-value' not in repr(summary)
+        assert not any('key' == k or k.endswith('_key') for k in summary)
+
+
+# ── the write surface must not exist ────────────────────────────────────
+
+class TestItIsStructurallyReadOnly:
+    """The same credential can create requests and merge people (§ 4.7).
+
+    So GET-only is enforced by there being nothing else to call, not by
+    reviewers remembering.
+    """
+
+    def test_the_client_exposes_no_write_verb(self):
+        forbidden = ('post', 'put', 'patch', 'delete', 'request', 'post_json',
+                     'put_json', 'patch_json', 'delete_json', 'send')
+        for name in forbidden:
+            assert not hasattr(XrasApiClient, name), \
+                f'XrasApiClient.{name} exists — the client must stay GET-only'
+
+    def test_the_only_transport_primitive_is_get(self):
+        source = inspect.getsource(XrasApiClient)
+        assert "'GET'" in source
+        for verb in ("'POST'", "'PUT'", "'PATCH'", "'DELETE'"):
+            assert verb not in source, f'{verb} appears in the client'
+
+
+# ── transport ───────────────────────────────────────────────────────────
+
+class TestTransport:
+    """Retry policy: a 4xx is an answer, a 5xx is worth another attempt."""
+
+    def test_404_is_none_not_an_error(self, monkeypatch):
+        client = _client(monkeypatch, [_response(404, {'message': 'not found'})])
+        assert client.get_person('nobody') is None
+        assert client.session.request.call_count == 1
+
+    def test_4xx_does_not_retry(self, monkeypatch):
+        # 401 is what an unprovisioned context returns — a configuration
+        # fact, not an outage, and retrying cannot change it.
+        client = _client(monkeypatch, [_response(401, text='denied')])
+        with pytest.raises(XrasSourceUnavailable):
+            client.get_resources()
+        assert client.session.request.call_count == 1
+
+    def test_5xx_retries_then_succeeds(self, monkeypatch):
+        client = _client(monkeypatch, [_response(503),
+                                       _response(200, _envelope(RESOURCES))])
+        assert client.get_resources() == RESOURCES
+        assert client.session.request.call_count == 2
+
+    def test_exhausted_retries_raise(self, monkeypatch):
+        client = _client(monkeypatch, [_response(503)] * 3)
+        with pytest.raises(XrasSourceUnavailable):
+            client.get_resources()
+        assert client.session.request.call_count == 3
+
+    def test_network_error_retries(self, monkeypatch):
+        client = _client(monkeypatch, [requests.ConnectionError('down'),
+                                       _response(200, _envelope(RESOURCES))])
+        assert client.get_resources() == RESOURCES
+        assert client.session.request.call_count == 2
+
+    def test_a_non_json_body_is_unavailable(self, monkeypatch):
+        resp = _response(200)
+        resp.json.side_effect = ValueError('Expecting value')
+        client = _client(monkeypatch, [resp])
+        with pytest.raises(XrasSourceUnavailable):
+            client.get_resources()
+
+    def test_every_call_carries_the_four_headers(self, monkeypatch):
+        client = _client(monkeypatch, [_response(200, _envelope(RESOURCES))])
+        client.get_resources()
+        headers = client.session.headers
+        assert headers['XA-API-KEY'] == 'not-a-real-key'
+        assert headers['XA-ALLOCATIONS-PROCESS'] == 'NCAR'
+        assert headers['XA-USER'] == 'arcguest'
+
+    def test_the_context_is_hardcoded_to_report(self, monkeypatch):
+        """`submit` cannot see the Reports family at all — there is no knob."""
+        client = _client(monkeypatch, [_response(200, _envelope(RESOURCES))])
+        assert client.session.headers['XA-CONTEXT'] == 'report'
+        assert 'context' not in inspect.signature(
+            XrasApiClient.__init__).parameters
+
+    def test_the_timeout_is_always_passed(self, monkeypatch):
+        client = _client(monkeypatch, [_response(200, _envelope(RESOURCES))])
+        client.get_resources()
+        assert client.session.request.call_args.kwargs['timeout'] == 10
+
+
+# ── envelope and endpoint shapes ────────────────────────────────────────
+
+class TestEndpoints:
+
+    def test_the_envelope_is_unwrapped_centrally(self, monkeypatch):
+        client = _client(monkeypatch, [_response(200, _envelope(PERSON))])
+        assert client.get_person('invented-user-00001') == PERSON
+
+    def test_a_body_without_an_envelope_passes_through(self, monkeypatch):
+        client = _client(monkeypatch, [_response(200, RESOURCES)])
+        assert client.get_resources() == RESOURCES
+
+    def test_a_null_result_reads_as_not_found(self, monkeypatch):
+        # XRAS answers `{"message": "...", "result": null}` for a route that
+        # exists and matched nothing — the same meaning as a 404 to a caller.
+        client = _client(monkeypatch, [_response(200, _envelope(None))])
+        assert client.get_person('nobody') is None
+
+    def test_the_person_carries_what_account_creation_needs(self, monkeypatch):
+        client = _client(monkeypatch, [_response(200, _envelope(PERSON))])
+        person = client.get_person('invented-user-00001')
+        # residenceCountry is the field the inbound payload does NOT carry.
+        assert person['residenceCountry'] == 'United States'
+        assert person['isReconciled'] is False
+
+    def test_a_username_is_url_quoted(self, monkeypatch):
+        client = _client(monkeypatch, [_response(200, _envelope(PERSON))])
+        client.get_person('a b/c')
+        url = client.session.request.call_args.args[1]
+        assert url.endswith('/v1/people/a%20b%2Fc')
+
+    def test_request_lookup_uses_the_reports_path(self, monkeypatch):
+        """`GET /v1/requests/<number>` 401s — the number is not its key."""
+        client = _client(monkeypatch,
+                         [_response(200, _envelope([_request(1, 'NCAR0001')]))])
+        row = client.get_request_by_number('NCAR0001')
+        assert row['requestNumber'] == 'NCAR0001'
+        url = client.session.request.call_args.args[1]
+        assert '/v1/reports/request_numbers/NCAR0001' in url
+
+    def test_search_people_hits_the_search_route(self, monkeypatch):
+        client = _client(monkeypatch, [_response(200, _envelope([PERSON]))])
+        assert client.search_people('Invented') == [PERSON]
+        call = client.session.request.call_args
+        assert call.args[1].endswith('/v1/search/people')
+        assert call.kwargs['params'] == {'q': 'Invented'}
+
+
+class TestPagination:
+    """Descending requestId, strictly-less-than, smallest id asks for the next."""
+
+    def test_it_walks_pages_until_they_run_out(self, monkeypatch):
+        page1 = [_request(30, 'NCAR0030'), _request(29, 'NCAR0029')]
+        page2 = [_request(28, 'NCAR0028')]
+        client = _client(monkeypatch, [_response(200, _envelope(page1)),
+                                       _response(200, _envelope(page2))])
+        rows = list(client.iter_requests(status='Approved', page_size=2))
+        assert [r['requestNumber'] for r in rows] == \
+            ['NCAR0030', 'NCAR0029', 'NCAR0028']
+        # A short page ends the walk without a third round trip.
+        assert client.session.request.call_count == 2
+
+    def test_the_cursor_is_the_smallest_id_seen(self, monkeypatch):
+        page1 = [_request(30, 'NCAR0030'), _request(29, 'NCAR0029')]
+        client = _client(monkeypatch, [_response(200, _envelope(page1)),
+                                       _response(200, _envelope([]))])
+        list(client.iter_requests(page_size=2))
+        second = client.session.request.call_args_list[1]
+        assert second.kwargs['params']['prevMinRequestId'] == 29
+
+    def test_max_pages_stops_the_walk(self, monkeypatch):
+        page = [_request(30, 'NCAR0030'), _request(29, 'NCAR0029')]
+        client = _client(monkeypatch, [_response(200, _envelope(page))] * 5)
+        rows = list(client.iter_requests(page_size=2, max_pages=2))
+        assert len(rows) == 4
+        assert client.session.request.call_count == 2
+
+    def test_a_page_that_does_not_advance_stops_the_walk(self, monkeypatch):
+        """Defensive: a server repeating a page would otherwise loop forever."""
+        page = [_request(30, 'NCAR0030'), _request(29, 'NCAR0029')]
+        client = _client(monkeypatch, [_response(200, _envelope(page))] * 5)
+        pages = list(client.iter_request_pages(page_size=2))
+        assert len(pages) == 2      # the repeat is detected on the second page
+
+    def test_pages_are_countable_so_a_cap_is_never_silent(self, monkeypatch):
+        """The page-level primitive exists so a caller can see it was capped."""
+        page = [_request(i, f'NCAR{i:04d}') for i in range(40, 38, -1)]
+        client = _client(monkeypatch, [_response(200, _envelope(page)),
+                                       _response(200, _envelope(
+                                           [_request(20, 'NCAR0020'),
+                                            _request(19, 'NCAR0019')]))])
+        pages = list(client.iter_request_pages(page_size=2, max_pages=2))
+        assert len(pages) == 2
+
+    def test_status_is_passed_through_as_a_filter(self, monkeypatch):
+        client = _client(monkeypatch, [_response(200, _envelope([]))])
+        client.get_requests_page(status='Approved', limit=200)
+        params = client.session.request.call_args.kwargs['params']
+        assert params == {'limit': 200, 'status': 'Approved'}
+
+
+# ── caching ─────────────────────────────────────────────────────────────
+
+class TestCaching:
+
+    def test_a_person_lookup_is_memoised(self, monkeypatch):
+        xras_cache._adapters.clear()          # re-enable; the fixture pins it off
+        calls = []
+
+        def fake_person(self, username):
+            calls.append(username)
+            return dict(PERSON)
+
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        monkeypatch.setattr(XrasApiClient, 'get_person', fake_person)
+
+        xras_people.get_person('invented-user-00001')
+        xras_people.get_person('invented-user-00001')
+        assert len(calls) == 1
+
+    def test_the_key_is_casefolded(self, monkeypatch):
+        xras_cache._adapters.clear()
+        calls = []
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        monkeypatch.setattr(XrasApiClient, 'get_person',
+                            lambda self, u: calls.append(u) or dict(PERSON))
+        xras_people.get_person('Invented-User-00001')
+        xras_people.get_person('invented-user-00001')
+        assert len(calls) == 1
+
+    def test_an_outage_is_never_memoised(self, monkeypatch):
+        # Re-enable — with the cache off this would pass vacuously, since
+        # nothing is memoised either way.
+        xras_cache._adapters.clear()
+        calls = []
+
+        def boom(self, username):
+            calls.append(username)
+            raise XrasSourceUnavailable('down')
+
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        monkeypatch.setattr(XrasApiClient, 'get_person', boom)
+
+        for _ in range(2):
+            with pytest.raises(XrasSourceUnavailable):
+                xras_people.get_person('invented-user-00001')
+        assert len(calls) == 2
+
+    def test_a_definite_negative_is_memoised(self, monkeypatch):
+        """A 404 is a real answer; re-asking costs a round trip per render."""
+        xras_cache._adapters.clear()
+        calls = []
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        monkeypatch.setattr(XrasApiClient, 'get_person',
+                            lambda self, u: calls.append(u) or None)
+        assert xras_people.get_person('nobody') is None
+        assert xras_people.get_person('nobody') is None
+        assert len(calls) == 1
+
+    def test_it_is_registered_with_the_webapp_facade(self):
+        """One line in `_BUCKETED_CACHE_MODULES` buys the admin card row."""
+        from webapp.caching import _BUCKETED_CACHE_MODULES
+        assert 'sam.integration.xras_api.cache' in _BUCKETED_CACHE_MODULES
+
+    def test_the_cli_can_scope_a_refresh_to_it(self):
+        """The click.Choice is hand-maintained — it drifts silently."""
+        from cli.cmds.admin import cli
+        choice = next(p for p in cli.commands['cache'].params
+                      if p.name == 'category')
+        assert 'xras_api' in choice.type.choices
+
+    def test_the_bucket_prefixes_are_namespaced(self):
+        """Bucket names are global Redis key prefixes."""
+        assert all(p.startswith('xras_') for p in xras_cache._CACHE.prefixes)
+
+
+class TestResourceKeys:
+
+    def test_it_extracts_the_join_keys(self, monkeypatch):
+        xras_cache._adapters.clear()
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        monkeypatch.setattr(XrasApiClient, 'get_resources',
+                            lambda self: list(RESOURCES))
+        assert xras_people.resource_repository_keys() == [101, 102]
+
+    def test_a_non_numeric_key_is_dropped(self, monkeypatch):
+        xras_cache._adapters.clear()
+        monkeypatch.setenv('XRAS_OUTGOING_ENABLED', '1')
+        monkeypatch.setenv('XRAS_API_KEY', 'k')
+        monkeypatch.setattr(
+            XrasApiClient, 'get_resources',
+            lambda self: [{'resourceRepositoryKey': 'nope'},
+                          {'resourceRepositoryKey': 7}])
+        # It could never have joined to the integer column, so reporting it
+        # as "XRAS sent a key SAM lacks" would be a lie.
+        assert xras_people.resource_repository_keys() == [7]

--- a/tests/unit/test_xras_dashboard.py
+++ b/tests/unit/test_xras_dashboard.py
@@ -604,7 +604,11 @@ class TestActivityCardGating:
         resp = auth_client.get('/allocations/xras')
         assert resp.status_code == 200
         assert b'xras-activity-filters' in resp.data
-        assert b'hx-include="#xras-activity-filters"' in resp.data
+        # The pane now includes TWO forms: the shared window control and its
+        # own facet state. The window moved to the page shell so that only one
+        # start_date/end_date pair exists across the three tabs.
+        assert b'hx-include="#xras-window-filters, #xras-activity-filters"' \
+            in resp.data
 
 
 class TestStatusVocabularyIsRenderable:


### PR DESCRIPTION
## Summary

SAM's first **outbound** XRAS code. Everything under `src/sam/xras/` and
`src/webapp/api/xras/` is XRAS → SAM; this is the opposite direction, SAM
calling `https://api.xras.org/v1/…`.

It produces a dashboard card listing **the user accounts that must be created
or reactivated in SAM before an XRAS handoff can succeed**. Unreconciled ARC
placeholder identities are, by this repo's own measurements
(`src/sam/xras/handlers/new.py:24-27`), **55% of the legacy 70% failure
rate** — the single largest cause of handoff failure. Account creation is
manual, so the deliverable is a worklist, not automation.

Design and probe results: `docs/xras/outgoing/XRAS_OUTGOING_QUERIES.md`
(moved here from `docs/plans/` in the last commit; § 0 records what the build
learned).

## ⚠️ Read this before reviewing the card

There are **two feeds behind three tabs**, and they fail empty for opposite
reasons — which is the whole reason both exist:

- **Accounts Needed (Feed A)** reads `xras_action_log`, and renders
  legitimately **empty in production** until ACCESS is repointed at SAM. That
  table is at **0 rows** today. Empty is a designed state, not a broken one.
- **Pending Requests (Feed B)** reaches XRAS directly and therefore works
  *before* cutover. Verified live in production 2026-08-20: 22 requests,
  18 accounts needed.

*Unconfigured* is also a designed state: with `XRAS_OUTGOING_ENABLED` off,
Feed A still renders in full from the action log and Feed B renders empty,
with XRAS-sourced person detail marked unavailable.

## The commits

| # | Commit | What |
|---|---|---|
| 1 | `sam/integration/xras_api` | GET-only client + cache + probe script |
| 2 | `sam/queries/xras_accounts` | Two feeds → one classifier |
| 3 | `allocations dashboard` | The card, read-only |
| 4 | `sam-admin xras` | `--accounts`, `--person`, two-sided `--validate-mapping` |
| 5 | `scheduling: xras_sweep` | Enumerate-and-diff, **hourly on business hours** |
| 6 | `helm` | Fail-closed config, key via ExternalSecret |
| 7 | `docs` | File under `docs/xras/outgoing/`, settle the co-PI question |
| 8 | `tabs + Feed B` | Three-tab shell, shared date filter, request column/chips |
| 9 | `prod fixes` | `CACHE_REDIS_URL` + Redis NetworkPolicy for the task pods |

## Three things worth a reviewer's attention

**GET-only is structural, not conventional.** The same credential can create
requests, delete them, modify roles, and *merge one person into another*. So
the client has no verb method at all — `_get` is the only transport
primitive, and a test asserts no `post`/`put`/`patch`/`delete` callable
exists on the class. Likewise `XA-CONTEXT: report` is hardcoded, not a
parameter.

**PII is gated in the route, not the template.** Person detail (name, email,
organization, academic status, residence country) is assembled only for
`MANAGE_XRAS`; a `VIEW_XRAS` response never carries the bytes. A test asserts
the stubbed email, surname, organization and country are all *absent* from a
VIEW-only response body — not merely undrawn. `isReconciled` is deliberately
on the VIEW side: it is account state, and it is the signal an item is about
to close itself.

**`isAccountToBeCreated` is never the predicate.** XRAS sets it when a role
is created and never clears it. Validated against the unscrubbed corpus and
the dev database: **all 5 usernames carrying the flag were existing, active
SAM accounts** — 100% stale. Using it would have produced 5 false positives
and found none of the 9 real cases. It ships as a hint column with a
regression test pinning that a flagged active user does not appear.

## Verification

**Live probe against production** (`scripts/xras/probe_outgoing.py`, opt-in,
skips without a key):

- 13 resources, all carrying `resourceRepositoryKey`, reconciling **13/13**
  against `xras_resource_repository_key_resource` — zero unmapped, zero
  dangling. `sam-admin xras --validate-mapping` now proves this instead of
  assuming it.
- `reports/requests` paginates cleanly: 3 pages × 10, 30 distinct, zero overlap.
- Person objects arrive **inline** in every roster with `isReconciled` and
  `residenceCountry`.
- **Zero co-PIs across 64 sampled role entries**, confirming `/v1/types/roles`:
  the NCAR process declares exactly three role types, so a co-PI cannot appear
  on this wire. That closes a hedge carried in three places.
- 7 of 43 sampled role-people are `isReconciled: false` — the worklist has
  real content waiting.

**Tier-III, against the unscrubbed corpus + the dev database** (the only way
to validate the core predicate — scrubbed fixtures make "no `users` row"
trivially true for every row): 41/41 payloads parsed, 72 distinct real
usernames, **9 worklist rows — 4 absent, 5 inactive**. An existence-only
predicate would have found 4 of 9. Counts only; nothing derived from that
corpus is committed.

**Tests**: `7,196 passed, 42 skipped, 1 xfailed` across unit + integration +
api. 132 new tests. `bash helm/tests/test-cronjob-render.sh` passes, and its
new assertions were negative-tested (deleting `XRAS_API_USER` from the CronJob
exits 1; restoring it exits 0).

Three existing test rosters were updated — the cache-adapter list, the
cache-category set, and the audit window-form check. Each is a deliberate
enumeration that a new registration is *supposed* to break. The third had
been counting `name="days"` per *page* while its docstring described the
invariant per *form*; it now asserts what it means.

## Deployment notes

- **The OpenBao secret already exists** at `csg/xras-api-key`, property
  `token`, so `webapp.xrasApiCredentials.enabled: true` is safe on arrival.
- **Both levers ship ON**, and they are ONE decision: `XRAS_OUTGOING_ENABLED:
  "1"` with `xras_sweep` removed from `SAM_TASKS_DISABLED`. The task skips
  while the lever is off and the tab renders only what the task publishes, so
  a split state is just a dead tab; `helm/tests/test-cronjob-render.sh` fails
  if the two disagree. That list is fail-open — a registered task goes live on
  the next hourly wake unless the chart names it.
- `XRAS_API_KEY` is injected into **both** the Deployment and the CronJob.
  They share no env anchor; this is the same cross-referencing trap `NOTIFY_*`
  hit, and the render assertions are per-manifest for that reason.
- Nothing is written by any of this. No new table, no migration, no write path.

## Deferred, deliberately

`xras_account_event` (operator notes and dismissal — `XrasActivationEvent`
cannot carry it: `project_id` is NOT NULL and project-scoped, while this
worklist is username-keyed and a New request has no project yet) is the
immediate follow-up. Also deferred: the `opportunityId` → allocation-type map
(now sketched in `docs/plans/XRAS_OPPORTUNITY_ALLOCATION_TYPE.md`, designed to
be purely additive so ingestion never depends on the outbound API) and key
rotation. Each is recorded in § 14 of the design doc with what would change
the decision. **No longer deferred**: the sweep and the lever are both on,
and verified in production below.

## Verified in production, 2026-08-20

Deployed to CIRRUS and watched two sweep slots. **Two bugs only production
could show, both fixed in this branch:**

1. **The task pods had no `CACHE_REDIS_URL`.** `cronjob-tasks.yaml` renders
   `.Values.tasks.env` plus a hand-listed set and does *not* inherit
   `.Values.webapp.env` — the same trap `NOTIFY_*` hit. The sweep published
   into a per-worker cache that died with the pod, so the dashboard read
   nothing while the ledger said `published: true`.
2. **The Redis NetworkPolicy denied the task pods.**
   `samuel-redis-allow-webapp` admitted only `app: samuel`; task pods are
   `app: samuel-tasks`, so the connection timed out. Added the second peer.

`store_pending_worklist()` now returns *where* the snapshot landed
(`redis` / `local` / `disabled` / `full`) and `published` is true only for
`redis`, so this class of bug reports itself instead of claiming success.

| | 11:07 (pre-fix) | 12:07 (post-fix) |
|---|---|---|
| `publish_backend` | `local` | **`redis`** |
| `published` | `false` | **`true`** |
| duration | 59s | 47s |
| pages / in-window | 21 / 1640 of 4088 | 21 / 1640 of 4088 |
| accounts needed | 18 (10 absent, 8 inactive, 9 placeholder) | 18 (same) |

`unavailable_errors: 0` on both. Enumeration is stable run to run.

**Read-only Playwright pass against `sam.hpc.ucar.edu`**: the Pending Requests
tab renders the published snapshot, the shared date pills restyle *and* move
counts (7D → 2 rows, 90D → 9), zero console errors, zero 4xx/5xx. The one
unexplained 404 seen pre-publish did not reappear — it was an artifact of the
empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
